### PR TITLE
CLI commands to edit asset/sensor attributes

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -17,6 +17,7 @@ New features
 
 * Add CLI command for attaching annotations to assets: ``flexmeasures add holidays`` adds public holidays [see `PR #343 <http://www.github.com/FlexMeasures/flexmeasures/pull/343>`_]
 * Add CLI command for resampling existing sensor data to new resolution [see `PR #360 <http://www.github.com/FlexMeasures/flexmeasures/pull/360>`_]
+* Add CLI command to edit/add an attribute on an asset or sensor. [see `PR #380 <http://www.github.com/FlexMeasures/flexmeasures/pull/380>`_]
 * Add CLI command to add a toy account for tutorials and trying things [see `PR #368 <http://www.github.com/FlexMeasures/flexmeasures/pull/368>`_].
 * Support for percent (%) and permille (‰) sensor units [see `PR #359 <http://www.github.com/FlexMeasures/flexmeasures/pull/359>`_]
 

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -9,6 +9,7 @@ since v0.9.0 | January 26, 2022
 
 * Add CLI commands for showing data ``flexmeasures show accounts``, ``flexmeasures show account``, ``flexmeasures show roles``, ``flexmeasures show asset-types``, ``flexmeasures show asset`` and ``flexmeasures show data-sources``.
 * Add ``flexmeasures edit resample-data`` CLI command to resample sensor data to a different resolution.
+* Add ``flexmeasures edit attribute`` CLI command to edit/add an attribute on an asset or sensor.
 * Add ``flexmeasures add toy-account`` for tutorials and trying things.
 * Rename ``flexmeasures add structure`` to ``flexmeasures add initial-structure``. 
 

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -8,7 +8,7 @@ since v0.9.0 | January 26, 2022
 =====================
 
 * Add CLI commands for showing data ``flexmeasures show accounts``, ``flexmeasures show account``, ``flexmeasures show roles``, ``flexmeasures show asset-types``, ``flexmeasures show asset`` and ``flexmeasures show data-sources``.
-* Add ``flexmeasures db-ops resample-data`` CLI command to resample sensor data to a different resolution.
+* Add ``flexmeasures edit resample-data`` CLI command to resample sensor data to a different resolution.
 * Add ``flexmeasures add toy-account`` for tutorials and trying things.
 * Rename ``flexmeasures add structure`` to ``flexmeasures add initial-structure``. 
 

--- a/flexmeasures/cli/__init__.py
+++ b/flexmeasures/cli/__init__.py
@@ -8,6 +8,7 @@ def register_at(app: Flask):
             import flexmeasures.cli.jobs
             import flexmeasures.cli.monitor
             import flexmeasures.cli.data_add
+            import flexmeasures.cli.data_edit
             import flexmeasures.cli.data_show
             import flexmeasures.cli.data_delete
             import flexmeasures.cli.db_ops

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -179,7 +179,7 @@ def new_user(
     required=False,
     type=str,
     default="{}",
-    help='Additional attributes. Passed as JSON string, should be a dict. Hint: Currently, for sensors that measures power, use {"capacity_in_mw": 10} to set a capacity of 10 MW',
+    help='Additional attributes. Passed as JSON string, should be a dict. Hint: Currently, for sensors that measure power, use {"capacity_in_mw": 10} to set a capacity of 10 MW',
 )
 def add_sensor(**args):
     """Add a sensor."""

