### PR TITLE
Issue 376 facilitate saving feedback annotations

### DIFF
--- a/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
+++ b/flexmeasures/data/migrations/versions/7f8b8920355f_create_annotation_table.py
@@ -148,7 +148,7 @@ def create_annotation_table():
         sa.Column("source_id", sa.Integer(), nullable=False),
         sa.Column(
             "type",
-            sa.Enum("alert", "holiday", "label", name="annotation_type"),
+            sa.Enum("alert", "holiday", "label", "feedback", name="annotation_type"),
             nullable=False,
         ),
         sa.Column("content", sa.String(1024), nullable=False),

--- a/flexmeasures/data/models/annotations.py
+++ b/flexmeasures/data/models/annotations.py
@@ -24,7 +24,9 @@ class Annotation(db.Model):
         foreign_keys=[source_id],
         backref=db.backref("annotations", lazy=True),
     )
-    type = db.Column(db.Enum("alert", "holiday", "label", name="annotation_type"))
+    type = db.Column(
+        db.Enum("alert", "holiday", "label", "feedback", name="annotation_type")
+    )
     content = db.Column(db.String(1024), nullable=False)
     __table_args__ = (
         db.UniqueConstraint(

--- a/flexmeasures/data/models/annotations.py
+++ b/flexmeasures/data/models/annotations.py
@@ -56,7 +56,7 @@ class Annotation(db.Model):
         bulk_save_objects: bool = False,
         commit_transaction: bool = False,
     ) -> List["Annotation"]:
-        """Add a data frame describing annotations as Annotations in the database.
+        """Add a data frame describing annotations to the database and return the Annotation objects.
 
         :param df:                  Data frame describing annotations.
                                     Expects the following columns (or multi-index levels):

--- a/flexmeasures/data/models/annotations.py
+++ b/flexmeasures/data/models/annotations.py
@@ -47,10 +47,10 @@ class Annotation(db.Model):
         return self.end - self.start
 
     @classmethod
-    def save(
-        cls, df: pd.DataFrame, annotation_type: str, commit_session: bool = False
+    def add(
+        cls, df: pd.DataFrame, annotation_type: str, commit_transaction: bool = False
     ) -> List["Annotation"]:
-        """Save a data frame with annotations.
+        """Add a data frame describing annotations as Annotations in the database.
 
         Expects the following columns (or multi-index levels):
         - start
@@ -85,7 +85,7 @@ class Annotation(db.Model):
         ]
         db.session.add_all(annotations)
 
-        if commit_session:
+        if commit_transaction:
             db.session.commit()
 
         return annotations

--- a/flexmeasures/data/models/annotations.py
+++ b/flexmeasures/data/models/annotations.py
@@ -58,13 +58,14 @@ class Annotation(db.Model):
     ) -> List["Annotation"]:
         """Add a data frame describing annotations as Annotations in the database.
 
-        Expects the following columns (or multi-index levels):
-        - start
-        - end or duration
-        - content
-        - belief_time
-        - source
-
+        :param df:                  Data frame describing annotations.
+                                    Expects the following columns (or multi-index levels):
+                                    - start
+                                    - end or duration
+                                    - content
+                                    - belief_time
+                                    - source
+        :param annotation_type:     One of the possible Enum values for annotation.type
         :param expunge_session:     if True, all non-flushed instances are removed from the session before adding annotations.
                                     Expunging can resolve problems you might encounter with states of objects in your session.
                                     When using this option, you might want to flush newly-created objects which are not annotations

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -2,8 +2,8 @@ from datetime import datetime
 from typing import Optional, Tuple, List, Union
 
 from flask_security import current_user
+import pandas as pd
 from sqlalchemy.engine import Row
-
 from sqlalchemy.ext.hybrid import hybrid_method
 from sqlalchemy.sql.expression import func
 from sqlalchemy.ext.mutable import MutableDict
@@ -17,6 +17,7 @@ from flexmeasures.data.models.annotations import (
 from flexmeasures.data.models.data_sources import DataSource
 from flexmeasures.data.models.parsing_utils import parse_source_arg
 from flexmeasures.data.models.user import User
+from flexmeasures.data.queries.annotations import query_asset_annotations
 from flexmeasures.auth.policy import AuthModelMixin, EVERY_LOGGED_IN_USER
 from flexmeasures.utils import geo_utils
 
@@ -83,7 +84,7 @@ class GenericAsset(db.Model, AuthModelMixin):
         }
 
     def __repr__(self):
-        return "<GenericAsset %s:%r (%s)>" % (
+        return "<GenericAsset %s: %r (%s)>" % (
             self.id,
             self.name,
             self.generic_asset_type.name,
@@ -185,31 +186,33 @@ class GenericAsset(db.Model, AuthModelMixin):
         source: Optional[
             Union[DataSource, List[DataSource], int, List[int], str, List[str]]
         ] = None,
+        annotation_type: str = None,
         include_account_annotations: bool = False,
-    ):
+        as_frame: bool = False,
+    ) -> Union[List[Annotation], pd.DataFrame]:
+        """Return annotations assigned to this asset, and optionally, also those assigned to the asset's account."""
         parsed_sources = parse_source_arg(source)
