### PR TITLE
Simplify db import statements

### DIFF
--- a/flexmeasures/api/common/implementations.py
+++ b/flexmeasures/api/common/implementations.py
@@ -6,7 +6,7 @@ from flask import request, current_app
 from flask_json import as_json
 from sqlalchemy import exc as sqla_exc
 
-from flexmeasures.data.config import db
+from flexmeasures.data import db
 from flexmeasures.data.models.task_runs import LatestTaskRun
 from flexmeasures.auth.error_handling import UNAUTH_STATUS_CODE, FORBIDDEN_STATUS_CODE
 

--- a/flexmeasures/api/common/utils/validators.py
+++ b/flexmeasures/api/common/utils/validators.py
@@ -40,8 +40,8 @@ from flexmeasures.api.common.utils.api_utils import (
     contains_empty_items,
     upsample_values,
 )
+from flexmeasures.data import db
 from flexmeasures.data.models.data_sources import DataSource
-from flexmeasures.data.config import db
 from flexmeasures.data.services.users import get_users
 from flexmeasures.utils.time_utils import server_now
 

--- a/flexmeasures/api/dev/assets.py
+++ b/flexmeasures/api/dev/assets.py
@@ -4,12 +4,12 @@ from flask_json import as_json
 from webargs.flaskparser import use_kwargs, use_args
 
 from flexmeasures.auth.decorators import permission_required_for_context
+from flexmeasures.data import db
 from flexmeasures.data.models.user import Account
 from flexmeasures.data.models.generic_assets import GenericAsset as AssetModel
 from flexmeasures.data.schemas.generic_assets import GenericAssetSchema as AssetSchema
 from flexmeasures.api.common.schemas.generic_assets import AssetIdField
 from flexmeasures.api.common.schemas.users import AccountIdField
-from flexmeasures.data.config import db
 
 
 asset_schema = AssetSchema()

--- a/flexmeasures/api/play/implementations.py
+++ b/flexmeasures/api/play/implementations.py
@@ -8,7 +8,7 @@ from flexmeasures.api.common.responses import (
     request_processed,
     unrecognized_backup,
 )
