### PR TITLE
Issue 294 post udi event bug rolling back due to integrity error

### DIFF
--- a/documentation/api/change_log.rst
+++ b/documentation/api/change_log.rst
@@ -39,6 +39,16 @@ v2.0-0 | 2020-11-14
 - REST endpoints for managing assets: `/assets/` (GET, POST) and `/asset/<id>` (GET, PATCH, DELETE).
 
 
+v1.3-11 | 2022-01-05
+""""""""""""""""""""
+
+*Affects all versions since v1.3*.
+
+- Changed the *postUdiEvent* endpoint:
+
+    - The recording time of new schedules triggered by calling the endpoint is now the time at which the endpoint was called, rather than the datetime of the sent state of charge (SOC).
+    - Introduced the "prior" field for the purpose of communicating an alternative recording time, thereby keeping support for simulations.
+
 v1.3-10 | 2021-11-08
 """"""""""""""""""""
 

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -11,7 +11,7 @@ New features
 
 Bugfixes
 -----------
-* Fix recording time of schedules triggered by UDI events [see `PR #297 <http://www.github.com/FlexMeasures/flexmeasures/pull/297>`_]
+* Fix recording time of schedules triggered by UDI events [see `PR #300 <http://www.github.com/FlexMeasures/flexmeasures/pull/300>`_]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -11,6 +11,7 @@ New features
 
 Bugfixes
 -----------
+* Fix recording time of schedules triggered by UDI events [see `PR #297 <http://www.github.com/FlexMeasures/flexmeasures/pull/297>`_]
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/api/v1_3/implementations.py
+++ b/flexmeasures/api/v1_3/implementations.py
@@ -1,5 +1,5 @@
 # flake8: noqa: C901
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import inflect
 import isodate
@@ -218,7 +218,7 @@ def get_device_message_response(generic_asset_name_groups, duration):
 @units_accepted("State of charge", "kWh", "MWh")
 @optional_prior_accepted()
 @as_json
-def post_udi_event_response(unit, prior):
+def post_udi_event_response(unit: str, prior: datetime):
 
     if not has_assets():
         current_app.logger.info("User doesn't seem to have any assets.")
@@ -362,7 +362,7 @@ def post_udi_event_response(unit, prior):
         start_of_schedule,
         end_of_schedule,
         resolution=resolution,
-        belief_time=prior,
+        belief_time=prior,  # server time if no prior time was sent
         soc_at_start=value,
         soc_targets=soc_targets,
         udi_event_ea=form.get("event"),

--- a/flexmeasures/api/v1_3/implementations.py
+++ b/flexmeasures/api/v1_3/implementations.py
@@ -35,6 +35,7 @@ from flexmeasures.api.common.utils.validators import (
     type_accepted,
     assets_required,
     optional_duration_accepted,
+    optional_prior_accepted,
     units_accepted,
     parse_isodate_str,
 )
@@ -215,8 +216,9 @@ def get_device_message_response(generic_asset_name_groups, duration):
 
 @type_accepted("PostUdiEventRequest")
 @units_accepted("State of charge", "kWh", "MWh")
+@optional_prior_accepted()
 @as_json
-def post_udi_event_response(unit):
+def post_udi_event_response(unit, prior):
 
     if not has_assets():
         current_app.logger.info("User doesn't seem to have any assets.")
@@ -360,7 +362,7 @@ def post_udi_event_response(unit):
         start_of_schedule,
         end_of_schedule,
         resolution=resolution,
-        belief_time=datetime,
+        belief_time=prior,
         soc_at_start=value,
         soc_targets=soc_targets,
         udi_event_ea=form.get("event"),


### PR DESCRIPTION
Fix recording time of schedules triggered by UDI events.

Although I consider this a fix, I'm not intending it to be backported. Closes #294.