### PR TITLE
Sub issue 284a initialize timed belief when initializing power/price/weather

### DIFF
--- a/flexmeasures/api/v1/implementations.py
+++ b/flexmeasures/api/v1/implementations.py
@@ -301,12 +301,13 @@ def create_connection_and_value_groups(  # noqa: C901
                         (start + duration) - (dt + duration / len(value_group))
                     )
                 p = Power(
-                    datetime=dt,
-                    value=value
+                    use_legacy_kwargs=False,
+                    event_start=dt,
+                    event_value=value
                     * -1,  # Reverse sign for FlexMeasures specs with positive production and negative consumption
-                    horizon=h,
-                    sensor_id=sensor_id,
-                    data_source_id=data_source.id,
+                    belief_horizon=h,
+                    sensor=sensor,
+                    source=data_source,
                 )
                 power_measurements.append(p)
 

--- a/flexmeasures/api/v1/tests/conftest.py
+++ b/flexmeasures/api/v1/tests/conftest.py
@@ -91,20 +91,22 @@ def setup_api_test_data(db, setup_accounts, setup_roles_users, add_market_prices
     meter_data = []
     for i in range(6):
         p_1 = Power(
-            datetime=isodate.parse_datetime("2015-01-01T00:00:00Z")
+            use_legacy_kwargs=False,
+            event_start=isodate.parse_datetime("2015-01-01T00:00:00Z")
             + timedelta(minutes=15 * i),
-            horizon=timedelta(0),
-            value=(100.0 + i) * -1,
-            sensor_id=cs_5.id,
-            data_source_id=user1_data_source.id,
+            belief_horizon=timedelta(0),
+            event_value=(100.0 + i) * -1,
+            sensor=cs_5.corresponding_sensor,
+            source=user1_data_source,
         )
         p_2 = Power(
-            datetime=isodate.parse_datetime("2015-01-01T00:00:00Z")
+            use_legacy_kwargs=False,
+            event_start=isodate.parse_datetime("2015-01-01T00:00:00Z")
             + timedelta(minutes=15 * i),
-            horizon=timedelta(hours=0),
-            value=(1000.0 - 10 * i) * -1,
-            sensor_id=cs_5.id,
-            data_source_id=user2_data_source.id,
+            belief_horizon=timedelta(hours=0),
+            event_value=(1000.0 - 10 * i) * -1,
+            sensor=cs_5.corresponding_sensor,
+            source=user2_data_source,
         )
         meter_data.append(p_1)
         meter_data.append(p_2)

--- a/flexmeasures/api/v1_1/implementations.py
+++ b/flexmeasures/api/v1_1/implementations.py
@@ -114,11 +114,12 @@ def post_price_data_response(
                         (start + duration) - (dt + duration / len(value_group))
                     )
                 p = Price(
-                    datetime=dt,
-                    value=value,
-                    horizon=h,
-                    sensor_id=sensor.id,
-                    data_source_id=data_source.id,
+                    use_legacy_kwargs=False,
+                    event_start=dt,
+                    event_value=value,
+                    belief_horizon=h,
+                    sensor=sensor,
+                    source=data_source,
                 )
                 prices.append(p)
 

--- a/flexmeasures/api/v1_1/implementations.py
+++ b/flexmeasures/api/v1_1/implementations.py
@@ -198,11 +198,11 @@ def post_weather_data_response(  # noqa: C901
                         (start + duration) - (dt + duration / len(value_group))
                     )
                 w = Weather(
-                    datetime=dt,
-                    value=value,
-                    horizon=h,
-                    sensor_id=sensor.id,
-                    data_source_id=data_source.id,
+                    event_start=dt,
+                    event_value=value,
+                    belief_horizon=h,
+                    sensor=sensor,
+                    source=data_source,
                 )
                 weather_measurements.append(w)
 

--- a/flexmeasures/api/v1_1/implementations.py
+++ b/flexmeasures/api/v1_1/implementations.py
@@ -198,6 +198,7 @@ def post_weather_data_response(  # noqa: C901
                         (start + duration) - (dt + duration / len(value_group))
                     )
                 w = Weather(
+                    use_legacy_kwargs=False,
                     event_start=dt,
                     event_value=value,
                     belief_horizon=h,

--- a/flexmeasures/api/v1_1/tests/conftest.py
+++ b/flexmeasures/api/v1_1/tests/conftest.py
@@ -58,28 +58,31 @@ def setup_api_test_data(db, setup_accounts, setup_roles_users, add_market_prices
     power_forecasts = []
     for i in range(6):
         p_1 = Power(
-            datetime=isodate.parse_datetime("2015-01-01T00:00:00Z")
+            use_legacy_kwargs=False,
+            event_start=isodate.parse_datetime("2015-01-01T00:00:00Z")
             + timedelta(minutes=15 * i),
-            horizon=timedelta(hours=6),
-            value=(300 + i) * -1,
-            sensor_id=cs_1.id,
-            data_source_id=data_source.id,
+            belief_horizon=timedelta(hours=6),
+            event_value=(300 + i) * -1,
+            sensor=cs_1.corresponding_sensor,
+            source=data_source,
         )
         p_2 = Power(
-            datetime=isodate.parse_datetime("2015-01-01T00:00:00Z")
+            use_legacy_kwargs=False,
+            event_start=isodate.parse_datetime("2015-01-01T00:00:00Z")
             + timedelta(minutes=15 * i),
-            horizon=timedelta(hours=6),
-            value=(300 - i) * -1,
-            sensor_id=cs_2.id,
-            data_source_id=data_source.id,
+            belief_horizon=timedelta(hours=6),
+            event_value=(300 - i) * -1,
+            sensor=cs_2.corresponding_sensor,
+            source=data_source,
         )
         p_3 = Power(
-            datetime=isodate.parse_datetime("2015-01-01T00:00:00Z")
+            use_legacy_kwargs=False,
+            event_start=isodate.parse_datetime("2015-01-01T00:00:00Z")
             + timedelta(minutes=15 * i),
-            horizon=timedelta(hours=6),
-            value=(0 + i) * -1,
-            sensor_id=cs_3.id,
-            data_source_id=data_source.id,
+            belief_horizon=timedelta(hours=6),
+            event_value=(0 + i) * -1,
+            sensor=cs_3.corresponding_sensor,
+            source=data_source,
         )
         power_forecasts.append(p_1)
         power_forecasts.append(p_2)

--- a/flexmeasures/api/v1_2/tests/test_api_v1_2.py
+++ b/flexmeasures/api/v1_2/tests/test_api_v1_2.py
@@ -27,7 +27,8 @@ def test_get_device_message(client, message):
     assert get_device_message_response.json["type"] == "GetDeviceMessageResponse"
     assert len(get_device_message_response.json["values"]) == 192
 
-    # Test that a shorter planning horizon yields the same result
+    # Test that a shorter planning horizon yields a shorter result
+    # Note that the scheduler might give a different result, because it doesn't look as far ahead
     message["duration"] = "PT6H"
     get_device_message_response_short = client.get(
         url_for("flexmeasures_api_v1_2.get_device_message"),
@@ -36,10 +37,7 @@ def test_get_device_message(client, message):
     )
     print("Server responded with:\n%s" % get_device_message_response_short.json)
     assert get_device_message_response_short.status_code == 200
-    assert (
-        get_device_message_response_short.json["values"]
-        == get_device_message_response.json["values"][0:24]
-    )
+    assert len(get_device_message_response_short.json["values"]) == 24
 
     # Test that a much longer planning horizon yields the same result (when there are only 2 days of prices)
     message["duration"] = "PT1000H"

--- a/flexmeasures/api/v2_0/implementations/sensors.py
+++ b/flexmeasures/api/v2_0/implementations/sensors.py
@@ -186,6 +186,7 @@ def post_weather_data_response(  # noqa: C901
             weather_measurements.extend(
                 [
                     Weather(
+                        use_legacy_kwargs=False,
                         event_start=event_start,
                         event_value=event_value,
                         belief_horizon=belief_horizon,

--- a/flexmeasures/api/v2_0/implementations/sensors.py
+++ b/flexmeasures/api/v2_0/implementations/sensors.py
@@ -173,7 +173,7 @@ def post_weather_data_response(  # noqa: C901
             if unit not in accepted_units:
                 return invalid_unit(weather_sensor_type_name, accepted_units)
 
-            sensor = get_sensor_by_generic_asset_type_and_location(
+            sensor: Sensor = get_sensor_by_generic_asset_type_and_location(
                 weather_sensor_type_name, latitude, longitude
             )
 
@@ -186,11 +186,11 @@ def post_weather_data_response(  # noqa: C901
             weather_measurements.extend(
                 [
                     Weather(
-                        datetime=event_start,
-                        value=event_value,
-                        horizon=belief_horizon,
-                        sensor_id=sensor.id,
-                        data_source_id=data_source.id,
+                        event_start=event_start,
+                        event_value=event_value,
+                        belief_horizon=belief_horizon,
+                        sensor=sensor,
+                        source=data_source,
                     )
                     for event_start, event_value, belief_horizon in zip(
                         event_starts, event_values, belief_horizons

--- a/flexmeasures/api/v2_0/implementations/sensors.py
+++ b/flexmeasures/api/v2_0/implementations/sensors.py
@@ -356,12 +356,13 @@ def post_power_data(
             power_measurements.extend(
                 [
                     Power(
-                        datetime=event_start,
-                        value=event_value
+                        use_legacy_kwargs=False,
+                        event_start=event_start,
+                        event_value=event_value
                         * -1,  # Reverse sign for FlexMeasures specs with positive production and negative consumption
-                        horizon=belief_horizon,
-                        sensor_id=sensor_id,
-                        data_source_id=data_source.id,
+                        belief_horizon=belief_horizon,
+                        sensor=sensor,
+                        source=data_source,
                     )
                     for event_start, event_value, belief_horizon in zip(
                         event_starts, event_values, belief_horizons

--- a/flexmeasures/api/v2_0/implementations/sensors.py
+++ b/flexmeasures/api/v2_0/implementations/sensors.py
@@ -99,11 +99,12 @@ def post_price_data_response(  # noqa C901
             prices.extend(
                 [
                     Price(
-                        datetime=event_start,
-                        value=event_value,
-                        horizon=belief_horizon,
-                        sensor_id=sensor.id,
-                        data_source_id=data_source.id,
+                        use_legacy_kwargs=False,
+                        event_start=event_start,
+                        event_value=event_value,
+                        belief_horizon=belief_horizon,
+                        sensor=sensor,
+                        source=data_source,
                     )
                     for event_start, event_value, belief_horizon in zip(
                         event_starts, event_values, belief_horizons

--- a/flexmeasures/conftest.py
+++ b/flexmeasures/conftest.py
@@ -242,9 +242,11 @@ def create_test_markets(db) -> Dict[str, Market]:
 
 @pytest.fixture(scope="module")
 def setup_sources(db) -> Dict[str, DataSource]:
-    data_source = DataSource(name="Seita", type="demo script")
-    db.session.add(data_source)
-    return {"Seita": data_source}
+    seita_source = DataSource(name="Seita", type="demo script")
+    db.session.add(seita_source)
+    entsoe_source = DataSource(name="ENTSO-E", type="demo script")
+    db.session.add(entsoe_source)
+    return {"Seita": seita_source, "ENTSO-E": entsoe_source}
 
 
 @pytest.fixture(scope="module")
@@ -329,7 +331,10 @@ def setup_assets(
         time_slots = pd.date_range(
             datetime(2015, 1, 1), datetime(2015, 1, 1, 23, 45), freq="15T"
         )
-        values = [random() * (1 + np.sin(x * 2 * np.pi / (4 * 24))) for x in range(len(time_slots))]
+        values = [
+            random() * (1 + np.sin(x * 2 * np.pi / (4 * 24)))
+            for x in range(len(time_slots))
+        ]
         for dt, val in zip(time_slots, values):
             p = Power(
                 datetime=as_server_time(dt),
@@ -351,21 +356,21 @@ def setup_beliefs(db: SQLAlchemy, setup_markets, setup_sources) -> int:
     beliefs = [
         TimedBelief(
             sensor=sensor,
-            source=setup_sources["Seita"],
+            source=setup_sources["ENTSO-E"],
             event_value=21,
             event_start="2021-03-28 16:00+01",
             belief_horizon=timedelta(0),
         ),
         TimedBelief(
             sensor=sensor,
-            source=setup_sources["Seita"],
+            source=setup_sources["ENTSO-E"],
             event_value=21,
             event_start="2021-03-28 17:00+01",
             belief_horizon=timedelta(0),
         ),
         TimedBelief(
             sensor=sensor,
-            source=setup_sources["Seita"],
+            source=setup_sources["ENTSO-E"],
             event_value=20,
             event_start="2021-03-28 17:00+01",
             belief_horizon=timedelta(hours=2),
@@ -373,7 +378,7 @@ def setup_beliefs(db: SQLAlchemy, setup_markets, setup_sources) -> int:
         ),
         TimedBelief(
             sensor=sensor,
-            source=setup_sources["Seita"],
+            source=setup_sources["ENTSO-E"],
             event_value=21,
             event_start="2021-03-28 17:00+01",
             belief_horizon=timedelta(hours=2),
@@ -392,7 +397,9 @@ def add_market_prices(db: SQLAlchemy, setup_assets, setup_markets, setup_sources
     time_slots = pd.date_range(
         datetime(2015, 1, 1), datetime(2015, 1, 2), freq="1H", closed="left"
     )
-    values = [random() * (1 + np.sin(x * 2 * np.pi / 24)) for x in range(len(time_slots))]
+    values = [
+        random() * (1 + np.sin(x * 2 * np.pi / 24)) for x in range(len(time_slots))
+    ]
     for dt, val in zip(time_slots, values):
         p = Price(
             use_legacy_kwargs=False,

--- a/flexmeasures/conftest.py
+++ b/flexmeasures/conftest.py
@@ -337,11 +337,12 @@ def setup_assets(
         ]
         for dt, val in zip(time_slots, values):
             p = Power(
-                datetime=as_server_time(dt),
-                horizon=parse_duration("PT0M"),
-                value=val,
-                data_source_id=setup_sources["Seita"].id,
-                asset_id=asset.id,
+                use_legacy_kwargs=False,
+                event_start=as_server_time(dt),
+                belief_horizon=parse_duration("PT0M"),
+                event_value=val,
+                sensor=asset.corresponding_sensor,
+                source=setup_sources["Seita"],
             )
             db.session.add(p)
     return {asset.name: asset for asset in assets}

--- a/flexmeasures/conftest.py
+++ b/flexmeasures/conftest.py
@@ -329,7 +329,7 @@ def setup_assets(
         time_slots = pd.date_range(
             datetime(2015, 1, 1), datetime(2015, 1, 1, 23, 45), freq="15T"
         )
-        values = [random() * (1 + np.sin(x / 15)) for x in range(len(time_slots))]
+        values = [random() * (1 + np.sin(x * 2 * np.pi / (4 * 24))) for x in range(len(time_slots))]
         for dt, val in zip(time_slots, values):
             p = Power(
                 datetime=as_server_time(dt),
@@ -390,9 +390,9 @@ def add_market_prices(db: SQLAlchemy, setup_assets, setup_markets, setup_sources
 
     # one day of test data (one complete sine curve)
     time_slots = pd.date_range(
-        datetime(2015, 1, 1), datetime(2015, 1, 2), freq="15T", closed="left"
+        datetime(2015, 1, 1), datetime(2015, 1, 2), freq="1H", closed="left"
     )
-    values = [random() * (1 + np.sin(x / 15)) for x in range(len(time_slots))]
+    values = [random() * (1 + np.sin(x * 2 * np.pi / 24)) for x in range(len(time_slots))]
     for dt, val in zip(time_slots, values):
         p = Price(
             use_legacy_kwargs=False,
@@ -406,9 +406,9 @@ def add_market_prices(db: SQLAlchemy, setup_assets, setup_markets, setup_sources
 
     # another day of test data (8 expensive hours, 8 cheap hours, and again 8 expensive hours)
     time_slots = pd.date_range(
-        datetime(2015, 1, 2), datetime(2015, 1, 3), freq="15T", closed="left"
+        datetime(2015, 1, 2), datetime(2015, 1, 3), freq="1H", closed="left"
     )
-    values = [100] * 8 * 4 + [90] * 8 * 4 + [100] * 8 * 4
+    values = [100] * 8 + [90] * 8 + [100] * 8
     for dt, val in zip(time_slots, values):
         p = Price(
             use_legacy_kwargs=False,

--- a/flexmeasures/conftest.py
+++ b/flexmeasures/conftest.py
@@ -395,11 +395,12 @@ def add_market_prices(db: SQLAlchemy, setup_assets, setup_markets, setup_sources
     values = [random() * (1 + np.sin(x / 15)) for x in range(len(time_slots))]
     for dt, val in zip(time_slots, values):
         p = Price(
-            datetime=as_server_time(dt),
-            horizon=timedelta(hours=0),
-            value=val,
-            data_source_id=setup_sources["Seita"].id,
-            market_id=setup_markets["epex_da"].id,
+            use_legacy_kwargs=False,
+            event_start=as_server_time(dt),
+            belief_horizon=timedelta(hours=0),
+            event_value=val,
+            source=setup_sources["Seita"],
+            sensor=setup_markets["epex_da"].corresponding_sensor,
         )
         db.session.add(p)
 
@@ -410,11 +411,12 @@ def add_market_prices(db: SQLAlchemy, setup_assets, setup_markets, setup_sources
     values = [100] * 8 * 4 + [90] * 8 * 4 + [100] * 8 * 4
     for dt, val in zip(time_slots, values):
         p = Price(
-            datetime=as_server_time(dt),
-            horizon=timedelta(hours=0),
-            value=val,
-            data_source_id=setup_sources["Seita"].id,
-            sensor_id=setup_markets["epex_da"].id,
+            use_legacy_kwargs=False,
+            event_start=as_server_time(dt),
+            belief_horizon=timedelta(hours=0),
+            event_value=val,
+            source=setup_sources["Seita"],
+            sensor=setup_markets["epex_da"].corresponding_sensor,
         )
         db.session.add(p)
 

--- a/flexmeasures/data/models/weather.py
+++ b/flexmeasures/data/models/weather.py
@@ -11,7 +11,7 @@ from flexmeasures.data.models.legacy_migration_utils import (
     copy_old_sensor_attributes,
     get_old_model_type,
 )
-from flexmeasures.data.models.time_series import Sensor, TimedValue
+from flexmeasures.data.models.time_series import Sensor, TimedValue, TimedBelief
 from flexmeasures.data.models.generic_assets import (
     create_generic_asset,
     GenericAsset,
@@ -259,6 +259,18 @@ class Weather(TimedValue, db.Model):
         return super().make_query(**kwargs)
 
     def __init__(self, **kwargs):
+
+        # Create corresponding TimedBelief
+        belief = TimedBelief(**kwargs)
+        db.session.add(belief)
+
+        # Convert key names for legacy model
+        kwargs["value"] = kwargs.pop("event_value")
+        kwargs["datetime"] = kwargs.pop("event_start")
+        kwargs["horizon"] = kwargs.pop("belief_horizon")
+        kwargs["sensor_id"] = kwargs.pop("sensor").id
+        kwargs["data_source_id"] = kwargs.pop("source").id
+
         super(Weather, self).__init__(**kwargs)
 
     def __repr__(self):

--- a/flexmeasures/data/models/weather.py
+++ b/flexmeasures/data/models/weather.py
@@ -258,18 +258,28 @@ class Weather(TimedValue, db.Model):
         """Construct the database query."""
         return super().make_query(**kwargs)
 
-    def __init__(self, **kwargs):
+    def __init__(self, use_legacy_kwargs: bool = True, **kwargs):
 
-        # Create corresponding TimedBelief
-        belief = TimedBelief(**kwargs)
-        db.session.add(belief)
+        # todo: deprecate the 'Weather' class in favor of 'TimedBelief' (announced v0.8.0)
+        if use_legacy_kwargs is False:
 
-        # Convert key names for legacy model
-        kwargs["value"] = kwargs.pop("event_value")
-        kwargs["datetime"] = kwargs.pop("event_start")
-        kwargs["horizon"] = kwargs.pop("belief_horizon")
-        kwargs["sensor_id"] = kwargs.pop("sensor").id
-        kwargs["data_source_id"] = kwargs.pop("source").id
+            # Create corresponding TimedBelief
+            belief = TimedBelief(**kwargs)
+            db.session.add(belief)
+
+            # Convert key names for legacy model
+            kwargs["value"] = kwargs.pop("event_value")
+            kwargs["datetime"] = kwargs.pop("event_start")
+            kwargs["horizon"] = kwargs.pop("belief_horizon")
+            kwargs["sensor_id"] = kwargs.pop("sensor").id
+            kwargs["data_source_id"] = kwargs.pop("source").id
+        else:
+            import warnings
+
+            warnings.warn(
+                f"The {self.__class__} class is deprecated. Switch to using the TimedBelief class to suppress this warning.",
+                FutureWarning,
+            )
 
         super(Weather, self).__init__(**kwargs)
 

--- a/flexmeasures/data/scripts/data_gen.py
+++ b/flexmeasures/data/scripts/data_gen.py
@@ -343,11 +343,11 @@ def populate_time_series_forecasts(  # noqa: C901
             elif isinstance(old_sensor, WeatherSensor):
                 beliefs = [
                     Weather(
-                        datetime=ensure_local_timezone(dt, tz_name=LOCAL_TIME_ZONE),
-                        horizon=horizon,
-                        value=value,
-                        sensor_id=old_sensor.id,
-                        data_source_id=data_source.id,
+                        event_start=ensure_local_timezone(dt, tz_name=LOCAL_TIME_ZONE),
+                        belief_horizon=horizon,
+                        event_value=value,
+                        sensor=old_sensor.corresponding_sensor,
+                        source=data_source,
                     )
                     for dt, value in forecasts.items()
                 ]

--- a/flexmeasures/data/scripts/data_gen.py
+++ b/flexmeasures/data/scripts/data_gen.py
@@ -343,6 +343,7 @@ def populate_time_series_forecasts(  # noqa: C901
             elif isinstance(old_sensor, WeatherSensor):
                 beliefs = [
                     Weather(
+                        use_legacy_kwargs=False,
                         event_start=ensure_local_timezone(dt, tz_name=LOCAL_TIME_ZONE),
                         belief_horizon=horizon,
                         event_value=value,

--- a/flexmeasures/data/scripts/data_gen.py
+++ b/flexmeasures/data/scripts/data_gen.py
@@ -322,11 +322,12 @@ def populate_time_series_forecasts(  # noqa: C901
             if isinstance(old_sensor, Asset):
                 beliefs = [
                     Power(
-                        datetime=ensure_local_timezone(dt, tz_name=LOCAL_TIME_ZONE),
-                        horizon=horizon,
-                        value=value,
-                        asset_id=old_sensor.id,
-                        data_source_id=data_source.id,
+                        use_legacy_kwargs=False,
+                        event_start=ensure_local_timezone(dt, tz_name=LOCAL_TIME_ZONE),
+                        belief_horizon=horizon,
+                        event_value=value,
+                        sensor=old_sensor.corresponding_sensor,
+                        source=data_source,
                     )
                     for dt, value in forecasts.items()
                 ]

--- a/flexmeasures/data/scripts/data_gen.py
+++ b/flexmeasures/data/scripts/data_gen.py
@@ -162,11 +162,12 @@ def add_dummy_tou_market(db: SQLAlchemy):
     for year in range(2015, 2025):
         db.session.add(
             Price(
-                value=50,
-                datetime=datetime(year, 1, 1, tzinfo=pytz.utc),
-                horizon=timedelta(0),
-                data_source_id=source.id,
-                sensor_id=market.id,
+                use_legacy_kwargs=False,
+                event_value=50,
+                event_start=datetime(year, 1, 1, tzinfo=pytz.utc),
+                belief_horizon=timedelta(0),
+                source=source,
+                sensor=market.corresponding_sensor,
             )
         )
 
@@ -332,11 +333,12 @@ def populate_time_series_forecasts(  # noqa: C901
             elif isinstance(old_sensor, Market):
                 beliefs = [
                     Price(
-                        datetime=ensure_local_timezone(dt, tz_name=LOCAL_TIME_ZONE),
-                        horizon=horizon,
-                        value=value,
-                        sensor_id=old_sensor.id,
-                        data_source_id=data_source.id,
+                        use_legacy_kwargs=False,
+                        event_start=ensure_local_timezone(dt, tz_name=LOCAL_TIME_ZONE),
+                        belief_horizon=horizon,
+                        event_value=value,
+                        sensor=old_sensor.corresponding_sensor,
+                        source=data_source,
                     )
                     for dt, value in forecasts.items()
                 ]

--- a/flexmeasures/data/scripts/grid_weather.py
+++ b/flexmeasures/data/scripts/grid_weather.py
@@ -417,6 +417,7 @@ def save_forecasts_in_db(
 
                     db_forecasts.append(
                         Weather(
+                            use_legacy_kwargs=False,
                             event_start=fc_datetime,
                             belief_horizon=fc_horizon,
                             event_value=fc_value,

--- a/flexmeasures/data/scripts/grid_weather.py
+++ b/flexmeasures/data/scripts/grid_weather.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import os
-from typing import Tuple, List, Dict
+from typing import Tuple, List, Dict, Optional
 import json
 from datetime import datetime
 
@@ -17,6 +17,7 @@ from flexmeasures.data.config import db
 from flexmeasures.data.transactional import task_with_status_report
 from flexmeasures.data.models.weather import Weather
 from flexmeasures.data.models.data_sources import DataSource
+from flexmeasures.data.models.time_series import Sensor
 
 FILE_PATH_LOCATION = "/../raw_data/weather-forecasts"
 DATA_SOURCE_NAME = "OpenWeatherMap"
@@ -382,7 +383,7 @@ def save_forecasts_in_db(
                 if needed_response_label in fc:
                     weather_sensor = weather_sensors.get(flexmeasures_sensor_type, None)
                     if weather_sensor is None:
-                        weather_sensor = find_closest_sensor(
+                        weather_sensor: Optional[Sensor] = find_closest_sensor(
                             flexmeasures_sensor_type, lat=location[0], lng=location[1]
                         )
                         if weather_sensor is not None:
@@ -416,11 +417,11 @@ def save_forecasts_in_db(
 
                     db_forecasts.append(
                         Weather(
-                            datetime=fc_datetime,
-                            horizon=fc_horizon,
-                            value=fc_value,
-                            sensor_id=weather_sensor.id,
-                            data_source_id=data_source.id,
+                            event_start=fc_datetime,
+                            belief_horizon=fc_horizon,
+                            event_value=fc_value,
+                            sensor=weather_sensor,
+                            source=data_source,
                         )
                     )
                 else:

--- a/flexmeasures/data/services/forecasting.py
+++ b/flexmeasures/data/services/forecasting.py
@@ -246,11 +246,12 @@ def make_rolling_viewpoint_forecasts(
 
     ts_value_forecasts = [
         timed_value_type(
-            datetime=dt,
-            horizon=horizon,
-            value=value,
-            sensor_id=old_sensor_id,
-            data_source_id=data_source.id,
+            use_legacy_kwargs=False,
+            event_start=dt,
+            belief_horizon=horizon,
+            event_value=value,
+            sensor=sensor,
+            source=data_source,
         )
         for dt, value in forecasts.items()
     ]

--- a/flexmeasures/data/services/scheduling.py
+++ b/flexmeasures/data/services/scheduling.py
@@ -146,11 +146,12 @@ def make_schedule(
 
     ts_value_schedule = [
         Power(
-            datetime=dt,
-            horizon=dt.astimezone(pytz.utc) - belief_time.astimezone(pytz.utc),
-            value=-value,
-            sensor_id=asset_id,
-            data_source_id=data_source.id,
+            use_legacy_kwargs=False,
+            event_start=dt,
+            belief_horizon=dt.astimezone(pytz.utc) - belief_time.astimezone(pytz.utc),
+            event_value=-value,
+            sensor=sensor,
+            source=data_source,
         )
         for dt, value in consumption_schedule.items()
     ]  # For consumption schedules, positive values denote consumption. For the db, consumption is negative

--- a/flexmeasures/data/tests/conftest.py
+++ b/flexmeasures/data/tests/conftest.py
@@ -131,11 +131,11 @@ def add_test_weather_sensor_and_forecasts(db: SQLAlchemy):
         for dt, val in zip(time_slots, values):
             db.session.add(
                 Weather(
-                    sensor_id=sensor.id,
-                    datetime=as_server_time(dt),
-                    value=val,
-                    horizon=timedelta(hours=6),
-                    data_source_id=data_source.id,
+                    sensor=sensor.corresponding_sensor,
+                    event_start=as_server_time(dt),
+                    event_value=val,
+                    belief_horizon=timedelta(hours=6),
+                    source=data_source,
                 )
             )
 

--- a/flexmeasures/data/tests/conftest.py
+++ b/flexmeasures/data/tests/conftest.py
@@ -131,6 +131,7 @@ def add_test_weather_sensor_and_forecasts(db: SQLAlchemy):
         for dt, val in zip(time_slots, values):
             db.session.add(
                 Weather(
+                    use_legacy_kwargs=False,
                     sensor=sensor.corresponding_sensor,
                     event_start=as_server_time(dt),
                     event_value=val,

--- a/flexmeasures/data/tests/conftest.py
+++ b/flexmeasures/data/tests/conftest.py
@@ -76,11 +76,12 @@ def setup_fresh_test_data(
         values = [random() * (1 + np.sin(x / 15)) for x in range(len(time_slots))]
         for dt, val in zip(time_slots, values):
             p = Power(
-                datetime=as_server_time(dt),
-                horizon=parse_duration("PT0M"),
-                value=val,
-                data_source_id=data_source.id,
-                sensor_id=asset.id,
+                use_legacy_kwargs=False,
+                event_start=as_server_time(dt),
+                belief_horizon=parse_duration("PT0M"),
+                event_value=val,
+                sensor=asset.corresponding_sensor,
+                source=data_source,
             )
             db.session.add(p)
     add_test_weather_sensor_and_forecasts(fresh_db)

--- a/flexmeasures/data/tests/test_time_series_services.py
+++ b/flexmeasures/data/tests/test_time_series_services.py
@@ -68,7 +68,7 @@ def test_do_not_drop_changed_probabilistic_belief(setup_beliefs):
 
     # Set a reference for the number of beliefs stored
     sensor = Sensor.query.filter_by(name="epex_da").one_or_none()
-    bdf = sensor.search_beliefs(source="Seita")
+    bdf = sensor.search_beliefs(source="ENTSO-E")
     num_beliefs_before = len(bdf)
 
     # See what happens when storing a belief with more certainty one hour later
@@ -91,6 +91,6 @@ def test_do_not_drop_changed_probabilistic_belief(setup_beliefs):
     save_to_db(new_belief)
 
     # Verify that the whole probabilistic belief was added
-    bdf = sensor.search_beliefs(source="Seita")
+    bdf = sensor.search_beliefs(source="ENTSO-E")
     num_beliefs_after = len(bdf)
     assert num_beliefs_after == num_beliefs_before + len(new_belief)


### PR DESCRIPTION
I'm planning to make a few smaller PRs for each of the sub-issues of #284. This is the first in that series, namely:

- [x] Initialize TimedBelief when initializing Power/Price/Weather

This PR just ensures that new data is saved in both the old (`Power`/`Price`/`Weather`) and the new model (`TimedBelief`). The only significant complication I encountered was an interference between some tests using day-ahead price data. I resolved that by adjusting the data source of the price data for tests using the new model.