### PR TITLE
Issue 420 dark mode logo in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,5 @@
-![FlexMeasures Logo Light](https://artwork.lfenergy.org/projects/flexmeasures/horizontal/color/flexmeasures-horizontal-color.png#gh-light-mode-only)
-![FlexMeasures Logo Dark](https://artwork.lfenergy.org/projects/flexmeasures/horizontal/white/flexmeasures-horizontal-white.png#gh-dark-mode-only)
+![FlexMeasures Logo Light](https://github.com/FlexMeasures/screenshots/blob/main/logo/flexmeasures-horizontal-color.svg#gh-light-mode-only)
+![FlexMeasures Logo Dark](https://github.com/FlexMeasures/screenshots/blob/main/logo/flexmeasures-horizontal-dark.svg#gh-dark-mode-only)
 
 [![License](https://img.shields.io/github/license/seitabv/flexmeasures?color=blue)](https://github.com/FlexMeasures/flexmeasures/blob/main/LICENSE)
 ![lint-and-test](https://github.com/FlexMeasures/flexmeasures/workflows/lint-and-test/badge.svg)

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,5 @@
-![FlexMeasures Logo](https://artwork.lfenergy.org/projects/flexmeasures/horizontal/color/flexmeasures-horizontal-color.png)
+![FlexMeasures Logo Light](https://artwork.lfenergy.org/projects/flexmeasures/horizontal/color/flexmeasures-horizontal-color.svg#gh-light-mode-only)
+![FlexMeasures Logo Dark](https://artwork.lfenergy.org/projects/flexmeasures/horizontal/white/flexmeasures-horizontal-white.svg#gh-dark-mode-only)
 
 [![License](https://img.shields.io/github/license/seitabv/flexmeasures?color=blue)](https://github.com/FlexMeasures/flexmeasures/blob/main/LICENSE)
 ![lint-and-test](https://github.com/FlexMeasures/flexmeasures/workflows/lint-and-test/badge.svg)

--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,5 @@
-![FlexMeasures Logo Light](https://artwork.lfenergy.org/projects/flexmeasures/horizontal/color/flexmeasures-horizontal-color.svg#gh-light-mode-only)
-![FlexMeasures Logo Dark](https://artwork.lfenergy.org/projects/flexmeasures/horizontal/white/flexmeasures-horizontal-white.svg#gh-dark-mode-only)
+![FlexMeasures Logo Light](https://artwork.lfenergy.org/projects/flexmeasures/horizontal/color/flexmeasures-horizontal-color.png#gh-light-mode-only)
+![FlexMeasures Logo Dark](https://artwork.lfenergy.org/projects/flexmeasures/horizontal/white/flexmeasures-horizontal-white.png#gh-dark-mode-only)
 
 [![License](https://img.shields.io/github/license/seitabv/flexmeasures?color=blue)](https://github.com/FlexMeasures/flexmeasures/blob/main/LICENSE)
 ![lint-and-test](https://github.com/FlexMeasures/flexmeasures/workflows/lint-and-test/badge.svg)


### PR DESCRIPTION
Note that the images needed to be stored in GitHub else they won't display dynamically based on the theme. [~ source](https://stackoverflow.com/questions/65413712/changing-readme-md-image-display-conditional-to-github-light-mode-dark-mode)

closes #420 