### PR TITLE
Default chart legibility

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -8,6 +8,7 @@ v0.10.0 | April XX, 2022
 
 New features
 -----------
+* Improve legibility of chart axes [see `PR #413 <http://www.github.com/FlexMeasures/flexmeasures/pull/413>`_]
 
 Bugfixes
 -----------

--- a/flexmeasures/data/models/charts/defaults.py
+++ b/flexmeasures/data/models/charts/defaults.py
@@ -4,6 +4,7 @@ from typing import Callable, Union
 import altair as alt
 
 
+FONT_SIZE = 16
 HEIGHT = 300
 WIDTH = 600
 REDUCED_HEIGHT = REDUCED_WIDTH = 60
@@ -59,6 +60,34 @@ def apply_chart_defaults(fn):
             chart_specs["height"] = HEIGHT
         if "width" not in chart_specs:
             chart_specs["width"] = WIDTH
+
+        # Improve default legibility
+        if "config" not in chart_specs:
+            chart_specs["config"] = {}
+        if "axis" not in chart_specs["config"]:
+            chart_specs["config"]["axis"] = {}
+        chart_specs["config"]["axis"] = {
+            **chart_specs["config"]["axis"],
+            **dict(
+                titleFontSize=FONT_SIZE,
+                labelFontSize=FONT_SIZE,
+            ),
+        }
+        if "title" in chart_specs:
+            if isinstance(chart_specs["title"], str):
+                chart_specs["title"] = dict(text=chart_specs["title"])
+            chart_specs["title"] = {
+                **chart_specs["title"],
+                **dict(
+                    fontSize=FONT_SIZE,
+                ),
+            }
+        if (
+            "color" in chart_specs["encoding"]
+            and "legend" in chart_specs["encoding"]["color"]
+        ):
+            chart_specs["encoding"]["color"]["legend"]["titleFontSize"] = FONT_SIZE
+            chart_specs["encoding"]["color"]["legend"]["labelFontSize"] = FONT_SIZE
 
         # Add transform function to calculate full date
         if "transform" not in chart_specs:

--- a/flexmeasures/data/models/charts/defaults.py
+++ b/flexmeasures/data/models/charts/defaults.py
@@ -82,8 +82,8 @@ def apply_chart_defaults(fn):
 
         # Improve default legibility
         chart_specs = merge_vega_lite_specs(
-            chart_specs,
             LEGIBILITY_DEFAULTS,
+            chart_specs,
         )
 
         # Add transform function to calculate full date
@@ -117,7 +117,7 @@ def merge_vega_lite_specs(child: dict, parent: dict) -> dict:
             and k in child
             and isinstance(child[k], dict)
         ):
-            v = merge_vega_lite_specs(parent[k], child[k])
+            v = merge_vega_lite_specs(child[k], parent[k])
         elif k in parent:
             v = parent[k]
         else:

--- a/flexmeasures/data/models/charts/defaults.py
+++ b/flexmeasures/data/models/charts/defaults.py
@@ -56,6 +56,10 @@ LEGIBILITY_DEFAULTS = dict(
         )
     ),
 )
+vega_lite_field_mapping = {
+    "title": "text",
+    "mark": "type",
+}
 
 
 def apply_chart_defaults(fn):
@@ -104,13 +108,14 @@ def merge_vega_lite_specs(child: dict, parent: dict) -> dict:
     """Merge nested dictionaries, with child inheriting values from parent.
 
     Child values are updated with parent values if they exist.
-    In case the 'title' field is a string and the field is updated with some dict,
-    that string is moved inside the dict under the 'text' field.
+    In case a field is a string and that field is updated with some dict,
+    the string is moved inside the dict under a field defined in vega_lite_field_mapping.
+    For example, 'title' becomes 'text' and 'mark' becomes 'type'.
     """
     d = {}
     for k in set().union(child, parent):
