### PR TITLE
upgrade dependencies for v0.12

### DIFF
--- a/requirements/app.in
+++ b/requirements/app.in
@@ -51,4 +51,7 @@ marshmallow-sqlalchemy>=0.23.1
 webargs
 uniplot
 # flask should be after all the flask plugins, because setup might find they ARE flask
-flask>=1.0
+# Minimum here due to Flask-Classful not supporting Werkzeug 2.2.0 yet, see https://github.com/teracyhq/flask-classful/pull/145
+flask>=1.0, <=2.1.2
+# remove if Flask max constraint is removed 
+werkzeug <=2.1.2

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -40,7 +40,8 @@ Flask-Migrate
 Flask-WTF
 Flask-Login
 Flask-Mail
-Flask-Security-Too>=4.0
+# We wait a little with upgrading to 5, until it's less fresh (Aug 2022)
+Flask-Security-Too>=4.0, <5.0
 Flask-Classful
 Flask-Marshmallow
 Flask-Cors
@@ -53,5 +54,5 @@ uniplot
 # flask should be after all the flask plugins, because setup might find they ARE flask
 # Minimum here due to Flask-Classful not supporting Werkzeug 2.2.0 yet, see https://github.com/teracyhq/flask-classful/pull/145
 flask>=1.0, <=2.1.2
-# remove if Flask max constraint is removed 
-werkzeug <=2.1.2
+# remove if flask max constraint (see above) is removed 
+werkzeug <2.1

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -23,7 +23,7 @@ rq-dashboard
 # the following uses environment markers (see PEP 496)
 rq-win; os_name == 'nt' or os_name == 'win'
 # This limit resolves a conflict with test.in. The culprit is fakeredis (check their setup.cfg)
-redis < 4.2.0
+redis < 4.4.0
 tldextract
 pyomo>=5.6
 tabulate

--- a/requirements/app.txt
+++ b/requirements/app.txt
@@ -63,7 +63,7 @@ entrypoints==0.4
     # via altair
 filelock==3.8.0
     # via tldextract
-flask==2.2.2
+flask==2.1.2
     # via
     #   -r requirements/app.in
     #   flask-classful
@@ -162,7 +162,6 @@ markupsafe==2.1.1
     # via
     #   jinja2
     #   mako
-    #   werkzeug
     #   wtforms
 marshmallow==3.17.1
     # via
@@ -349,8 +348,9 @@ urllib3[socks]==1.26.12
     #   sentry-sdk
 webargs==8.2.0
     # via -r requirements/app.in
-werkzeug==2.2.2
+werkzeug==2.1.2
     # via
+    #   -r requirements/app.in
     #   flask
     #   flask-login
 workalendar==16.3.0

--- a/requirements/app.txt
+++ b/requirements/app.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/app.txt requirements/app.in
 #
-alembic==1.7.6
+alembic==1.8.1
     # via flask-migrate
 altair==4.2.0
     # via
@@ -16,33 +16,29 @@ async-generator==1.10
     # via
     #   trio
     #   trio-websocket
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   jsonschema
     #   outcome
     #   trio
-babel==2.9.1
+babel==2.10.3
     # via py-moneyed
-bcrypt==3.2.0
+bcrypt==4.0.0
     # via -r requirements/app.in
-blinker==1.4
+blinker==1.5
     # via
     #   flask-mail
     #   flask-principal
     #   flask-security-too
     #   sentry-sdk
-certifi==2021.10.8
+certifi==2022.6.15
     # via
     #   requests
+    #   selenium
     #   sentry-sdk
-    #   urllib3
-cffi==1.15.0
-    # via
-    #   bcrypt
-    #   cryptography
-charset-normalizer==2.0.12
+charset-normalizer==2.1.1
     # via requests
-click==8.0.3
+click==8.1.3
     # via
     #   -r requirements/app.in
     #   flask
@@ -51,27 +47,23 @@ colour==0.1.5
     # via -r requirements/app.in
 convertdate==2.4.0
     # via workalendar
-cryptography==36.0.1
-    # via
-    #   pyopenssl
-    #   urllib3
 cycler==0.11.0
     # via matplotlib
 deprecated==1.2.13
     # via redis
-dill==0.3.4
+dill==0.3.5.1
     # via openturns
-dnspython==2.2.0
+dnspython==2.2.1
     # via email-validator
-email-validator==1.1.3
+email-validator==1.2.1
     # via
     #   -r requirements/app.in
     #   flask-security-too
 entrypoints==0.4
     # via altair
