### PR TITLE
Issue 499 allow showing sensor data from other assets in the same account

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -9,6 +9,7 @@ New features
 -------------
 
 * Hit the replay button to replay what happened, available on the sensor and asset pages [see `PR #463 <http://www.github.com/FlexMeasures/flexmeasures/pull/463>`_]
+* The asset page also allows to show sensor data from other assets that belong to the same account [see `PR #500 <http://www.github.com/FlexMeasures/flexmeasures/pull/500>`_]
 
 Bugfixes
 -----------

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -41,7 +41,7 @@ from flexmeasures.data.queries.utils import simplify_index
 from flexmeasures.data.schemas.sensors import SensorSchema, SensorIdField
 from flexmeasures.data.schemas.units import QuantityField
 from flexmeasures.data.schemas import AwareDateTimeField
-from flexmeasures.data.services.sensors import get_account_sensors
+from flexmeasures.data.services.sensors import get_sensors
 from flexmeasures.data.services.scheduling import create_scheduling_job
 from flexmeasures.utils.time_utils import duration_isoformat
 from flexmeasures.utils.unit_utils import ur
@@ -110,7 +110,7 @@ class SensorAPI(FlaskView):
         :status 403: INVALID_SENDER
         :status 422: UNPROCESSABLE_ENTITY
         """
-        sensors = get_account_sensors(accounts=[account])
+        sensors = get_sensors(accounts=[account])
         return sensors_schema.dump(sensors), 200
 
     @route("/data", methods=["POST"])

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -110,7 +110,7 @@ class SensorAPI(FlaskView):
         :status 403: INVALID_SENDER
         :status 422: UNPROCESSABLE_ENTITY
         """
-        sensors = get_account_sensors(account=account)
+        sensors = get_account_sensors(accounts=[account])
         return sensors_schema.dump(sensors), 200
 
     @route("/data", methods=["POST"])

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -110,7 +110,7 @@ class SensorAPI(FlaskView):
         :status 403: INVALID_SENDER
         :status 422: UNPROCESSABLE_ENTITY
         """
-        sensors = get_sensors(account_name=account.name)
+        sensors = get_sensors(account=account)
         return sensors_schema.dump(sensors), 200
 
     @route("/data", methods=["POST"])

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -41,7 +41,7 @@ from flexmeasures.data.queries.utils import simplify_index
 from flexmeasures.data.schemas.sensors import SensorSchema, SensorIdField
 from flexmeasures.data.schemas.units import QuantityField
 from flexmeasures.data.schemas import AwareDateTimeField
-from flexmeasures.data.services.sensors import get_sensors
+from flexmeasures.data.services.sensors import get_account_sensors
 from flexmeasures.data.services.scheduling import create_scheduling_job
 from flexmeasures.utils.time_utils import duration_isoformat
 from flexmeasures.utils.unit_utils import ur
@@ -110,7 +110,7 @@ class SensorAPI(FlaskView):
         :status 403: INVALID_SENDER
         :status 422: UNPROCESSABLE_ENTITY
         """
