### PR TITLE
Copy Asset and WeatherSensor locations to GenericAsset

### DIFF
--- a/flexmeasures/data/migrations/versions/6cf5b241b85f_copy_attributes_from_old_data_models_to_GenericAsset.py
+++ b/flexmeasures/data/migrations/versions/6cf5b241b85f_copy_attributes_from_old_data_models_to_GenericAsset.py
@@ -50,6 +50,8 @@ def upgrade():
         sa.MetaData(),
         sa.Column("id"),
         sa.Column("generic_asset_type_id"),
+        sa.Column("latitude"),
+        sa.Column("longitude"),
         sa.Column("attributes"),
     )
     t_sensor = sa.Table(
@@ -90,6 +92,8 @@ def upgrade():
         sa.Column("id"),
         sa.Column("asset_type_name"),
         sa.Column("display_name"),  # Copy to both Sensor and to GenericAsset
+        sa.Column("latitude"),  # Copy to GenericAsset
+        sa.Column("longitude"),  # Copy to GenericAsset
         sa.Column("capacity_in_mw"),  # Copy to Sensor
         sa.Column("min_soc_in_mwh"),  # Copy to GenericAsset [1]
         sa.Column("max_soc_in_mwh"),  # Copy to GenericAsset [1]
@@ -124,6 +128,8 @@ def upgrade():
         sa.Column("id"),
         sa.Column("weather_sensor_type_name"),
         sa.Column("display_name"),  # Copy to both Sensor and to GenericAsset
+        sa.Column("latitude"),  # Copy to GenericAsset
+        sa.Column("longitude"),  # Copy to GenericAsset
         sa.Column("unit"),  # Copy to Sensor [done]
         sa.Column("event_resolution"),  # Copy to Sensor [done]
         sa.Column("knowledge_horizon_fnc"),  # Copy to Sensor [done]
@@ -183,7 +189,13 @@ def upgrade():
         t_generic_asset,
         t_target=t_sensor,
         t_old_model_type=t_weather_sensor_type,
-        old_model_attributes=["id", "weather_sensor_type_name", "display_name"],
+        old_model_attributes=[
+            "id",
+            "weather_sensor_type_name",
+            "display_name",
+            "latitude",
+            "longitude",
+        ],
         extra_attributes={
             "daily_seasonality": True,
             "weekly_seasonality": False,
@@ -212,6 +224,8 @@ def upgrade():
             "id",
             "asset_type_name",
             "display_name",
+            "latitude",
+            "longitude",
             "capacity_in_mw",
             "market_id",
         ],
@@ -279,11 +293,42 @@ def upgrade():
     copy_sensor_columns(connection, t_market, t_sensor)
     copy_sensor_columns(connection, t_weather_sensor, t_sensor)
     copy_sensor_columns(connection, t_asset, t_sensor)
+    copy_location_columns(connection, t_weather_sensor, t_generic_asset, t_sensor)
+    copy_location_columns(connection, t_asset, t_generic_asset, t_sensor)
 
 
 def downgrade():
     op.drop_column("sensor", "attributes")
     op.drop_column("generic_asset", "attributes")
+
+
+def copy_location_columns(connection, t_old_model, t_generic_asset, t_sensor):
+    old_model_attributes = [
+        "id",
+        "latitude",
+        "longitude",
+    ]
+    # Get columns from old model
+    results = connection.execute(
+        sa.select([getattr(t_old_model.c, a) for a in old_model_attributes])
+    ).fetchall()
+
+    for sensor_id, *args in results:
+        # Obtain columns we want to copy over, from the old model
+        old_model_columns_to_copy = {
+            k: v if not isinstance(v, dict) else json.dumps(v)
+            for k, v in zip(old_model_attributes[-len(args) :], args)
+        }
+
+        # Fill in the GenericAsset's columns
+        connection.execute(
+            t_generic_asset.update()
+            .where(t_generic_asset.c.id == t_sensor.c.generic_asset_id)
+            .where(t_sensor.c.id == sensor_id)
+            .values(
+                **old_model_columns_to_copy,
+            )
+        )
 
 
 def copy_sensor_columns(connection, t_old_model, t_sensor):

--- a/flexmeasures/data/migrations/versions/6cf5b241b85f_copy_attributes_from_old_data_models_to_GenericAsset.py
+++ b/flexmeasures/data/migrations/versions/6cf5b241b85f_copy_attributes_from_old_data_models_to_GenericAsset.py
@@ -293,8 +293,12 @@ def upgrade():
     copy_sensor_columns(connection, t_market, t_sensor)
     copy_sensor_columns(connection, t_weather_sensor, t_sensor)
     copy_sensor_columns(connection, t_asset, t_sensor)
-    copy_location_columns(connection, t_weather_sensor, t_generic_asset, t_sensor)
-    copy_location_columns(connection, t_asset, t_generic_asset, t_sensor)
+    copy_location_columns_to_generic_asset(
+        connection, t_weather_sensor, t_generic_asset, t_sensor
+    )
+    copy_location_columns_to_generic_asset(
+        connection, t_asset, t_generic_asset, t_sensor
+    )
 
 
 def downgrade():
@@ -302,7 +306,9 @@ def downgrade():
     op.drop_column("generic_asset", "attributes")
 
 
-def copy_location_columns(connection, t_old_model, t_generic_asset, t_sensor):
+def copy_location_columns_to_generic_asset(
+    connection, t_old_model, t_generic_asset, t_sensor
+):
     old_model_attributes = [
         "id",
         "latitude",


### PR DESCRIPTION
Closes #275.

This PR copies Asset and WeatherSensor locations to GenericAsset (Markets didn't have a location). Sensor attributes get a copy, too, because multiple Sensors under one GenericAsset may have slightly different locations, while the GenericAsset has only one location.

To test:
```
flexmeasures db downgrade 1ae32ffc8c3f
flexmeasures db upgrade
```