-        if k == "title" and k in parent and k in child and isinstance(child[k], str):
-            child[k] = dict(text=child[k])
+        if k in parent and k in child and isinstance(child[k], str):
+            child[k] = {vega_lite_field_mapping.get(k, "type"): child[k]}
         if (
             k in parent
             and isinstance(parent[k], dict)

--- a/flexmeasures/data/models/charts/defaults.py
+++ b/flexmeasures/data/models/charts/defaults.py
@@ -114,8 +114,11 @@ def merge_vega_lite_specs(child: dict, parent: dict) -> dict:
     """
     d = {}
     for k in set().union(child, parent):
-        if k in parent and k in child and isinstance(child[k], str):
-            child[k] = {vega_lite_field_mapping.get(k, "type"): child[k]}
+        if k in parent and k in child:
+            if isinstance(child[k], str):
+                child[k] = {vega_lite_field_mapping.get(k, "type"): child[k]}
+            if isinstance(parent[k], str):
+                parent[k] = {vega_lite_field_mapping.get(k, "type"): parent[k]}
         if (
             k in parent
             and isinstance(parent[k], dict)

--- a/flexmeasures/data/models/charts/defaults.py
+++ b/flexmeasures/data/models/charts/defaults.py
@@ -37,6 +37,25 @@ FIELD_DEFINITIONS = {
         title="Time and date",
     ),
 }
+LEGIBILITY_DEFAULTS = dict(
+    config=dict(
+        axis=dict(
+            titleFontSize=FONT_SIZE,
+            labelFontSize=FONT_SIZE,
+        )
+    ),
+    title=dict(fontSize=FONT_SIZE),
+    encoding=dict(
+        color=dict(
+            dict(
+                legend=dict(
+                    titleFontSize=FONT_SIZE,
+                    labelFontSize=FONT_SIZE,
+                )
+            )
+        )
+    ),
+)
 
 
 def apply_chart_defaults(fn):
@@ -64,25 +83,7 @@ def apply_chart_defaults(fn):
         # Improve default legibility
         chart_specs = merge_vega_lite_specs(
             chart_specs,
-            dict(
-                config=dict(
-                    axis=dict(
-                        titleFontSize=FONT_SIZE,
-                        labelFontSize=FONT_SIZE,
-                    )
-                ),
-                title=dict(fontSize=FONT_SIZE),
-                encoding=dict(
-                    color=dict(
-                        dict(
-                            legend=dict(
-                                titleFontSize=FONT_SIZE,
-                                labelFontSize=FONT_SIZE,
-                            )
-                        )
-                    )
-                ),
-            ),
+            LEGIBILITY_DEFAULTS,
         )
 
         # Add transform function to calculate full date

--- a/flexmeasures/data/tests/test_chart_utils.py
+++ b/flexmeasures/data/tests/test_chart_utils.py
@@ -1,0 +1,24 @@
+import pytest
+
+from flexmeasures.data.models.charts.defaults import merge_vega_lite_specs
+
+
+@pytest.mark.parametrize(
+    "default_specs, custom_specs, expected_specs",
+    [
+        (
+            {"legend": {"titleFontSize": 16}},
+            {"title": "foo"},
+            {"legend": {"titleFontSize": 16}, "title": "foo"},
+        ),
+        (
+            {"title": {"fontSize": 16}},
+            {"title": "foo"},
+            {"title": {"fontSize": 16, "text": "foo"}},
+        ),
+    ],
+)
+def test_merge_vega_lite_specs(
+    default_specs: dict, custom_specs: dict, expected_specs: dict
+):
+    assert merge_vega_lite_specs(default_specs, custom_specs) == expected_specs

--- a/flexmeasures/ui/static/css/flexmeasures.css
+++ b/flexmeasures/ui/static/css/flexmeasures.css
@@ -504,3 +504,5 @@ i.icon-wind:hover:before {
 .icon-buildings:before { content: '\e803'; } /* '' */
 .icon-charging_stations:before { content: '\e805'; } /* '' */
 .icon-bidirectional_charging_stations:before { content: '\e805'; } /* '' */
+
+.litepicker { font-size: 14px;}

--- a/flexmeasures/ui/templates/views/sensors.html
+++ b/flexmeasures/ui/templates/views/sensors.html
@@ -71,7 +71,7 @@
           numberOfMonths: 2,
           numberOfColumns: 2,
           inlineMode: true,
-          switchingMonths: 2,
+          switchingMonths: 1,
           singleMode: false,
           dropdowns: {
               years: true,


### PR DESCRIPTION
I saw some people having trouble reading our chart axes in meetings, so I increased the default font size a bit. Also for our calendar widget.

Some of this code should be useful for chart specs defined in plugins, too.