### PR TITLE
Except all errors when checking for valid unit

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -22,7 +22,7 @@ Infrastructure / Support
 * Allow to filter data by source using a tuple instead of a list [see `PR #421 <http://www.github.com/FlexMeasures/flexmeasures/pull/421>`_]
 
 
-v0.9.4 | April 26, 2022
+v0.9.4 | April 28, 2022
 ===========================
 
 Bugfixes

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -22,6 +22,14 @@ Infrastructure / Support
 * Allow to filter data by source using a tuple instead of a list [see `PR #421 <http://www.github.com/FlexMeasures/flexmeasures/pull/421>`_]
 
 
+v0.9.4 | April 26, 2022
+===========================
+
+Bugfixes
+--------
+* Support checking validity of custom units (i.e. non-SI, non-currency units) [see `PR #424 <http://www.github.com/FlexMeasures/flexmeasures/pull/424>`_]
+
+
 v0.9.3 | April 15, 2022
 ===========================
 

--- a/flexmeasures/utils/tests/test_unit_utils.py
+++ b/flexmeasures/utils/tests/test_unit_utils.py
@@ -151,6 +151,7 @@ def test_units_are_convertible():
         ("°C", False),
         ("", False),
         ("not-a-unit", False),
+        ("#", False),
     ],
 )
 def test_is_power_unit(unit: str, power_unit: bool):

--- a/flexmeasures/utils/unit_utils.py
+++ b/flexmeasures/utils/unit_utils.py
@@ -78,9 +78,7 @@ def is_valid_unit(unit: str) -> bool:
     """Return True if the pint library can work with this unit identifier."""
     try:
         ur.Quantity(unit)
-    except ValueError:
-        return False
-    except pint.errors.UndefinedUnitError:
+    except Exception:  # noqa B902
         return False
     return True
 

--- a/flexmeasures/utils/unit_utils.py
+++ b/flexmeasures/utils/unit_utils.py
@@ -79,6 +79,8 @@ def is_valid_unit(unit: str) -> bool:
     try:
         ur.Quantity(unit)
     except Exception:  # noqa B902
+        # in practice, we encountered pint.errors.UndefinedUnitError, ValueError and AttributeError,
+        # but since there may be more, here we simply catch them all
         return False
     return True
 


### PR DESCRIPTION
I believe this is a good use case for not only catching specific exceptions.