### PR TITLE
Get resampled data

### DIFF
--- a/documentation/api/change_log.rst
+++ b/documentation/api/change_log.rst
@@ -6,6 +6,11 @@ API change log
 .. note:: The FlexMeasures API follows its own versioning scheme. This is also reflected in the URL, allowing developers to upgrade at their own pace.
 
 
+v3.0-2 | 2022-07-08
+"""""""""""""""""""
+
+- Introduced the "resolution" field to `/sensors/data` (GET) to obtain data in a given resolution.
+
 v3.0-1 | 2022-05-08
 """""""""""""""""""
 

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -10,6 +10,7 @@ New features
 * Individual sensor charts show available annotations [see `PR #428 <http://www.github.com/FlexMeasures/flexmeasures/pull/428>`_]
 * Collapsible sidepanel (hover/swipe) used for date selection on sensor charts, and various styling improvements [see `PR #447 <http://www.github.com/FlexMeasures/flexmeasures/pull/447>`_]
 * Switched from 12-hour AM/PM to 24-hour clock notation for time series chart axis labels [see `PR #446 <http://www.github.com/FlexMeasures/flexmeasures/pull/446>`_]
+* Get data in a given resolution [see `PR #458 <http://www.github.com/FlexMeasures/flexmeasures/pull/458>`_]
 
 Bugfixes
 -----------

--- a/flexmeasures/api/common/schemas/sensor_data.py
+++ b/flexmeasures/api/common/schemas/sensor_data.py
@@ -180,7 +180,7 @@ class GetSensorDataSchema(SensorDataDescriptionSchema):
 
         # Convert to desired time range
         index = pd.date_range(
-            start=start, end=end, freq=sensor.event_resolution, closed="left"
+            start=start, end=end, freq=df.event_resolution, closed="left"
         )
         df = df.reindex(index)
 

--- a/flexmeasures/api/common/schemas/sensor_data.py
+++ b/flexmeasures/api/common/schemas/sensor_data.py
@@ -141,6 +141,7 @@ class GetSensorDataSchema(SensorDataDescriptionSchema):
         - converts to a single deterministic belief per event
         - ensures the response respects the requested time frame
         - converts values to the requested unit