--- a/flexmeasures/cli/data_edit.py
+++ b/flexmeasures/cli/data_edit.py
@@ -1,0 +1,134 @@
+from typing import Union
+
+import click
+from flask import current_app as app
+from flask.cli import with_appcontext
+
+from flexmeasures import Sensor
+from flexmeasures.data import db
+from flexmeasures.data.models.generic_assets import GenericAsset
+
+
+@click.group("edit")
+def fm_edit_data():
+    """FlexMeasures: Edit data."""
+
+
+@fm_edit_data.command("asset-attribute")
+@with_appcontext
+@click.option(
+    "--asset-id",
+    "generic_asset_id",
+    required=True,
+    help="Add/edit attribute to this asset. Follow up with the asset's ID.",
+)
+@click.option(
+    "--attribute",
+    "attribute_key",
+    required=True,
+    help="Add/edit this attribute. Follow up with the name of the asset attribute.",
+)
+@click.option(
+    "--value",
+    "attribute_value",
+    required=True,
+    help="Set the asset attribute to this float value. Use --type to set a type other than a float. Use 'None' to set a null value.",
+)
+@click.option(
+    "--type",
+    "attribute_value_type",
+    required=False,
+    default="float",
+    type=click.Choice(["bool", "str", "int", "float"]),
+    help="Parse the asset attribute value as this type.",
+)
+def edit_asset_attribute(
+    generic_asset_id: int,
+    attribute_key: str,
+    attribute_value: Union[bool, str, int, float, None],
+    attribute_value_type: str,
+):
+    """Edit (or add) an asset attribute."""
+
+    # Parse attribute value
+    attribute_value = parse_attribute_value(
+        attribute_value=attribute_value,
+        attribute_value_type=attribute_value_type,
+    )
+
+    # Set attribute
+    asset = GenericAsset.query.get(generic_asset_id)
+    asset.attributes[attribute_key] = attribute_value
+    db.session.add(asset)
+    db.session.commit()
+
+
+@fm_edit_data.command("sensor-attribute")
+@with_appcontext
+@click.option(
+    "--sensor-id",
+    "sensor_id",
+    required=True,
+    help="Add/edit attribute to this sensor. Follow up with the sensor's ID.",
+)
+@click.option(
+    "--attribute",
+    "attribute_key",
+    required=True,
+    help="Add/edit this attribute. Follow up with the name of the sensor attribute.",
+)
+@click.option(
+    "--value",
+    "attribute_value",
+    required=True,
+    help="Set the sensor attribute to this float value. Use --type to set a type other than a float. Use 'None' to set a null value.",
+)
+@click.option(
+    "--type",
+    "attribute_value_type",
+    required=False,
+    default="float",
+    type=click.Choice(["bool", "str", "int", "float"]),
+    help="Parse the asset attribute value as this type.",
+)
+def edit_sensor_attribute(
+    sensor_id: int,
+    attribute_key: str,
+    attribute_value: Union[bool, str, int, float, None],
+    attribute_value_type: str,
+):
+    """Edit (or add) a sensor attribute."""
+
+    # Parse attribute value
+    attribute_value = parse_attribute_value(
+        attribute_value=attribute_value,
+        attribute_value_type=attribute_value_type,
+    )
+
+    # Set attribute
+    sensor = Sensor.query.get(sensor_id)
+    sensor.attributes[attribute_key] = attribute_value
+    db.session.add(sensor)
+    db.session.commit()
+
+
+app.cli.add_command(fm_edit_data)
+
+
+def parse_attribute_value(
+    attribute_value: str, attribute_value_type: str
+) -> Union[float, int, bool, str, None]:
+    """Parse attribute value."""
+    if attribute_value == "None":
+        attribute_value = None
+    elif attribute_value_type == "float":
+        attribute_value = float(attribute_value)
+    elif attribute_value_type == "int":
+        attribute_value = int(attribute_value)
+    elif attribute_value_type == "bool":
+        attribute_value = bool(attribute_value)
+    elif attribute_value_type == "str":
+        pass
+    else:
+        raise ValueError(f"Unrecognized --type '{attribute_value_type}'.")
+    return attribute_value

--- a/flexmeasures/cli/data_edit.py
+++ b/flexmeasures/cli/data_edit.py
@@ -8,8 +8,8 @@ from flask.cli import with_appcontext
 
 from flexmeasures import Sensor
 from flexmeasures.data import db
-from flexmeasures.data.schemas.generic_assets import GenericAssetField
-from flexmeasures.data.schemas.sensors import SensorField
+from flexmeasures.data.schemas.generic_assets import GenericAssetIdField
+from flexmeasures.data.schemas.sensors import SensorIdField
 from flexmeasures.data.models.generic_assets import GenericAsset
 from flexmeasures.data.models.time_series import TimedBelief
 from flexmeasures.data.utils import save_to_db
@@ -27,7 +27,7 @@ def fm_edit_data():
     "assets",
     required=False,
     multiple=True,
