### PR TITLE
Fetch latest tag

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -26,9 +26,12 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.py_version }}
-      - uses: actions/checkout@v2
-      - run: git fetch --prune --unshallow
-      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - name: Check out src from Git
+        uses: actions/checkout@v2
+      - name: Get history and tags for SCM versioning to work
+        run: |
+          git fetch --prune --unshallow
+          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - run: ci/SETUP.sh
       - run: make test
     env:

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -27,8 +27,11 @@ jobs:
         with:
           python-version: ${{ matrix.py_version }}
       - uses: actions/checkout@v2
-      - run: ci/SETUP.sh
-      - run: make test
+      - run: |
+        git fetch --prune --unshallow
+        git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+        ci/SETUP.sh
+        make test
     env:
       PGHOST: 127.0.0.1
       PGPORT: 5432

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -27,11 +27,10 @@ jobs:
         with:
           python-version: ${{ matrix.py_version }}
       - uses: actions/checkout@v2
-      - run: |
-        git fetch --prune --unshallow
-        git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-        ci/SETUP.sh
-        make test
+      - run: git fetch --prune --unshallow
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - run: ci/SETUP.sh
+      - run: make test
     env:
       PGHOST: 127.0.0.1
       PGPORT: 5432


### PR DESCRIPTION
Instead of
```
Processing dependencies for flexmeasures==0.1.dev1
```
we now get the proper tag from `setuptools_scm`
```
Processing dependencies for flexmeasures==0.9.0.dev18
```
in our GH action logs.