### PR TITLE
Default recording time for posting sensor data

### DIFF
--- a/flexmeasures/api/dev/tests/utils.py
+++ b/flexmeasures/api/dev/tests/utils.py
@@ -14,6 +14,7 @@ def make_sensor_data_request_for_gas_sensor(
         "values": num_values * [-11.28],
         "start": "2021-06-07T00:00:00+02:00",
         "duration": duration,
+        "horizon": "PT0H",
         "unit": unit,
     }
     if num_values == 1:


### PR DESCRIPTION
This PR changes the default recording time for POSTing sensor data, from a zero horizon, to the time at which the data was received. This corresponds to our default for other POST endpoints.

One of the use cases behind this is that it allows users to send some historical data along with new data, to fill up potential data gaps, along with possible measurement corrections, without the trouble of calculating and communicating a horizon or prior field.