### PR TITLE
Sources are nominal data

### DIFF
--- a/flexmeasures/data/models/charts/defaults.py
+++ b/flexmeasures/data/models/charts/defaults.py
@@ -27,7 +27,7 @@ FIELD_DEFINITIONS = {
     ),
     "source": dict(
         field="source",
-        type="ordinal",
+        type="nominal",
         title="Source",
     ),
     "full_date": dict(


### PR DESCRIPTION
Nominal data used for the vega-lite color encoding leads to much more distinct colors than ordinal data.