### PR TITLE
Deprecation notice urllib3[secure]

### DIFF
--- a/requirements/app.txt
+++ b/requirements/app.txt
@@ -371,7 +371,7 @@ typing-extensions==4.1.1
     # via py-moneyed
 uniplot==0.5.0
     # via -r requirements/app.in
-urllib3[secure]==1.26.8
+urllib3==1.26.8
     # via
     #   requests
     #   selenium

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -116,7 +116,7 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 sphinxcontrib.httpdomain==1.8.0
     # via -r requirements/docs.in
-urllib3[secure]==1.26.8
+urllib3==1.26.8
     # via
     #   -c requirements/app.txt
     #   requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -124,7 +124,7 @@ tomli==1.2.3
     # via
     #   coverage
     #   pytest
-urllib3[secure]==1.26.8
+urllib3==1.26.8
     # via
     #   -c requirements/app.txt
     #   requests


### PR DESCRIPTION
- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with FlexMeasures

### Description
pyOpenSSL and urllib3[secure] are deprecated in the upcoming release (1.26.12)
https://github.com/urllib3/urllib3/issues/2680