-        query = Annotation.query.join(GenericAssetAnnotationRelationship).filter(
-            GenericAssetAnnotationRelationship.generic_asset_id == self.id,
-            GenericAssetAnnotationRelationship.annotation_id == Annotation.id,
-        )
-        if annotation_starts_after is not None:
-            query = query.filter(
-                Annotation.start >= annotation_starts_after,
-            )
-        if annotation_ends_before is not None:
-            query = query.filter(
-                Annotation.end <= annotation_ends_before,
-            )
-        if parsed_sources:
-            query = query.filter(
-                Annotation.source.in_(parsed_sources),
-            )
-        annotations = query.all()
+        annotations = query_asset_annotations(
+            asset_id=self.id,
+            annotation_starts_after=annotation_starts_after,
+            annotation_ends_before=annotation_ends_before,
+            sources=parsed_sources,
+            annotation_type=annotation_type,
+        ).all()
         if include_account_annotations:
             annotations += self.owner.search_annotations(
                 annotation_starts_before=annotation_starts_after,
                 annotation_ends_before=annotation_ends_before,
                 source=source,
+            )
+
+        if as_frame:
+            return pd.DataFrame(
+                [
+                    [a.start, a.end, a.belief_time, a.source, a.type, a.content]
+                    for a in annotations
+                ],
+                columns=["start", "end", "belief_time", "source", "type", "content"],
             )
         return annotations
 

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -229,6 +229,25 @@ class GenericAsset(db.Model, AuthModelMixin):
             )
         return annotations
 
