### PR TITLE
Fix sign conversion

### DIFF
--- a/flexmeasures/utils/tests/test_unit_utils.py
+++ b/flexmeasures/utils/tests/test_unit_utils.py
@@ -25,7 +25,12 @@ from flexmeasures.utils.unit_utils import (
         ("m³", "m³/h", 4, None),
         ("MW", "kW", 1000, None),
         ("kWh", "kW", 4, None),
+        ("-W", "W", -1, None),
+        ("l/(100km)", "l/km", 0.01, None),
         ("°C", "K", None, [273.15, 283.15, 284.15]),
+        # no support for combining an offset unit with a scaling factor, but this is also overly specific
+        # ("-°C", "K", None, [273.15, 263.15, 262.15]),
+        # ("l/(10°C)", "l/(°C)", 0.1, None),
     ],
 )
 def test_convert_unit(

--- a/flexmeasures/utils/unit_utils.py
+++ b/flexmeasures/utils/unit_utils.py
@@ -164,15 +164,15 @@ def convert_units(
         try:
             if isinstance(data, pd.Series):
                 data = pd.Series(
-                    pint.Quantity(data.values, from_unit)
-                    .to(pint.Quantity(to_unit))
+                    ur.Quantity(data.values, from_unit)
+                    .to(ur.Quantity(to_unit))
                     .magnitude,
                     index=data.index,
                     name=data.name,
                 )
             else:
                 data = list(
-                    pint.Quantity(data, from_unit).to(pint.Quantity(to_unit)).magnitude
+                    ur.Quantity(data, from_unit).to(ur.Quantity(to_unit)).magnitude
                 )
         except pint.errors.DimensionalityError:
             multiplier = determine_unit_conversion_multiplier(


### PR DESCRIPTION
This PR adds a test for switching signs and fixes the regression (from https://github.com/FlexMeasures/flexmeasures/pull/341) that broke that conversion. Also adds a test for another unit that includes a scaling factor (l/100km, used for car fuel consumption), and comments out two test cases that show the current limitations of our unit conversion function.