### PR TITLE
Add custom requirements to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command:
     - |
+      pip install -r instance/requirements.txt
       flexmeasures db upgrade
       flexmeasures add toy-account --name 'Docker Toy Account'
       gunicorn --bind 0.0.0.0:5000 --worker-tmp-dir /dev/shm --workers 2 --threads 4 wsgi:application

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ version: "3.4"
 
 services:
   dev-db:
-    image: postgres:14
+    image: postgres
     expose:
       - 5432
     restart: always
@@ -80,7 +80,7 @@ services:
       - ./flexmeasures-instance/:/usr/var/flexmeasures-instance/:ro
     command: flexmeasures jobs run-worker --name flexmeasures-worker --queue forecasting\|scheduling
   test-db:
-    image: postgres:14
+    image: postgres
     expose:
       - 5432
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ version: "3.4"
 
 services:
   dev-db:
-    image: postgres
+    image: postgres:14
     expose:
       - 5432
     restart: always
@@ -77,7 +77,7 @@ services:
       - ./flexmeasures-instance/:/usr/var/flexmeasures-instance/:ro
     command: flexmeasures jobs run-worker --name flexmeasures-worker --queue forecasting\|scheduling
   test-db:
-    image: postgres
+    image: postgres:14
     expose:
       - 5432
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,10 +53,12 @@ services:
       # a place for config and plugin code - the mount point is for running the FlexMeasures CLI, the 2nd for gunicorn
       - ./flexmeasures-instance/:/usr/var/flexmeasures-instance/:ro
       - ./flexmeasures-instance/:/app/instance/:ro
-    command: >
-      bash -c "flexmeasures db upgrade
-      && flexmeasures add toy-account --name 'Docker Toy Account'
-      && gunicorn --bind 0.0.0.0:5000 --worker-tmp-dir /dev/shm --workers 2 --threads 4 wsgi:application"
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+    - |
+      flexmeasures db upgrade
+      flexmeasures add toy-account --name 'Docker Toy Account'
+      gunicorn --bind 0.0.0.0:5000 --worker-tmp-dir /dev/shm --workers 2 --threads 4 wsgi:application
   worker:
     build:
       context: .

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -24,6 +24,7 @@ Infrastructure / Support
 ----------------------
 
 * Reduce size of Docker image (from 2GB to 1.4GB) [see `PR #512 <http://www.github.com/FlexMeasures/flexmeasures/pull/512>`_]
+* Allow extra requirements to be freshly installed when running ``docker-compose up`` [see `PR #528 <http://www.github.com/FlexMeasures/flexmeasures/pull/528>`_]
 * Remove bokeh dependency and obsolete UI views [see `PR #476 <http://www.github.com/FlexMeasures/flexmeasures/pull/476>`_]
 * Fix ``flexmeasures db-ops dump`` and ``flexmeasures db-ops restore`` incorrectly reporting a success when `pg_dump` and `pg_restore` are not installed [see `PR #526 <http://www.github.com/FlexMeasures/flexmeasures/pull/526>`_]
 * Plugins can save BeliefsSeries, too, instead of just BeliefsDataFrames [see `PR #523 <http://www.github.com/FlexMeasures/flexmeasures/pull/523>`_]

--- a/documentation/dev/docker-compose.rst
+++ b/documentation/dev/docker-compose.rst
@@ -65,6 +65,8 @@ Configuration
 
 You can pass in your own configuration (e.g. for MapBox access token, or db URI, see below) like we described in :ref:`docker_configuration` ― put a file ``flexmeasures.cfg`` into a local folder called ``flexmeasures-instance`` (the volume should be already mapped).
 
+In case your configuration loads FlexMeasures plugins that have additional dependencies, you can add a requirements.txt file to the same local folder. The dependencies listed in that file will be freshly installed each time you run ``docker-compose up``.
+
 
 Data
 -------


### PR DESCRIPTION
To do:
- [x] Documentation regarding the possibility of adding custom requirements by adding a `requirements.txt` file to the `flexmeasures-instance` folder.
- [x] Changelog entry.