### PR TITLE
Switch from 12-hour clock to 24-hour clock in time axis labels and in tooltips

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -8,6 +8,7 @@ v0.11.0 | June XX, 2022
 New features
 -------------
 * Individual sensor charts show available annotations [see `PR #428 <http://www.github.com/FlexMeasures/flexmeasures/pull/428>`_]
+* Switched from 12-hour AM/PM to 24-hour clock notation for time series chart axis labels [see `PR #446 <http://www.github.com/FlexMeasures/flexmeasures/pull/446>`_]
 
 Bugfixes
 -----------

--- a/flexmeasures/data/models/charts/defaults.py
+++ b/flexmeasures/data/models/charts/defaults.py
@@ -11,6 +11,7 @@ WIDTH = "container"
 REDUCED_HEIGHT = REDUCED_WIDTH = 60
 SELECTOR_COLOR = "darkred"
 TIME_FORMAT = "%H:%M on %A %b %e, %Y"
+# Use default timeFormat for date or second labels, and use 24-hour clock notation for other (hour and minute) labels
 FORMAT_24H = "(hours(datum.value) == 0 & minutes(datum.value) == 0) | seconds(datum.value) != 0 ? timeFormat(datum.value) : timeFormat(datum.value, '%H:%M')"
 TIME_SELECTION_TOOLTIP = "Click and drag to select a time window"
 FIELD_DEFINITIONS = {

--- a/flexmeasures/data/models/charts/defaults.py
+++ b/flexmeasures/data/models/charts/defaults.py
@@ -10,18 +10,21 @@ HEIGHT = 300
 WIDTH = "container"
 REDUCED_HEIGHT = REDUCED_WIDTH = 60
 SELECTOR_COLOR = "darkred"
-TIME_FORMAT = "%I:%M %p on %A %b %e, %Y"
+TIME_FORMAT = "%H:%M on %A %b %e, %Y"
+FORMAT_24H = "hours(datum.value) == 0 & minutes(datum.value) == 0 | seconds(datum.value) != 0 ? timeFormat(datum.value) : timeFormat(datum.value, '%H:%M')"
 TIME_SELECTION_TOOLTIP = "Click and drag to select a time window"
 FIELD_DEFINITIONS = {
     "event_start": dict(
         field="event_start",
         type="temporal",
         title=None,
+        axis={"labelExpr": FORMAT_24H},
     ),
     "event_end": dict(
         field="event_end",
         type="temporal",
         title=None,
+        axis={"labelExpr": FORMAT_24H},
     ),
     "event_value": dict(
         field="event_value",

--- a/flexmeasures/data/models/charts/defaults.py
+++ b/flexmeasures/data/models/charts/defaults.py
@@ -11,7 +11,7 @@ WIDTH = "container"
 REDUCED_HEIGHT = REDUCED_WIDTH = 60
 SELECTOR_COLOR = "darkred"
 TIME_FORMAT = "%H:%M on %A %b %e, %Y"
-FORMAT_24H = "hours(datum.value) == 0 & minutes(datum.value) == 0 | seconds(datum.value) != 0 ? timeFormat(datum.value) : timeFormat(datum.value, '%H:%M')"
+FORMAT_24H = "(hours(datum.value) == 0 & minutes(datum.value) == 0) | seconds(datum.value) != 0 ? timeFormat(datum.value) : timeFormat(datum.value, '%H:%M')"
 TIME_SELECTION_TOOLTIP = "Click and drag to select a time window"
 FIELD_DEFINITIONS = {
     "event_start": dict(

--- a/flexmeasures/data/models/charts/test_chart_defaults.py
+++ b/flexmeasures/data/models/charts/test_chart_defaults.py
@@ -6,4 +6,4 @@ from flexmeasures.data.models.charts.defaults import FIELD_DEFINITIONS
 def test_default_encodings():
     """Check default encodings for valid vega-lite specifications."""
     for field_name, field_definition in FIELD_DEFINITIONS.items():
-        assert alt.StringFieldDefWithCondition(**field_definition)
+        assert alt.PositionFieldDef(**field_definition)


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/30658763/174431981-cddea68e-b9e7-43ff-8c38-45a812709984.png)
After:
![image](https://user-images.githubusercontent.com/30658763/174431941-3eb08d82-67d8-4225-a458-e8ec2a7d8666.png)

And for tooltips, before:
![image](https://user-images.githubusercontent.com/30658763/174434148-7c7dad19-19a7-4571-beaa-5536cf3e9d2b.png)
And after:
![image](https://user-images.githubusercontent.com/30658763/174434085-12fe2729-87c5-4af3-9742-4ed9ce8ad5d3.png)


Closes #445.