### PR TITLE
Naturalized pandas timestamps

### DIFF
--- a/flexmeasures/utils/tests/test_time_utils.py
+++ b/flexmeasures/utils/tests/test_time_utils.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 
+import pandas as pd
 import pytz
 import pytest
 
@@ -11,10 +12,12 @@ from flexmeasures.utils.time_utils import (
 
 
 @pytest.mark.parametrize(
-    "dt_tz,now,server_tz,delta_in_h,exp_result",
+    "dt_tz, now, server_tz, delta_in_h, exp_result",
     # there can be two results depending of today's date, due to humanize.
     # Monekypatching was too hard.
     [
+        (None, pd.Timestamp.utcnow(), "UTC", 3, "3 hours ago"),
+        (None, pd.Timestamp.utcnow().tz_convert("Asia/Seoul"), "UTC", 3, "3 hours ago"),
         (None, datetime.utcnow(), "UTC", 3, "3 hours ago"),
         (
             None,
@@ -61,7 +64,7 @@ def test_naturalized_datetime_str(
 
 
 @pytest.mark.parametrize(
-    "window_size,now,exp_start,exp_end",
+    "window_size, now, exp_start, exp_end",
     [
         (
             5,

--- a/flexmeasures/utils/time_utils.py
+++ b/flexmeasures/utils/time_utils.py
@@ -108,20 +108,20 @@ def naturalized_datetime_str(
 
     # Convert or localize to utc
     if dt.tzinfo is None:
-        dt = pd.Timestamp(dt).tz_localize("utc")
+        utc_dt = pd.Timestamp(dt).tz_localize("utc")
     else:
-        dt = pd.Timestamp(dt).tz_convert("utc")
+        utc_dt = pd.Timestamp(dt).tz_convert("utc")
 
     # decide which humanize call to use for naturalization
-    if naive_utc_from(dt) >= naive_utc_now - timedelta(hours=24):
+    if naive_utc_from(utc_dt) >= naive_utc_now - timedelta(hours=24):
         # return natural time (naive utc dt with respect to naive utc now)
         return naturaltime(
-            dt.replace(tzinfo=None),
+            utc_dt.replace(tzinfo=None),
             when=naive_utc_now,
         )
     else:
         # return natural date in the user's timezone
-        local_dt = dt.tz_convert(get_timezone(of_user=True))
+        local_dt = utc_dt.tz_convert(get_timezone(of_user=True))
         return naturaldate(local_dt)
 
 

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -17,7 +17,6 @@ humanize
 psycopg2-binary
 bcrypt
 pytz
-tzlocal
 numpy
 isodate
 click

--- a/requirements/app.txt
+++ b/requirements/app.txt
@@ -25,8 +25,6 @@ babel==2.9.1
     # via py-moneyed
 backports.zoneinfo==0.2.1
     # via
-    #   pytz-deprecation-shim
-    #   tzlocal
     #   workalendar
 bcrypt==3.2.0
     # via -r requirements/app.in
@@ -318,8 +316,6 @@ pytz==2021.3
     #   pvlib
     #   timely-beliefs
     #   timetomodel
-pytz-deprecation-shim==0.1.0.post0
-    # via tzlocal
 pyyaml==6.0
     # via bokeh
 redis==4.1.3
@@ -409,10 +405,6 @@ trio-websocket==0.9.2
     # via selenium
 typing-extensions==4.1.1
     # via py-moneyed
-tzdata==2021.5
-    # via pytz-deprecation-shim
-tzlocal==4.1
-    # via -r requirements/app.in
 urllib3[secure]==1.26.8
     # via
     #   requests


### PR DESCRIPTION
I ran into the need to naturalize a `pd.Timestamp` in a plugin. Instead of calling `to_pydatetime()` on it, I took the opportunity to improve our naturalization util function. This happened to lead to 3 less dependencies.

@nhoening, could you please run a `pip-compile --output-file=requirements/app.txt requirements/app.in` on Python 3.8 to be sure? When I run it for 3.9, it's telling me we can rid of `backports.zoneinfo` and `importlib-resources`, too, but that doesn't seem to be related to this PR (I get told the same when I run `pip-compile` against `main`).