### PR TITLE
Unchanged ex-ante and ex-post beliefs

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -23,6 +23,7 @@ Infrastructure / Support
 
 * Reduce size of Docker image (from 2GB to 1.4GB) [see `PR #512 <http://www.github.com/FlexMeasures/flexmeasures/pull/512>`_]
 * Remove bokeh dependency and obsolete UI views [see `PR #476 <http://www.github.com/FlexMeasures/flexmeasures/pull/476>`_]
+* Revised strategy for removing unchanged beliefs when saving data: retain the oldest measurement (ex-post belief), too [see `PR #518 <http://www.github.com/FlexMeasures/flexmeasures/pull/518>`_]
 
 
 v0.11.2 | September 6, 2022

--- a/flexmeasures/api/common/utils/api_utils.py
+++ b/flexmeasures/api/common/utils/api_utils.py
@@ -409,11 +409,7 @@ def save_to_db(
 
         if save_changed_beliefs_only:
             # Drop beliefs that haven't changed
-            timed_values = (
-                timed_values.convert_index_from_belief_horizon_to_time()
-                .groupby(level=["belief_time", "source"], as_index=False)
-                .apply(drop_unchanged_beliefs)
-            )
+            timed_values = drop_unchanged_beliefs(timed_values)
 
             # Work around bug in which groupby still introduces an index level, even though we asked it not to
             if None in timed_values.index.names:

--- a/flexmeasures/data/services/time_series.py
+++ b/flexmeasures/data/services/time_series.py
@@ -353,10 +353,6 @@ def drop_unchanged_beliefs(bdf: tb.BeliefsDataFrame) -> tb.BeliefsDataFrame:
 
 def _drop_unchanged_beliefs(bdf: tb.BeliefsDataFrame) -> tb.BeliefsDataFrame:
     """Only works on BeliefsDataFrames with a unique belief time and unique source."""
-    if len(bdf.lineage.belief_times) > 1:
-        raise NotImplementedError("Beliefs should share a unique belief time.")
-    if len(bdf.lineage.sources) > 1:
-        raise NotImplementedError("Beliefs should share a unique source.")
     previous_beliefs_in_db = bdf.sensor.search_beliefs(
         event_starts_after=bdf.event_starts[0],
         event_ends_before=bdf.event_ends[-1],

--- a/flexmeasures/data/services/time_series.py
+++ b/flexmeasures/data/services/time_series.py
@@ -326,7 +326,7 @@ def drop_unchanged_beliefs(bdf: tb.BeliefsDataFrame) -> tb.BeliefsDataFrame:
     ex_ante_bdf = bdf[bdf.belief_horizons > timedelta(0)]
     ex_post_bdf = bdf[bdf.belief_horizons <= timedelta(0)]
     if not ex_ante_bdf.empty and not ex_post_bdf.empty:
-        # Recursive function call
+        # We treat each part separately to avoid the ex-post knowledge would be lost
         ex_ante_bdf = drop_unchanged_beliefs(ex_ante_bdf)
         ex_post_bdf = drop_unchanged_beliefs(ex_post_bdf)
         bdf = pd.concat([ex_ante_bdf, ex_post_bdf])

--- a/flexmeasures/data/services/time_series.py
+++ b/flexmeasures/data/services/time_series.py
@@ -352,7 +352,11 @@ def drop_unchanged_beliefs(bdf: tb.BeliefsDataFrame) -> tb.BeliefsDataFrame:
 
 
 def _drop_unchanged_beliefs(bdf: tb.BeliefsDataFrame) -> tb.BeliefsDataFrame:
-    """Only works on BeliefsDataFrames with a unique belief time and unique source."""
+    """Drop beliefs that are already stored in the database with an earlier belief time.
+
+    Assumes a BeliefsDataFrame with a unique belief time and unique source,
+    and either all ex-ante beliefs or all ex-post beliefs.
+    """
     if bdf.belief_horizons[0] > timedelta(0):
         # Look up only ex-ante beliefs (horizon > 0)
         kwargs = dict(horizons_at_least=timedelta(0))

--- a/flexmeasures/data/services/time_series.py
+++ b/flexmeasures/data/services/time_series.py
@@ -320,6 +320,15 @@ def drop_unchanged_beliefs(bdf: tb.BeliefsDataFrame) -> tb.BeliefsDataFrame:
     """
     if bdf.empty:
         return bdf
+    return (
+        bdf.convert_index_from_belief_horizon_to_time()
+        .groupby(level=["belief_time", "source"], as_index=False)
+        .apply(_drop_unchanged_beliefs)
+    )
+
+
+def _drop_unchanged_beliefs(bdf: tb.BeliefsDataFrame) -> tb.BeliefsDataFrame:
+    """Only works on BeliefsDataFrames with a unique belief time and unique source."""
     if len(bdf.lineage.belief_times) > 1:
         raise NotImplementedError("Beliefs should share a unique belief time.")
     if len(bdf.lineage.sources) > 1:

--- a/flexmeasures/data/services/time_series.py
+++ b/flexmeasures/data/services/time_series.py
@@ -360,7 +360,7 @@ def _drop_unchanged_beliefs(bdf: tb.BeliefsDataFrame) -> tb.BeliefsDataFrame:
         source=bdf.lineage.sources[0],  # unique source
         most_recent_beliefs_only=False,
     )
-    # todo: delete next line and set most_recent_beliefs_only=True when this is resolved: https://github.com/SeitaBV/timely-beliefs/issues/97
+    # todo: delete next line and set most_recent_beliefs_only=True when this is resolved: https://github.com/SeitaBV/timely-beliefs/pull/117
     previous_most_recent_beliefs_in_db = belief_utils.select_most_recent_belief(
         previous_beliefs_in_db
     )

--- a/flexmeasures/data/services/time_series.py
+++ b/flexmeasures/data/services/time_series.py
@@ -344,18 +344,23 @@ def drop_unchanged_beliefs(bdf: tb.BeliefsDataFrame) -> tb.BeliefsDataFrame:
         .set_index(index_names)
     )
 
+    # Remove unchanged beliefs with respect to what is already stored in the database
     return (
         bdf.convert_index_from_belief_horizon_to_time()
         .groupby(level=["belief_time", "source"], as_index=False)
-        .apply(_drop_unchanged_beliefs)
+        .apply(_drop_unchanged_beliefs_compared_to_db)
     )
 
 
-def _drop_unchanged_beliefs(bdf: tb.BeliefsDataFrame) -> tb.BeliefsDataFrame:
+def _drop_unchanged_beliefs_compared_to_db(
+    bdf: tb.BeliefsDataFrame,
+) -> tb.BeliefsDataFrame:
     """Drop beliefs that are already stored in the database with an earlier belief time.
 
     Assumes a BeliefsDataFrame with a unique belief time and unique source,
     and either all ex-ante beliefs or all ex-post beliefs.
+
+    It is preferable to call the public function drop_unchanged_beliefs instead.
     """
     if bdf.belief_horizons[0] > timedelta(0):
         # Look up only ex-ante beliefs (horizon > 0)

--- a/flexmeasures/data/services/time_series.py
+++ b/flexmeasures/data/services/time_series.py
@@ -323,6 +323,16 @@ def drop_unchanged_beliefs(bdf: tb.BeliefsDataFrame) -> tb.BeliefsDataFrame:
     if bdf.empty:
         return bdf
 
+    # Save the oldest ex-post beliefs explicitly, even if they do not deviate from the most recent ex-ante beliefs
+    ex_ante_bdf = bdf[bdf.belief_horizons > timedelta(0)]
+    ex_post_bdf = bdf[bdf.belief_horizons <= timedelta(0)]
+    if not ex_ante_bdf.empty and not ex_post_bdf.empty:
+        # Recursive function call
+        ex_ante_bdf = drop_unchanged_beliefs(ex_ante_bdf)
+        ex_post_bdf = drop_unchanged_beliefs(ex_post_bdf)
+        bdf = pd.concat([ex_ante_bdf, ex_post_bdf])
+        return bdf
+
     # Remove unchanged beliefs from within the new data itself
     index_names = bdf.index.names
     bdf = (

--- a/flexmeasures/data/services/time_series.py
+++ b/flexmeasures/data/services/time_series.py
@@ -318,7 +318,6 @@ def drop_unchanged_beliefs(bdf: tb.BeliefsDataFrame) -> tb.BeliefsDataFrame:
     Also drop beliefs that are already in the data with an earlier belief time.
 
     Quite useful function to prevent cluttering up your database with beliefs that remain unchanged over time.
-    Only works on BeliefsDataFrames with a unique belief time and unique source.
     """
     if bdf.empty:
         return bdf

--- a/flexmeasures/data/services/time_series.py
+++ b/flexmeasures/data/services/time_series.py
@@ -353,12 +353,19 @@ def drop_unchanged_beliefs(bdf: tb.BeliefsDataFrame) -> tb.BeliefsDataFrame:
 
 def _drop_unchanged_beliefs(bdf: tb.BeliefsDataFrame) -> tb.BeliefsDataFrame:
     """Only works on BeliefsDataFrames with a unique belief time and unique source."""
+    if bdf.belief_horizons[0] > timedelta(0):
+        # Look up only ex-ante beliefs (horizon > 0)
+        kwargs = dict(horizons_at_least=timedelta(0))
+    else:
+        # Look up only ex-post beliefs (horizon <= 0)
+        kwargs = dict(horizons_at_most=timedelta(0))
     previous_beliefs_in_db = bdf.sensor.search_beliefs(
         event_starts_after=bdf.event_starts[0],
         event_ends_before=bdf.event_ends[-1],
         beliefs_before=bdf.lineage.belief_times[0],  # unique belief time
         source=bdf.lineage.sources[0],  # unique source
         most_recent_beliefs_only=False,
+        **kwargs,
     )
     # todo: delete next line and set most_recent_beliefs_only=True when this is resolved: https://github.com/SeitaBV/timely-beliefs/pull/117
     previous_most_recent_beliefs_in_db = belief_utils.select_most_recent_belief(

--- a/flexmeasures/data/utils.py
+++ b/flexmeasures/data/utils.py
@@ -105,11 +105,7 @@ def save_to_db(
         if save_changed_beliefs_only:
 
             # Drop beliefs that haven't changed
-            timed_values = (
-                timed_values.convert_index_from_belief_horizon_to_time()
-                .groupby(level=["belief_time", "source"], as_index=False)
-                .apply(drop_unchanged_beliefs)
-            )
+            timed_values = drop_unchanged_beliefs(timed_values)
             len_after = len(timed_values)
             if len_after < len_before:
                 status = "success_with_unchanged_beliefs_skipped"


### PR DESCRIPTION
This PR: 1) prevents more redundant data from entering the database, and 2) retains data that one might usually consider not to be redundant. Let me explain:

1. We usually wish to remove unchanged beliefs from saved data. Whereas before, only data was removed that didn't represent a changed belief with respect to the already saved data, now also data is removed that doesn't represent a changed belief with respect to the other new data.
2. Before this PR, when a measurement (ex-post belief) was equal to the most recent forecast (ex-ante belief), it wasn't saved. However, we started making a visual distinction between ex-post and ex-ante beliefs in charts (solid and dashed lines, respectively). Therefore, we wish to save the oldest ex-post belief explicitly, regardless of whether it represents a changed belief.