-filelock==3.4.2
+filelock==3.8.0
     # via tldextract
-flask==2.0.2
+flask==2.2.2
     # via
     #   -r requirements/app.in
     #   flask-classful
@@ -94,7 +86,7 @@ flask-cors==3.0.10
     # via -r requirements/app.in
 flask-json==0.3.4
     # via -r requirements/app.in
-flask-login==0.5.0
+flask-login==0.6.2
     # via
     #   -r requirements/app.in
     #   flask-security-too
@@ -106,7 +98,7 @@ flask-migrate==3.1.0
     # via -r requirements/app.in
 flask-principal==0.4.0
     # via flask-security-too
-flask-security-too==4.1.2
+flask-security-too==5.0.0
     # via -r requirements/app.in
 flask-sqlalchemy==2.5.1
     # via
@@ -114,17 +106,17 @@ flask-sqlalchemy==2.5.1
     #   flask-migrate
 flask-sslify==0.1.5
     # via -r requirements/app.in
-flask-wtf==1.0.0
+flask-wtf==1.0.1
     # via
     #   -r requirements/app.in
     #   flask-security-too
-fonttools==4.29.1
+fonttools==4.37.1
     # via matplotlib
-greenlet==1.1.2
+greenlet==1.1.3
     # via sqlalchemy
 h11==0.13.0
     # via wsproto
-humanize==4.0.0
+humanize==4.3.0
     # via -r requirements/app.in
 idna==3.3
     # via
@@ -132,12 +124,12 @@ idna==3.3
     #   requests
     #   tldextract
     #   trio
-    #   urllib3
-importlib-metadata==4.11.0
+importlib-metadata==4.12.0
     # via
     #   -r requirements/app.in
+    #   flask
     #   timely-beliefs
-inflect==5.4.0
+inflect==6.0.0
     # via -r requirements/app.in
 inflection==0.5.1
     # via -r requirements/app.in
@@ -147,31 +139,32 @@ isodate==0.6.1
     # via
     #   -r requirements/app.in
     #   timely-beliefs
-itsdangerous==2.0.1
+itsdangerous==2.1.2
     # via
     #   flask
     #   flask-security-too
     #   flask-wtf
-jinja2==3.0.3
+jinja2==3.1.2
     # via
     #   altair
     #   flask
 joblib==1.1.0
     # via scikit-learn
-jsonschema==4.4.0
+jsonschema==4.15.0
     # via altair
-kiwisolver==1.3.2
+kiwisolver==1.4.4
     # via matplotlib
 lunardate==0.2.0
     # via workalendar
-mako==1.1.6
+mako==1.2.2
     # via alembic
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   jinja2
     #   mako
+    #   werkzeug
     #   wtforms
-marshmallow==3.14.1
+marshmallow==3.17.1
     # via
     #   -r requirements/app.in
     #   flask-marshmallow
@@ -180,11 +173,11 @@ marshmallow==3.14.1
     #   webargs
 marshmallow-polyfield==5.10
     # via -r requirements/app.in
-marshmallow-sqlalchemy==0.27.0
+marshmallow-sqlalchemy==0.28.1
     # via -r requirements/app.in
-matplotlib==3.5.1
+matplotlib==3.5.3
     # via timetomodel
-numpy==1.22.2
+numpy==1.23.2
     # via
     #   -r requirements/app.in
     #   altair
@@ -198,12 +191,14 @@ numpy==1.22.2
     #   timely-beliefs
     #   timetomodel
     #   uniplot
-openturns==1.18
+openturns==1.19.post1
     # via timely-beliefs
-outcome==1.1.0
+outcome==1.2.0
     # via trio
 packaging==21.3
     # via
+    #   marshmallow
+    #   marshmallow-sqlalchemy
     #   matplotlib
     #   redis
     #   statsmodels
@@ -219,9 +214,9 @@ passlib==1.7.4
     # via flask-security-too
 patsy==0.5.2
     # via statsmodels
-pillow==9.0.1
+pillow==9.2.0
     # via matplotlib
-pint==0.19.1
+pint==0.19.2
     # via -r requirements/app.in
 ply==3.11
     # via pyomo
@@ -229,7 +224,7 @@ properscoring==0.1
     # via timely-beliefs
 pscript==0.7.7
     # via -r requirements/app.in
