### PR TITLE
Search annotations

### DIFF
--- a/flexmeasures/api/v1/implementations.py
+++ b/flexmeasures/api/v1/implementations.py
@@ -12,8 +12,8 @@ from flexmeasures.utils.entity_address_utils import (
     EntityAddressException,
 )
 from flexmeasures.data import db
-from flexmeasures.data.models.data_sources import get_or_create_source
 from flexmeasures.data.models.time_series import Sensor, TimedBelief
+from flexmeasures.data.queries.data_sources import get_or_create_source
 from flexmeasures.data.services.resources import get_sensors
 from flexmeasures.data.services.forecasting import create_forecasting_jobs
 from flexmeasures.api.common.responses import (

--- a/flexmeasures/api/v1_1/implementations.py
+++ b/flexmeasures/api/v1_1/implementations.py
@@ -41,8 +41,8 @@ from flexmeasures.api.v1.implementations import (
 from flexmeasures.api.common.utils.api_utils import (
     get_sensor_by_generic_asset_type_and_location,
 )
-from flexmeasures.data.models.data_sources import get_or_create_source
 from flexmeasures.data.models.time_series import TimedBelief
+from flexmeasures.data.queries.data_sources import get_or_create_source
 from flexmeasures.data.services.resources import get_sensors
 from flexmeasures.data.services.forecasting import create_forecasting_jobs
 

--- a/flexmeasures/api/v2_0/implementations/sensors.py
+++ b/flexmeasures/api/v2_0/implementations/sensors.py
@@ -32,7 +32,7 @@ from flexmeasures.api.common.utils.validators import (
     period_required,
     values_required,
 )
-from flexmeasures.data.models.data_sources import get_or_create_source
+from flexmeasures.data.queries.data_sources import get_or_create_source
 from flexmeasures.data.models.time_series import Sensor, TimedBelief
 from flexmeasures.data.services.forecasting import create_forecasting_jobs
 from flexmeasures.data.services.resources import get_sensors

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -31,11 +31,8 @@ from flexmeasures.data.schemas.generic_assets import (
 from flexmeasures.data.models.generic_assets import GenericAsset, GenericAssetType
 from flexmeasures.data.models.weather import WeatherSensor
 from flexmeasures.data.schemas.weather import WeatherSensorSchema
-from flexmeasures.data.models.data_sources import (
-    get_or_create_source,
-    get_source_or_none,
-)
 from flexmeasures.data.models.user import User
+from flexmeasures.data.queries.data_sources import get_or_create_source, get_source_or_none
 from flexmeasures.utils import flexmeasures_inflection
 from flexmeasures.utils.time_utils import server_now
 from flexmeasures.utils.unit_utils import convert_units

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -32,7 +32,10 @@ from flexmeasures.data.models.generic_assets import GenericAsset, GenericAssetTy
 from flexmeasures.data.models.weather import WeatherSensor
 from flexmeasures.data.schemas.weather import WeatherSensorSchema
 from flexmeasures.data.models.user import User
-from flexmeasures.data.queries.data_sources import get_or_create_source, get_source_or_none
+from flexmeasures.data.queries.data_sources import (
+    get_or_create_source,
+    get_source_or_none,
+)
 from flexmeasures.utils import flexmeasures_inflection
 from flexmeasures.utils.time_utils import server_now
 from flexmeasures.utils.unit_utils import convert_units

--- a/flexmeasures/conftest.py
+++ b/flexmeasures/conftest.py
@@ -682,6 +682,18 @@ def add_sensors(db: SQLAlchemy, setup_generic_assets):
     return height_sensor
 
 
+@pytest.fixture(scope="module")
+def battery_soc_sensor(db: SQLAlchemy, setup_generic_assets):
+    """Add a battery SOC sensor."""
+    soc_sensor = Sensor(
+        name="state of charge",
+        unit="%",
+        generic_asset=setup_generic_assets["test_battery"],
+    )
+    db.session.add(soc_sensor)
+    return soc_sensor
+
+
 @pytest.fixture(scope="function")
 def clean_redis(app):
     failed = app.queues["forecasting"].failed_job_registry

--- a/flexmeasures/data/models/annotations.py
+++ b/flexmeasures/data/models/annotations.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 
 from flexmeasures.data import db
-from flexmeasures.data.models.data_sources import DataSource
 
 
 class Annotation(db.Model):
@@ -19,7 +18,7 @@ class Annotation(db.Model):
     content = db.Column(db.String(255), nullable=False)
     start = db.Column(db.DateTime(timezone=True), nullable=False)
     end = db.Column(db.DateTime(timezone=True), nullable=False)
-    source_id = db.Column(db.Integer, db.ForeignKey(DataSource.__tablename__ + ".id"))
+    source_id = db.Column(db.Integer, db.ForeignKey("data_source.id"))
     source = db.relationship(
         "DataSource",
         foreign_keys=[source_id],

--- a/flexmeasures/data/models/data_sources.py
+++ b/flexmeasures/data/models/data_sources.py
@@ -1,10 +1,12 @@
-from typing import Optional, Union
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
 
 import timely_beliefs as tb
-from flask import current_app
 
 from flexmeasures.data import db
-from flexmeasures.data.models.user import User, is_user
+
+if TYPE_CHECKING:
+    from flexmeasures.data.models.user import User
 
 
 class DataSource(db.Model, tb.BeliefSourceDBMixin):
@@ -84,42 +86,3 @@ class DataSource(db.Model, tb.BeliefSourceDBMixin):
 
     def __str__(self):
         return self.description
-
-
-def get_or_create_source(
-    source: Union[User, str],
-    source_type: Optional[str] = None,
-    model: Optional[str] = None,
-    flush: bool = True,
-) -> DataSource:
-    if is_user(source):
-        source_type = "user"
-    query = DataSource.query.filter(DataSource.type == source_type)
-    if model is not None:
-        query = query.filter(DataSource.model == model)
-    if is_user(source):
-        query = query.filter(DataSource.user == source)
-    elif isinstance(source, str):
-        query = query.filter(DataSource.name == source)
-    else:
-        raise TypeError("source should be of type User or str")
-    _source = query.one_or_none()
-    if not _source:
-        if is_user(source):
-            _source = DataSource(user=source, model=model)
-        else:
-            if source_type is None:
-                raise TypeError("Please specify a source type")
-            _source = DataSource(name=source, model=model, type=source_type)
-        current_app.logger.info(f"Setting up {_source} as new data source...")
-        db.session.add(_source)
-        if flush:
-            # assigns id so that we can reference the new object in the current db session
-            db.session.flush()
-    return _source
-
-
-def get_source_or_none(source: int, source_type: str) -> Optional[DataSource]:
-    query = DataSource.query.filter(DataSource.type == source_type)
-    query = query.filter(DataSource.id == int(source))
-    return query.one_or_none()

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -175,7 +175,7 @@ class GenericAsset(db.Model, AuthModelMixin):
 
     @property
     def has_energy_sensors(self) -> bool:
-        """True if at least one power energy is attached"""
+        """True if at least one energy sensor is attached"""
         return any([s.measures_energy for s in self.sensors])
 
     def search_annotations(

--- a/flexmeasures/data/models/parsing_utils.py
+++ b/flexmeasures/data/models/parsing_utils.py
@@ -1,0 +1,43 @@
+from typing import Optional, Union, List
+
+from flask import current_app
+from flexmeasures.data import db
+
+
+def parse_source_arg(
+    source: Optional[
+        Union["DataSource", List["DataSource"], int, List[int], str, List[str]]
+    ]
+) -> Optional[List["DataSource"]]:
+    """Parse the "source" argument by looking up DataSources corresponding to any given ids or names."""
+    if source is None:
+        return source
+    if not isinstance(source, list):
+        sources = [source]
+    else:
+        sources = source
+    parsed_sources: List["DataSource"] = []
+    for source in sources:
+        if isinstance(source, int):
+            parsed_source = (
+                db.session.query("DataSource").filter_by(id=source).one_or_none()
+            )
+            if parsed_source is None:
+                current_app.logger.warning(
+                    f"Beliefs searched for unknown source {source}"
+                )
+            else:
+                parsed_sources.append(parsed_source)
+        elif isinstance(source, str):
+            _parsed_sources = (
+                db.session.query("DataSource").filter_by(name=source).all()
+            )
+            if _parsed_sources is []:
+                current_app.logger.warning(
+                    f"Beliefs searched for unknown source {source}"
+                )
+            else:
+                parsed_sources.extend(_parsed_sources)
+        else:
+            parsed_sources.append(source)
+    return parsed_sources

--- a/flexmeasures/data/models/parsing_utils.py
+++ b/flexmeasures/data/models/parsing_utils.py
@@ -3,6 +3,7 @@ from typing import Optional, Union, List, TYPE_CHECKING
 
 from flask import current_app
 from flexmeasures.data import db
+
 if TYPE_CHECKING:
     from flexmeasures.data.models.data_sources import DataSource
 

--- a/flexmeasures/data/models/parsing_utils.py
+++ b/flexmeasures/data/models/parsing_utils.py
@@ -1,14 +1,17 @@
-from typing import Optional, Union, List
+from __future__ import annotations
+from typing import Optional, Union, List, TYPE_CHECKING
 
 from flask import current_app
 from flexmeasures.data import db
+if TYPE_CHECKING:
+    from flexmeasures.data.models.data_sources import DataSource
 
 
 def parse_source_arg(
     source: Optional[
-        Union["DataSource", List["DataSource"], int, List[int], str, List[str]]
+        Union[DataSource, List[DataSource], int, List[int], str, List[str]]
     ]
-) -> Optional[List["DataSource"]]:
+) -> Optional[List[DataSource]]:
     """Parse the "source" argument by looking up DataSources corresponding to any given ids or names."""
     if source is None:
         return source

--- a/flexmeasures/data/models/parsing_utils.py
+++ b/flexmeasures/data/models/parsing_utils.py
@@ -1,11 +1,9 @@
-from __future__ import annotations
-from typing import Optional, Union, List, TYPE_CHECKING
+from typing import Optional, Union, List
 
 from flask import current_app
 from flexmeasures.data import db
 
-if TYPE_CHECKING:
-    from flexmeasures.data.models.data_sources import DataSource
+from flexmeasures.data.models.data_sources import DataSource
 
 
 def parse_source_arg(
@@ -20,11 +18,11 @@ def parse_source_arg(
         sources = [source]
     else:
         sources = source
-    parsed_sources: List["DataSource"] = []
+    parsed_sources: List[DataSource] = []
     for source in sources:
         if isinstance(source, int):
             parsed_source = (
-                db.session.query("DataSource").filter_by(id=source).one_or_none()
+                db.session.query(DataSource).filter_by(id=source).one_or_none()
             )
             if parsed_source is None:
                 current_app.logger.warning(
@@ -33,9 +31,7 @@ def parse_source_arg(
             else:
                 parsed_sources.append(parsed_source)
         elif isinstance(source, str):
-            _parsed_sources = (
-                db.session.query("DataSource").filter_by(name=source).all()
-            )
+            _parsed_sources = db.session.query(DataSource).filter_by(name=source).all()
             if _parsed_sources is []:
                 current_app.logger.warning(
                     f"Beliefs searched for unknown source {source}"

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -2,7 +2,6 @@ from typing import Any, List, Dict, Optional, Union, Type, Tuple
 from datetime import datetime as datetime_type, timedelta
 import json
 
-from flask import current_app
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Query, Session
@@ -12,6 +11,7 @@ import timely_beliefs.utils as tb_utils
 
 from flexmeasures.auth.policy import AuthModelMixin, EVERY_LOGGED_IN_USER
 from flexmeasures.data import db
+from flexmeasures.data.models.parsing_utils import parse_source_arg
 from flexmeasures.data.queries.utils import (
     create_beliefs_query,
     get_belief_timing_criteria,
@@ -23,6 +23,10 @@ from flexmeasures.data.services.time_series import (
 )
 from flexmeasures.utils.entity_address_utils import build_entity_address
 from flexmeasures.utils.unit_utils import is_energy_unit, is_power_unit
+from flexmeasures.data.models.annotations import (
+    Annotation,
+    SensorAnnotationRelationship,
+)
 from flexmeasures.data.models.charts import chart_type_to_chart_specs
 from flexmeasures.data.models.data_sources import DataSource
 from flexmeasures.data.models.generic_assets import GenericAsset
@@ -181,6 +185,48 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
             most_recent_events_only=True,
             one_deterministic_belief_per_event=True,
         )
+
+    def search_annotations(
+        self,
+        annotation_starts_after: Optional[datetime_type] = None,
+        annotation_ends_before: Optional[datetime_type] = None,
+        source: Optional[
+            Union[DataSource, List[DataSource], int, List[int], str, List[str]]
+        ] = None,
+        include_asset_annotations: bool = False,
+        include_account_annotations: bool = False,
+    ):
+        parsed_sources = parse_source_arg(source)
+        query = Annotation.query.join(SensorAnnotationRelationship).filter(
+            SensorAnnotationRelationship.sensor_id == self.id,
+            SensorAnnotationRelationship.annotation_id == Annotation.id,
+        )
+        if annotation_starts_after is not None:
+            query = query.filter(
+                Annotation.start >= annotation_starts_after,
+            )
+        if annotation_ends_before is not None:
+            query = query.filter(
+                Annotation.end <= annotation_ends_before,
+            )
+        if parsed_sources:
+            query = query.filter(
+                Annotation.source.in_(parsed_sources),
+            )
+        annotations = query.all()
+        if include_asset_annotations:
+            annotations += self.generic_asset.search_annotations(
+                annotation_starts_before=annotation_starts_after,
+                annotation_ends_before=annotation_ends_before,
+                source=source,
+            )
+        if include_account_annotations:
+            annotations += self.generic_asset.owner.search_annotations(
+                annotation_starts_before=annotation_starts_after,
+                annotation_ends_before=annotation_ends_before,
+                source=source,
+            )
+        return annotations
 
     def search_beliefs(
         self,
@@ -652,38 +698,3 @@ class TimedValue(object):
             resolution=resolution,
             sum_multiple=sum_multiple,
         )
-
-
-def parse_source_arg(
-    source: Optional[
-        Union[DataSource, List[DataSource], int, List[int], str, List[str]]
-    ]
-) -> Optional[List[DataSource]]:
-    """Parse the "source" argument by looking up DataSources corresponding to any given ids or names."""
-    if source is None:
-        return source
-    if not isinstance(source, list):
-        sources = [source]
-    else:
-        sources = source
-    parsed_sources: List[DataSource] = []
-    for source in sources:
-        if isinstance(source, int):
-            parsed_source = DataSource.query.filter_by(id=source).one_or_none()
-            if parsed_source is None:
-                current_app.logger.warning(
-                    f"Beliefs searched for unknown source {source}"
-                )
-            else:
-                parsed_sources.append(parsed_source)
-        elif isinstance(source, str):
-            _parsed_sources = DataSource.query.filter_by(name=source).all()
-            if _parsed_sources is []:
-                current_app.logger.warning(
-                    f"Beliefs searched for unknown source {source}"
-                )
-            else:
-                parsed_sources.extend(_parsed_sources)
-        else:
-            parsed_sources.append(source)
-    return parsed_sources

--- a/flexmeasures/data/models/user.py
+++ b/flexmeasures/data/models/user.py
@@ -14,6 +14,7 @@ from flexmeasures.data.models.annotations import (
 )
 from flexmeasures.data.models.parsing_utils import parse_source_arg
 from flexmeasures.auth.policy import AuthModelMixin
+
 if TYPE_CHECKING:
     from flexmeasures.data.models.data_sources import DataSource
 

--- a/flexmeasures/data/models/user.py
+++ b/flexmeasures/data/models/user.py
@@ -1,4 +1,5 @@
-from typing import List, Optional, Union
+from __future__ import annotations
+from typing import List, Optional, Union, TYPE_CHECKING
 from datetime import datetime
 
 from flask_security import UserMixin, RoleMixin
@@ -13,6 +14,8 @@ from flexmeasures.data.models.annotations import (
 )
 from flexmeasures.data.models.parsing_utils import parse_source_arg
 from flexmeasures.auth.policy import AuthModelMixin
+if TYPE_CHECKING:
+    from flexmeasures.data.models.data_sources import DataSource
 
 
 class RolesAccounts(db.Model):

--- a/flexmeasures/data/models/user.py
+++ b/flexmeasures/data/models/user.py
@@ -92,7 +92,7 @@ class Account(db.Model, AuthModelMixin):
         annotation_starts_after: Optional[datetime] = None,
         annotation_ends_before: Optional[datetime] = None,
         source: Optional[
-            Union["DataSource", List["DataSource"], int, List[int], str, List[str]]
+            Union[DataSource, List[DataSource], int, List[int], str, List[str]]
         ] = None,
     ):
         parsed_sources = parse_source_arg(source)

--- a/flexmeasures/data/queries/data_sources.py
+++ b/flexmeasures/data/queries/data_sources.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Union, Optional
+
+from flask import current_app
+from flexmeasures import User
+from flexmeasures.data import db
+from flexmeasures.data.models.data_sources import DataSource
+from flexmeasures.data.models.user import is_user
+
+
+def get_or_create_source(
+    source: Union[User, str],
+    source_type: Optional[str] = None,
+    model: Optional[str] = None,
+    flush: bool = True,
+) -> DataSource:
+    if is_user(source):
+        source_type = "user"
+    query = DataSource.query.filter(DataSource.type == source_type)
+    if model is not None:
+        query = query.filter(DataSource.model == model)
+    if is_user(source):
+        query = query.filter(DataSource.user == source)
+    elif isinstance(source, str):
+        query = query.filter(DataSource.name == source)
+    else:
+        raise TypeError("source should be of type User or str")
+    _source = query.one_or_none()
+    if not _source:
+        if is_user(source):
+            _source = DataSource(user=source, model=model)
+        else:
+            if source_type is None:
+                raise TypeError("Please specify a source type")
+            _source = DataSource(name=source, model=model, type=source_type)
+        current_app.logger.info(f"Setting up {_source} as new data source...")
+        db.session.add(_source)
+        if flush:
+            # assigns id so that we can reference the new object in the current db session
+            db.session.flush()
+    return _source
+
+
+def get_source_or_none(source: int, source_type: str) -> Optional[DataSource]:
+    query = DataSource.query.filter(DataSource.type == source_type)
+    query = query.filter(DataSource.id == int(source))
+    return query.one_or_none()

--- a/flexmeasures/data/tests/conftest.py
+++ b/flexmeasures/data/tests/conftest.py
@@ -9,6 +9,7 @@ import numpy as np
 from flask_sqlalchemy import SQLAlchemy
 from statsmodels.api import OLS
 
+from flexmeasures.data.models.annotations import Annotation
 from flexmeasures.data.models.assets import Asset
 from flexmeasures.data.models.data_sources import DataSource
 from flexmeasures.data.models.time_series import TimedBelief
@@ -185,3 +186,34 @@ def add_nearby_weather_sensors(db, add_weather_sensors) -> Dict[str, WeatherSens
     add_weather_sensors["farther_temperature"] = farther_temp_sensor
     add_weather_sensors["even_farther_temperature"] = even_farther_temp_sensor
     return add_weather_sensors
+
+
+@pytest.fixture(scope="module")
+def setup_annotations(
+    db,
+    battery_soc_sensor,
+    setup_sources,
+    app,
+):
+    """Set up an annotation for an account, an asset and a sensor."""
+    sensor = battery_soc_sensor
+    asset = sensor.generic_asset
+    account = asset.owner
+    source = setup_sources["Seita"]
+    annotation = Annotation(
+        content="Dutch new year",
+        start=pd.Timestamp("2020-01-01 00:00+01"),
+        end=pd.Timestamp("2020-01-02 00:00+01"),
+        source=source,
+        type="holiday",
+    )
+    account.annotations.append(annotation)
+    asset.annotations.append(annotation)
+    sensor.annotations.append(annotation)
+    db.session.flush()
+    return dict(
+        annotation=annotation,
+        account=account,
+        asset=asset,
+        sensor=sensor,
+    )

--- a/flexmeasures/data/tests/test_annotations.py
+++ b/flexmeasures/data/tests/test_annotations.py
@@ -39,3 +39,13 @@ def test_get_or_create_annotation(db):
     num_annotations_after = Annotation.query.count()
     assert num_annotations_after == num_annotations_intermediate
     assert second_annotation.id is None
+
+
+def test_search_annotations(db, setup_annotations):
+    account = setup_annotations["account"]
+    asset = setup_annotations["asset"]
+    sensor = setup_annotations["sensor"]
+    for obj in (account, asset, sensor):
+        annotations = getattr(obj, "search_annotations")()
+        assert len(annotations) == 1
+        assert annotations[0].content == "Dutch new year"


### PR DESCRIPTION
This PR Introduces a new class method `search_annotations` on the `Account`, `GenericAsset` and `Sensor` classes.

You'll notice I had to refactor a bit to avoid circular imports, and in doing so also found out how to work around circular imports that are solely caused by type annotations.

```
from __future__ import annotations
from typing import TYPE_CHECKING
if TYPE_CHECKING:
    from flexmeasures import DataSource  # or any other circular import of a class that is only used below as a type annotation

def x(a: DataSource):
    pass
```