-    type=GenericAssetField(),
+    type=GenericAssetIdField(),
     help="Add/edit attribute to this asset. Follow up with the asset's ID.",
 )
 @click.option(
@@ -35,7 +35,7 @@ def fm_edit_data():
     "sensors",
     required=False,
     multiple=True,
-    type=SensorField(),
+    type=SensorIdField(),
     help="Add/edit attribute to this sensor. Follow up with the sensor's ID.",
 )
 @click.option(

--- a/flexmeasures/cli/data_edit.py
+++ b/flexmeasures/cli/data_edit.py
@@ -36,31 +36,59 @@ def fm_edit_data():
     help="Add/edit this attribute. Follow up with the name of the asset attribute.",
 )
 @click.option(
-    "--value",
-    "attribute_value",
-    required=True,
-    help="Set the asset attribute to this float value. Use --type to set a type other than a float. Use 'None' to set a null value.",
+    "--float",
+    "attribute_float_value",
+    required=False,
+    type=float,
+    help="Set the asset attribute to this float value.",
 )
 @click.option(
-    "--type",
-    "attribute_value_type",
+    "--bool",
+    "attribute_bool_value",
     required=False,
-    default="float",
-    type=click.Choice(["bool", "str", "int", "float"]),
-    help="Parse the asset attribute value as this type.",
+    type=bool,
+    help="Set the asset attribute to this bool value.",
+)
+@click.option(
+    "--str",
+    "attribute_str_value",
+    required=False,
+    type=str,
+    help="Set the asset attribute to this string value.",
+)
+@click.option(
+    "--int",
+    "attribute_int_value",
+    required=False,
+    type=int,
+    help="Set the asset attribute to this integer value.",
+)
+@click.option(
+    "--null",
+    "attribute_null_value",
+    required=False,
+    is_flag=True,
+    default=False,
+    help="Set the asset attribute to a null value.",
 )
 def edit_asset_attribute(
     asset: GenericAsset,
     attribute_key: str,
-    attribute_value: Union[bool, str, int, float, None],
-    attribute_value_type: str,
+    attribute_float_value: float,
+    attribute_bool_value: bool,
+    attribute_str_value: str,
+    attribute_int_value: int,
+    attribute_null_value: bool,
 ):
     """Edit (or add) an asset attribute."""
 
     # Parse attribute value
     attribute_value = parse_attribute_value(
-        attribute_value=attribute_value,
-        attribute_value_type=attribute_value_type,
+        attribute_float_value=attribute_float_value,
+        attribute_bool_value=attribute_bool_value,
+        attribute_str_value=attribute_str_value,
+        attribute_int_value=attribute_int_value,
+        attribute_null_value=attribute_null_value,
     )
 
     # Set attribute
@@ -85,31 +113,59 @@ def edit_asset_attribute(
     help="Add/edit this attribute. Follow up with the name of the sensor attribute.",
 )
 @click.option(
-    "--value",
-    "attribute_value",
-    required=True,
-    help="Set the sensor attribute to this float value. Use --type to set a type other than a float. Use 'None' to set a null value.",
+    "--float",
+    "attribute_float_value",
+    required=False,
+    type=float,
+    help="Set the sensor attribute to this float value.",
 )
 @click.option(
-    "--type",
-    "attribute_value_type",
+    "--bool",
+    "attribute_bool_value",
     required=False,
-    default="float",
-    type=click.Choice(["bool", "str", "int", "float"]),
-    help="Parse the asset attribute value as this type.",
+    type=bool,
+    help="Set the sensor attribute to this bool value.",
+)
+@click.option(
+    "--str",
+    "attribute_str_value",
+    required=False,
+    type=str,
+    help="Set the sensor attribute to this string value.",
+)
+@click.option(
+    "--int",
+    "attribute_int_value",
+    required=False,
+    type=int,
+    help="Set the sensor attribute to this integer value.",
+)
+@click.option(
+    "--null",
+    "attribute_null_value",
+    required=False,
+    is_flag=True,
+    default=False,
+    help="Set the sensor attribute to a null value.",
 )
 def edit_sensor_attribute(
     sensor: Sensor,
     attribute_key: str,
-    attribute_value: Union[bool, str, int, float, None],
-    attribute_value_type: str,
+    attribute_float_value: float,
+    attribute_bool_value: bool,
+    attribute_str_value: str,
+    attribute_int_value: int,
+    attribute_null_value: bool,
 ):
     """Edit (or add) a sensor attribute."""
 
     # Parse attribute value
     attribute_value = parse_attribute_value(
-        attribute_value=attribute_value,
-        attribute_value_type=attribute_value_type,
+        attribute_float_value=attribute_float_value,
+        attribute_bool_value=attribute_bool_value,
+        attribute_str_value=attribute_str_value,
+        attribute_int_value=attribute_int_value,
+        attribute_null_value=attribute_null_value,
     )
 
     # Set attribute
@@ -209,19 +265,37 @@ app.cli.add_command(fm_edit_data)
 
 
 def parse_attribute_value(
-    attribute_value: str, attribute_value_type: str
+    attribute_null_value: bool,
+    attribute_float_value: Optional[float] = None,
+    attribute_bool_value: Optional[bool] = None,
+    attribute_str_value: Optional[str] = None,
+    attribute_int_value: Optional[int] = None,
 ) -> Union[float, int, bool, str, None]:
     """Parse attribute value."""