-psutil==5.9.0
+psutil==5.9.1
     # via openturns
 psycopg2-binary==2.9.3
     # via
@@ -237,22 +232,22 @@ psycopg2-binary==2.9.3
     #   timely-beliefs
 py-moneyed==2.0
     # via -r requirements/app.in
-pycparser==2.21
-    # via cffi
-pyluach==1.3.0
+pydantic==1.10.0
+    # via inflect
+pyluach==2.0.1
     # via workalendar
 pymeeus==0.5.11
     # via convertdate
-pyomo==6.2
+pyomo==6.4.2
     # via -r requirements/app.in
-pyopenssl==22.0.0
-    # via urllib3
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via
     #   matplotlib
     #   packaging
 pyrsistent==0.18.1
     # via jsonschema
+pysocks==1.7.1
+    # via urllib3
 python-dateutil==2.8.2
     # via
     #   arrow
@@ -260,48 +255,47 @@ python-dateutil==2.8.2
     #   pandas
     #   timetomodel
     #   workalendar
-python-dotenv==0.19.2
+python-dotenv==0.20.0
     # via -r requirements/app.in
-pytz==2021.3
+pytz==2022.2.1
     # via
     #   -r requirements/app.in
     #   babel
     #   pandas
     #   timely-beliefs
     #   timetomodel
-redis==4.1.3
+redis==4.1.4
     # via
     #   -r requirements/app.in
     #   rq
     #   rq-dashboard
-requests==2.27.1
+requests==2.28.1
     # via
     #   requests-file
     #   tldextract
 requests-file==1.5.1
     # via tldextract
-rq==1.10.1
+rq==1.11.0
     # via
     #   -r requirements/app.in
     #   rq-dashboard
 rq-dashboard==0.6.1
     # via -r requirements/app.in
-scikit-learn==1.0.2
+scikit-learn==1.1.2
     # via sklearn
-scipy==1.8.0
+scipy==1.9.1
     # via
     #   properscoring
     #   scikit-learn
     #   statsmodels
     #   timely-beliefs
     #   timetomodel
-selenium==4.1.0
+selenium==4.4.3
     # via timely-beliefs
-sentry-sdk[flask]==1.5.5
+sentry-sdk[flask]==1.9.5
     # via -r requirements/app.in
 six==1.16.0
     # via
-    #   bcrypt
     #   flask-cors
     #   flask-marshmallow
     #   isodate
@@ -314,7 +308,7 @@ sniffio==1.2.0
     # via trio
 sortedcontainers==2.4.0
     # via trio
-sqlalchemy==1.4.31
+sqlalchemy==1.4.40
     # via
     #   -r requirements/app.in
     #   alembic
@@ -324,7 +318,7 @@ sqlalchemy==1.4.31
     #   timetomodel
 statsmodels==0.13.2
     # via timetomodel
-tabulate==0.8.9
+tabulate==0.8.10
     # via -r requirements/app.in
 threadpoolctl==3.1.0
     # via scikit-learn
@@ -332,38 +326,44 @@ timely-beliefs==1.11.5
     # via -r requirements/app.in
 timetomodel==0.7.1
     # via -r requirements/app.in
-tldextract==3.1.2
+tldextract==3.3.1
     # via -r requirements/app.in
-toolz==0.11.2
+toolz==0.12.0
     # via altair
-trio==0.19.0
+trio==0.21.0
     # via
     #   selenium
     #   trio-websocket
 trio-websocket==0.9.2
     # via selenium
-typing-extensions==4.1.1
-    # via py-moneyed
+typing-extensions==4.3.0
+    # via
+    #   py-moneyed
+    #   pydantic
 uniplot==0.5.0
     # via -r requirements/app.in
-urllib3==1.26.8
+urllib3[socks]==1.26.12
     # via
     #   requests
     #   selenium
     #   sentry-sdk
-webargs==8.1.0
+webargs==8.2.0
     # via -r requirements/app.in
-werkzeug==2.0.3
-    # via flask
-workalendar==16.2.0
+werkzeug==2.2.2
+    # via
+    #   flask
+    #   flask-login
+workalendar==16.3.0
     # via -r requirements/app.in
-wrapt==1.13.3
+wrapt==1.14.1
     # via deprecated
-wsproto==1.0.0
+wsproto==1.2.0
     # via trio-websocket
 wtforms==3.0.1
-    # via flask-wtf
+    # via
+    #   flask-security-too
+    #   flask-wtf
 xlrd==2.0.1
     # via -r requirements/app.in
