### PR TITLE
Fix for bug introduced in PR #491

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -19,6 +19,13 @@ Infrastructure / Support
 * Remove bokeh dependency and obsolete UI views [see `PR #476 <http://www.github.com/FlexMeasures/flexmeasures/pull/476>`_]
 
 
+v0.11.2 | September XX, 2022
+============================
+
+Bugfixes
+-----------
+* Fix regression for sensors recording non-instantaneous values [see `PR #498 <http://www.github.com/FlexMeasures/flexmeasures/pull/498>`_]
+
 
 v0.11.1 | September 5, 2022
 ============================

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -72,7 +72,7 @@ def chart_for_multiple_sensors(
     **override_chart_specs: dict,
 ):
     sensors_specs = []
-    condition = (
+    condition = list(
         sensor.event_resolution
         for sensor in sensors
         if sensor.event_resolution > timedelta(0)

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -381,7 +381,7 @@ class GenericAsset(db.Model, AuthModelMixin):
             from flexmeasures.data.services.time_series import simplify_index
 
             if sensors:
-                condition = (
+                condition = list(
                     bdf.event_resolution
                     for bdf in bdf_dict.values()
                     if bdf.event_resolution > timedelta(0)


### PR DESCRIPTION
This PR fixes a recently introduced bug when viewing the asset page with non-instantaneous sensors.

Without the `list()`, a Generator object is created, which is used up by the `any()` call, causing the `min()` call to crash with:
```
ValueError: min() arg is an empty sequence
```