-        sensors = get_sensors(account=account)
+        sensors = get_account_sensors(account=account)
         return sensors_schema.dump(sensors), 200
 
     @route("/data", methods=["POST"])

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -110,7 +110,7 @@ class SensorAPI(FlaskView):
         :status 403: INVALID_SENDER
         :status 422: UNPROCESSABLE_ENTITY
         """
-        sensors = get_sensors(accounts=[account])
+        sensors = get_sensors(account=account)
         return sensors_schema.dump(sensors), 200
 
     @route("/data", methods=["POST"])

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -448,7 +448,7 @@ class GenericAsset(db.Model, AuthModelMixin):
         sensor_map = {
             sensor.id: sensor
             for sensor in self.sensors
-            + get_sensors(self.account_id)
+            + get_sensors(self.owner)
             + get_public_sensors(sensor_ids)
             if sensor.id in sensor_ids
         }

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -436,12 +436,14 @@ class GenericAsset(db.Model, AuthModelMixin):
         if not self.has_attribute("sensors_to_show"):
             return self.sensors[:2]
 
-        from flexmeasures.data.services.sensors import get_public_sensors
+        from flexmeasures.data.services.sensors import get_sensors, get_public_sensors
 
         sensor_ids = self.get_attribute("sensors_to_show")
         sensor_map = {
             sensor.id: sensor
-            for sensor in self.sensors + get_public_sensors(sensor_ids)
+            for sensor in self.sensors
+            + get_sensors(self.account_id)
+            + get_public_sensors(sensor_ids)
             if sensor.id in sensor_ids
         }
 

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -448,7 +448,7 @@ class GenericAsset(db.Model, AuthModelMixin):
         sensor_map = {
             sensor.id: sensor
             for sensor in get_sensors(
-                accounts=[self.owner],
+                account=self.owner,
                 include_public_assets=True,
                 filter_by_sensor_ids=sensor_ids,
             )

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -447,9 +447,7 @@ class GenericAsset(db.Model, AuthModelMixin):
         sensor_ids = self.get_attribute("sensors_to_show")
         sensor_map = {
             sensor.id: sensor
-            for sensor in self.sensors
-            + get_sensors(self.owner)
-            + get_public_sensors(sensor_ids)
+            for sensor in get_sensors(self.owner) + get_public_sensors(sensor_ids)
             if sensor.id in sensor_ids
         }
 

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -447,7 +447,8 @@ class GenericAsset(db.Model, AuthModelMixin):
         sensor_ids = self.get_attribute("sensors_to_show")
         sensor_map = {
             sensor.id: sensor
-            for sensor in get_sensors(self.owner) + get_public_sensors(sensor_ids)
+            for sensor in get_sensors(self.owner, sensor_ids)
+            + get_public_sensors(sensor_ids)
             if sensor.id in sensor_ids
         }
 

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -449,7 +449,6 @@ class GenericAsset(db.Model, AuthModelMixin):
             sensor.id: sensor
             for sensor in get_sensors(self.owner, sensor_ids)
             + get_public_sensors(sensor_ids)
-            if sensor.id in sensor_ids
         }
 
         # Return sensors in the order given by the sensors_to_show attribute

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -442,14 +442,14 @@ class GenericAsset(db.Model, AuthModelMixin):
         if not self.has_attribute("sensors_to_show"):
             return self.sensors[:2]
 
-        from flexmeasures.data.services.sensors import get_account_sensors
+        from flexmeasures.data.services.sensors import get_sensors
 
         sensor_ids = self.get_attribute("sensors_to_show")
         sensor_map = {
             sensor.id: sensor
-            for sensor in get_account_sensors(
+            for sensor in get_sensors(
                 accounts=[self.owner, None],  # include public sensors
-                sensor_ids=sensor_ids,
+                filter_by_sensor_ids=sensor_ids,
             )
         }
 

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -442,16 +442,15 @@ class GenericAsset(db.Model, AuthModelMixin):
         if not self.has_attribute("sensors_to_show"):
             return self.sensors[:2]
 
-        from flexmeasures.data.services.sensors import (
-            get_account_sensors,
-            get_public_sensors,
-        )
+        from flexmeasures.data.services.sensors import get_account_sensors
 
         sensor_ids = self.get_attribute("sensors_to_show")
         sensor_map = {
             sensor.id: sensor
-            for sensor in get_account_sensors(self.owner, sensor_ids)
-            + get_public_sensors(sensor_ids)
+            for sensor in get_account_sensors(
+                accounts=[self.owner, None],  # include public sensors
+                sensor_ids=sensor_ids,
+            )
         }
 
         # Return sensors in the order given by the sensors_to_show attribute

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -442,12 +442,15 @@ class GenericAsset(db.Model, AuthModelMixin):
         if not self.has_attribute("sensors_to_show"):
             return self.sensors[:2]
 
-        from flexmeasures.data.services.sensors import get_sensors, get_public_sensors
+        from flexmeasures.data.services.sensors import (
+            get_account_sensors,
+            get_public_sensors,
+        )
 
         sensor_ids = self.get_attribute("sensors_to_show")
         sensor_map = {
             sensor.id: sensor
-            for sensor in get_sensors(self.owner, sensor_ids)
+            for sensor in get_account_sensors(self.owner, sensor_ids)
             + get_public_sensors(sensor_ids)
         }
 

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -448,7 +448,8 @@ class GenericAsset(db.Model, AuthModelMixin):
         sensor_map = {
             sensor.id: sensor
             for sensor in get_sensors(
-                accounts=[self.owner, None],  # include public sensors
+                accounts=[self.owner],
+                include_public_assets=True,
                 filter_by_sensor_ids=sensor_ids,
             )
         }

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -431,6 +431,12 @@ class GenericAsset(db.Model, AuthModelMixin):
     def sensors_to_show(self) -> List["Sensor"]:  # noqa F821
         """Sensors to show, as defined by the sensors_to_show attribute.
 