-zipp==3.7.0
+zipp==3.8.1
     # via importlib-metadata

--- a/requirements/app.txt
+++ b/requirements/app.txt
@@ -86,7 +86,7 @@ flask-cors==3.0.10
     # via -r requirements/app.in
 flask-json==0.3.4
     # via -r requirements/app.in
-flask-login==0.6.2
+flask-login==0.5.0
     # via
     #   -r requirements/app.in
     #   flask-security-too
@@ -98,7 +98,7 @@ flask-migrate==3.1.0
     # via -r requirements/app.in
 flask-principal==0.4.0
     # via flask-security-too
-flask-security-too==5.0.0
+flask-security-too==4.1.5
     # via -r requirements/app.in
 flask-sqlalchemy==2.5.1
     # via
@@ -348,11 +348,10 @@ urllib3[socks]==1.26.12
     #   sentry-sdk
 webargs==8.2.0
     # via -r requirements/app.in
-werkzeug==2.1.2
+werkzeug==2.0.3
     # via
     #   -r requirements/app.in
     #   flask
-    #   flask-login
 workalendar==16.3.0
     # via -r requirements/app.in
 wrapt==1.14.1
@@ -360,9 +359,7 @@ wrapt==1.14.1
 wsproto==1.2.0
     # via trio-websocket
 wtforms==3.0.1
-    # via
-    #   flask-security-too
-    #   flask-wtf
+    # via flask-wtf
 xlrd==2.0.1
     # via -r requirements/app.in
 zipp==3.8.1

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,5 +1,6 @@
 -c app.txt
 -c test.txt
+# we are not using app.in and test.in, because we want to develop against exactly what is being packaged and tested
 
 pre-commit
 # we're pinning the following two to what .pre-commit-config.yaml says

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,84 +8,78 @@ black==22.3.0
     # via -r requirements/dev.in
 cfgv==3.3.1
     # via pre-commit
-click==8.0.3
+click==8.1.3
     # via
     #   -c requirements/app.txt
     #   -c requirements/test.txt
     #   black
-distlib==0.3.4
+distlib==0.3.6
     # via virtualenv
-filelock==3.4.2
+filelock==3.8.0
     # via
     #   -c requirements/app.txt
     #   virtualenv
 flake8==4.0.1
     # via -r requirements/dev.in
-flake8-blind-except==0.2.0
+flake8-blind-except==0.2.1
     # via -r requirements/dev.in
-identify==2.4.10
+identify==2.5.3
     # via pre-commit
 mccabe==0.6.1
     # via flake8
-mypy==0.931
+mypy==0.971
     # via -r requirements/dev.in
 mypy-extensions==0.4.3
     # via
     #   black
     #   mypy
-nodeenv==1.6.0
+nodeenv==1.7.0
     # via pre-commit
 packaging==21.3
     # via
     #   -c requirements/app.txt
     #   -c requirements/test.txt
     #   setuptools-scm
-pathspec==0.9.0
+pathspec==0.10.0
     # via black
-platformdirs==2.5.0
+platformdirs==2.5.2
     # via
     #   black
     #   virtualenv
-pre-commit==2.17.0
+pre-commit==2.20.0
     # via -r requirements/dev.in
 pycodestyle==2.8.0
     # via flake8
 pyflakes==2.4.0
     # via flake8
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via
     #   -c requirements/app.txt
     #   -c requirements/test.txt
     #   packaging
-pytest-runner==5.3.1
+pytest-runner==6.0.0
     # via -r requirements/dev.in
 pyyaml==6.0
-    # via
-    #   -c requirements/app.txt
-    #   pre-commit
-setuptools-scm==6.4.2
+    # via pre-commit
+setuptools-scm==7.0.5
     # via -r requirements/dev.in
-six==1.16.0
-    # via
-    #   -c requirements/app.txt
-    #   -c requirements/test.txt
-    #   virtualenv
 toml==0.10.2
     # via pre-commit
-tomli==1.2.3
+tomli==2.0.1
     # via
     #   -c requirements/test.txt
     #   black
     #   mypy
     #   setuptools-scm
-typing-extensions==4.1.1
+typing-extensions==4.3.0
     # via
     #   -c requirements/app.txt
     #   black
     #   mypy
-virtualenv==20.13.1
+    #   setuptools-scm
+virtualenv==20.16.4
     # via pre-commit
