### PR TITLE
Issue 502 visually distinguish forecasts from measurements

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -9,6 +9,7 @@ New features
 -------------
 
 * Hit the replay button to replay what happened, available on the sensor and asset pages [see `PR #463 <http://www.github.com/FlexMeasures/flexmeasures/pull/463>`_]
+* Visually distinguish forecasts/schedules (dashed lines) from measurements (solid lines), and expand the tooltip with timing info regarding the forecast/schedule horizon or measurement lag [see `PR #503 <http://www.github.com/FlexMeasures/flexmeasures/pull/503>`_]
 * Improved import of time series data from CSV file: 1) drop duplicate records with warning, and 2) allow configuring which column contains explicit recording times for each data point (use case: import forecasts) [see `PR #501 <http://www.github.com/FlexMeasures/flexmeasures/pull/501>`_]
 
 Bugfixes

--- a/flexmeasures/api/dev/sensors.py
+++ b/flexmeasures/api/dev/sensors.py
@@ -166,8 +166,8 @@ class AssetAPI(FlaskView):
             **{attr: getattr(asset, attr) for attr in attributes},
             **{
                 "timerange_of_sensors_to_show": {
-                    'start': datetime.datetime(2020, 12, 3, 14, 0, tzinfo=pytz.utc),
-                    'end': datetime.datetime(2020, 12, 3, 14, 30, tzinfo=pytz.utc)
+                    "start": datetime.datetime(2020, 12, 3, 14, 0, tzinfo=pytz.utc),
+                    "end": datetime.datetime(2020, 12, 3, 14, 30, tzinfo=pytz.utc),
                 },
             },
         }

--- a/flexmeasures/api/dev/sensors.py
+++ b/flexmeasures/api/dev/sensors.py
@@ -1,5 +1,3 @@
-import datetime
-import pytz
 import json
 import warnings
 

--- a/flexmeasures/api/dev/sensors.py
+++ b/flexmeasures/api/dev/sensors.py
@@ -159,18 +159,8 @@ class AssetAPI(FlaskView):
 
         .. :quickref: Chart; Download asset attributes for use in charts
         """
-        # attributes = ["name", "timezone", "timerange_of_sensors_to_show"]
-        # return {attr: getattr(asset, attr) for attr in attributes}
-        attributes = ["name", "timezone"]  # , "timerange_of_sensors_to_show"]
-        return {
-            **{attr: getattr(asset, attr) for attr in attributes},
-            **{
-                "timerange_of_sensors_to_show": {
-                    "start": datetime.datetime(2020, 12, 3, 14, 0, tzinfo=pytz.utc),
-                    "end": datetime.datetime(2020, 12, 3, 14, 30, tzinfo=pytz.utc),
-                },
-            },
-        }
+        attributes = ["name", "timezone", "timerange_of_sensors_to_show"]
+        return {attr: getattr(asset, attr) for attr in attributes}
 
 
 def get_sensor_or_abort(id: int) -> Sensor:

--- a/flexmeasures/api/dev/sensors.py
+++ b/flexmeasures/api/dev/sensors.py
@@ -1,3 +1,5 @@
+import datetime
+import pytz
 import json
 import warnings
 
@@ -157,8 +159,18 @@ class AssetAPI(FlaskView):
 
         .. :quickref: Chart; Download asset attributes for use in charts
         """
