### PR TITLE
Ensure backwards compatibility of Power init and Market init

### DIFF
--- a/flexmeasures/data/models/assets.py
+++ b/flexmeasures/data/models/assets.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import isodate
 import timely_beliefs as tb
+import timely_beliefs.utils as tb_utils
 from sqlalchemy.orm import Query
 
 from flexmeasures.data.config import db
@@ -347,8 +348,14 @@ class Power(TimedValue, db.Model):
         }
 
     def __init__(self, **kwargs):
+        # todo: deprecate the 'asset_id' argument in favor of 'sensor_id' (announced v0.8.0)
         if "asset_id" in kwargs and "sensor_id" not in kwargs:
-            kwargs["sensor_id"] = kwargs["asset_id"]
+            kwargs["sensor_id"] = tb_utils.replace_deprecated_argument(
+                "sensor_id",
+                kwargs["sensor_id"],
+                "asset_id",
+                kwargs["asset_id"],
+            )
         super(Power, self).__init__(**kwargs)
 
     def __repr__(self):

--- a/flexmeasures/data/models/assets.py
+++ b/flexmeasures/data/models/assets.py
@@ -356,6 +356,7 @@ class Power(TimedValue, db.Model):
                 "asset_id",
                 kwargs["asset_id"],
             )
+            kwargs.pop("asset_id", None)
         super(Power, self).__init__(**kwargs)
 
     def __repr__(self):

--- a/flexmeasures/data/models/assets.py
+++ b/flexmeasures/data/models/assets.py
@@ -347,6 +347,8 @@ class Power(TimedValue, db.Model):
         }
 
     def __init__(self, **kwargs):
+        if "asset_id" in kwargs and "sensor_id" not in kwargs:
+            kwargs["sensor_id"] = kwargs["asset_id"]
         super(Power, self).__init__(**kwargs)
 
     def __repr__(self):

--- a/flexmeasures/data/models/markets.py
+++ b/flexmeasures/data/models/markets.py
@@ -2,6 +2,7 @@ from typing import Dict
 
 import timely_beliefs as tb
 from timely_beliefs.sensors.func_store import knowledge_horizons
+import timely_beliefs.utils as tb_utils
 from sqlalchemy.orm import Query
 
 from flexmeasures.data.config import db
@@ -203,6 +204,12 @@ class Price(TimedValue, db.Model):
         return super().make_query(**kwargs)
 
     def __init__(self, **kwargs):
+        # todo: deprecate the 'market_id' argument in favor of 'sensor_id' (announced v0.8.0)
         if "market_id" in kwargs and "sensor_id" not in kwargs:
-            kwargs["sensor_id"] = kwargs["market_id"]
+            kwargs["sensor_id"] = tb_utils.replace_deprecated_argument(
+                "sensor_id",
+                kwargs["sensor_id"],
+                "market_id",
+                kwargs["market_id"],
+            )
         super(Price, self).__init__(**kwargs)

--- a/flexmeasures/data/models/markets.py
+++ b/flexmeasures/data/models/markets.py
@@ -203,4 +203,6 @@ class Price(TimedValue, db.Model):
         return super().make_query(**kwargs)
 
     def __init__(self, **kwargs):
+        if "market_id" in kwargs and "sensor_id" not in kwargs:
+            kwargs["sensor_id"] = kwargs["market_id"]
         super(Price, self).__init__(**kwargs)

--- a/flexmeasures/data/models/markets.py
+++ b/flexmeasures/data/models/markets.py
@@ -212,4 +212,5 @@ class Price(TimedValue, db.Model):
                 "market_id",
                 kwargs["market_id"],
             )
+            kwargs.pop("market_id", None)
         super(Price, self).__init__(**kwargs)


### PR DESCRIPTION
In case old plugins are still initializing Power and Price objects, ensure backwards compatibility and warn for deprecation.

NB Weather objects were already backwards compatible, because we already used `sensor_id` to mean `weather_sensor_id` for the old model.