### PR TITLE
Issue 374 allow storing the recording time of annotations

### DIFF
--- a/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
+++ b/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
@@ -157,5 +157,5 @@ def create_annotation_table():
     op.create_unique_constraint(
         op.f("annotation_content_key"),
         "annotation",
-        ["content", "start", "source_id", "type"],
+        ["content", "start", "belief_time", "source_id", "type"],
     )

--- a/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
+++ b/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
@@ -142,7 +142,6 @@ def create_annotation_table():
         sa.Column(
             "id", sa.Integer(), nullable=False, autoincrement=True, primary_key=True
         ),
-        sa.Column("content", sa.String(255), nullable=False),
         sa.Column("start", sa.DateTime(timezone=True), nullable=False),
         sa.Column("end", sa.DateTime(timezone=True), nullable=False),
         sa.Column("belief_time", sa.DateTime(timezone=True), nullable=True),
@@ -152,6 +151,7 @@ def create_annotation_table():
             sa.Enum("alert", "holiday", "label", name="annotation_type"),
             nullable=False,
         ),
+        sa.Column("content", sa.String(1024), nullable=False),
         sa.ForeignKeyConstraint(("source_id",), ["data_source.id"]),
     )
     op.create_unique_constraint(

--- a/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
+++ b/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
@@ -145,6 +145,7 @@ def create_annotation_table():
         sa.Column("content", sa.String(255), nullable=False),
         sa.Column("start", sa.DateTime(timezone=True), nullable=False),
         sa.Column("end", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("belief_time", sa.DateTime(timezone=True), nullable=True),
         sa.Column("source_id", sa.Integer(), nullable=False),
         sa.Column(
             "type",

--- a/flexmeasures/data/models/annotations.py
+++ b/flexmeasures/data/models/annotations.py
@@ -30,6 +30,7 @@ class Annotation(db.Model):
         db.UniqueConstraint(
             "content",
             "start",
+            "belief_time",
             "source_id",
             "type",
             name="annotation_content_key",

--- a/flexmeasures/data/models/annotations.py
+++ b/flexmeasures/data/models/annotations.py
@@ -18,6 +18,7 @@ class Annotation(db.Model):
     content = db.Column(db.String(255), nullable=False)
     start = db.Column(db.DateTime(timezone=True), nullable=False)
     end = db.Column(db.DateTime(timezone=True), nullable=False)
+    belief_time = db.Column(db.DateTime(timezone=True), nullable=True)
     source_id = db.Column(db.Integer, db.ForeignKey("data_source.id"))
     source = db.relationship(
         "DataSource",

--- a/flexmeasures/data/models/annotations.py
+++ b/flexmeasures/data/models/annotations.py
@@ -15,7 +15,6 @@ class Annotation(db.Model):
     """
 
     id = db.Column(db.Integer, nullable=False, autoincrement=True, primary_key=True)
-    content = db.Column(db.String(255), nullable=False)
     start = db.Column(db.DateTime(timezone=True), nullable=False)
     end = db.Column(db.DateTime(timezone=True), nullable=False)
     belief_time = db.Column(db.DateTime(timezone=True), nullable=True)
@@ -26,6 +25,7 @@ class Annotation(db.Model):
         backref=db.backref("annotations", lazy=True),
     )
     type = db.Column(db.Enum("alert", "holiday", "label", name="annotation_type"))
+    content = db.Column(db.String(1024), nullable=False)
     __table_args__ = (
         db.UniqueConstraint(
             "content",


### PR DESCRIPTION
This PR prepares the database to support users in adding multiple annotations (such as labels) for the same chain of events.

closes #374