### PR TITLE
Allow distinct sensor locations per generic asset

### DIFF
--- a/flexmeasures/api/common/utils/api_utils.py
+++ b/flexmeasures/api/common/utils/api_utils.py
@@ -333,8 +333,7 @@ def get_sensor_by_generic_asset_type_and_location(
             ).first()
             if nearest_weather_sensor is not None:
                 return unrecognized_sensor(
-                    nearest_weather_sensor.latitude,
-                    nearest_weather_sensor.longitude,
+                    *nearest_weather_sensor.location,
                 )
             else:
                 return unrecognized_sensor()

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -59,9 +59,9 @@ class GenericAsset(db.Model):
 
     @property
     def location(self) -> Optional[Tuple[float, float]]:
-        if None not in (self.latitude, self.longitude):
-            return self.latitude, self.longitude
-        return None
+        location = (self.latitude, self.longitude)
+        if None not in location:
+            return location
 
     @hybrid_method
     def great_circle_distance(self, **kwargs):

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -108,6 +108,8 @@ class Sensor(db.Model, tb.SensorDBMixin):
             return getattr(self, attribute)
         if attribute in self.attributes:
             return self.attributes[attribute]
+        if hasattr(self.generic_asset, attribute):
+            return getattr(self.generic_asset, attribute)
         if attribute in self.generic_asset.attributes:
             return self.generic_asset.attributes[attribute]
         return default

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -72,18 +72,10 @@ class Sensor(db.Model, tb.SensorDBMixin):
         return build_entity_address(dict(sensor_id=self.id), "sensor")
 
     @property
-    def latitude(self) -> float:
-        return self.generic_asset.latitude
-
-    @property
-    def longitude(self) -> float:
-        return self.generic_asset.longitude
-
-    @property
     def location(self) -> Optional[Tuple[float, float]]:
-        if None not in (self.latitude, self.longitude):
-            return self.latitude, self.longitude
-        return None
+        location = (self.get_attribute("latitude"), self.get_attribute("longitude"))
+        if None not in location:
+            return location
 
     @property
     def is_strictly_non_positive(self) -> bool:

--- a/flexmeasures/utils/geo_utils.py
+++ b/flexmeasures/utils/geo_utils.py
@@ -62,6 +62,8 @@ def parse_lat_lng(kwargs) -> Union[Tuple[float, float], Tuple[None, None]]:
                 return obj.latitude, obj.longitude
             elif hasattr(obj, "lat") and hasattr(obj, "lng"):
                 return obj.lat, obj.lng
+            elif hasattr(obj, "location"):
+                return obj.location
     return None, None
 
 


### PR DESCRIPTION
This PR lets a Sensor define a custom location in its attributes column. If not specified, the Sensor location defaults to that of the GenericAsset it belongs to.