### PR TITLE
Make sure vega view is embedded in page before attempting to change its dataset

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -18,6 +18,7 @@ New features
 Bugfixes
 -----------
 * Do not fail asset page if entity addresses cannot be built [see `PR #457 <http://www.github.com/FlexMeasures/flexmeasures/pull/457>`_]
+* Asynchronous reloading of a chart's dataset relies on that chart already having been embedded [see `PR #472 <http://www.github.com/FlexMeasures/flexmeasures/pull/472>`_]
 * Time scale axes in sensor data charts now match the requested date range, rather than stopping at the edge of the available data [see `PR #449 <http://www.github.com/FlexMeasures/flexmeasures/pull/449>`_]
 * The docker-based tutorial now works with UI on all platforms (port 5000 did not expose on MacOS) [see `PR #465 <http://www.github.com/FlexMeasures/flexmeasures/pull/465>`_]
 * Fix interpretation of scheduling results in toy tutorial [see `PR #466 <http://www.github.com/FlexMeasures/flexmeasures/pull/466>`_]

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -229,7 +229,6 @@
       signal = controller.signal
 
       $("#spinner").show();
-      embedAndLoad(chartSpecsPath + 'event_starts_after=' + queryStartDate + '&event_ends_before=' + queryEndDate + '&', elementId, datasetName, previousResult, startDate, endDate);
       Promise.all([
           // Fetch time series data
           fetch(assetPath + '/chart_data/?event_starts_after=' + queryStartDate + '&event_ends_before=' + queryEndDate, {
@@ -246,8 +245,10 @@
               headers: {"Content-Type": "application/json"},
               signal: signal,
           })
-          .then(function(response) { return response.json(); })
+          .then(function(response) { return response.json(); }),
           */
+
+          embedAndLoad(chartSpecsPath + 'event_starts_after=' + queryStartDate + '&event_ends_before=' + queryEndDate + '&', elementId, datasetName, previousResult, startDate, endDate),
       ]).then(function(result) {
             $("#spinner").hide();
             vegaView.change(datasetName, vega.changeset().remove(vega.truthy).insert(result[0])).resize().run();

--- a/flexmeasures/ui/templates/views/sensors.html
+++ b/flexmeasures/ui/templates/views/sensors.html
@@ -110,7 +110,6 @@
           signal = controller.signal
 
           $("#spinner").show();
-          embedAndLoad(chartSpecsPath + 'event_starts_after=' + queryStartDate + '&event_ends_before=' + queryEndDate + '&', elementId, datasetName, previousResult, startDate, endDate);
           Promise.all([
               // Fetch time series data
               fetch(sensorPath + '/chart_data/?event_starts_after=' + queryStartDate + '&event_ends_before=' + queryEndDate, {
@@ -124,7 +123,10 @@
                   method: "GET",
                   headers: {"Content-Type": "application/json"},
               })
-              .then(function(response) { return response.json(); })
+              .then(function(response) { return response.json(); }),
+
+              // Embed chart
+              embedAndLoad(chartSpecsPath + 'event_starts_after=' + queryStartDate + '&event_ends_before=' + queryEndDate + '&', elementId, datasetName, previousResult, startDate, endDate),
           ]).then(function(result) {
                 $("#spinner").hide();
                 vegaView.change(datasetName, vega.changeset().remove(vega.truthy).insert(result[0])).resize().run();


### PR DESCRIPTION
Asynchronous reloading of a chart's dataset relies on that chart already having been embedded. This fix makes sure the `vegaView` variable is set up before any of the data fetching promises's `then` blocks try to load the view with data.

Closes #468.