### PR TITLE
Fix conftest ids

### DIFF
--- a/flexmeasures/conftest.py
+++ b/flexmeasures/conftest.py
@@ -289,15 +289,15 @@ def create_generic_assets(db, setup_generic_asset_types, setup_accounts):
     )
     db.session.add(troposphere)
     test_battery = GenericAsset(
-        name="Test battery",
+        name="Test grid connected battery storage",
         generic_asset_type=setup_generic_asset_types["battery"],
-        account_id=setup_accounts["Prosumer"].id,
+        owner=setup_accounts["Prosumer"],
     )
     db.session.add(test_battery)
     test_wind_turbine = GenericAsset(
         name="Test wind turbine",
         generic_asset_type=setup_generic_asset_types["wind"],
-        account_id=setup_accounts["Supplier"].id,
+        owner=setup_accounts["Supplier"],
     )
     db.session.add(test_wind_turbine)
 
@@ -325,9 +325,9 @@ def create_generic_asset_types(db):
         name="public good",
     )
     db.session.add(public_good)
-    solar = GenericAssetType(name="solar")
+    solar = GenericAssetType(name="solar panel")
     db.session.add(solar)
-    wind = GenericAssetType(name="wind")
+    wind = GenericAssetType(name="wind turbine")
     db.session.add(wind)
     battery = GenericAssetType(name="battery")
     db.session.add(battery)

--- a/flexmeasures/data/models/user.py
+++ b/flexmeasures/data/models/user.py
@@ -24,7 +24,7 @@ class AccountRole(db.Model):
     description = Column(String(255))
 
     def __repr__(self):
-        return "<AccountRole:%s (ID:%d)>" % (self.name, self.id)
+        return "<AccountRole:%s (ID:%s)>" % (self.name, self.id)
 
 
 class Account(db.Model, AuthModelMixin):
@@ -43,7 +43,7 @@ class Account(db.Model, AuthModelMixin):
     )
 
     def __repr__(self):
-        return "<Account %s (ID:%d)" % (self.name, self.id)
+        return "<Account %s (ID:%s)" % (self.name, self.id)
 
     def __acl__(self):
         """
@@ -81,7 +81,7 @@ class Role(db.Model, RoleMixin):
     description = Column(String(255))
 
     def __repr__(self):
-        return "<Role:%s (ID:%d)>" % (self.name, self.id)
+        return "<Role:%s (ID:%s)>" % (self.name, self.id)
 
 
 class User(db.Model, UserMixin, AuthModelMixin):
@@ -116,7 +116,7 @@ class User(db.Model, UserMixin, AuthModelMixin):
     )
 
     def __repr__(self):
-        return "<User %s (ID:%d)>" % (self.username, self.id)
+        return "<User %s (ID:%s)>" % (self.username, self.id)
 
     def __acl__(self):
         """


### PR DESCRIPTION
I found out that some test accounts hadn't been flushed before we used their id to assign asset ownership. This PR fixes that.

This PR also renames some test generic asset types that we set up explicitly, to avoid clashing with generic asset types that are set up implicitly through setting up (non-generic) asset types. (That implicit setup supports our data model migration and won't be around much longer of course.)