### PR TITLE
Skip autoscheduling if none of the posted values represent a state change

### DIFF
--- a/flexmeasures/api/common/utils/api_utils.py
+++ b/flexmeasures/api/common/utils/api_utils.py
@@ -365,13 +365,16 @@ def save_and_enqueue(
     )
 
     # Only enqueue forecasting jobs upon successfully saving new data
-    if status[:7] == "success":
+    if status[:7] == "success" and status != "success_but_nothing_new":
         enqueue_forecasting_jobs(forecasting_jobs)
 
     # Pick a response
     if status == "success":
         return request_processed()
-    elif status == "success_with_unchanged_beliefs_skipped":
+    elif status in (
+        "success_with_unchanged_beliefs_skipped",
+        "success_but_nothing_new",
+    ):
         return already_received_and_successfully_processed()
     return invalid_replacement()
 

--- a/flexmeasures/data/utils.py
+++ b/flexmeasures/data/utils.py
@@ -80,6 +80,7 @@ def save_to_db(
     :returns: status string, one of the following:
               - 'success': all beliefs were saved
               - 'success_with_unchanged_beliefs_skipped': not all beliefs represented a state change
+              - 'success_but_nothing_new': no beliefs represented a state change
     """
 
     # Convert to list
@@ -89,6 +90,7 @@ def save_to_db(
         timed_values_list = data
 
     status = "success"
+    values_saved = 0
     for timed_values in timed_values_list:
 
         if timed_values.empty:
@@ -124,6 +126,10 @@ def save_to_db(
             if current_app.config.get("FLEXMEASURES_MODE", "") != "play"
             else True,
         )
+        values_saved += len(timed_values)
     # Flush to bring up potential unique violations (due to attempting to replace beliefs)
     db.session.flush()
+
+    if values_saved == 0:
+        status = "success_but_nothing_new"
     return status


### PR DESCRIPTION
This PR stops autoscheduling when API calls save nothing new to the database, thereby saving redundant computation.