### PR TITLE
Add optional fields to set custom min/max SOC in UDI Events

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -14,6 +14,7 @@ New features
 * Charts with sensor data can be requested in one of the supported  [`vega-lite themes <https://github.com/vega/vega-themes#included-themes>`_] (incl. a dark theme) [see `PR #221 <http://www.github.com/FlexMeasures/flexmeasures/pull/221>`_]
 * Mobile friendly (responsive) charts of sensor data, and such charts can be requested with a custom width and height [see `PR #313 <http://www.github.com/FlexMeasures/flexmeasures/pull/313>`_]
 * Schedulers take into account round-trip efficiency if set [see `PR #291 <http://www.github.com/FlexMeasures/flexmeasures/pull/291>`_]
+* Schedulers take into account min/max state of charge if set [see `PR #325 <http://www.github.com/FlexMeasures/flexmeasures/pull/325>`_]
 * Fallback policies for charging schedules of batteries and Charge Points, in cases where the solver is presented with an infeasible problem [see `PR #267 <http://www.github.com/FlexMeasures/flexmeasures/pull/267>`_ and `PR #270 <http://www.github.com/FlexMeasures/flexmeasures/pull/270>`_]
 
 Deprecations

--- a/flexmeasures/api/v1_3/implementations.py
+++ b/flexmeasures/api/v1_3/implementations.py
@@ -285,6 +285,14 @@ def post_udi_event_response(unit: str, prior: datetime):
     # get optional efficiency
     roundtrip_efficiency = form.get("roundtrip_efficiency", None)
 
+    # get optional min and max SOC
+    soc_min = form.get("soc_min", None)
+    soc_max = form.get("soc_max", None)
+    if soc_min is not None and unit == "kWh":
+        soc_min = soc_min / 1000.0
+    if soc_max is not None and unit == "kWh":
+        soc_max = soc_max / 1000.0
+
     # set soc targets
     start_of_schedule = datetime
     end_of_schedule = datetime + current_app.config.get("FLEXMEASURES_PLANNING_HORIZON")
@@ -354,6 +362,8 @@ def post_udi_event_response(unit: str, prior: datetime):
         belief_time=prior,  # server time if no prior time was sent
         soc_at_start=value,
         soc_targets=soc_targets,
+        soc_min=soc_min,
+        soc_max=soc_max,
         roundtrip_efficiency=roundtrip_efficiency,
         udi_event_ea=form.get("event"),
         enqueue=True,

--- a/flexmeasures/api/v1_3/routes.py
+++ b/flexmeasures/api/v1_3/routes.py
@@ -104,6 +104,7 @@ def post_udi_event():
     This "PostUdiEventRequest" message posts a state of charge (soc) of 12.1 kWh at 10.00am,
     and a target state of charge of 25 kWh at 4.00pm,
     as UDI event 204 of device 10 of owner 7.
+    The minimum and maximum soc are set to 10 and 25 kWh, respectively.
     Roundtrip efficiency for use in scheduling is set to 98%.
 
     .. code-block:: json
@@ -120,6 +121,8 @@ def post_udi_event():
                     "datetime": "2015-06-02T16:00:00+00:00"
                 }
             ],
+            "soc_min": 10,
+            "soc_max": 25,
             "roundtrip_efficiency": 0.98
         }
 

--- a/flexmeasures/data/services/scheduling.py
+++ b/flexmeasures/data/services/scheduling.py
@@ -36,6 +36,8 @@ def create_scheduling_job(
     resolution: timedelta = DEFAULT_RESOLUTION,
     soc_at_start: Optional[float] = None,
     soc_targets: Optional[pd.Series] = None,
+    soc_min: Optional[float] = None,
+    soc_max: Optional[float] = None,
     roundtrip_efficiency: Optional[float] = None,
     udi_event_ea: Optional[str] = None,
     enqueue: bool = True,
@@ -62,6 +64,8 @@ def create_scheduling_job(
             resolution=resolution,
             soc_at_start=soc_at_start,
             soc_targets=soc_targets,
+            soc_min=soc_min,
+            soc_max=soc_max,
             roundtrip_efficiency=roundtrip_efficiency,
         ),
         id=udi_event_ea,
@@ -90,6 +94,8 @@ def make_schedule(
     resolution: timedelta,
     soc_at_start: Optional[float] = None,
     soc_targets: Optional[pd.Series] = None,
+    soc_min: Optional[float] = None,
+    soc_max: Optional[float] = None,
     roundtrip_efficiency: Optional[float] = None,
 ) -> bool:
     """Preferably, a starting soc is given.
@@ -131,6 +137,8 @@ def make_schedule(
             resolution,
             soc_at_start,
             soc_targets,
+            soc_min,
+            soc_max,
             roundtrip_efficiency,
         )
     elif sensor.generic_asset.generic_asset_type.name in (
@@ -144,6 +152,8 @@ def make_schedule(
             resolution,
             soc_at_start,
             soc_targets,
+            soc_min,
+            soc_max,
             roundtrip_efficiency,
         )
     else:


### PR DESCRIPTION
Plus test revision and changelog entry.

With this PR, the functionality of our battery and Charge Point schedulers have grown to become almost indistinguishable. I'd like to keep the scope of this PR limited to just adding the min/max SOC functionality, and I suggest I make a separate PR for refactoring the two schedulers.

Closes #244 