### PR TITLE
In is_running(), list CLI commands generically

### DIFF
--- a/flexmeasures/cli/__init__.py
+++ b/flexmeasures/cli/__init__.py
@@ -29,9 +29,8 @@ def is_running() -> bool:
 
     See also: the run_as_cli test fixture, which uses the (non-public) PRETEND_RUNNING_AS_CLI env setting.
 
-    TODO: How can plugins add their CLI set here, should they need that?
     """
-    cli_sets = ("add", "delete", "show", "monitor", "jobs", "db-ops")
+    cli_sets = current_app.cli.list_commands(ctx=None)
     command_line = " ".join(sys.argv)
     for cli_set in cli_sets:
         if f"flexmeasures {cli_set}" in command_line:

--- a/flexmeasures/cli/tests/test_utils.py
+++ b/flexmeasures/cli/tests/test_utils.py
@@ -1,0 +1,11 @@
+import sys
+
+from flexmeasures.cli import is_running as cli_is_running
+
+
+def test_cli_is_running(app, monkeypatch):
+    assert cli_is_running() is False
+    monkeypatch.setattr(
+        sys, "argv", ["/bin/flexmeasures", "add", "account", "--name", "XCorp."]
+    )
+    assert cli_is_running() is True


### PR DESCRIPTION
Aside from being a solution which would not fail when we add another CLI command, it also allows commands from loaded plugins to be recognized. We need this especially for allowing CLI to do things outside of one account only.