### PR TITLE
do not fail the sensor attribute when building an entity address

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,13 @@ repos:
     hooks:
     - id: flake8
       name: flake8 (code linting)
-      language_version: python3.8
+      language_version: python3.9
 -   repo: https://github.com/psf/black
     rev: 22.3.0  # New version tags can be found here: https://github.com/psf/black/tags
     hooks:
     - id: black
       name: black (code formatting)
-      language_version: python3.8
+      language_version: python3.9
 -   repo: local
     hooks:
     - id: mypy

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -12,10 +12,12 @@ New features
 
 Bugfixes
 -----------
+* Do not fail asset page if entity addresses cannot be built [see `PR #457 <http://www.github.com/FlexMeasures/flexmeasures/pull/457>`_]
 
 Infrastructure / Support
 ----------------------
 * Allow access tokens to be passed as env vars as well [see `PR #443 <http://www.github.com/FlexMeasures/flexmeasures/pull/443>`_]
+
 
 v0.10.1 | June XX, 2022
 ===========================

--- a/flexmeasures/utils/entity_address_utils.py
+++ b/flexmeasures/utils/entity_address_utils.py
@@ -325,7 +325,7 @@ def build_ea_scheme_and_naming_authority(
                 "FLEXMEASURES_HOSTS_AND_AUTH_START", {}
             )[config_var_domain_key]
         else:
-            raise Exception(
+            raise EntityAddressException(
                 f"Could not find out when authority for {config_var_domain_key} started. Is FLEXMEASURES_HOSTS_AND_AUTH_START configured for it?"
             )
     regex = r"^\d{4}-\d{2}$"


### PR DESCRIPTION
Closes #456 

Do warn about failure to build entity addresses, however.

This particular failure to build them has to do with the domain FlexMeasures runs on, which becomes part of the address.
When FlexMeasuresa starts, we don't know the domain ― currently, we find out where we run on request information. 

Thus, warning about this failure in the terminal when FlexMeasures starts seems difficult. The failure becomes visual when the asset page is visited ("no entity address available"), so it will come up. 

It will also come up if someone gets sensor data programmatically, via the API's GET /sensors endpoint, which also includes the entity address.
