### PR TITLE
Fix scheduler for Charge Points

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -25,6 +25,14 @@ Infrastructure / Support
 * Remove bokeh dependency and obsolete UI views [see `PR #476 <http://www.github.com/FlexMeasures/flexmeasures/pull/476>`_]
 
 
+v0.11.3 | November XX, 2022
+============================
+
+Bugfixes
+-----------
+* Fix scheduler for Charge Points when taking into account inflexible devices [see `PR #517 <http://www.github.com/FlexMeasures/flexmeasures/pull/517>`_]
+
+
 v0.11.2 | September 6, 2022
 ============================
 

--- a/flexmeasures/data/models/planning/charging_station.py
+++ b/flexmeasures/data/models/planning/charging_station.py
@@ -110,9 +110,10 @@ def schedule_charging_station(
     ]
     if inflexible_device_sensors is None:
         inflexible_device_sensors = []
-    device_constraints = [initialize_df(columns, start, end, resolution)] * (
-        1 + len(inflexible_device_sensors)
-    )
+    device_constraints = [
+        initialize_df(columns, start, end, resolution)
+        for i in range(1 + len(inflexible_device_sensors))
+    ]
     for i, inflexible_sensor in enumerate(inflexible_device_sensors):
         device_constraints[i + 1]["derivative equals"] = get_power_values(
             query_window=(start, end),


### PR DESCRIPTION
Fix bug: list multiplication refers to the same object; as a consequence, any new device constraint overwrote all previously set device constraints.