### PR TITLE
Get rid of old sensor models imported in old db revision file

### DIFF
--- a/flexmeasures/data/migrations/versions/994170c26bc6_add_account_table.py
+++ b/flexmeasures/data/migrations/versions/994170c26bc6_add_account_table.py
@@ -137,10 +137,9 @@ def upgrade_data():
         old_owner_id = _get_old_owner_id_from_db_result(
             asset_ownership_db, generic_asset.id
         )
-        if old_owner_id is None:
-            user = None
-        else:
-            user = session.query(User).get(old_owner_id)
+        user = (
+            session.query(User).get(old_owner_id) if old_owner_id is not None else None
+        )
         # 2. Otherwise, then try the old-style Asset's ownership (via Sensor)
         if user is None:
             sensor = (
@@ -153,9 +152,7 @@ def upgrade_data():
                     f"GenericAsset {generic_asset.id} ({generic_asset.name}) does not have an assorted sensor. Please investigate ..."
                 )
             asset_results = connection.execute(
-                sa.select(
-                    t_assets.c.owner_id,
-                ).where(t_assets.c.id == sensor.id)
+                sa.select([t_assets.c.owner_id]).where(t_assets.c.id == sensor.id)
             ).one_or_none()
             if asset_results is None:
                 print(

--- a/flexmeasures/data/migrations/versions/b6d49ed7cceb_introduce_the_GenericAsset_table.py
+++ b/flexmeasures/data/migrations/versions/b6d49ed7cceb_introduce_the_GenericAsset_table.py
@@ -127,7 +127,7 @@ def upgrade_data():
                 f"At least some of these sensor ids {sensor_group_dict['sensor_ids']} do not exist."
             )
         generic_asset_type_results = connection.execute(
-            sa.select([t_generic_asset_types.c.id,]).where(
+            sa.select([t_generic_asset_types.c.id]).where(
                 t_generic_asset_types.c.name == sensor_group_dict["asset_type_name"]
             )
         ).one_or_none()


### PR DESCRIPTION
This PR stops the import of old sensor models (`Asset`, `Market` and `WeatherSensor`) in migration files, in preparation of removing these classes.

Closes #297.

NB we're still importing some other classes, like `Sensor`, `GenericAsset` and `GenericAssetType`. Would you like me to extend this PR to include those, too? Other imports we used: `User`, `Account`. Interested to hear your opinion, @nhoening.