### PR TITLE
Fall back scheduler heuristics

### DIFF
--- a/flexmeasures/api/v1/implementations.py
+++ b/flexmeasures/api/v1/implementations.py
@@ -274,7 +274,7 @@ def create_connection_and_value_groups(  # noqa: C901
                 return unrecognized_connection_group()
 
             # Validate the sign of the values (following USEF specs with positive consumption and negative production)
-            if sensor.get_attribute("is_pure_consumer") and any(
+            if sensor.get_attribute("is_strictly_non_positive") and any(
                 v < 0 for v in value_group
             ):
                 extra_info = (
@@ -282,7 +282,7 @@ def create_connection_and_value_groups(  # noqa: C901
                     % sensor.entity_address
                 )
                 return power_value_too_small(extra_info)
-            elif sensor.get_attribute("is_pure_producer") and any(
+            elif sensor.get_attribute("is_strictly_non_negative") and any(
                 v > 0 for v in value_group
             ):
                 extra_info = (

--- a/flexmeasures/api/v2_0/implementations/sensors.py
+++ b/flexmeasures/api/v2_0/implementations/sensors.py
@@ -328,7 +328,7 @@ def post_power_data(
                 return unrecognized_connection_group()
 
             # Validate the sign of the values (following USEF specs with positive consumption and negative production)
-            if sensor.get_attribute("is_pure_consumer") and any(
+            if sensor.get_attribute("is_strictly_non_positive") and any(
                 v < 0 for v in event_values
             ):
                 extra_info = (
@@ -336,7 +336,7 @@ def post_power_data(
                     % sensor.entity_address
                 )
                 return power_value_too_small(extra_info)
-            elif sensor.get_attribute("is_pure_producer") and any(
+            elif sensor.get_attribute("is_strictly_non_negative") and any(
                 v > 0 for v in event_values
             ):
                 extra_info = (

--- a/flexmeasures/data/models/planning/charging_station.py
+++ b/flexmeasures/data/models/planning/charging_station.py
@@ -84,17 +84,13 @@ def schedule_charging_station(
         timedelta(hours=1) / resolution
     )  # Lacking information about the battery's nominal capacity, we use the highest target value as the maximum state of charge
 
-    if sensor.get_attribute("is_consumer", False) and not sensor.get_attribute(
-        "is_producer", True
-    ):
+    if sensor.get_attribute("is_strictly_non_positive"):
         device_constraints[0]["derivative min"] = 0
     else:
         device_constraints[0]["derivative min"] = (
             sensor.get_attribute("capacity_in_mw") * -1
         )
-    if sensor.get_attribute("is_producer", False) and not sensor.get_attribute(
-        "is_consumer", True
-    ):
+    if sensor.get_attribute("is_strictly_non_negative"):
         device_constraints[0]["derivative max"] = 0
     else:
         device_constraints[0]["derivative max"] = sensor.get_attribute("capacity_in_mw")

--- a/flexmeasures/data/models/planning/charging_station.py
+++ b/flexmeasures/data/models/planning/charging_station.py
@@ -10,6 +10,7 @@ from flexmeasures.data.models.planning.utils import (
     initialize_series,
     add_tiny_price_slope,
     get_prices,
+    fallback_charging_policy,
 )
 
 
@@ -82,13 +83,18 @@ def schedule_charging_station(
     ) - soc_at_start * (
         timedelta(hours=1) / resolution
     )  # Lacking information about the battery's nominal capacity, we use the highest target value as the maximum state of charge
-    if sensor.get_attribute("is_pure_consumer", False):
+
+    if sensor.get_attribute("is_consumer", False) and not sensor.get_attribute(
+        "is_producer", True
+    ):
         device_constraints[0]["derivative min"] = 0
     else:
         device_constraints[0]["derivative min"] = (
             sensor.get_attribute("capacity_in_mw") * -1
         )
-    if sensor.get_attribute("is_pure_producer", False):
+    if sensor.get_attribute("is_producer", False) and not sensor.get_attribute(
+        "is_consumer", True
+    ):
         device_constraints[0]["derivative max"] = 0
     else:
         device_constraints[0]["derivative max"] = sensor.get_attribute("capacity_in_mw")
@@ -97,13 +103,19 @@ def schedule_charging_station(
     columns = ["derivative max", "derivative min"]
     ems_constraints = initialize_df(columns, start, end, resolution)
 
-    ems_schedule, expected_costs = device_scheduler(
+    ems_schedule, expected_costs, scheduler_results = device_scheduler(
         device_constraints,
         ems_constraints,
         commitment_quantities,
         commitment_downwards_deviation_price,
         commitment_upwards_deviation_price,
     )
-    charging_station_schedule = ems_schedule[0]
+    if scheduler_results.solver.termination_condition == "infeasible":
+        # Fallback policy if the problem was unsolvable
+        charging_station_schedule = fallback_charging_policy(
+            sensor, device_constraints[0], start, end, resolution
+        )
+    else:
+        charging_station_schedule = ems_schedule[0]
 
     return charging_station_schedule

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -85,14 +85,30 @@ class Sensor(db.Model, tb.SensorDBMixin):
             return self.latitude, self.longitude
         return None
 
+    @property
+    def is_strictly_non_positive(self) -> bool:
+        """Return True if this sensor strictly records non-positive values."""
+        return self.get_attribute("is_consumer", False) and not self.get_attribute(
+            "is_producer", True
+        )
+
+    @property
+    def is_strictly_non_negative(self) -> bool:
+        """Return True if this sensor strictly records non-negative values."""
+        return self.get_attribute("is_producer", False) and not self.get_attribute(
+            "is_consumer", True
+        )
+
     def get_attribute(self, attribute: str, default: Any = None) -> Any:
         """Looks for the attribute on the Sensor.
         If not found, looks for the attribute on the Sensor's GenericAsset.
         If not found, returns the default.
         """
+        if hasattr(self, attribute):
+            return getattr(self, attribute)
         if attribute in self.attributes:
             return self.attributes[attribute]
-        elif attribute in self.generic_asset.attributes:
+        if attribute in self.generic_asset.attributes:
             return self.generic_asset.attributes[attribute]
         return default
 


### PR DESCRIPTION
This PR builds on project 9, but is not really part of it. It introduces a fallback policy for charging schedules of batteries and Charge Points, in cases where the solver is presented with an infeasible problem.