### PR TITLE
Add beliefs with belief timing

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -9,6 +9,7 @@ New features
 -------------
 
 * Hit the replay button to replay what happened, available on the sensor and asset pages [see `PR #463 <http://www.github.com/FlexMeasures/flexmeasures/pull/463>`_]
+* Simplified import of time series data from CSV file that includes a column with explicit recording times for each data point (use case: importing forecasts) [see `PR #501 <http://www.github.com/FlexMeasures/flexmeasures/pull/501>`_]
 
 Bugfixes
 -----------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -9,7 +9,7 @@ New features
 -------------
 
 * Hit the replay button to replay what happened, available on the sensor and asset pages [see `PR #463 <http://www.github.com/FlexMeasures/flexmeasures/pull/463>`_]
-* Simplified import of time series data from CSV file that includes a column with explicit recording times for each data point (use case: importing forecasts) [see `PR #501 <http://www.github.com/FlexMeasures/flexmeasures/pull/501>`_]
+* Improved import of time series data from CSV file: 1) drop duplicate records with warning, and 2) allow configuring which column contains explicit recording times for each data point (use case: import forecasts) [see `PR #501 <http://www.github.com/FlexMeasures/flexmeasures/pull/501>`_]
 
 Bugfixes
 -----------

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -467,7 +467,7 @@ def add_beliefs(
         na_values=na_values,
         **kwargs,
     )
-    duplicate_rows = bdf.index.duplicated(keep="first") == True
+    duplicate_rows = bdf.index.duplicated(keep="first")
     if any(duplicate_rows) > 0:
         print("Duplicates found. Dropping duplicates for the following records:")
         print(bdf[duplicate_rows])

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -467,6 +467,11 @@ def add_beliefs(
         na_values=na_values,
         **kwargs,
     )
+    duplicate_rows = bdf.index.duplicated(keep="first") == True
+    if any(duplicate_rows) > 0:
+        print("Duplicates found. Dropping duplicates for the following records:")
+        print(bdf[duplicate_rows])
+        bdf = bdf[~duplicate_rows]
     if unit is not None:
         bdf["event_value"] = convert_units(
             bdf["event_value"],

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -28,7 +28,7 @@ tldextract
 pyomo>=5.6
 tabulate
 timetomodel>=0.7.1
-timely-beliefs>=1.11.5
+timely-beliefs>=1.12
 python-dotenv
 # a backport, not needed in Python3.8
 importlib_metadata


### PR DESCRIPTION
This PR allows reading time series from a file that explicitly includes belief times. Also we now drop duplicate rows when reading time series from file, with a warning to the user.