-    if attribute_value == "None":
-        attribute_value = None
-    elif attribute_value_type == "float":
-        attribute_value = float(attribute_value)
-    elif attribute_value_type == "int":
-        attribute_value = int(attribute_value)
-    elif attribute_value_type == "bool":
-        attribute_value = bool(attribute_value)
-    elif attribute_value_type == "str":
-        pass
-    else:
-        raise ValueError(f"Unrecognized --type '{attribute_value_type}'.")
-    return attribute_value
+    if not single_true(
+        [attribute_null_value]
+        + [
+            v is not None
+            for v in [
+                attribute_float_value,
+                attribute_bool_value,
+                attribute_str_value,
+                attribute_int_value,
+            ]
+        ]
+    ):
+        raise ValueError("Cannot set multiple values simultaneously.")
+    if attribute_null_value:
+        return None
+    elif attribute_float_value is not None:
+        return float(attribute_float_value)
+    elif attribute_bool_value is not None:
+        return bool(attribute_bool_value)
+    elif attribute_int_value is not None:
+        return int(attribute_int_value)
+    return attribute_str_value
+
+
+def single_true(iterable):
+    i = iter(iterable)
+    return any(i) and not any(i)

--- a/flexmeasures/cli/data_edit.py
+++ b/flexmeasures/cli/data_edit.py
@@ -80,7 +80,7 @@ def fm_edit_data():
     default=False,
     help="Set the attribute to a null value.",
 )