+        Sensors to show are defined as a list of sensor ids, which
+        is set by the "sensors_to_show" field of the asset's "attributes" column.
+        Valid sensors either belong to the asset itself, to other assets in the same account,
+        or to public assets.
+
+
         Defaults to two of the asset's sensors.
         """
         if not self.has_attribute("sensors_to_show"):

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -450,7 +450,7 @@ class GenericAsset(db.Model, AuthModelMixin):
             for sensor in get_sensors(
                 account=self.owner,
                 include_public_assets=True,
-                filter_by_sensor_ids=sensor_ids,
+                sensor_id_allowlist=sensor_ids,
             )
         }
 

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -20,7 +20,7 @@ def get_sensors(
     :param sensor_name_allowlist:   optionally, allow only sensors whose name is in this list
     """
     sensor_query = Sensor.query
-    if isinstance(list, account):
+    if isinstance(account, list):
         account_ids = [account.id for account in account]
     else:
         account_ids = [account.id]

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -7,24 +7,25 @@ from flexmeasures.data.models.generic_assets import GenericAsset
 
 
 def get_sensors(
-    accounts: list[Account | None] = None,
+    accounts: list[Account] = None,
+    include_public_assets: bool = False,
     filter_by_sensor_ids: list[int] | None = None,
     filter_by_sensor_names: list[str] | None = None,
 ) -> list[Sensor]:
     """Return a list of Sensor objects that belong to any of the given accounts, and/or public sensors.
 
     :param accounts:                optionally, select only sensors from this list of accounts
-                                    (include None to select sensors that belong to a public asset).
-    :param filter_by_sensor_ids:    optionally, filter by sensor id.
-    :param filter_by_sensor_names:  optionally, filter by sensor name.
+    :param include_public_assets:   if True, include sensors that belong to a public asset
+    :param filter_by_sensor_ids:    optionally, filter by sensor id
+    :param filter_by_sensor_names:  optionally, filter by sensor name
     """
     sensor_query = Sensor.query
     if accounts is not None:
-        account_ids = [account.id for account in accounts if account is not None]
+        account_ids = [account.id for account in accounts]
         sensor_query = sensor_query.join(GenericAsset).filter(
             Sensor.generic_asset_id == GenericAsset.id
         )