-watchdog==2.1.6
+watchdog==2.1.9
     # via -r requirements/dev.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,28 +6,18 @@
 #
 alabaster==0.7.12
     # via sphinx
-babel==2.9.1
+babel==2.10.3
     # via
     #   -c requirements/app.txt
     #   sphinx
-certifi==2021.10.8
+certifi==2022.6.15
     # via
     #   -c requirements/app.txt
     #   requests
-    #   urllib3
-cffi==1.15.0
-    # via
-    #   -c requirements/app.txt
-    #   cryptography
-charset-normalizer==2.0.12
+charset-normalizer==2.1.1
     # via
     #   -c requirements/app.txt
     #   requests
-cryptography==36.0.1
-    # via
-    #   -c requirements/app.txt
-    #   pyopenssl
-    #   urllib3
 docutils==0.17.1
     # via
     #   sphinx
@@ -37,18 +27,17 @@ idna==3.3
     # via
     #   -c requirements/app.txt
     #   requests
-    #   urllib3
 imagesize==1.3.0
     # via sphinx
-importlib-metadata==4.11.0
+importlib-metadata==4.12.0
     # via
     #   -c requirements/app.txt
     #   sphinx
-jinja2==3.0.3
+jinja2==3.1.2
     # via
     #   -c requirements/app.txt
     #   sphinx
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   -c requirements/app.txt
     #   jinja2
@@ -56,27 +45,23 @@ packaging==21.3
     # via
     #   -c requirements/app.txt
     #   sphinx
-pycparser==2.21
-    # via
-    #   -c requirements/app.txt
-    #   cffi
 pygments==2.11.2
     # via
     #   sphinx
     #   sphinx-tabs
-pyopenssl==22.0.0
-    # via
-    #   -c requirements/app.txt
-    #   urllib3
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via
     #   -c requirements/app.txt
     #   packaging
-pytz==2021.3
+pysocks==1.7.1
+    # via
+    #   -c requirements/app.txt
+    #   urllib3
+pytz==2022.2.1
     # via
     #   -c requirements/app.txt
     #   babel
-requests==2.27.1
+requests==2.28.1
     # via
     #   -c requirements/app.txt
     #   sphinx
@@ -116,11 +101,11 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-urllib3==1.26.8
+urllib3[socks]==1.26.12
     # via
     #   -c requirements/app.txt
     #   requests
-zipp==3.7.0
+zipp==3.8.1
     # via
     #   -c requirements/app.txt
     #   importlib-metadata

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,4 +1,5 @@
 -c app.txt
+# we are not using app.in, because we want to test exactly what is being packaged
 
 pytest
 pytest-flask

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,41 +4,31 @@
 #
 #    pip-compile --output-file=requirements/test.txt requirements/test.in
 #
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   -c requirements/app.txt
     #   pytest
-certifi==2021.10.8
+certifi==2022.6.15
     # via
     #   -c requirements/app.txt
     #   requests
-    #   urllib3
-cffi==1.15.0
-    # via
-    #   -c requirements/app.txt
-    #   cryptography
-charset-normalizer==2.0.12
+charset-normalizer==2.1.1
     # via
     #   -c requirements/app.txt
     #   requests
-click==8.0.3
+click==8.1.3
     # via
     #   -c requirements/app.txt
     #   flask
-coverage[toml]==6.3.1
+coverage[toml]==6.4.4
     # via pytest-cov
-cryptography==36.0.1
-    # via
-    #   -c requirements/app.txt
-    #   pyopenssl
-    #   urllib3
 deprecated==1.2.13
     # via
     #   -c requirements/app.txt
     #   redis
-fakeredis==1.7.1
+fakeredis==1.9.0
     # via -r requirements/test.in
-flask==2.0.2
+flask==2.2.2
     # via
     #   -c requirements/app.txt
     #   pytest-flask
@@ -46,27 +36,30 @@ idna==3.3
     # via
     #   -c requirements/app.txt
     #   requests
-    #   urllib3
+importlib-metadata==4.12.0
+    # via
+    #   -c requirements/app.txt
+    #   flask
 iniconfig==1.1.1
     # via pytest
-itsdangerous==2.0.1
+itsdangerous==2.1.2
     # via
     #   -c requirements/app.txt
     #   flask
-jinja2==3.0.3
+jinja2==3.1.2
     # via
     #   -c requirements/app.txt
     #   flask
-lupa==1.10
+lupa==1.13
     # via -r requirements/test.in
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   -c requirements/app.txt
     #   jinja2
