### PR TITLE
Small CLI fixes

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -24,6 +24,7 @@ Infrastructure / Support
 
 * Reduce size of Docker image (from 2GB to 1.4GB) [see `PR #512 <http://www.github.com/FlexMeasures/flexmeasures/pull/512>`_]
 * Remove bokeh dependency and obsolete UI views [see `PR #476 <http://www.github.com/FlexMeasures/flexmeasures/pull/476>`_]
+* Fix ``flexmeasures db-ops dump`` and ``flexmeasures db-ops restore`` incorrectly reporting a success when `pg_dump` and `pg_restore` are not installed [see `PR #526 <http://www.github.com/FlexMeasures/flexmeasures/pull/526>`_]
 
 
 v0.11.3 | November 2, 2022

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -4,6 +4,11 @@
 FlexMeasures CLI Changelog
 **********************
 
+since v0.12.0 | November xx, 2022
+=================================
+
+* Fix ``flexmeasures db-ops dump`` and ``flexmeasures db-ops restore`` incorrectly reporting a success when `pg_dump` and `pg_restore` are not installed.
+
 since v0.11.0 | August 28, 2022
 ==============================
 

--- a/flexmeasures/cli/data_delete.py
+++ b/flexmeasures/cli/data_delete.py
@@ -12,6 +12,7 @@ from flexmeasures.data.models.user import Account, AccountRole, RolesAccounts, U
 from flexmeasures.data.models.generic_assets import GenericAsset
 from flexmeasures.data.models.time_series import Sensor, TimedBelief
 from flexmeasures.data.schemas.generic_assets import GenericAssetIdField
+from flexmeasures.data.schemas.sensors import SensorIdField
 from flexmeasures.data.services.users import find_user_by_email, delete_user
 
 
@@ -123,7 +124,7 @@ def delete_asset_and_data(asset: GenericAsset, force: bool):
     Delete an asset & also its sensors and data.
     """
     if not force:
-        prompt = f"Delete {asset}, including all its sensors and data?"
+        prompt = f"Delete {asset.__repr__()}, including all its sensors and data?"
         click.confirm(prompt, abort=True)
     db.session.delete(asset)
     db.session.commit()
@@ -295,21 +296,18 @@ def delete_nan_beliefs(sensor_id: Optional[int] = None):
 @with_appcontext
 @click.option(
     "--id",
-    "sensor_id",
-    type=int,
+    "sensor",
+    type=SensorIdField(),
     required=True,
     help="Delete a single sensor and its (time series) data. Follow up with the sensor's ID.",
 )
 def delete_sensor(
-    sensor_id: int,
+    sensor: Sensor,
 ):
     """Delete a sensor and all beliefs about it."""
-    sensor = Sensor.query.get(sensor_id)
-    n = TimedBelief.query.filter(TimedBelief.sensor_id == sensor_id).delete()
+    n = TimedBelief.query.filter(TimedBelief.sensor_id == sensor.id).delete()
     db.session.delete(sensor)
-    click.confirm(
-        f"Really delete sensor {sensor_id}, along with {n} beliefs?", abort=True
-    )
+    click.confirm(f"Delete {sensor.__repr__()}, along with {n} beliefs?", abort=True)
     db.session.commit()
 
 

--- a/flexmeasures/cli/db_ops.py
+++ b/flexmeasures/cli/db_ops.py
@@ -95,10 +95,7 @@ def dump():
     dump_filename = f"pgbackup_{db_name}_{time_of_saving}.dump"
     command_for_dumping = f"pg_dump --no-privileges --no-owner --data-only --format=c --file={dump_filename} {db_uri}"
     try:
-        proc = subprocess.Popen(command_for_dumping, shell=True)  # , env={
-        # 'PGPASSWORD': DB_PASSWORD
-        # })
-        proc.wait()
+        subprocess.check_output(command_for_dumping, shell=True)
         click.echo(f"db dump successful: saved to {dump_filename}")
 
     except Exception as e:

--- a/flexmeasures/cli/db_ops.py
+++ b/flexmeasures/cli/db_ops.py
@@ -122,10 +122,7 @@ def restore(file: str):
     click.echo(f"Restoring {db_host_and_db_name} database from file {file}")
     command_for_restoring = f"pg_restore -d {db_uri} {file}"
     try:
-        proc = subprocess.Popen(command_for_restoring, shell=True)  # , env={
-        # 'PGPASSWORD': DB_PASSWORD
-        # })
-        proc.wait()
+        subprocess.check_output(command_for_restoring, shell=True)
         click.echo("db restore successful")
 
     except Exception as e:

--- a/flexmeasures/data/models/user.py
+++ b/flexmeasures/data/models/user.py
@@ -67,7 +67,7 @@ class Account(db.Model, AuthModelMixin):
     )
 
     def __repr__(self):
-        return "<Account %s (ID:%s)" % (self.name, self.id)
+        return "<Account %s (ID:%s)>" % (self.name, self.id)
 
     def __acl__(self):
         """

--- a/flexmeasures/utils/coding_utils.py
+++ b/flexmeasures/utils/coding_utils.py
@@ -1,4 +1,5 @@
 import functools
+import time
 
 
 def make_registering_decorator(foreign_decorator):
@@ -114,3 +115,16 @@ def optional_arg_decorator(fn):
 def sort_dict(unsorted_dict: dict) -> dict:
     sorted_dict = dict(sorted(unsorted_dict.items(), key=lambda item: item[0]))
     return sorted_dict
+
+
+def timeit(func):
+    """Decorator for printing the time it took to execute the decorated function."""
+    @functools.wraps(func)
+    def new_func(*args, **kwargs):
+        start_time = time.time()
+        result = func(*args, **kwargs)
+        elapsed_time = time.time() - start_time
+        print(f"{func.__name__} finished in {int(elapsed_time * 1_000)} ms")
+        return result
+
+    return new_func

--- a/flexmeasures/utils/coding_utils.py
+++ b/flexmeasures/utils/coding_utils.py
@@ -119,6 +119,7 @@ def sort_dict(unsorted_dict: dict) -> dict:
 
 def timeit(func):
     """Decorator for printing the time it took to execute the decorated function."""
+
     @functools.wraps(func)
     def new_func(*args, **kwargs):
         start_time = time.time()


### PR DESCRIPTION
This PR combines a bug fix with several tiny improvements to CLI functions, and the introduction of a developer util decorator.

The bug is this (reporting a successful `flexmeasures db-ops dump` when in fact it failed):
```
Backing up 127.0.0.1/flexmeasures-db database
/bin/sh: line 1: pg_dump: command not found
db dump successful: saved to pgbackup_flexmeasures-db_2022-11-01-1510.dump
```
Likewise for `flexmeasures db-ops restore`.

The `timeit` decorator can be added to to CLI functions (or any function, really) to print out the run time of that function. Is this something you'd consider adding as a default for all CLI commands?