-def edit_asset_attribute(
+def edit_attribute(
     attribute_key: str,
     assets: List[GenericAsset],
     sensors: List[Sensor],

--- a/flexmeasures/cli/data_edit.py
+++ b/flexmeasures/cli/data_edit.py
@@ -20,89 +20,19 @@ def fm_edit_data():
     """FlexMeasures: Edit data."""
 
 
-@fm_edit_data.command("asset-attribute")
+@fm_edit_data.command("attribute")
 @with_appcontext
 @click.option(
     "--asset-id",
     "asset",
-    required=True,
+    required=False,
     type=GenericAssetField(),
     help="Add/edit attribute to this asset. Follow up with the asset's ID.",
 )
 @click.option(
-    "--attribute",
-    "attribute_key",
-    required=True,
-    help="Add/edit this attribute. Follow up with the name of the asset attribute.",
-)
-@click.option(
-    "--float",
-    "attribute_float_value",
-    required=False,
-    type=float,
-    help="Set the asset attribute to this float value.",
-)
-@click.option(
-    "--bool",
-    "attribute_bool_value",
-    required=False,
-    type=bool,
-    help="Set the asset attribute to this bool value.",
-)
-@click.option(
-    "--str",
-    "attribute_str_value",
-    required=False,
-    type=str,
-    help="Set the asset attribute to this string value.",
-)
-@click.option(
-    "--int",
-    "attribute_int_value",
-    required=False,
-    type=int,
-    help="Set the asset attribute to this integer value.",
-)
-@click.option(
-    "--null",
-    "attribute_null_value",
-    required=False,
-    is_flag=True,
-    default=False,
-    help="Set the asset attribute to a null value.",
-)
-def edit_asset_attribute(
-    asset: GenericAsset,
-    attribute_key: str,
-    attribute_float_value: float,
-    attribute_bool_value: bool,
-    attribute_str_value: str,
-    attribute_int_value: int,
-    attribute_null_value: bool,
-):
-    """Edit (or add) an asset attribute."""
-
-    # Parse attribute value
-    attribute_value = parse_attribute_value(
-        attribute_float_value=attribute_float_value,
-        attribute_bool_value=attribute_bool_value,
-        attribute_str_value=attribute_str_value,
-        attribute_int_value=attribute_int_value,
-        attribute_null_value=attribute_null_value,
-    )
-
-    # Set attribute
-    asset.attributes[attribute_key] = attribute_value
-    db.session.add(asset)
-    db.session.commit()
-
-
-@fm_edit_data.command("sensor-attribute")
-@with_appcontext
-@click.option(
     "--sensor-id",
     "sensor",
-    required=True,
+    required=False,
     type=SensorField(),
     help="Add/edit attribute to this sensor. Follow up with the sensor's ID.",
 )
@@ -110,35 +40,35 @@ def edit_asset_attribute(
     "--attribute",
     "attribute_key",
     required=True,
-    help="Add/edit this attribute. Follow up with the name of the sensor attribute.",
+    help="Add/edit this attribute. Follow up with the name of the attribute.",
 )
 @click.option(
     "--float",
     "attribute_float_value",
     required=False,
     type=float,
-    help="Set the sensor attribute to this float value.",
+    help="Set the attribute to this float value.",
 )
 @click.option(
     "--bool",
     "attribute_bool_value",
     required=False,
     type=bool,
-    help="Set the sensor attribute to this bool value.",
+    help="Set the attribute to this bool value.",
 )
 @click.option(
     "--str",
     "attribute_str_value",
     required=False,
     type=str,
-    help="Set the sensor attribute to this string value.",
+    help="Set the attribute to this string value.",
 )
 @click.option(
     "--int",
     "attribute_int_value",
     required=False,
     type=int,
-    help="Set the sensor attribute to this integer value.",
+    help="Set the attribute to this integer value.",
 )
 @click.option(
     "--null",
@@ -146,18 +76,22 @@ def edit_asset_attribute(
     required=False,
     is_flag=True,
     default=False,
-    help="Set the sensor attribute to a null value.",
+    help="Set the attribute to a null value.",
 )
-def edit_sensor_attribute(
-    sensor: Sensor,
+def edit_asset_attribute(
     attribute_key: str,
-    attribute_float_value: float,
-    attribute_bool_value: bool,
-    attribute_str_value: str,
-    attribute_int_value: int,
     attribute_null_value: bool,
+    asset: Optional[GenericAsset] = None,
+    sensor: Optional[Sensor] = None,
+    attribute_float_value: Optional[float] = None,
+    attribute_bool_value: Optional[bool] = None,
+    attribute_str_value: Optional[str] = None,
+    attribute_int_value: Optional[int] = None,
 ):
-    """Edit (or add) a sensor attribute."""
+    """Edit (or add) an asset attribute or sensor attribute."""
+
+    if asset is None and sensor is None:
+        raise ValueError("Missing flag: pass an --asset-id or --sensor-id.")
 
     # Parse attribute value
     attribute_value = parse_attribute_value(
@@ -169,8 +103,12 @@ def edit_sensor_attribute(
     )
 
     # Set attribute
-    sensor.attributes[attribute_key] = attribute_value
-    db.session.add(sensor)
+    if asset is not None:
+        asset.attributes[attribute_key] = attribute_value
+        db.session.add(asset)
+    if sensor is not None:
+        sensor.attributes[attribute_key] = attribute_value
+        db.session.add(sensor)
     db.session.commit()
 
 

--- a/flexmeasures/cli/data_edit.py
+++ b/flexmeasures/cli/data_edit.py
@@ -24,15 +24,17 @@ def fm_edit_data():
 @with_appcontext
 @click.option(
     "--asset-id",
-    "asset",
+    "assets",
     required=False,
+    multiple=True,
     type=GenericAssetField(),
     help="Add/edit attribute to this asset. Follow up with the asset's ID.",
 )
 @click.option(
     "--sensor-id",
-    "sensor",
+    "sensors",
     required=False,
+    multiple=True,
     type=SensorField(),
     help="Add/edit attribute to this sensor. Follow up with the sensor's ID.",
 )
@@ -80,9 +82,9 @@ def fm_edit_data():
 )
 def edit_asset_attribute(
     attribute_key: str,
+    assets: List[GenericAsset],
+    sensors: List[Sensor],
     attribute_null_value: bool,
-    asset: Optional[GenericAsset] = None,
-    sensor: Optional[Sensor] = None,
     attribute_float_value: Optional[float] = None,
     attribute_bool_value: Optional[bool] = None,
     attribute_str_value: Optional[str] = None,
@@ -90,8 +92,8 @@ def edit_asset_attribute(
 ):
     """Edit (or add) an asset attribute or sensor attribute."""
 
-    if asset is None and sensor is None:
-        raise ValueError("Missing flag: pass an --asset-id or --sensor-id.")
+    if not assets and not sensors:
+        raise ValueError("Missing flag: pass at least one --asset-id or --sensor-id.")
 
     # Parse attribute value
     attribute_value = parse_attribute_value(
@@ -103,10 +105,10 @@ def edit_asset_attribute(
     )
 
     # Set attribute
-    if asset is not None:
+    for asset in assets:
         asset.attributes[attribute_key] = attribute_value
         db.session.add(asset)
-    if sensor is not None:
+    for sensor in sensors:
         sensor.attributes[attribute_key] = attribute_value
         db.session.add(sensor)
     db.session.commit()
@@ -234,6 +236,6 @@ def parse_attribute_value(
     return attribute_str_value
 
 
-def single_true(iterable):
+def single_true(iterable) -> bool:
     i = iter(iterable)
     return any(i) and not any(i)

--- a/flexmeasures/cli/data_edit.py
+++ b/flexmeasures/cli/data_edit.py
@@ -112,6 +112,7 @@ def edit_attribute(
         sensor.attributes[attribute_key] = attribute_value
         db.session.add(sensor)
     db.session.commit()
+    print("Successfully edited/added attribute.")
 
 
 @fm_edit_data.command("resample-data")

--- a/flexmeasures/cli/data_edit.py
+++ b/flexmeasures/cli/data_edit.py
@@ -8,6 +8,7 @@ from flask.cli import with_appcontext
 
 from flexmeasures import Sensor
 from flexmeasures.data import db
+from flexmeasures.data.schemas.generic_assets import GenericAssetField
 from flexmeasures.data.models.generic_assets import GenericAsset
 from flexmeasures.data.models.time_series import TimedBelief
 from flexmeasures.data.utils import save_to_db
@@ -22,8 +23,9 @@ def fm_edit_data():
 @with_appcontext
 @click.option(
     "--asset-id",
-    "generic_asset_id",
+    "asset",
     required=True,
+    type=GenericAssetField(),
     help="Add/edit attribute to this asset. Follow up with the asset's ID.",
 )
 @click.option(
@@ -47,7 +49,7 @@ def fm_edit_data():
     help="Parse the asset attribute value as this type.",
 )
 def edit_asset_attribute(
-    generic_asset_id: int,
+    asset: GenericAsset,
     attribute_key: str,
     attribute_value: Union[bool, str, int, float, None],
     attribute_value_type: str,
@@ -61,7 +63,6 @@ def edit_asset_attribute(
     )
 
     # Set attribute
-    asset = GenericAsset.query.get(generic_asset_id)
     asset.attributes[attribute_key] = attribute_value
     db.session.add(asset)
     db.session.commit()
@@ -70,7 +71,7 @@ def edit_asset_attribute(
 @fm_edit_data.command("sensor-attribute")
 @with_appcontext
 @click.option(
-    "--sensor-id",
+    "--sensor-id",  # todo: use SensorField
     "sensor_id",
     required=True,
     help="Add/edit attribute to this sensor. Follow up with the sensor's ID.",

--- a/flexmeasures/cli/data_edit.py
+++ b/flexmeasures/cli/data_edit.py
@@ -9,6 +9,7 @@ from flask.cli import with_appcontext
 from flexmeasures import Sensor
 from flexmeasures.data import db
 from flexmeasures.data.schemas.generic_assets import GenericAssetField
+from flexmeasures.data.schemas.sensors import SensorField
 from flexmeasures.data.models.generic_assets import GenericAsset
 from flexmeasures.data.models.time_series import TimedBelief
 from flexmeasures.data.utils import save_to_db
@@ -71,9 +72,10 @@ def edit_asset_attribute(
 @fm_edit_data.command("sensor-attribute")
 @with_appcontext
 @click.option(
-    "--sensor-id",  # todo: use SensorField
-    "sensor_id",
+    "--sensor-id",
+    "sensor",
     required=True,
+    type=SensorField(),
     help="Add/edit attribute to this sensor. Follow up with the sensor's ID.",
 )
 @click.option(
@@ -97,7 +99,7 @@ def edit_asset_attribute(
     help="Parse the asset attribute value as this type.",
 )
 def edit_sensor_attribute(
-    sensor_id: int,
+    sensor: Sensor,
     attribute_key: str,
     attribute_value: Union[bool, str, int, float, None],
     attribute_value_type: str,
@@ -111,7 +113,6 @@ def edit_sensor_attribute(
     )
 
     # Set attribute
-    sensor = Sensor.query.get(sensor_id)
     sensor.attributes[attribute_key] = attribute_value
     db.session.add(sensor)
     db.session.commit()

--- a/flexmeasures/cli/db_ops.py
+++ b/flexmeasures/cli/db_ops.py
@@ -1,19 +1,12 @@
 """CLI Tasks for saving, resetting, etc of the database"""
 
-from datetime import datetime, timedelta
+from datetime import datetime
 import subprocess
-from typing import List, Optional
 
 from flask import current_app as app
 from flask.cli import with_appcontext
 import flask_migrate as migrate
 import click
-import pandas as pd
-
-from flexmeasures.data import db
-from flexmeasures.data.models.time_series import Sensor, TimedBelief
-from flexmeasures.data.utils import save_to_db
-
 
 BACKUP_PATH: str = app.config.get("FLEXMEASURES_DB_BACKUP_PATH")  # type: ignore
 
@@ -141,93 +134,6 @@ def restore(file: str):
     except Exception as e:
         click.echo(f"Exception happened during restore: {e}")
         click.echo("db restore unsuccessful")
-
-
-@fm_db_ops.command("resample-data")
-@with_appcontext
-@click.option(
-    "--sensor-id",
-    "sensor_ids",
-    multiple=True,
-    required=True,
-    help="Resample data for this sensor. Follow up with the sensor's ID. This argument can be given multiple times.",
-)
-@click.option(
-    "--event-resolution",
-    "event_resolution_in_minutes",
-    type=int,
-    required=True,
-    help="New event resolution as an integer number of minutes.",
-)
-@click.option(
-    "--from",
-    "start_str",
-    required=False,
-    help="Resample only data from this datetime onwards. Follow up with a timezone-aware datetime in ISO 6801 format.",
-)
-@click.option(
-    "--until",
-    "end_str",
-    required=False,
-    help="Resample only data until this datetime. Follow up with a timezone-aware datetime in ISO 6801 format.",
-)
-@click.option(
-    "--skip-integrity-check",
-    is_flag=True,
-    help="Whether to skip checking the resampled time series data for each sensor."
-    " By default, an excerpt and the mean value of the original"
-    " and resampled data will be shown for manual approval.",
-)
-def resample_sensor_data(
-    sensor_ids: List[int],
-    event_resolution_in_minutes: int,
-    start_str: Optional[str] = None,
-    end_str: Optional[str] = None,
-    skip_integrity_check: bool = False,
-):
-    """Assign a new event resolution to an existing sensor and resample its data accordingly."""
-    event_resolution = timedelta(minutes=event_resolution_in_minutes)
-    event_starts_after = pd.Timestamp(start_str)  # note that "" or None becomes NaT
-    event_ends_before = pd.Timestamp(end_str)
-    for sensor_id in sensor_ids:
-        sensor = Sensor.query.get(sensor_id)
-        if sensor.event_resolution == event_resolution:
-            print(f"{sensor} already has the desired event resolution.")
-            continue
-        df_original = sensor.search_beliefs(
-            most_recent_beliefs_only=False,
-            event_starts_after=event_starts_after,
-            event_ends_before=event_ends_before,
-        ).sort_values("event_start")
-        df_resampled = df_original.resample_events(event_resolution).sort_values(
-            "event_start"
-        )
-        if not skip_integrity_check:
-            message = ""
-            if sensor.event_resolution < event_resolution:
-                message += f"Downsampling {sensor} to {event_resolution} will result in a loss of data. "
-            click.confirm(
-                message
-                + f"Data before:\n{df_original}\nData after:\n{df_resampled}\nMean before: {df_original['event_value'].mean()}\nMean after: {df_resampled['event_value'].mean()}\nContinue?",
-                abort=True,
-            )
-
-        # Update sensor
-        sensor.event_resolution = event_resolution
-        db.session.add(sensor)
-
-        # Update sensor data
-        query = TimedBelief.query.filter(TimedBelief.sensor == sensor)
-        if not pd.isnull(event_starts_after):
-            query = query.filter(TimedBelief.event_start >= event_starts_after)
-        if not pd.isnull(event_ends_before):
-            query = query.filter(
-                TimedBelief.event_start + sensor.event_resolution <= event_ends_before
-            )
-        query.delete()
-        save_to_db(df_resampled, bulk_save_objects=True)
-    db.session.commit()
-    print("Successfully resampled sensor data.")
 
 
 app.cli.add_command(fm_db_ops)

--- a/flexmeasures/cli/tests/test_data_edit.py
+++ b/flexmeasures/cli/tests/test_data_edit.py
@@ -7,6 +7,30 @@ from flexmeasures.cli.tests.utils import to_flags
 from flexmeasures.data.models.time_series import Sensor, TimedBelief
 
 
+@pytest.mark.skip
+def test_add_one_sensor_attribute(app, db, setup_markets):
+    from flexmeasures.cli.data_edit import edit_attribute
+
+    # Load sensor from database and count attributes
+    sensor = Sensor.query.filter(Sensor.name == "epex_da").one_or_none()
+    n_attributes_before = len(sensor.attributes)
+
+    cli_input = {
+        "sensor-id": sensor.id,
+        "attribute": "some new attribute",
+        "float": 3,
+    }
+    runner = app.test_cli_runner()
+    result = runner.invoke(edit_attribute, to_flags(cli_input))
+    assert result.exit_code == 0 and "Success" in result.output, result.exception
+
+    # Reload sensor from database and count attributes
+    sensor = Sensor.query.filter(Sensor.name == "epex_da").one_or_none()
+    n_attributes_after = len(sensor.attributes)
+
+    assert n_attributes_after == n_attributes_before + 1
+
+
 @pytest.mark.skip_github
 @pytest.mark.parametrize(
     "event_starts_after, event_ends_before",

--- a/flexmeasures/cli/tests/test_data_edit.py
+++ b/flexmeasures/cli/tests/test_data_edit.py
@@ -20,7 +20,7 @@ def test_resample_sensor_data(
 ):
     """Check resampling market data from hourly to 30 minute resolution and back."""
 
-    from flexmeasures.cli.db_ops import resample_sensor_data
+    from flexmeasures.cli.data_edit import resample_sensor_data
 
     sensor = Sensor.query.filter(Sensor.name == "epex_da").one_or_none()
     event_starts_after = pd.Timestamp(event_starts_after)

--- a/flexmeasures/data/schemas/generic_assets.py
+++ b/flexmeasures/data/schemas/generic_assets.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from flask.cli import with_appcontext
 from marshmallow import validates, validates_schema, ValidationError, fields
 
 from flexmeasures.data import ma
@@ -95,6 +96,7 @@ class GenericAssetTypeSchema(ma.SQLAlchemySchema):
 class GenericAssetField(fields.Int, MarshmallowClickMixin):
     """Field that deserializes to a GenericAsset and serializes back to an integer."""
 
+    @with_appcontext
     def _deserialize(self, value, attr, obj, **kwargs) -> GenericAsset:
         """Turn a generic asset id into a GenericAsset."""
         generic_asset = GenericAsset.query.get(value)

--- a/flexmeasures/data/schemas/generic_assets.py
+++ b/flexmeasures/data/schemas/generic_assets.py
@@ -93,7 +93,7 @@ class GenericAssetTypeSchema(ma.SQLAlchemySchema):
         model = GenericAssetType
 
 
-class GenericAssetField(fields.Int, MarshmallowClickMixin):
+class GenericAssetIdField(fields.Int, MarshmallowClickMixin):
     """Field that deserializes to a GenericAsset and serializes back to an integer."""
 
     @with_appcontext

--- a/flexmeasures/data/schemas/generic_assets.py
+++ b/flexmeasures/data/schemas/generic_assets.py
@@ -5,6 +5,7 @@ from marshmallow import validates, validates_schema, ValidationError, fields
 from flexmeasures.data import ma
 from flexmeasures.data.models.user import Account
 from flexmeasures.data.models.generic_assets import GenericAsset, GenericAssetType
+from flexmeasures.data.schemas.utils import FMValidationError, MarshmallowClickMixin
 
 
 class GenericAssetSchema(ma.SQLAlchemySchema):
@@ -89,3 +90,18 @@ class GenericAssetTypeSchema(ma.SQLAlchemySchema):
 
     class Meta:
         model = GenericAssetType
+
+
+class GenericAssetField(fields.Int, MarshmallowClickMixin):
+    """Field that deserializes to a GenericAsset and serializes back to an integer."""
+
+    def _deserialize(self, value, attr, obj, **kwargs) -> GenericAsset:
+        """Turn a generic asset id into a GenericAsset."""
+        generic_asset = GenericAsset.query.get(value)
+        if generic_asset is None:
+            raise FMValidationError(f"No asset found with id {value}.")
+        return generic_asset
+
+    def _serialize(self, value, attr, data, **kwargs):
+        """Turn a GenericAsset into a generic asset id."""
+        return value.id

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -52,7 +52,7 @@ class SensorSchema(SensorSchemaMixin, ma.SQLAlchemySchema):
         model = Sensor
 
 
-class SensorField(fields.Int, MarshmallowClickMixin):
+class SensorIdField(fields.Int, MarshmallowClickMixin):
     """Field that deserializes to a Sensor and serializes back to an integer."""
 
     @with_appcontext

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -1,8 +1,10 @@
+from flask.cli import with_appcontext
 from marshmallow import Schema, fields, validates, ValidationError
 
 from flexmeasures.data import ma
 from flexmeasures.data.models.generic_assets import GenericAsset
 from flexmeasures.data.models.time_series import Sensor
+from flexmeasures.data.schemas.utils import FMValidationError, MarshmallowClickMixin
 from flexmeasures.utils.unit_utils import is_valid_unit
 
 
@@ -48,3 +50,19 @@ class SensorSchema(SensorSchemaMixin, ma.SQLAlchemySchema):
 
     class Meta:
         model = Sensor
+
+
+class SensorField(fields.Int, MarshmallowClickMixin):
+    """Field that deserializes to a Sensor and serializes back to an integer."""
+
+    @with_appcontext
+    def _deserialize(self, value, attr, obj, **kwargs) -> Sensor:
+        """Turn a sensor id into a Sensor."""
+        sensor = Sensor.query.get(value)
+        if sensor is None:
+            raise FMValidationError(f"No sensor found with id {value}.")
+        return sensor
+
+    def _serialize(self, value, attr, data, **kwargs):
+        """Turn a Sensor into a sensor id."""
+        return value.id


### PR DESCRIPTION
This PR introduces a new CLI command to provide better control over editing key-value pairs in the attributes column of the generic asset and sensor tables. It also introduces the `flexmeasures edit` CLI group, to which I also moved the `resample-data` command (away from `flexmeasures db-ops`).
Note that I cherry-picked the `GenericAssetField` from another ongoing PR and introduce here the new marshmallow validator `SensorField`.