+    #   werkzeug
 packaging==21.3
     # via
     #   -c requirements/app.txt
-    #   fakeredis
     #   pytest
     #   pytest-sugar
     #   redis
@@ -74,19 +67,15 @@ pluggy==1.0.0
     # via pytest
 py==1.11.0
     # via pytest
-pycparser==2.21
-    # via
-    #   -c requirements/app.txt
-    #   cffi
-pyopenssl==22.0.0
-    # via
-    #   -c requirements/app.txt
-    #   urllib3
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via
     #   -c requirements/app.txt
     #   packaging
-pytest==7.0.1
+pysocks==1.7.1
+    # via
+    #   -c requirements/app.txt
+    #   urllib3
+pytest==7.1.2
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -96,18 +85,18 @@ pytest-cov==3.0.0
     # via -r requirements/test.in
 pytest-flask==1.2.0
     # via -r requirements/test.in
-pytest-sugar==0.9.4
+pytest-sugar==0.9.5
     # via -r requirements/test.in
-redis==4.1.3
+redis==4.1.4
     # via
     #   -c requirements/app.txt
     #   fakeredis
-requests==2.27.1
+requests==2.28.1
     # via
     #   -c requirements/app.txt
     #   -r requirements/test.in
     #   requests-mock
-requests-mock==1.9.3
+requests-mock==1.10.0
     # via -r requirements/test.in
 six==1.16.0
     # via
@@ -120,20 +109,24 @@ sortedcontainers==2.4.0
     #   fakeredis
 termcolor==1.1.0
     # via pytest-sugar
-tomli==1.2.3
+tomli==2.0.1
     # via
     #   coverage
     #   pytest
-urllib3==1.26.8
+urllib3[socks]==1.26.12
     # via
     #   -c requirements/app.txt
     #   requests
-werkzeug==2.0.3
+werkzeug==2.2.2
     # via
     #   -c requirements/app.txt
     #   flask
     #   pytest-flask
-wrapt==1.13.3
+wrapt==1.14.1
     # via
     #   -c requirements/app.txt
     #   deprecated
+zipp==3.8.1
+    # via
+    #   -c requirements/app.txt
+    #   importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -28,7 +28,7 @@ deprecated==1.2.13
     #   redis
 fakeredis==1.9.0
     # via -r requirements/test.in
-flask==2.2.2
+flask==2.1.2
     # via
     #   -c requirements/app.txt
     #   pytest-flask
@@ -56,7 +56,6 @@ markupsafe==2.1.1
     # via
     #   -c requirements/app.txt
     #   jinja2
-    #   werkzeug
 packaging==21.3
     # via
     #   -c requirements/app.txt
@@ -117,7 +116,7 @@ urllib3[socks]==1.26.12
     # via
     #   -c requirements/app.txt
     #   requests
-werkzeug==2.2.2
+werkzeug==2.1.2
     # via
     #   -c requirements/app.txt
     #   flask

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -116,7 +116,7 @@ urllib3[socks]==1.26.12
     # via
     #   -c requirements/app.txt
     #   requests
-werkzeug==2.1.2
+werkzeug==2.0.3
     # via
     #   -c requirements/app.txt
     #   flask


### PR DESCRIPTION
I ran `make upgrade-deps`. Notes:

- docs dependencies could not be updated, as there is a conflict between dependencies. This can wait, maybe it resolves itself.
- From skimming the diff, only a few changes are sticking out to me:
  - Flask upgrades to version 2.2 (from 2.0). Release notes: [2.2](https://flask.palletsprojects.com/en/2.2.x/changes/#version-2-2-0), [2.1](https://flask.palletsprojects.com/en/2.2.x/changes/#version-2-1-0)  One thing I saw: we can remove @with_appcontext from custom CLI commands :)
  -  Flask-Security-Too is moving version 5 (from 4.1.2), which was released just days ago. I started reading [the release notes](https://flask-security-too.readthedocs.io/en/stable/changelog.html#version-5-0-0), and did not find something worrying yet. But good to keep this in mind, they document very well what we'd need to look for and adapt.

- The selenium dependency is still in there, as timely-beliefs requires it. We'll [change that](https://github.com/SeitaBV/timely-beliefs/pull/107) requirement, so when a new timely-beliefs version lands soon, we could run `make upgrade-deps` once more, to also catch that and remove a large dependency.
- I still have to run `make test` and discover potential problems there... 