### PR TITLE
Upgrade timely-beliefs dependency

### DIFF
--- a/requirements/app.in
+++ b/requirements/app.in
@@ -31,7 +31,7 @@ tldextract
 pyomo>=5.6
 tabulate
 timetomodel>=0.7.1
-timely-beliefs>=1.11.2
+timely-beliefs>=1.11.5
 python-dotenv
 # a backport, not needed in Python3.8
 importlib_metadata

--- a/requirements/app.txt
+++ b/requirements/app.txt
@@ -352,7 +352,7 @@ tabulate==0.8.9
     # via -r requirements/app.in
 threadpoolctl==3.1.0
     # via scikit-learn
-timely-beliefs==1.11.2
+timely-beliefs==1.11.5
     # via -r requirements/app.in
 timetomodel==0.7.1
     # via -r requirements/app.in


### PR DESCRIPTION
Upgrading timely-beliefs fixes a problem that can occur with resampling, when an event resolution of "H" should be interpreted as "1H" but isn't. This was fixed in https://github.com/SeitaBV/timely-beliefs/pull/100.
```
ValueError: Could not parse timedelta H, because unit abbreviation w/o a number
```