### PR TITLE
Fix password reset link on account page.

### DIFF
--- a/flexmeasures/ui/templates/admin/account.html
+++ b/flexmeasures/ui/templates/admin/account.html
@@ -17,7 +17,7 @@
             </form>
         </div>
         <div class="col-sm-2">
-            <form action="/users/reset_passsword_for/{{ logged_in_user.id }}" method="get">
+            <form action="/users/reset_password_for/{{ logged_in_user.id }}" method="get">
                 <button class="btn btn-sm btn-responsive btn-info" type="submit">Send password reset instructions</button>
             </form>
         </div>


### PR DESCRIPTION
The password reset button on the account page wasn't working. This PR should fix that. (I don't know why this hadn't been noticed before, but I guess everyone had been using the alternative password reset button on the users page.)

* Typo causing 404 Not Found.