### PR TITLE
Account annotations

### DIFF
--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -677,7 +677,7 @@ def add_holidays(
         asset.annotations += annotations
     db.session.commit()
     print(
-        f"Successfully added holidays to {len(accounts)} {flexmeasures_inflection.pluralize('account', len(account))} and {len(assets)} {flexmeasures_inflection.pluralize('asset', len(assets))}:\n{num_holidays}"
+        f"Successfully added holidays to {len(accounts)} {flexmeasures_inflection.pluralize('account', len(accounts))} and {len(assets)} {flexmeasures_inflection.pluralize('asset', len(assets))}:\n{num_holidays}"
     )
 
 

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -22,7 +22,7 @@ from flexmeasures.data.models.time_series import (
     Sensor,
     TimedBelief,
 )
-from flexmeasures.data.models.annotations import Annotation
+from flexmeasures.data.models.annotations import Annotation, get_or_create_annotation
 from flexmeasures.data.schemas.sensors import SensorSchema
 from flexmeasures.data.schemas.generic_assets import (
     GenericAssetSchema,
@@ -587,12 +587,14 @@ def add_annotation(
     _source = get_or_create_source(user)
 
     # Create annotation
-    annotation = Annotation(
-        content=content,
-        start=start,
-        end=end,
-        source=_source,
-        type="label",
+    annotation = get_or_create_annotation(
+        Annotation(
+            content=content,
+            start=start,
+            end=end,
+            source=_source,
+            type="label",
+        )
     )
     for account in accounts:
         account.annotations.append(annotation)
@@ -661,12 +663,14 @@ def add_holidays(
             start = pd.Timestamp(holiday[0])
             end = start + pd.offsets.DateOffset(days=1)
             annotations.append(
-                Annotation(
-                    content=holiday[1],
-                    start=start,
-                    end=end,
-                    source=_source,
-                    type="holiday",
+                get_or_create_annotation(
+                    Annotation(
+                        content=holiday[1],
+                        start=start,
+                        end=end,
+                        source=_source,
+                        type="holiday",
+                    )
                 )
             )
         num_holidays[country] = len(holidays)

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -603,6 +603,7 @@ def add_annotation(
     for sensor in sensors:
         sensor.annotations.append(annotation)
     db.session.commit()
+    print("Successfully added annotation.")
 
 
 @fm_add_data.command("holidays")

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -569,12 +569,12 @@ def add_annotation(
         else start + pd.offsets.DateOffset(days=1)
     )
     accounts = (
-        db.session.query(Account).filter(Account.id.in_(account_ids))
+        db.session.query(Account).filter(Account.id.in_(account_ids)).all()
         if account_ids
         else []
     )
     assets = (
-        db.session.query(GenericAsset).filter(GenericAsset.id.in_(generic_asset_ids))
+        db.session.query(GenericAsset).filter(GenericAsset.id.in_(generic_asset_ids)).all()
         if generic_asset_ids
         else []
     )
@@ -642,12 +642,12 @@ def add_holidays(
     num_holidays = {}
 
     accounts = (
-        db.session.query(Account).filter(Account.id.in_(account_ids))
+        db.session.query(Account).filter(Account.id.in_(account_ids)).all()
         if account_ids
         else []
     )
     assets = (
-        db.session.query(GenericAsset).filter(GenericAsset.id.in_(generic_asset_ids))
+        db.session.query(GenericAsset).filter(GenericAsset.id.in_(generic_asset_ids)).all()
         if generic_asset_ids
         else []
     )

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -574,7 +574,9 @@ def add_annotation(
         else []
     )
     assets = (
-        db.session.query(GenericAsset).filter(GenericAsset.id.in_(generic_asset_ids)).all()
+        db.session.query(GenericAsset)
+        .filter(GenericAsset.id.in_(generic_asset_ids))
+        .all()
         if generic_asset_ids
         else []
     )
@@ -650,7 +652,9 @@ def add_holidays(
         else []
     )
     assets = (
-        db.session.query(GenericAsset).filter(GenericAsset.id.in_(generic_asset_ids)).all()
+        db.session.query(GenericAsset)
+        .filter(GenericAsset.id.in_(generic_asset_ids))
+        .all()
         if generic_asset_ids
         else []
     )

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -508,7 +508,6 @@ def add_beliefs(
 @with_appcontext
 @click.option(
     "--content",
-    "name",
     required=True,
     prompt="Enter annotation",
 )
@@ -552,7 +551,7 @@ def add_beliefs(
     help="Attribute annotation to this user. Follow up with the user's ID.",
 )
 def add_annotation(
-    name: str,
+    content: str,
     start_str: str,
     end_str: Optional[str],
     account_ids: List[int],
@@ -589,7 +588,7 @@ def add_annotation(
 
     # Create annotation
     annotation = Annotation(
-        name=name,
+        content=content,
         start=start,
         end=end,
         source=_source,
@@ -663,7 +662,7 @@ def add_holidays(
             end = start + pd.offsets.DateOffset(days=1)
             annotations.append(
                 Annotation(
-                    name=holiday[1],
+                    content=holiday[1],
                     start=start,
                     end=end,
                     source=_source,

--- a/flexmeasures/cli/tests/test_data_add.py
+++ b/flexmeasures/cli/tests/test_data_add.py
@@ -1,4 +1,4 @@
-def test_add_annotation(app):
+def test_add_annotation(app, db, setup_roles_users):
     from flexmeasures.cli.data_add import add_annotation
 
     runner = app.test_cli_runner()
@@ -16,7 +16,7 @@ def test_add_annotation(app):
     # todo: Check database
 
 
-def test_add_holidays(app):
+def test_add_holidays(app, db, setup_roles_users):
     from flexmeasures.cli.data_add import add_holidays
 
     runner = app.test_cli_runner()

--- a/flexmeasures/cli/tests/test_data_add.py
+++ b/flexmeasures/cli/tests/test_data_add.py
@@ -1,33 +1,73 @@
+from flexmeasures.cli.tests.utils import to_flags
+from flexmeasures.data.models.annotations import (
+    Annotation,
+    AccountAnnotationRelationship,
+)
+from flexmeasures.data.models.data_sources import DataSource
+
+
 def test_add_annotation(app, db, setup_roles_users):
     from flexmeasures.cli.data_add import add_annotation
 
+    cli_input = {
+        "content": "Company founding day",
+        "at": "2016-05-11T00:00+02:00",
+        "account-id": 1,
+        "user-id": 1,
+    }
     runner = app.test_cli_runner()
-    result = runner.invoke(
-        add_annotation,
-        [
-            *("--content", "Company founding day"),
-            *("--at", "2016-05-11T00:00+02:00"),
-            *("--account-id", "1"),
-            *("--user-id", "1"),
-        ],
-    )
+    result = runner.invoke(add_annotation, to_flags(cli_input))
+
     # Check result for success
     assert "Successfully added annotation" in result.output
-    # todo: Check database
+
+    # Check database for annotation entry
+    assert (
+        Annotation.query.filter(
+            Annotation.content == cli_input["content"],
+            Annotation.start == cli_input["at"],
+        )
+        .join(AccountAnnotationRelationship)
+        .filter(
+            AccountAnnotationRelationship.account_id == cli_input["account-id"],
+            AccountAnnotationRelationship.annotation_id == Annotation.id,
+        )
+        .join(DataSource)
+        .filter(
+            DataSource.id == Annotation.source_id,
+            DataSource.user_id == cli_input["user-id"],
+        )
+        .one_or_none()
+    )
 
 
 def test_add_holidays(app, db, setup_roles_users):
     from flexmeasures.cli.data_add import add_holidays
 
+    cli_input = {
+        "year": 2020,
+        "country": "NL",
+        "account-id": 1,
+    }
     runner = app.test_cli_runner()
-    result = runner.invoke(
-        add_holidays,
-        [
-            *("--year", "2020"),
-            *("--country", "NL"),
-            *("--account-id", "1"),
-        ],
-    )
+    result = runner.invoke(add_holidays, to_flags(cli_input))
+
     # Check result for 11 public holidays
     assert "'NL': 11" in result.output
-    # todo: Check database
+
+    # Check database for 11 annotation entries
+    assert (
+        Annotation.query.join(AccountAnnotationRelationship)
+        .filter(
+            AccountAnnotationRelationship.account_id == cli_input["account-id"],
+            AccountAnnotationRelationship.annotation_id == Annotation.id,
+        )
+        .join(DataSource)
+        .filter(
+            DataSource.id == Annotation.source_id,
+            DataSource.name == "workalendar",
+            DataSource.model == cli_input["country"],
+        )
+        .count()
+        == 11
+    )

--- a/flexmeasures/cli/tests/test_data_add.py
+++ b/flexmeasures/cli/tests/test_data_add.py
@@ -1,0 +1,33 @@
+def test_add_annotation(app):
+    from flexmeasures.cli.data_add import add_annotation
+
+    runner = app.test_cli_runner()
+    result = runner.invoke(
+        add_annotation,
+        [
+            *("--content", "Company founding day"),
+            *("--at", "2016-05-11T00:00+02:00"),
+            *("--account-id", "1"),
+            *("--user-id", "1"),
+        ],
+    )
+    # Check result for success
+    assert "Successfully added annotation" in result.output
+    # todo: Check database
+
+
+def test_add_holidays(app):
+    from flexmeasures.cli.data_add import add_holidays
+
+    runner = app.test_cli_runner()
+    result = runner.invoke(
+        add_holidays,
+        [
+            *("--year", "2020"),
+            *("--country", "NL"),
+            *("--account-id", "1"),
+        ],
+    )
+    # Check result for 11 public holidays
+    assert "'NL': 11" in result.output
+    # todo: Check database

--- a/flexmeasures/cli/tests/utils.py
+++ b/flexmeasures/cli/tests/utils.py
@@ -1,0 +1,20 @@
+def to_flags(cli_input: dict) -> list:
+    """Turn dictionary of CLI input into a list of CLI flags ready for use in FlaskCliRunner.invoke().
+
+    Example:
+        cli_input = {
+            "year": 2020,
+            "country": "NL",
+        }
+        cli_flags = to_flags(cli_input)  # ["--year", 2020, "--country", "NL"]
+        runner = app.test_cli_runner()
+        result = runner.invoke(some_cli_function, to_flags(cli_input))
+    """
+    return [
+        item
+        for sublist in zip(
+            [f"--{key.replace('_', '-')}" for key in cli_input.keys()],
+            cli_input.values(),
+        )
+        for item in sublist
+    ]

--- a/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
+++ b/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
@@ -29,6 +29,7 @@ def downgrade():
         "This downgrade drops the tables 'annotations_assets', 'annotations_sensors' and 'annotation'. Continue?",
         abort=True,
     )
+    op.drop_table("annotations_accounts")
     op.drop_table("annotations_assets")
     op.drop_table("annotations_sensors")
     op.drop_constraint(op.f("annotation_name_key"), "annotation", type_="unique")

--- a/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
+++ b/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
@@ -22,12 +22,24 @@ def upgrade():
     create_annotation_account_relationship_table()
     create_annotation_asset_relationship_table()
     create_annotation_sensor_relationship_table()
+    create_user_roles_unique_constraints()
+    create_account_roles_unique_constraints()
 
 
 def downgrade():
     click.confirm(
         "This downgrade drops the tables 'annotations_accounts', 'annotations_assets', 'annotations_sensors' and 'annotation'. Continue?",
         abort=True,
+    )
+    op.drop_constraint(
+        op.f("roles_accounts_role_id_key"),
+        "roles_accounts",
+        type_="unique",
+    )
+    op.drop_constraint(
+        op.f("roles_users_role_id_key"),
+        "roles_users",
+        type_="unique",
     )
     op.drop_constraint(
         op.f("annotations_accounts_annotation_id_key"),
@@ -50,6 +62,30 @@ def downgrade():
     op.drop_constraint(op.f("annotation_content_key"), "annotation", type_="unique")
     op.drop_table("annotation")
     op.execute("DROP TYPE annotation_type;")
+
+
+def create_account_roles_unique_constraints():
+    """Remove any duplicate relationships, then constrain any new relationships to be unique."""
+    op.execute(
+        "DELETE FROM roles_accounts WHERE id in (SELECT r1.id FROM roles_accounts r1, roles_accounts r2 WHERE r1.id > r2.id AND r1.role_id = r2.role_id and r1.account_id = r2.account_id);"
+    )
+    op.create_unique_constraint(
+        op.f("roles_accounts_role_id_key"),
+        "roles_accounts",
+        ["role_id", "account_id"],
+    )
+
+
+def create_user_roles_unique_constraints():
+    """Remove any duplicate relationships, then constrain any new relationships to be unique."""
+    op.execute(
+        "DELETE FROM roles_users WHERE id in (SELECT r1.id FROM roles_users r1, roles_users r2 WHERE r1.id > r2.id AND r1.role_id = r2.role_id and r1.user_id = r2.user_id);"
+    )
+    op.create_unique_constraint(
+        op.f("roles_users_role_id_key"),
+        "roles_users",
+        ["role_id", "user_id"],
+    )
 
 
 def create_annotation_sensor_relationship_table():

--- a/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
+++ b/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
@@ -26,7 +26,7 @@ def upgrade():
 
 def downgrade():
     click.confirm(
-        "This downgrade drops the tables 'annotations_assets', 'annotations_sensors' and 'annotation'. Continue?",
+        "This downgrade drops the tables 'annotations_accounts', 'annotations_assets', 'annotations_sensors' and 'annotation'. Continue?",
         abort=True,
     )
     op.drop_table("annotations_accounts")

--- a/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
+++ b/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
@@ -19,6 +19,7 @@ depends_on = None
 
 def upgrade():
     create_annotation_table()
+    create_annotation_account_relationship_table()
     create_annotation_asset_relationship_table()
     create_annotation_sensor_relationship_table()
 
@@ -53,6 +54,17 @@ def create_annotation_asset_relationship_table():
         sa.Column("generic_asset_id", sa.Integer()),
         sa.Column("annotation_id", sa.Integer()),
         sa.ForeignKeyConstraint(("generic_asset_id",), ["generic_asset.id"]),
+        sa.ForeignKeyConstraint(("annotation_id",), ["annotation.id"]),
+    )
+
+
+def create_annotation_account_relationship_table():
+    op.create_table(
+        "annotations_accounts",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("account_id", sa.Integer()),
+        sa.Column("annotation_id", sa.Integer()),
+        sa.ForeignKeyConstraint(("account_id",), ["account.id"]),
         sa.ForeignKeyConstraint(("annotation_id",), ["annotation.id"]),
     )
 

--- a/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
+++ b/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
@@ -29,9 +29,21 @@ def downgrade():
         "This downgrade drops the tables 'annotations_accounts', 'annotations_assets', 'annotations_sensors' and 'annotation'. Continue?",
         abort=True,
     )
-    op.drop_constraint(op.f("annotations_accounts_annotation_id_key"), "annotations_accounts", type_="unique")
-    op.drop_constraint(op.f("annotations_assets_annotation_id_key"), "annotations_assets", type_="unique")
-    op.drop_constraint(op.f("annotations_sensors_annotation_id_key"), "annotations_sensors", type_="unique")
+    op.drop_constraint(
+        op.f("annotations_accounts_annotation_id_key"),
+        "annotations_accounts",
+        type_="unique",
+    )
+    op.drop_constraint(
+        op.f("annotations_assets_annotation_id_key"),
+        "annotations_assets",
+        type_="unique",
+    )
+    op.drop_constraint(
+        op.f("annotations_sensors_annotation_id_key"),
+        "annotations_sensors",
+        type_="unique",
+    )
     op.drop_table("annotations_accounts")
     op.drop_table("annotations_assets")
     op.drop_table("annotations_sensors")

--- a/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
+++ b/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
@@ -29,6 +29,9 @@ def downgrade():
         "This downgrade drops the tables 'annotations_accounts', 'annotations_assets', 'annotations_sensors' and 'annotation'. Continue?",
         abort=True,
     )
+    op.drop_constraint(op.f("annotations_accounts_annotation_id_key"), "annotations_accounts", type_="unique")
+    op.drop_constraint(op.f("annotations_assets_annotation_id_key"), "annotations_assets", type_="unique")
+    op.drop_constraint(op.f("annotations_sensors_annotation_id_key"), "annotations_sensors", type_="unique")
     op.drop_table("annotations_accounts")
     op.drop_table("annotations_assets")
     op.drop_table("annotations_sensors")
@@ -46,6 +49,11 @@ def create_annotation_sensor_relationship_table():
         sa.ForeignKeyConstraint(("sensor_id",), ["sensor.id"]),
         sa.ForeignKeyConstraint(("annotation_id",), ["annotation.id"]),
     )
+    op.create_unique_constraint(
+        op.f("annotations_sensors_annotation_id_key"),
+        "annotations_sensors",
+        ["annotation_id", "sensor_id"],
+    )
 
 
 def create_annotation_asset_relationship_table():
@@ -57,6 +65,11 @@ def create_annotation_asset_relationship_table():
         sa.ForeignKeyConstraint(("generic_asset_id",), ["generic_asset.id"]),
         sa.ForeignKeyConstraint(("annotation_id",), ["annotation.id"]),
     )
+    op.create_unique_constraint(
+        op.f("annotations_assets_annotation_id_key"),
+        "annotations_assets",
+        ["annotation_id", "generic_asset_id"],
+    )
 
 
 def create_annotation_account_relationship_table():
@@ -67,6 +80,11 @@ def create_annotation_account_relationship_table():
         sa.Column("annotation_id", sa.Integer()),
         sa.ForeignKeyConstraint(("account_id",), ["account.id"]),
         sa.ForeignKeyConstraint(("annotation_id",), ["annotation.id"]),
+    )
+    op.create_unique_constraint(
+        op.f("annotations_accounts_annotation_id_key"),
+        "annotations_accounts",
+        ["annotation_id", "account_id"],
     )
 
 

--- a/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
+++ b/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
@@ -75,7 +75,7 @@ def create_annotation_table():
         sa.Column(
             "id", sa.Integer(), nullable=False, autoincrement=True, primary_key=True
         ),
-        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("content", sa.String(255), nullable=False),
         sa.Column("start", sa.DateTime(timezone=True), nullable=False),
         sa.Column("end", sa.DateTime(timezone=True), nullable=False),
         sa.Column("source_id", sa.Integer(), nullable=False),
@@ -89,5 +89,5 @@ def create_annotation_table():
     op.create_unique_constraint(
         op.f("annotation_name_key"),
         "annotation",
-        ["name", "start", "source_id", "type"],
+        ["content", "start", "source_id", "type"],
     )

--- a/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
+++ b/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
@@ -32,7 +32,7 @@ def downgrade():
     op.drop_table("annotations_accounts")
     op.drop_table("annotations_assets")
     op.drop_table("annotations_sensors")
-    op.drop_constraint(op.f("annotation_name_key"), "annotation", type_="unique")
+    op.drop_constraint(op.f("annotation_content_key"), "annotation", type_="unique")
     op.drop_table("annotation")
     op.execute("DROP TYPE annotation_type;")
 
@@ -88,7 +88,7 @@ def create_annotation_table():
         sa.ForeignKeyConstraint(("source_id",), ["data_source.id"]),
     )
     op.create_unique_constraint(
-        op.f("annotation_name_key"),
+        op.f("annotation_content_key"),
         "annotation",
         ["content", "start", "source_id", "type"],
     )

--- a/flexmeasures/data/models/annotations.py
+++ b/flexmeasures/data/models/annotations.py
@@ -16,7 +16,7 @@ class Annotation(db.Model):
     """
 
     id = db.Column(db.Integer, nullable=False, autoincrement=True, primary_key=True)
-    name = db.Column(db.String(255), nullable=False)
+    content = db.Column(db.String(255), nullable=False)
     start = db.Column(db.DateTime(timezone=True), nullable=False)
     end = db.Column(db.DateTime(timezone=True), nullable=False)
     source_id = db.Column(db.Integer, db.ForeignKey(DataSource.__tablename__ + ".id"))
@@ -28,7 +28,7 @@ class Annotation(db.Model):
     type = db.Column(db.Enum("alert", "holiday", "label", name="annotation_type"))
     __table_args__ = (
         db.UniqueConstraint(
-            "name",
+            "content",
             "start",
             "source_id",
             "type",

--- a/flexmeasures/data/models/annotations.py
+++ b/flexmeasures/data/models/annotations.py
@@ -52,6 +52,13 @@ class AccountAnnotationRelationship(db.Model):
     id = db.Column(db.Integer(), primary_key=True)
     account_id = db.Column(db.Integer, db.ForeignKey("account.id"))
     annotation_id = db.Column(db.Integer, db.ForeignKey("annotation.id"))
+    __table_args__ = (
+        db.UniqueConstraint(
+            "annotation_id",
+            "account_id",
+            name="annotations_accounts_annotation_id_key",
+        ),
+    )
 
 
 class GenericAssetAnnotationRelationship(db.Model):
@@ -62,6 +69,13 @@ class GenericAssetAnnotationRelationship(db.Model):
     id = db.Column(db.Integer(), primary_key=True)
     generic_asset_id = db.Column(db.Integer, db.ForeignKey("generic_asset.id"))
     annotation_id = db.Column(db.Integer, db.ForeignKey("annotation.id"))
+    __table_args__ = (
+        db.UniqueConstraint(
+            "annotation_id",
+            "generic_asset_id",
+            name="annotations_assets_annotation_id_key",
+        ),
+    )
 
 
 class SensorAnnotationRelationship(db.Model):
@@ -72,3 +86,10 @@ class SensorAnnotationRelationship(db.Model):
     id = db.Column(db.Integer(), primary_key=True)
     sensor_id = db.Column(db.Integer, db.ForeignKey("sensor.id"))
     annotation_id = db.Column(db.Integer, db.ForeignKey("annotation.id"))
+    __table_args__ = (
+        db.UniqueConstraint(
+            "annotation_id",
+            "sensor_id",
+            name="annotations_sensors_annotation_id_key",
+        ),
+    )

--- a/flexmeasures/data/models/annotations.py
+++ b/flexmeasures/data/models/annotations.py
@@ -41,7 +41,7 @@ class Annotation(db.Model):
         return self.end - self.start
 
     def __repr__(self) -> str:
-        return f"<Annotation {self.id}: {self.name} ({self.type}), start: {self.start} end: {self.end}, source: {self.source}>"
+        return f"<Annotation {self.id}: {self.content} ({self.type}), start: {self.start} end: {self.end}, source: {self.source}>"
 
 
 class AccountAnnotationRelationship(db.Model):

--- a/flexmeasures/data/models/annotations.py
+++ b/flexmeasures/data/models/annotations.py
@@ -44,6 +44,16 @@ class Annotation(db.Model):
         return f"<Annotation {self.id}: {self.name} ({self.type}), start: {self.start} end: {self.end}, source: {self.source}>"
 
 
+class AccountAnnotationRelationship(db.Model):
+    """Links annotations to accounts."""
+
+    __tablename__ = "annotations_accounts"
+
+    id = db.Column(db.Integer(), primary_key=True)
+    account_id = db.Column(db.Integer, db.ForeignKey("account.id"))
+    annotation_id = db.Column(db.Integer, db.ForeignKey("annotation.id"))
+
+
 class GenericAssetAnnotationRelationship(db.Model):
     """Links annotations to generic assets."""
 

--- a/flexmeasures/data/models/annotations.py
+++ b/flexmeasures/data/models/annotations.py
@@ -93,3 +93,23 @@ class SensorAnnotationRelationship(db.Model):
             name="annotations_sensors_annotation_id_key",
         ),
     )
+
+
+def get_or_create_annotation(
+    annotation: Annotation,
+) -> Annotation:
+    with db.session.no_autoflush:
+        existing_annotation = (
+            db.session.query(Annotation)
+            .filter(
+                Annotation.content == annotation.content,
+                Annotation.start == annotation.start,
+                Annotation.type == annotation.type,
+            )
+            .one_or_none()
+        )
+    if existing_annotation is None:
+        db.session.add(annotation)
+        return annotation
+    db.session.expunge(annotation)
+    return existing_annotation

--- a/flexmeasures/data/models/annotations.py
+++ b/flexmeasures/data/models/annotations.py
@@ -98,12 +98,18 @@ class SensorAnnotationRelationship(db.Model):
 def get_or_create_annotation(
     annotation: Annotation,
 ) -> Annotation:
+    """Add annotation to db session if it doesn't exist in the session already.
+
+    Return the old annotation object if it exists (and expunge the new one). Otherwise, return the new one.
+    """
     with db.session.no_autoflush:
         existing_annotation = (
             db.session.query(Annotation)
             .filter(
                 Annotation.content == annotation.content,
                 Annotation.start == annotation.start,
+                Annotation.end == annotation.end,
+                Annotation.source == annotation.source,
                 Annotation.type == annotation.type,
             )
             .one_or_none()
@@ -111,5 +117,6 @@ def get_or_create_annotation(
     if existing_annotation is None:
         db.session.add(annotation)
         return annotation
-    db.session.expunge(annotation)
+    if annotation in db.session:
+        db.session.expunge(annotation)
     return existing_annotation

--- a/flexmeasures/data/models/annotations.py
+++ b/flexmeasures/data/models/annotations.py
@@ -32,7 +32,7 @@ class Annotation(db.Model):
             "start",
             "source_id",
             "type",
-            name="annotation_name_key",
+            name="annotation_content_key",
         ),
     )
 

--- a/flexmeasures/data/models/user.py
+++ b/flexmeasures/data/models/user.py
@@ -41,6 +41,11 @@ class Account(db.Model, AuthModelMixin):
         secondary="roles_accounts",
         backref=backref("accounts", lazy="dynamic"),
     )
+    annotations = db.relationship(
+        "Annotation",
+        secondary="annotations_accounts",
+        backref=db.backref("accounts", lazy="dynamic"),
+    )
 
     def __repr__(self):
         return "<Account %s (ID:%d)" % (self.name, self.id)

--- a/flexmeasures/data/models/user.py
+++ b/flexmeasures/data/models/user.py
@@ -15,6 +15,13 @@ class RolesAccounts(db.Model):
     id = Column(Integer(), primary_key=True)
     account_id = Column("account_id", Integer(), ForeignKey("account.id"))
     role_id = Column("role_id", Integer(), ForeignKey("account_role.id"))
+    __table_args__ = (
+        db.UniqueConstraint(
+            "role_id",
+            "account_id",
+            name="roles_accounts_role_id_key",
+        ),
+    )
 
 
 class AccountRole(db.Model):
@@ -77,6 +84,13 @@ class RolesUsers(db.Model):
     id = Column(Integer(), primary_key=True)
     user_id = Column("user_id", Integer(), ForeignKey("fm_user.id"))
     role_id = Column("role_id", Integer(), ForeignKey("role.id"))
+    __table_args__ = (
+        db.UniqueConstraint(
+            "role_id",
+            "user_id",
+            name="roles_users_role_id_key",
+        ),
+    )
 
 
 class Role(db.Model, RoleMixin):

--- a/flexmeasures/data/tests/test_annotations.py
+++ b/flexmeasures/data/tests/test_annotations.py
@@ -1,0 +1,26 @@
+import pandas as pd
+
+from flexmeasures.data.models.annotations import Annotation, get_or_create_annotation
+from flexmeasures.data.models.data_sources import DataSource
+
+
+def test_get_or_create_annotation(db):
+    """Save an annotation, then get_or_create a new annotation with the same contents."""
+    source = DataSource.query.first()
+    first_annotation = Annotation(
+        content="Dutch new year",
+        start=pd.Timestamp("2020-01-01 00:00+01"),
+        end=pd.Timestamp("2020-01-02 00:00+01"),
+        source=source,
+        type="holiday",
+    )
+    assert first_annotation == get_or_create_annotation(first_annotation)
+    db.session.flush()
+    second_annotation = Annotation(
+        content="Dutch new year",
+        start=pd.Timestamp("2020-01-01 00:00+01"),
+        end=pd.Timestamp("2020-01-02 00:00+01"),
+        source=source,
+        type="holiday",
+    )
+    assert first_annotation == get_or_create_annotation(second_annotation)


### PR DESCRIPTION
This PR introduces annotations on the level of an organisation account (which is a much better place for organisation holidays, for example), and adds a CLI command to create a single user annotation. We'll now have three levels of annotations:
- Accounts
- Assets (GenericAssets)
- Sensors

It also adds unique constraints on the many-to-many relationships. @nhoening I think these are missing on the `roles_accounts` and `roles_users` tables, too?

NB Without an intermediate release, I'm taking the liberty to amend the original revision file introducing annotations. (hint for testing: consider downgrading to `c1d316c60985` while having `main` checked out, then check out this branch and upgrade to `7f8b8920355f`)