-from flexmeasures.data.config import db
+from flexmeasures.data import db
 from flexmeasures.data.scripts.data_gen import (
     depopulate_measurements,
     depopulate_prognoses,

--- a/flexmeasures/api/tests/utils.py
+++ b/flexmeasures/api/tests/utils.py
@@ -2,7 +2,7 @@ import json
 
 from flask import url_for, current_app
 
-from flexmeasures.data.config import db
+from flexmeasures.data import db
 from flexmeasures.data.services.users import find_user_by_email
 from flexmeasures.data.models.user import Account
 

--- a/flexmeasures/api/v1_2/implementations.py
+++ b/flexmeasures/api/v1_2/implementations.py
@@ -31,7 +31,7 @@ from flexmeasures.api.common.utils.validators import (
     units_accepted,
     parse_isodate_str,
 )
-from flexmeasures.data.config import db
+from flexmeasures.data import db
 from flexmeasures.data.models.planning.battery import schedule_battery
 from flexmeasures.data.models.planning.exceptions import (
     UnknownMarketException,

--- a/flexmeasures/api/v1_3/implementations.py
+++ b/flexmeasures/api/v1_3/implementations.py
@@ -38,7 +38,7 @@ from flexmeasures.api.common.utils.validators import (
     units_accepted,
     parse_isodate_str,
 )
-from flexmeasures.data.config import db
+from flexmeasures.data import db
 from flexmeasures.data.models.data_sources import DataSource
 from flexmeasures.data.models.time_series import Sensor
 from flexmeasures.data.queries.utils import simplify_index

--- a/flexmeasures/api/v2_0/implementations/assets.py
+++ b/flexmeasures/api/v2_0/implementations/assets.py
@@ -13,7 +13,7 @@ from flexmeasures.data.services.resources import get_assets
 from flexmeasures.data.models.user import User
 from flexmeasures.data.models.assets import Asset as AssetModel
 from flexmeasures.data.schemas.assets import AssetSchema
-from flexmeasures.data.config import db
+from flexmeasures.data import db
 from flexmeasures.api.common.responses import required_info_missing
 
 

--- a/flexmeasures/api/v2_0/implementations/users.py
+++ b/flexmeasures/api/v2_0/implementations/users.py
@@ -15,7 +15,7 @@ from flexmeasures.data.services.users import (
     remove_cookie_and_token_access,
 )
 from flexmeasures.auth.decorators import permission_required_for_context
-from flexmeasures.data.config import db
+from flexmeasures.data import db
 
 """
 API endpoints to manage users.

--- a/flexmeasures/auth/__init__.py
+++ b/flexmeasures/auth/__init__.py
@@ -3,7 +3,7 @@ from flask_security import Security, SQLAlchemySessionUserDatastore
 from flask_login import user_logged_in
 from werkzeug.exceptions import Forbidden, Unauthorized
 
-from flexmeasures.data.config import db
+from flexmeasures.data import db
 
 
 """

--- a/flexmeasures/conftest.py
+++ b/flexmeasures/conftest.py
@@ -96,7 +96,7 @@ def create_test_db(app):
     """
     print("DB FIXTURE")
     # app is an instance of a flask app, _db a SQLAlchemy DB
-    from flexmeasures.data.config import db as _db
+    from flexmeasures.data import db as _db
 
     _db.app = app
     with app.app_context():

--- a/flexmeasures/data/models/assets.py
+++ b/flexmeasures/data/models/assets.py
@@ -6,7 +6,7 @@ import timely_beliefs as tb
 import timely_beliefs.utils as tb_utils
 from sqlalchemy.orm import Query
 
-from flexmeasures.data.config import db
+from flexmeasures.data import db
 from flexmeasures.data.models.legacy_migration_utils import (
     copy_old_sensor_attributes,
     get_old_model_type,

--- a/flexmeasures/data/models/data_sources.py
+++ b/flexmeasures/data/models/data_sources.py
@@ -3,7 +3,7 @@ from typing import Optional, Union
 import timely_beliefs as tb
 from flask import current_app
 
-from flexmeasures.data.config import db
+from flexmeasures.data import db
 from flexmeasures.data.models.user import User, is_user
 
 

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -1,7 +1,6 @@
 from typing import Optional, Tuple, List
 
 from flask_security import current_user
-from sqlalchemy.orm import Session
 from sqlalchemy.engine import Row
 
 from sqlalchemy.ext.hybrid import hybrid_method
@@ -218,9 +217,7 @@ def assets_share_location(assets: List[GenericAsset]) -> bool:
     return all([a.location == assets[0].location for a in assets])
 
 
-def get_center_location_of_assets(
-    db: Session, user: Optional[User]
-) -> Tuple[float, float]:
+def get_center_location_of_assets(user: Optional[User]) -> Tuple[float, float]:
     """
     Find the center position between all generic assets of the user's account.
     """

--- a/flexmeasures/data/models/markets.py
+++ b/flexmeasures/data/models/markets.py
@@ -5,7 +5,7 @@ from timely_beliefs.sensors.func_store import knowledge_horizons
 import timely_beliefs.utils as tb_utils
 from sqlalchemy.orm import Query
 
-from flexmeasures.data.config import db
+from flexmeasures.data import db
 from flexmeasures.data.models.generic_assets import (
     create_generic_asset,
     GenericAsset,

--- a/flexmeasures/data/models/task_runs.py
+++ b/flexmeasures/data/models/task_runs.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import pytz
 
-from flexmeasures.data.config import db
+from flexmeasures.data import db
 
 
 class LatestTaskRun(db.Model):

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -11,7 +11,7 @@ from timely_beliefs.beliefs.probabilistic_utils import get_median_belief
 import timely_beliefs.utils as tb_utils
 
 from flexmeasures.auth.policy import AuthModelMixin, EVERY_LOGGED_IN_USER
-from flexmeasures.data.config import db
+from flexmeasures.data import db
 from flexmeasures.data.queries.utils import (
     create_beliefs_query,
     get_belief_timing_criteria,

--- a/flexmeasures/data/models/user.py
+++ b/flexmeasures/data/models/user.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import relationship, backref
 from sqlalchemy import Boolean, DateTime, Column, Integer, String, ForeignKey
 from sqlalchemy.ext.hybrid import hybrid_property
 
-from flexmeasures.data.config import db
+from flexmeasures.data import db
 from flexmeasures.auth.policy import AuthModelMixin
 
 

--- a/flexmeasures/data/models/weather.py
+++ b/flexmeasures/data/models/weather.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.hybrid import hybrid_method
 from sqlalchemy.sql.expression import func
 from sqlalchemy.schema import UniqueConstraint
 
-from flexmeasures.data.config import db
+from flexmeasures.data import db
 from flexmeasures.data.models.legacy_migration_utils import (
     copy_old_sensor_attributes,
     get_old_model_type,

--- a/flexmeasures/data/queries/utils.py
+++ b/flexmeasures/data/queries/utils.py
@@ -7,7 +7,7 @@ import timely_beliefs as tb
 from sqlalchemy.orm import Query, Session
 from sqlalchemy.sql.elements import BinaryExpression
 
-from flexmeasures.data.config import db
+from flexmeasures.data import db
 from flexmeasures.data.models.data_sources import DataSource
 from flexmeasures.utils import flexmeasures_inflection
 import flexmeasures.data.models.time_series as ts  # noqa: F401

--- a/flexmeasures/data/scripts/grid_weather.py
+++ b/flexmeasures/data/scripts/grid_weather.py
@@ -13,8 +13,8 @@ from timely_beliefs import BeliefsDataFrame
 
 from flexmeasures.utils.time_utils import as_server_time, get_timezone
 from flexmeasures.utils.geo_utils import compute_irradiance
+from flexmeasures.data import db
 from flexmeasures.data.services.resources import find_closest_sensor
-from flexmeasures.data.config import db
 from flexmeasures.data.transactional import task_with_status_report
 from flexmeasures.data.models.data_sources import DataSource
 from flexmeasures.data.models.time_series import Sensor, TimedBelief

--- a/flexmeasures/data/scripts/visualize_data_model.py
+++ b/flexmeasures/data/scripts/visualize_data_model.py
@@ -277,7 +277,7 @@ if __name__ == "__main__":
         )
     if args.uml:
         try:
-            from flexmeasures.data.config import db as flexmeasures_db
+            from flexmeasures.data import db as flexmeasures_db
         except ImportError as ie:
             print(
                 f"We need flexmeasures.data to be in the path, so we can read the data model. Error: '{ie}''."

--- a/flexmeasures/data/services/forecasting.py
+++ b/flexmeasures/data/services/forecasting.py
@@ -8,7 +8,7 @@ from rq.job import Job
 from timetomodel.forecasting import make_rolling_forecasts
 import timely_beliefs as tb
 
-from flexmeasures.data.config import db
+from flexmeasures.data import db
 from flexmeasures.data.models.forecasting import lookup_model_specs_configurator
 from flexmeasures.data.models.forecasting.exceptions import InvalidHorizonException
 from flexmeasures.data.models.time_series import Sensor, TimedBelief

--- a/flexmeasures/data/services/resources.py
+++ b/flexmeasures/data/services/resources.py
@@ -12,6 +12,7 @@ from functools import cached_property, wraps
 from typing import List, Dict, Tuple, Type, TypeVar, Union, Optional
 from datetime import datetime
 
+from flexmeasures.data import db
 from flexmeasures.data.queries.sensors import query_sensors_by_proximity
 from flexmeasures.utils.flexmeasures_inflection import parameterize, pluralize
 from itertools import groupby
@@ -19,7 +20,7 @@ from itertools import groupby
 from flask_security.core import current_user
 import inflect
 import pandas as pd
-from sqlalchemy.orm import Query, Session
+from sqlalchemy.orm import Query
 from sqlalchemy.engine import Row
 import timely_beliefs as tb
 
@@ -246,7 +247,7 @@ def mask_inaccessible_assets(
     return asset_queries
 
 
-def get_center_location(db: Session, user: Optional[User]) -> Tuple[float, float]:
+def get_center_location(user: Optional[User]) -> Tuple[float, float]:
     """
     Find the center position between all assets.
     If user is passed and not admin then we only consider assets

--- a/flexmeasures/data/services/scheduling.py
+++ b/flexmeasures/data/services/scheduling.py
@@ -10,7 +10,7 @@ from rq import get_current_job
 from rq.job import Job
 import timely_beliefs as tb
 
-from flexmeasures.data.config import db
+from flexmeasures.data import db
 from flexmeasures.data.models.planning.battery import schedule_battery
 from flexmeasures.data.models.planning.charging_station import schedule_charging_station
 from flexmeasures.data.models.time_series import Sensor, TimedBelief

--- a/flexmeasures/data/services/users.py
+++ b/flexmeasures/data/services/users.py
@@ -14,7 +14,7 @@ from email_validator import (
 from flask_security.utils import hash_password
 from werkzeug.exceptions import NotFound
 
-from flexmeasures.data.config import db
+from flexmeasures.data import db
 from flexmeasures.data.models.data_sources import DataSource
 from flexmeasures.data.models.user import User, Role, Account
 

--- a/flexmeasures/data/transactional.py
+++ b/flexmeasures/data/transactional.py
@@ -9,7 +9,7 @@ import click
 from flask import current_app
 from flask_sqlalchemy import SQLAlchemy
 
-from flexmeasures.data.config import db
+from flexmeasures.data import db
 from flexmeasures.utils.error_utils import get_err_source_info
 from flexmeasures.utils.coding_utils import optional_arg_decorator
 from flexmeasures.data.models.task_runs import LatestTaskRun

--- a/flexmeasures/ui/crud/assets.py
+++ b/flexmeasures/ui/crud/assets.py
@@ -9,7 +9,7 @@ from wtforms import StringField, DecimalField, SelectField
 from wtforms.validators import DataRequired
 from flexmeasures.auth.policy import ADMIN_ROLE
 
-from flexmeasures.data.config import db
+from flexmeasures.data import db
 from flexmeasures.auth.error_handling import unauthorized_handler
 from flexmeasures.data.services.resources import get_center_location
 from flexmeasures.data.models.generic_assets import GenericAssetType, GenericAsset

--- a/flexmeasures/ui/crud/assets.py
+++ b/flexmeasures/ui/crud/assets.py
@@ -195,7 +195,7 @@ class AssetCrudUI(FlaskView):
                 "crud/asset_new.html",
                 asset_form=asset_form,
                 msg="",
-                map_center=get_center_location(db, user=current_user),
+                map_center=get_center_location(user=current_user),
                 mapboxAccessToken=current_app.config.get("MAPBOX_ACCESS_TOKEN", ""),
             )
 
@@ -272,7 +272,7 @@ class AssetCrudUI(FlaskView):
                     "crud/asset_new.html",
                     asset_form=asset_form,
                     msg=msg,
-                    map_center=get_center_location(db, user=current_user),
+                    map_center=get_center_location(user=current_user),
                     mapboxAccessToken=current_app.config.get("MAPBOX_ACCESS_TOKEN", ""),
                 )
 

--- a/flexmeasures/ui/crud/users.py
+++ b/flexmeasures/ui/crud/users.py
@@ -9,7 +9,7 @@ from wtforms.validators import DataRequired
 from flask_security import roles_required, login_required
 
 from flexmeasures.auth.policy import ADMIN_ROLE
-from flexmeasures.data.config import db
+from flexmeasures.data import db
 from flexmeasures.data.models.user import User, Role, Account
 from flexmeasures.data.services.users import (
     get_user,

--- a/flexmeasures/ui/views/dashboard.py
+++ b/flexmeasures/ui/views/dashboard.py
@@ -3,7 +3,6 @@ from flask import request, current_app
 from flask_security import login_required
 from flask_security.core import current_user
 
-from flexmeasures.data import db
 from flexmeasures.ui.views import flexmeasures_ui
 from flexmeasures.ui.utils.view_utils import render_flexmeasures_template, clear_session
 from flexmeasures.data.services.resources import (
@@ -53,7 +52,7 @@ def dashboard_view():
         message=msg,
         bokeh_html_embedded=bokeh_html_embedded,
         mapboxAccessToken=current_app.config.get("MAPBOX_ACCESS_TOKEN", ""),
-        map_center=get_center_location(db, user=current_user),
+        map_center=get_center_location(user=current_user),
         asset_groups=map_asset_groups,
         aggregate_groups=aggregate_groups,
     )

--- a/flexmeasures/ui/views/dashboard.py
+++ b/flexmeasures/ui/views/dashboard.py
@@ -3,7 +3,7 @@ from flask import request, current_app
 from flask_security import login_required
 from flask_security.core import current_user
 
-from flexmeasures.data.config import db
+from flexmeasures.data import db
 from flexmeasures.ui.views import flexmeasures_ui
 from flexmeasures.ui.utils.view_utils import render_flexmeasures_template, clear_session
 from flexmeasures.data.services.resources import (

--- a/flexmeasures/ui/views/new_dashboard.py
+++ b/flexmeasures/ui/views/new_dashboard.py
@@ -3,7 +3,6 @@ from flask_security import login_required
 from flask_security.core import current_user
 from bokeh.resources import CDN
 
-from flexmeasures.data.config import db
 from flexmeasures.ui.views import flexmeasures_ui
 from flexmeasures.ui.utils.view_utils import render_flexmeasures_template, clear_session
 from flexmeasures.data.models.generic_assets import get_center_location_of_assets
@@ -59,7 +58,7 @@ def new_dashboard_view():
         message=msg,
         bokeh_html_embedded=bokeh_html_embedded,
         mapboxAccessToken=current_app.config.get("MAPBOX_ACCESS_TOKEN", ""),
-        map_center=get_center_location_of_assets(db, user=current_user),
+        map_center=get_center_location_of_assets(user=current_user),
         asset_groups=map_asset_groups,
         aggregate_groups=aggregate_groups,
     )

--- a/flexmeasures/utils/error_utils.py
+++ b/flexmeasures/utils/error_utils.py
@@ -112,7 +112,7 @@ def print_query(query: Query) -> str:
     regex = re.compile(r":(?P<name>\w+)")
     params = query.statement.compile().params
     sql = regex.sub(r"'{\g<name>}'", str(query.statement)).format(**params)
-    from flexmeasures.data.config import db
+    from flexmeasures.data import db
 
     print(f"\nPrinting SQLAlchemy query to database {db.engine.url.database}:\n\n")
     print(sql)


### PR DESCRIPTION
Simplify a lot of import statements, and also simplify two function signatures that had a wrong type annotation (`Session` instead of `SQLAlchemy`).