-        attributes = ["name", "timezone", "timerange_of_sensors_to_show"]
-        return {attr: getattr(asset, attr) for attr in attributes}
+        # attributes = ["name", "timezone", "timerange_of_sensors_to_show"]
+        # return {attr: getattr(asset, attr) for attr in attributes}
+        attributes = ["name", "timezone"]  # , "timerange_of_sensors_to_show"]
+        return {
+            **{attr: getattr(asset, attr) for attr in attributes},
+            **{
+                "timerange_of_sensors_to_show": {
+                    'start': datetime.datetime(2020, 12, 3, 14, 0, tzinfo=pytz.utc),
+                    'end': datetime.datetime(2020, 12, 3, 14, 30, tzinfo=pytz.utc)
+                },
+            },
+        }
 
 
 def get_sensor_or_abort(id: int) -> Sensor:

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -138,13 +138,13 @@ def chart_for_multiple_sensors(
         ex_ante_line_layer = {
             **line_layer,
             **{
-                "transform": [{"filter": f"datum.belief_horizon > 0"}],
+                "transform": [{"filter": "datum.belief_horizon > 0"}],
             },
         }
         ex_post_line_layer = {
             **line_layer,
             **{
-                "transform": [{"filter": f"datum.belief_horizon <= 0"}],
+                "transform": [{"filter": "datum.belief_horizon <= 0"}],
             },
         }
         sensor_specs = {

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -126,25 +126,32 @@ def chart_for_multiple_sensors(
                 "y": event_value_field_definition,
                 "color": FIELD_DEFINITIONS["source_name"],
                 "strokeDash": {
-                    "condition": {
-                        "test": "datum['belief_horizon'] > 0",
-                        "value": [1, 2],  # dashed
+                    "field": "belief_horizon",
+                    "type": "quantitative",
+                    "bin": {
+                        # Divide belief horizons into 2 bins by setting a very large bin size.
+                        # The bins should be defined as follows: ex ante (>0) and ex post (<=0),
+                        # but because the bin anchor is included in the ex-ante bin,
+                        # and 0 belief horizons should be attributed to the ex-post bin,
+                        # (and belief horizons are given with 1 ms precision,)
+                        # the bin anchor is set at 1 ms before knowledge time to obtain: ex ante (>=1) and ex post (<1).
+                        "anchor": 1,
+                        "step": 8640000000000000,  # JS max ms for a Date object (NB 10 times less than Python max ms)
+                        # "step": timedelta.max.total_seconds() * 10**2,
                     },
-                    "value": [1, 0],  # solid
+                    "legend": {
+                        # Belief horizons binned as 1 ms contain ex-ante beliefs; the other bin contains ex-post beliefs
+                        "labelExpr": f"datum.label > 0 ? 'ex ante' : 'ex post'",
+                        "title": "Recorded",
+                    },
+                    "scale": {
+                        # Positive belief horizons are clamped to 1, negative belief horizons are clamped to 0
+                        "domain": [1, 0],
+                        # belief horizons >= 1 ms get a dashed line, belief horizons < 1 ms get a solid line
+                        "range": [[1, 2], [1, 0]],
+                    },
                 },
                 "detail": FIELD_DEFINITIONS["source"],
-            },
-        }
-        ex_ante_line_layer = {
-            **line_layer,
-            **{
-                "transform": [{"filter": "datum.belief_horizon > 0"}],
-            },
-        }
-        ex_post_line_layer = {
-            **line_layer,
-            **{
-                "transform": [{"filter": "datum.belief_horizon <= 0"}],
             },
         }
         sensor_specs = {
@@ -153,8 +160,7 @@ def chart_for_multiple_sensors(
             else None,
             "transform": [{"filter": f"datum.sensor.id == {sensor.id}"}],
             "layer": [
-                ex_ante_line_layer,
-                ex_post_line_layer,
+                line_layer,
                 {
                     "mark": {
                         "type": "rect",

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -141,7 +141,7 @@ def chart_for_multiple_sensors(
                     },
                     "legend": {
                         # Belief horizons binned as 1 ms contain ex-ante beliefs; the other bin contains ex-post beliefs
-                        "labelExpr": f"datum.label > 0 ? 'ex ante' : 'ex post'",
+                        "labelExpr": "datum.label > 0 ? 'ex ante' : 'ex post'",
                         "title": "Recorded",
                     },
                     "scale": {

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -99,6 +99,13 @@ def chart_for_multiple_sensors(
             }
         shared_tooltip = [
             FIELD_DEFINITIONS["full_date"],
+            dict(
+                field="belief_horizon",
+                type="quantitative",
+                title="Horizon",
+                format=["d", 4],
+                formatType="timedeltaFormat",
+            ),
             {
                 **event_value_field_definition,
                 **dict(title=f"{capitalize(sensor.sensor_type)}"),

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -394,6 +394,7 @@ class GenericAsset(db.Model, AuthModelMixin):
                 for sensor, bdf in bdf_dict.items():
                     if bdf.event_resolution > timedelta(0):
                         bdf = bdf.resample_events(minimum_non_zero_resolution)
+                    bdf["belief_horizon"] = bdf.belief_horizons.to_numpy()
                     df = simplify_index(
                         bdf,
                         index_levels_to_columns=["source"]

--- a/flexmeasures/ui/static/js/flexmeasures.js
+++ b/flexmeasures/ui/static/js/flexmeasures.js
@@ -325,6 +325,10 @@ function submit_sensor_type() {
  *                     'format': [<d3-format>, <breakpoint>],
  *                     'formatType': 'timedeltaFormat'
  *                 }
+ *            <d3-format>  is a d3 format identifier, e.g. 'd' for decimal notation, rounded to integer.
+ *                         See https://github.com/d3/d3-format for more details.
+ *            <breakpoint> is a scalar that decides the breakpoint from one duration unit to the next larger unit.
+  *                        For example, a breakpoint of 4 means we format 4 days as '4 days', but 3.96 days as '95 hours'.
  */
 vega.expressionFunction('quantityWithUnitFormat', function(datum, params) {
     return d3.format(params[0])(datum) + " " + params[1];

--- a/flexmeasures/ui/static/js/flexmeasures.js
+++ b/flexmeasures/ui/static/js/flexmeasures.js
@@ -330,10 +330,10 @@ vega.expressionFunction('quantityWithUnitFormat', function(datum, params) {
     return d3.format(params[0])(datum) + " " + params[1];
 });
 vega.expressionFunction('timedeltaFormat', function(timedelta, params) {
-    return (timedelta > 1000 * 60 * 60 * 24 * 365.2425 * params[1] ? d3.format(params[0])(timedelta / (1000 * 60 * 60 * 24 * 365.2425)) + " years"
-        : timedelta > 1000 * 60 * 60 * 24 * params[1] ? d3.format(params[0])(timedelta / (1000 * 60 * 60 * 24)) + " days"
-        : timedelta > 1000 * 60 * 60 * params[1] ? d3.format(params[0])(timedelta / (1000 * 60 * 60)) + " hours"
-        : timedelta > 1000 * 60 * params[1] ? d3.format(params[0])(timedelta / (1000 * 60)) + " minutes"
-        : timedelta > 1000 * params[1] ? d3.format(params[0])(timedelta / 1000) + " seconds"
+    return (Math.abs(timedelta) > 1000 * 60 * 60 * 24 * 365.2425 * params[1] ? d3.format(params[0])(timedelta / (1000 * 60 * 60 * 24 * 365.2425)) + " years"
+        : Math.abs(timedelta) > 1000 * 60 * 60 * 24 * params[1] ? d3.format(params[0])(timedelta / (1000 * 60 * 60 * 24)) + " days"
+        : Math.abs(timedelta) > 1000 * 60 * 60 * params[1] ? d3.format(params[0])(timedelta / (1000 * 60 * 60)) + " hours"
+        : Math.abs(timedelta) > 1000 * 60 * params[1] ? d3.format(params[0])(timedelta / (1000 * 60)) + " minutes"
+        : Math.abs(timedelta) > 1000 * params[1] ? d3.format(params[0])(timedelta / 1000) + " seconds"
         : d3.format(params[0])(timedelta) + " milliseconds");
 });

--- a/flexmeasures/ui/static/js/flexmeasures.js
+++ b/flexmeasures/ui/static/js/flexmeasures.js
@@ -311,13 +311,29 @@ function submit_sensor_type() {
     $("#sensor_type-form").attr("action", empty_location).submit();
 }
 
-/** Tooltips: Register custom formatter for quantities incl. units
-              Usage:
-                  {
-                      'format': [<d3-format>, <sensor unit>],
-                      'formatType': 'quantityWithUnitFormat'
-                  }
-*/
+/** Tooltips: Register custom formatters
+ *
+ *          - Quantities incl. units
+ *            Usage:
+ *                 {
+ *                     'format': [<d3-format>, <sensor unit>],
+ *                     'formatType': 'quantityWithUnitFormat'
+ *                 }
+ *          - Timedeltas measured in human-readable quantities (usually not milliseconds)
+ *            Usage:
+ *                 {
+ *                     'format': [<d3-format>, <breakpoint>],
+ *                     'formatType': 'timedeltaFormat'
+ *                 }
+ */
 vega.expressionFunction('quantityWithUnitFormat', function(datum, params) {
     return d3.format(params[0])(datum) + " " + params[1];
+});
+vega.expressionFunction('timedeltaFormat', function(timedelta, params) {
+    return (timedelta > 1000 * 60 * 60 * 24 * 365.2425 * params[1] ? d3.format(params[0])(timedelta / (1000 * 60 * 60 * 24 * 365.2425)) + " years"
+        : timedelta > 1000 * 60 * 60 * 24 * params[1] ? d3.format(params[0])(timedelta / (1000 * 60 * 60 * 24)) + " days"
+        : timedelta > 1000 * 60 * 60 * params[1] ? d3.format(params[0])(timedelta / (1000 * 60 * 60)) + " hours"
+        : timedelta > 1000 * 60 * params[1] ? d3.format(params[0])(timedelta / (1000 * 60)) + " minutes"
+        : timedelta > 1000 * params[1] ? d3.format(params[0])(timedelta / 1000) + " seconds"
+        : d3.format(params[0])(timedelta) + " milliseconds");
 });


### PR DESCRIPTION
This PR creates a visual distinction between forecasts/schedules (dashed lines) and measurements (solid lines). It also expands the tooltip with timing info regarding the forecast/schedule horizon or measurement lag.

Closes #502.