+        - converts values to the requested resolution
         """
         sensor: Sensor = sensor_data_description["sensor"]
         start = sensor_data_description["start"]

--- a/flexmeasures/api/common/schemas/sensor_data.py
+++ b/flexmeasures/api/common/schemas/sensor_data.py
@@ -97,6 +97,8 @@ class SensorDataDescriptionSchema(ma.Schema):
 
 class GetSensorDataSchema(SensorDataDescriptionSchema):
 
+    resolution = DurationField(required=False)
+
     # Optional field that can be used for extra validation
     type = fields.Str(
         required=False,

--- a/flexmeasures/api/common/schemas/sensor_data.py
+++ b/flexmeasures/api/common/schemas/sensor_data.py
@@ -150,7 +150,7 @@ class GetSensorDataSchema(SensorDataDescriptionSchema):
         duration = sensor_data_description["duration"]
         end = sensor_data_description["start"] + duration
         unit = sensor_data_description["unit"]
-        resolution = sensor_data_description["resolution"]
+        resolution = sensor_data_description.get("resolution")
 
         # Post-load configuration of belief timing against message type
         horizons_at_least = sensor_data_description.get("horizon", None)

--- a/flexmeasures/api/common/schemas/sensor_data.py
+++ b/flexmeasures/api/common/schemas/sensor_data.py
@@ -147,6 +147,7 @@ class GetSensorDataSchema(SensorDataDescriptionSchema):
         duration = sensor_data_description["duration"]
         end = sensor_data_description["start"] + duration
         unit = sensor_data_description["unit"]
+        resolution = sensor_data_description["resolution"]
 
         # Post-load configuration of belief timing against message type
         horizons_at_least = sensor_data_description.get("horizon", None)
@@ -169,6 +170,7 @@ class GetSensorDataSchema(SensorDataDescriptionSchema):
                 horizons_at_most=horizons_at_most,
                 beliefs_before=sensor_data_description.get("prior", None),
                 one_deterministic_belief_per_event=True,
+                resolution=resolution,
                 as_json=False,
             )
         )

--- a/flexmeasures/api/common/schemas/tests/test_sensor_data_schema.py
+++ b/flexmeasures/api/common/schemas/tests/test_sensor_data_schema.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 import pytest
 
 from marshmallow import ValidationError
@@ -5,7 +6,31 @@ from marshmallow import ValidationError
 from flexmeasures.api.common.schemas.sensor_data import (
     SingleValueField,
     PostSensorDataSchema,
+    GetSensorDataSchema,
 )
+
+
+@pytest.mark.parametrize(
+    "deserialization_input, exp_deserialization_output",
+    [
+        (
+            "PT1H",
+            timedelta(hours=1),
+        ),
+        (
+            "PT15M",
+            timedelta(minutes=15),
+        ),
+    ],
+)
+def test_resolution_field_deserialization(
+    deserialization_input,
+    exp_deserialization_output,
+):
+    """Testing straightforward cases"""
+    vf = GetSensorDataSchema._declared_fields["resolution"]
+    deser = vf.deserialize(deserialization_input)
+    assert deser == exp_deserialization_output
 
 
 @pytest.mark.parametrize(

--- a/flexmeasures/api/common/schemas/tests/test_sensor_data_schema.py
+++ b/flexmeasures/api/common/schemas/tests/test_sensor_data_schema.py
@@ -27,7 +27,12 @@ def test_resolution_field_deserialization(
     deserialization_input,
     exp_deserialization_output,
 ):
-    """Testing straightforward cases"""
+    """Check parsing the resolution field of the GetSensorDataSchema schema.
+
+    These particular ISO durations are expected to be parsed as python timedeltas.
+    """
+    # todo: extend test cases with some nominal durations when timely-beliefs supports these
+    #       see https://github.com/SeitaBV/timely-beliefs/issues/13
     vf = GetSensorDataSchema._declared_fields["resolution"]
     deser = vf.deserialize(deserialization_input)
     assert deser == exp_deserialization_output

--- a/flexmeasures/api/dev/sensors.py
+++ b/flexmeasures/api/dev/sensors.py
@@ -10,7 +10,7 @@ from werkzeug.exceptions import abort
 from flexmeasures.auth.policy import ADMIN_ROLE, ADMIN_READER_ROLE
 from flexmeasures.auth.decorators import permission_required_for_context
 from flexmeasures.data.schemas.sensors import SensorIdField
-from flexmeasures.data.schemas.times import AwareDateTimeField
+from flexmeasures.data.schemas.times import AwareDateTimeField, DurationField
 from flexmeasures.data.models.time_series import Sensor
 from flexmeasures.data.services.annotations import prepare_annotations_for_chart
 
@@ -63,7 +63,7 @@ class SensorAPI(FlaskView):
             "event_ends_before": AwareDateTimeField(format="iso", required=False),
             "beliefs_after": AwareDateTimeField(format="iso", required=False),
             "beliefs_before": AwareDateTimeField(format="iso", required=False),
-            "resolution": fields.Str(),
+            "resolution": DurationField(required=False),
         },
         location="query",
     )

--- a/flexmeasures/api/dev/sensors.py
+++ b/flexmeasures/api/dev/sensors.py
@@ -63,6 +63,7 @@ class SensorAPI(FlaskView):
             "event_ends_before": AwareDateTimeField(format="iso", required=False),
             "beliefs_after": AwareDateTimeField(format="iso", required=False),
             "beliefs_before": AwareDateTimeField(format="iso", required=False),
+            "resolution": fields.Str(),
         },
         location="query",
     )

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -173,6 +173,7 @@ class SensorAPI(FlaskView):
                 "sensor": "ea1.2021-01.io.flexmeasures:fm1.1",
                 "start": "2021-06-07T00:00:00+02:00",
                 "duration": "PT1H",
+                "resolution": "PT15M",
                 "unit": "m³/h"
             }
 

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -292,6 +292,7 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
         most_recent_events_only: bool = False,
         most_recent_only: bool = None,  # deprecated
         one_deterministic_belief_per_event: bool = False,
+        resolution = None,
         as_json: bool = False,
     ) -> Union[tb.BeliefsDataFrame, str]:
         """Search all beliefs about events for this sensor.
@@ -331,6 +332,7 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
             most_recent_beliefs_only=most_recent_beliefs_only,
             most_recent_events_only=most_recent_events_only,
             one_deterministic_belief_per_event=one_deterministic_belief_per_event,
+            resolution=resolution,
         )
         if as_json:
             df = bdf.reset_index()

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -292,7 +292,7 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
         most_recent_events_only: bool = False,
         most_recent_only: bool = None,  # deprecated
         one_deterministic_belief_per_event: bool = False,
-        resolution = None,
+        resolution: Union[str, timedelta] = None,
         as_json: bool = False,
     ) -> Union[tb.BeliefsDataFrame, str]:
         """Search all beliefs about events for this sensor.


### PR DESCRIPTION
This PR introduces the "resolution" field to `/sensors/data` (GET) to obtain data in a given resolution.