### PR TITLE
Prefer conversion to short stock units

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -16,6 +16,14 @@ Infrastructure / Support
 ----------------------
 
 
+v0.9.2 | April XX, 2022
+===========================
+
+Bugfixes
+--------
+* Prefer unit conversions to short stock units [see `PR #412 <http://www.github.com/FlexMeasures/flexmeasures/pull/412>`_]
+
+
 v0.9.1 | March 31, 2022
 ===========================
 

--- a/flexmeasures/data/queries/annotations.py
+++ b/flexmeasures/data/queries/annotations.py
@@ -12,9 +12,9 @@ from flexmeasures.data.models.data_sources import DataSource
 
 def query_asset_annotations(
     asset_id: int,
-    annotation_starts_after: Optional[datetime],
-    annotation_ends_before: Optional[datetime],
-    sources: List[DataSource],
+    annotation_starts_after: Optional[datetime] = None,
+    annotation_ends_before: Optional[datetime] = None,
+    sources: Optional[List[DataSource]] = None,
     annotation_type: str = None,
 ) -> Query:
     """Match annotations assigned to the given asset."""

--- a/flexmeasures/utils/tests/test_unit_utils.py
+++ b/flexmeasures/utils/tests/test_unit_utils.py
@@ -91,6 +91,7 @@ def test_determine_flow_unit(
         ("kW", None, "kWh"),
         ("m/s", "s", "m"),
         ("m/s", "h", "km"),
+        ("t/h", None, "t"),
     ],
 )
 def test_determine_stock_unit(

--- a/flexmeasures/utils/unit_utils.py
+++ b/flexmeasures/utils/unit_utils.py
@@ -120,12 +120,17 @@ def determine_flow_unit(stock_unit: str, time_unit: str = "h"):
 
 
 def determine_stock_unit(flow_unit: str, time_unit: str = "h"):
-    """For example:
+    """Determine the shortest unit of stock, given a unit of flow.
+
+    For example:
     >>> determine_stock_unit("m³/h")  # m³
     >>> determine_stock_unit("kW")  # kWh
     """
-    stock = to_preferred(ur.Quantity(flow_unit) * ur.Quantity(time_unit))
-    return "{:~P}".format(stock.units)
+    stock = ur.Quantity(flow_unit) * ur.Quantity(time_unit)
+    return min(
+        ["{:~P}".format(stock.units), "{:~P}".format(to_preferred(stock).units)],
+        key=len,
+    )
 
 
 def units_are_convertible(


### PR DESCRIPTION
Catch another case of converting flow units to sensible stock units: `t/h` to `t` (tonne) instead of to `Mg`.