+    def count_annotations(
+        self,
+        annotation_starts_after: Optional[datetime] = None,
+        annotation_ends_before: Optional[datetime] = None,
+        source: Optional[
+            Union[DataSource, List[DataSource], int, List[int], str, List[str]]
+        ] = None,
+        annotation_type: str = None,
+    ) -> int:
+        """Count the number of annotations assigned to this asset."""
+        parsed_sources = parse_source_arg(source)
+        return query_asset_annotations(
+            asset_id=self.id,
+            annotation_starts_after=annotation_starts_after,
+            annotation_ends_before=annotation_ends_before,
+            sources=parsed_sources,
+            annotation_type=annotation_type,
+        ).count()
+
 
 def create_generic_asset(generic_asset_type: str, **kwargs) -> GenericAsset:
     """Create a GenericAsset and assigns it an id.

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -179,6 +179,19 @@ class GenericAsset(db.Model, AuthModelMixin):
         """True if at least one energy sensor is attached"""
         return any([s.measures_energy for s in self.sensors])
 
+    def save_annotations(
+        self,
+        df: pd.DataFrame,
+        annotation_type: str,
+        commit_session: bool = False,
+    ):
+        """Save a data frame with annotations and assign them to this asset."""
+        annotations = Annotation.save(df, annotation_type=annotation_type)
+        self.annotations += annotations
+        db.session.add(self)
+        if commit_session:
+            db.session.commit()
+
     def search_annotations(
         self,
         annotation_starts_after: Optional[datetime] = None,

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -176,17 +176,17 @@ class GenericAsset(db.Model, AuthModelMixin):
         """True if at least one energy sensor is attached"""
         return any([s.measures_energy for s in self.sensors])
 
-    def save_annotations(
+    def add_annotations(
         self,
         df: pd.DataFrame,
         annotation_type: str,
-        commit_session: bool = False,
+        commit_transaction: bool = False,
     ):
-        """Save a data frame with annotations and assign them to this asset."""
-        annotations = Annotation.save(df, annotation_type=annotation_type)
+        """Add a data frame describing annotations as Annotations in the database, and assign them to this asset."""
+        annotations = Annotation.add(df, annotation_type=annotation_type)
         self.annotations += annotations
         db.session.add(self)
-        if commit_session:
+        if commit_transaction:
             db.session.commit()
 
     def search_annotations(

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -10,10 +10,7 @@ from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.schema import UniqueConstraint
 
 from flexmeasures.data import db
-from flexmeasures.data.models.annotations import (
-    Annotation,
-    GenericAssetAnnotationRelationship,
-)
+from flexmeasures.data.models.annotations import Annotation
 from flexmeasures.data.models.data_sources import DataSource
 from flexmeasures.data.models.parsing_utils import parse_source_arg
 from flexmeasures.data.models.user import User

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -182,7 +182,7 @@ class GenericAsset(db.Model, AuthModelMixin):
         annotation_type: str,
         commit_transaction: bool = False,
     ):
-        """Add a data frame describing annotations as Annotations in the database, and assign them to this asset."""
+        """Add a data frame describing annotations to the database, and assign the annotations to this asset."""
         annotations = Annotation.add(df, annotation_type=annotation_type)
         self.annotations += annotations
         db.session.add(self)

--- a/flexmeasures/data/queries/annotations.py
+++ b/flexmeasures/data/queries/annotations.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+from typing import List, Optional
+
+from sqlalchemy.orm import Query
+
+from flexmeasures.data.models.annotations import (
+    Annotation,
+    GenericAssetAnnotationRelationship,
+)
+from flexmeasures.data.models.data_sources import DataSource
+
+
+def query_asset_annotations(
+    asset_id: int,
+    annotation_starts_after: Optional[datetime],
+    annotation_ends_before: Optional[datetime],
+    sources: List[DataSource],
+    annotation_type: str = None,
+) -> Query:
+    """Match annotations assigned to the given asset."""
+    query = Annotation.query.join(GenericAssetAnnotationRelationship).filter(
+        GenericAssetAnnotationRelationship.generic_asset_id == asset_id,
+        GenericAssetAnnotationRelationship.annotation_id == Annotation.id,
+    )
+    if annotation_starts_after is not None:
+        query = query.filter(
+            Annotation.start >= annotation_starts_after,
+        )
+    if annotation_ends_before is not None:
+        query = query.filter(
+            Annotation.end <= annotation_ends_before,
+        )
+    if sources:
+        query = query.filter(
+            Annotation.source.in_(sources),
+        )
+    if annotation_type is not None:
+        query = query.filter(
+            Annotation.type == annotation_type,
+        )
+    return query

--- a/flexmeasures/data/schemas/__init__.py
+++ b/flexmeasures/data/schemas/__init__.py
@@ -1,2 +1,2 @@
-from .generic_assets import GenericAssetField as AssetField
-from .times import AwareDateTimeField, DurationField
+from .generic_assets import GenericAssetField as AssetField  # noqa F401
+from .times import AwareDateTimeField, DurationField  # noqa F401

--- a/flexmeasures/data/schemas/__init__.py
+++ b/flexmeasures/data/schemas/__init__.py
@@ -1,0 +1,2 @@
+from .generic_assets import GenericAssetField as AssetField
+from .times import AwareDateTimeField, DurationField

--- a/flexmeasures/data/schemas/generic_assets.py
+++ b/flexmeasures/data/schemas/generic_assets.py
@@ -5,6 +5,7 @@ from marshmallow import validates, validates_schema, ValidationError, fields
 from flexmeasures.data import ma
 from flexmeasures.data.models.user import Account
 from flexmeasures.data.models.generic_assets import GenericAsset, GenericAssetType
+from flexmeasures.data.schemas.utils import FMValidationError, MarshmallowClickMixin
 
 
 class GenericAssetSchema(ma.SQLAlchemySchema):
@@ -89,3 +90,18 @@ class GenericAssetTypeSchema(ma.SQLAlchemySchema):
 
     class Meta:
         model = GenericAssetType
+
+
+class GenericAssetField(fields.Int, MarshmallowClickMixin):
+    """Field that deserializes to a GenericAsset and serializes back to an integer."""
+
+    def _deserialize(self, value, attr, obj, **kwargs) -> GenericAsset:
+        """Turn a generic asset id into a GenericAsset."""
+        generic_asset = GenericAsset.query.get(value)
+        if generic_asset is None:
+            raise FMValidationError(f"No asset found with id {value}.")
+        return generic_asset
+
+    def _serialize(self, value, attr, data, **kwargs):
+        """Turn a GenericAsset into a generic asset id."""
+        return value.id


### PR DESCRIPTION
This PR offers better support for saving and counting annotations on the level of generic assets. It also implements a Marshmallow validation field for generic asset ids.

closes #376