-        if None in accounts:
+        if include_public_assets:
             sensor_query = sensor_query.filter(
                 sa.or_(
                     GenericAsset.account_id.in_(account_ids),

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -6,7 +6,7 @@ from flexmeasures import Sensor, Account
 from flexmeasures.data.models.generic_assets import GenericAsset
 
 
-def get_sensors(
+def get_account_sensors(
     account: Account | int | str | None = None,
     sensor_ids: list[int] | None = None,
 ) -> list[Sensor]:

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -1,52 +1,34 @@
 from __future__ import annotations
 
-from werkzeug.exceptions import NotFound
+import sqlalchemy as sa
 
 from flexmeasures import Sensor, Account
 from flexmeasures.data.models.generic_assets import GenericAsset
 
 
 def get_account_sensors(
-    account: Account | int | str | None = None,
+    accounts: list[Account | None],
     sensor_ids: list[int] | None = None,
 ) -> list[Sensor]:
-    """Return a list of Sensor objects.
+    """Return a list of Sensor objects that belong to any of the given accounts.
 
-    :param account: optionally, filter by account by passing an Account, int (account id) or string (account name).
+    :param accounts: select only sensors from this list of accounts
+                     (include None to select sensors that belong to a public asset).
     :param sensor_ids: optionally, filter by sensor id.
     """
-    sensor_query = Sensor.query
-
-    if account is not None:
-        if isinstance(account, int):
-            account = Account.query.filter_by(id=account).one_or_none()
-            if not account:
-                raise NotFound(f"There is no account with id {account}!")
-        elif isinstance(account, str):
-            account = Account.query.filter_by(name=account).one_or_none()
-            if not account:
-                raise NotFound(f"There is no account named {account}!")
-        sensor_query = (
-            sensor_query.join(GenericAsset)
-            .filter(Sensor.generic_asset_id == GenericAsset.id)
-            .filter(GenericAsset.owner == account)
-        )
-    if sensor_ids:
-        sensor_query = sensor_query.filter(Sensor.id.in_(sensor_ids))
-
-    return sensor_query.all()
-
-
-def get_public_sensors(sensor_ids: list[int] | None = None) -> list[Sensor]:
-    """Return a list of Sensor objects that belong to a public asset.
-
-    :param sensor_ids: optionally, filter by sensor id.
-    """
-    sensor_query = (
-        Sensor.query.join(GenericAsset)
-        .filter(Sensor.generic_asset_id == GenericAsset.id)
-        .filter(GenericAsset.account_id.is_(None))
+    account_ids = [account.id for account in accounts if account is not None]
+    sensor_query = Sensor.query.join(GenericAsset).filter(
+        Sensor.generic_asset_id == GenericAsset.id
     )
+    if None in accounts:
+        sensor_query = sensor_query.filter(
+            sa.or_(
+                GenericAsset.account_id.in_(account_ids),
+                GenericAsset.account_id.is_(None),
+            )
+        )
+    else:
+        sensor_query = sensor_query.filter(GenericAsset.account_id.in_(account_ids))
     if sensor_ids:
         sensor_query = sensor_query.filter(Sensor.id.in_(sensor_ids))
     return sensor_query.all()

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -7,33 +7,32 @@ from flexmeasures.data.models.generic_assets import GenericAsset
 
 
 def get_sensors(
-    accounts: list[Account] = None,
+    accounts: list[Account],
     include_public_assets: bool = False,
     filter_by_sensor_ids: list[int] | None = None,
     filter_by_sensor_names: list[str] | None = None,
 ) -> list[Sensor]:
     """Return a list of Sensor objects that belong to any of the given accounts, and/or public sensors.
 
-    :param accounts:                optionally, select only sensors from this list of accounts
+    :param accounts:                select only sensors from this list of accounts
     :param include_public_assets:   if True, include sensors that belong to a public asset
     :param filter_by_sensor_ids:    optionally, filter by sensor id
     :param filter_by_sensor_names:  optionally, filter by sensor name
     """
     sensor_query = Sensor.query
-    if accounts is not None:
-        account_ids = [account.id for account in accounts]
-        sensor_query = sensor_query.join(GenericAsset).filter(
-            Sensor.generic_asset_id == GenericAsset.id
-        )
-        if include_public_assets:
-            sensor_query = sensor_query.filter(
-                sa.or_(
-                    GenericAsset.account_id.in_(account_ids),
-                    GenericAsset.account_id.is_(None),
-                )
+    account_ids = [account.id for account in accounts]
+    sensor_query = sensor_query.join(GenericAsset).filter(
+        Sensor.generic_asset_id == GenericAsset.id
+    )
+    if include_public_assets:
+        sensor_query = sensor_query.filter(
+            sa.or_(
+                GenericAsset.account_id.in_(account_ids),
+                GenericAsset.account_id.is_(None),
             )
-        else:
-            sensor_query = sensor_query.filter(GenericAsset.account_id.in_(account_ids))
+        )
+    else:
+        sensor_query = sensor_query.filter(GenericAsset.account_id.in_(account_ids))
     if filter_by_sensor_ids:
         sensor_query = sensor_query.filter(Sensor.id.in_(filter_by_sensor_ids))
     if filter_by_sensor_names:

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -8,10 +8,12 @@ from flexmeasures.data.models.generic_assets import GenericAsset
 
 def get_sensors(
     account: Account | int | str | None = None,
+    sensor_ids: list[int] | None = None,
 ) -> list[Sensor]:
     """Return a list of Sensor objects.
 
     :param account: optionally, filter by account by passing an Account, int (account id) or string (account name).
+    :param sensor_ids: optionally, filter by sensor id.
     """
     sensor_query = Sensor.query
 
@@ -29,6 +31,8 @@ def get_sensors(
             .filter(Sensor.generic_asset_id == GenericAsset.id)
             .filter(GenericAsset.owner == account)
         )
+    if sensor_ids:
+        sensor_query = sensor_query.filter(Sensor.id.in_(sensor_ids))
 
     return sensor_query.all()
 

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -9,12 +9,14 @@ from flexmeasures.data.models.generic_assets import GenericAsset
 def get_sensors(
     accounts: list[Account | None] = None,
     filter_by_sensor_ids: list[int] | None = None,
+    filter_by_sensor_names: list[str] | None = None,
 ) -> list[Sensor]:
     """Return a list of Sensor objects that belong to any of the given accounts, and/or public sensors.
 
-    :param accounts:             optionally, select only sensors from this list of accounts
-                                 (include None to select sensors that belong to a public asset).
-    :param filter_by_sensor_ids: optionally, filter by sensor id.
+    :param accounts:                optionally, select only sensors from this list of accounts
+                                    (include None to select sensors that belong to a public asset).
+    :param filter_by_sensor_ids:    optionally, filter by sensor id.
+    :param filter_by_sensor_names:  optionally, filter by sensor name.
     """
     sensor_query = Sensor.query
     if accounts is not None:
@@ -33,4 +35,6 @@ def get_sensors(
             sensor_query = sensor_query.filter(GenericAsset.account_id.in_(account_ids))
     if filter_by_sensor_ids:
         sensor_query = sensor_query.filter(Sensor.id.in_(filter_by_sensor_ids))
+    if filter_by_sensor_names:
+        sensor_query = sensor_query.filter(Sensor.name.in_(filter_by_sensor_names))
     return sensor_query.all()

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -7,20 +7,23 @@ from flexmeasures.data.models.generic_assets import GenericAsset
 
 
 def get_sensors(
-    accounts: list[Account],
+    account: Account | list[Account],
     include_public_assets: bool = False,
     filter_by_sensor_ids: list[int] | None = None,
     filter_by_sensor_names: list[str] | None = None,
 ) -> list[Sensor]:
-    """Return a list of Sensor objects that belong to any of the given accounts, and/or public sensors.
+    """Return a list of Sensor objects that belong to the given account, and/or public sensors.
 
-    :param accounts:                select only sensors from this list of accounts
+    :param account:                 select only sensors from this account (or list of accounts)
     :param include_public_assets:   if True, include sensors that belong to a public asset
     :param filter_by_sensor_ids:    optionally, filter by sensor id
     :param filter_by_sensor_names:  optionally, filter by sensor name
     """
     sensor_query = Sensor.query
-    account_ids = [account.id for account in accounts]
+    if isinstance(list, account):
+        account_ids = [account.id for account in account]
+    else:
+        account_ids = [account.id]
     sensor_query = sensor_query.join(GenericAsset).filter(
         Sensor.generic_asset_id == GenericAsset.id
     )

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -19,13 +19,13 @@ def get_sensors(
 
     if account is not None:
         if isinstance(account, int):
-            account = Account.query.filter_by(id=account_id).one_or_none()
+            account = Account.query.filter_by(id=account).one_or_none()
             if not account:
-                raise NotFound(f"There is no account with id {account_id}!")
+                raise NotFound(f"There is no account with id {account}!")
         elif isinstance(account, str):
-            account = Account.query.filter_by(name=account_name).one_or_none()
+            account = Account.query.filter_by(name=account).one_or_none()
             if not account:
-                raise NotFound(f"There is no account named {account_name}!")
+                raise NotFound(f"There is no account named {account}!")
         sensor_query = (
             sensor_query.join(GenericAsset)
             .filter(Sensor.generic_asset_id == GenericAsset.id)

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -7,14 +7,25 @@ from flexmeasures.data.models.generic_assets import GenericAsset
 
 
 def get_sensors(
+    account_id: int | None = None,
     account_name: str | None = None,
 ) -> list[Sensor]:
     """Return a list of Sensor objects.
 
+    :param account_id: optionally, filter by account id.
     :param account_name: optionally, filter by account name.
     """
     sensor_query = Sensor.query
 
+    if account_id is not None:
+        account = Account.query.filter_by(id=account_id).one_or_none()
+        if not account:
+            raise NotFound(f"There is no account with id {account_id}!")
+        sensor_query = (
+            sensor_query.join(GenericAsset)
+            .filter(Sensor.generic_asset_id == GenericAsset.id)
+            .filter(GenericAsset.owner == account)
+        )
     if account_name is not None:
         account = Account.query.filter(Account.name == account_name).one_or_none()
         if not account:

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -7,29 +7,23 @@ from flexmeasures.data.models.generic_assets import GenericAsset
 
 
 def get_sensors(
-    account_id: int | None = None,
-    account_name: str | None = None,
+    account: Account | int | str | None = None,
 ) -> list[Sensor]:
     """Return a list of Sensor objects.
 
-    :param account_id: optionally, filter by account id.
-    :param account_name: optionally, filter by account name.
+    :param account: optionally, filter by account by passing an Account, int (account id) or string (account name).
     """
     sensor_query = Sensor.query
 
-    if account_id is not None:
-        account = Account.query.filter_by(id=account_id).one_or_none()
-        if not account:
-            raise NotFound(f"There is no account with id {account_id}!")
-        sensor_query = (
-            sensor_query.join(GenericAsset)
-            .filter(Sensor.generic_asset_id == GenericAsset.id)
-            .filter(GenericAsset.owner == account)
-        )
-    if account_name is not None:
-        account = Account.query.filter(Account.name == account_name).one_or_none()
-        if not account:
-            raise NotFound(f"There is no account named {account_name}!")
+    if account is not None:
+        if isinstance(account, int):
+            account = Account.query.filter_by(id=account_id).one_or_none()
+            if not account:
+                raise NotFound(f"There is no account with id {account_id}!")
+        elif isinstance(account, str):
+            account = Account.query.filter_by(name=account_name).one_or_none()
+            if not account:
+                raise NotFound(f"There is no account named {account_name}!")
         sensor_query = (
             sensor_query.join(GenericAsset)
             .filter(Sensor.generic_asset_id == GenericAsset.id)

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -9,15 +9,15 @@ from flexmeasures.data.models.generic_assets import GenericAsset
 def get_sensors(
     account: Account | list[Account],
     include_public_assets: bool = False,
-    filter_by_sensor_ids: list[int] | None = None,
-    filter_by_sensor_names: list[str] | None = None,
+    sensor_id_allowlist: list[int] | None = None,
+    sensor_name_allowlist: list[str] | None = None,
 ) -> list[Sensor]:
     """Return a list of Sensor objects that belong to the given account, and/or public sensors.
 
     :param account:                 select only sensors from this account (or list of accounts)
     :param include_public_assets:   if True, include sensors that belong to a public asset
-    :param filter_by_sensor_ids:    optionally, filter by sensor id
-    :param filter_by_sensor_names:  optionally, filter by sensor name
+    :param sensor_id_allowlist:     optionally, allow only sensors whose id is in this list
+    :param sensor_name_allowlist:   optionally, allow only sensors whose name is in this list
     """
     sensor_query = Sensor.query
     if isinstance(list, account):
@@ -36,8 +36,8 @@ def get_sensors(
         )
     else:
         sensor_query = sensor_query.filter(GenericAsset.account_id.in_(account_ids))
-    if filter_by_sensor_ids:
-        sensor_query = sensor_query.filter(Sensor.id.in_(filter_by_sensor_ids))
-    if filter_by_sensor_names:
-        sensor_query = sensor_query.filter(Sensor.name.in_(filter_by_sensor_names))
+    if sensor_id_allowlist:
+        sensor_query = sensor_query.filter(Sensor.id.in_(sensor_id_allowlist))
+    if sensor_name_allowlist:
+        sensor_query = sensor_query.filter(Sensor.name.in_(sensor_name_allowlist))
     return sensor_query.all()

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -6,29 +6,31 @@ from flexmeasures import Sensor, Account
 from flexmeasures.data.models.generic_assets import GenericAsset
 
 
-def get_account_sensors(
-    accounts: list[Account | None],
-    sensor_ids: list[int] | None = None,
+def get_sensors(
+    accounts: list[Account | None] = None,
+    filter_by_sensor_ids: list[int] | None = None,
 ) -> list[Sensor]:
-    """Return a list of Sensor objects that belong to any of the given accounts.
+    """Return a list of Sensor objects that belong to any of the given accounts, and/or public sensors.
 
-    :param accounts: select only sensors from this list of accounts
-                     (include None to select sensors that belong to a public asset).
-    :param sensor_ids: optionally, filter by sensor id.
+    :param accounts:             optionally, select only sensors from this list of accounts
+                                 (include None to select sensors that belong to a public asset).
+    :param filter_by_sensor_ids: optionally, filter by sensor id.
     """
-    account_ids = [account.id for account in accounts if account is not None]
-    sensor_query = Sensor.query.join(GenericAsset).filter(
-        Sensor.generic_asset_id == GenericAsset.id
-    )
-    if None in accounts:
-        sensor_query = sensor_query.filter(
-            sa.or_(
-                GenericAsset.account_id.in_(account_ids),
-                GenericAsset.account_id.is_(None),
-            )
+    sensor_query = Sensor.query
+    if accounts is not None:
+        account_ids = [account.id for account in accounts if account is not None]
+        sensor_query = sensor_query.join(GenericAsset).filter(
+            Sensor.generic_asset_id == GenericAsset.id
         )
-    else:
-        sensor_query = sensor_query.filter(GenericAsset.account_id.in_(account_ids))
-    if sensor_ids:
-        sensor_query = sensor_query.filter(Sensor.id.in_(sensor_ids))
+        if None in accounts:
+            sensor_query = sensor_query.filter(
+                sa.or_(
+                    GenericAsset.account_id.in_(account_ids),
+                    GenericAsset.account_id.is_(None),
+                )
+            )
+        else:
+            sensor_query = sensor_query.filter(GenericAsset.account_id.in_(account_ids))
+    if filter_by_sensor_ids:
+        sensor_query = sensor_query.filter(Sensor.id.in_(filter_by_sensor_ids))
     return sensor_query.all()


### PR DESCRIPTION
This PR lets the asset page also show sensor data from other assets that belong to the same account.