### PR TITLE
Issue 515 slow loading of asset page due to timerange query of its sensors

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -19,6 +19,7 @@ Bugfixes
 -----------
 * The CLI command ``flexmeasures show beliefs`` now supports plotting time series data that includes NaN values, and provides better support for plotting multiple sensors that do not share the same unit [see `PR #516 <http://www.github.com/FlexMeasures/flexmeasures/pull/516>`_]
 * Consistent CLI/UI support for asset lat/lng positions up to 7 decimal places (previously the UI rounded to 4 decimal places, whereas the CLI allowed more than 4) [see `PR #522 <http://www.github.com/FlexMeasures/flexmeasures/pull/522>`_]
+* Faster loading of initial charts and calendar date selection [see `PR #533 <http://www.github.com/FlexMeasures/flexmeasures/pull/533>`_]
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -366,7 +366,7 @@
     /** If the page is done loading, get data (for the time range stored in the session, or the default range),
      * check for time zone differences, and then trigger the time range picker to display the correct range.
      */
-    document.onreadystatechange = () => {
+    document.onreadystatechange = async () => {
         if (document.readyState === 'complete') {
             {% if event_starts_after and event_ends_before %}
                 // Initialize picker to the date selection specified in the session
@@ -376,14 +376,13 @@
                 sessionStart.setHours(0,0,0,0); // get start of first day
                 sessionEnd.setHours(0,0,0,0); // get start of last day
                 $("#spinner").show();
-                Promise.all([
+                let fetchedInitialData = await Promise.all([
                     initialData,
                     embedAndLoad(chartSpecsPath + 'event_starts_after=' + '{{ event_starts_after }}' + '&event_ends_before=' + '{{ event_ends_before }}' + '&', elementId, datasetName, previousResult, sessionStart, sessionEnd),
-                ]).then(function(result) {
-                    $("#spinner").hide();
-                    vegaView.change(datasetName, vega.changeset().remove(vega.truthy).insert(result[0])).resize().run();
-                    previousResult = result[0];
-                }).catch(console.error);
+                ]).then(function (result) {return result[0]}).catch(console.error);
+                $("#spinner").hide();
+                vegaView.change(datasetName, vega.changeset().remove(vega.truthy).insert(fetchedInitialData)).resize().run();
+                previousResult = fetchedInitialData;
                 picker.setDateRange(
                     sessionStart,
                     sessionEnd,

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -356,6 +356,21 @@
      */
     document.onreadystatechange = () => {
         if (document.readyState === 'complete') {
+            {% if event_starts_after and event_ends_before %}
+                // Initialize picker to the date selection specified in the session
+                var sessionStart = new Date('{{ event_starts_after }}');
+                var sessionEnd = new Date('{{ event_ends_before }}');
+                sessionEnd.setSeconds(sessionEnd.getSeconds() - 1); // -1 second in case most recent event ends at midnight
+                sessionStart.setHours(0,0,0,0); // get start of first day
+                sessionEnd.setHours(0,0,0,0); // get start of last day
+                picker.setDateRange(
+                    sessionStart,
+                    sessionEnd,
+                );
+                var timerangeNotSetYet = false
+            {% else %}
+                var timerangeNotSetYet = true
+            {% endif %}
             fetch(dataDevPath, {
                 method: "GET",
                 headers: {"Content-Type": "application/json"},
@@ -380,18 +395,7 @@
                     start.setHours(0,0,0,0); // get start of first day
                     end.setHours(0,0,0,0); // get start of last day
 
-                    {% if event_starts_after and event_ends_before %}
-                        // Initialize picker to the date selection specified in the session
-                        var sessionStart = new Date('{{ event_starts_after }}');
-                        var sessionEnd = new Date('{{ event_ends_before }}');
-                        sessionEnd.setSeconds(sessionEnd.getSeconds() - 1); // -1 second in case most recent event ends at midnight
-                        sessionStart.setHours(0,0,0,0); // get start of first day
-                        sessionEnd.setHours(0,0,0,0); // get start of last day
-                        picker.setDateRange(
-                            sessionStart,
-                            sessionEnd,
-                        );
-                    {% else %}
+                    if (timerangeNotSetYet) {
                         // Initialize picker to the last 2 days of sensor data
                         var nearEnd = new Date(end)//.setDate(end.getDate() - 1);
                         nearEnd.setDate(nearEnd.getDate() - 1);
@@ -399,7 +403,7 @@
                             nearEnd,
                             end,
                         );
-                    {% endif %}
+                    }
 
                     // No use looking for data in years outside timerange of sensor data
                     picker.setOptions({

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -239,7 +239,6 @@
     let queryEndDate;
     let storeStartDate;
     let storeEndDate;
-    let firstLoadDone = false
 
     async function embedAndLoad(chartSpecsPath, elementId, datasetName, previousResult, startDate, endDate) {
 
@@ -275,6 +274,18 @@
     })
     .then(function(response) { return response.json(); });
 
+    // Set session start and end
+    {% if event_starts_after and event_ends_before %}
+        var sessionStart = new Date('{{ event_starts_after }}');
+        var sessionEnd = new Date('{{ event_ends_before }}');
+        sessionEnd.setSeconds(sessionEnd.getSeconds() - 1); // -1 second in case most recent event ends at midnight
+        sessionStart.setHours(0,0,0,0); // get start of first day
+        sessionEnd.setHours(0,0,0,0); // get start of last day
+    {% else %}
+        var sessionStart = null
+        var sessionEnd = null
+    {% endif %}
+
     // Set up abort controller to cancel requests
     var controller = new AbortController();
     var signal = controller.signal;
@@ -300,6 +311,8 @@
         inlineMode: true,
         switchingMonths: 1,
         singleMode: false,
+        startDate: sessionStart,
+        endDate: sessionEnd,
         dropdowns: {
             years: true,
             months: true,
@@ -307,60 +320,55 @@
         format: 'YYYY-MM-DD\\T00:00:00',
     });
     picker.on('selected', (startDate, endDate) => {
-        if (firstLoadDone) {
-            // Stop replay
-            let toggle = document.querySelector('#replay');
-            toggle.classList.remove('playing');
-            toggle.classList.remove('paused');
-            toggle.classList.add('stopped');
+        // Stop replay
+        let toggle = document.querySelector('#replay');
+        toggle.classList.remove('playing');
+        toggle.classList.remove('paused');
+        toggle.classList.add('stopped');
 
-            startDate = startDate.toJSDate();
-            endDate = endDate.toJSDate();
-            endDate.setDate(endDate.getDate() + 1);
-            storeStartDate = startDate;
-            storeEndDate = endDate;
-            var queryStartDate = (startDate != null) ? (startDate.toISOString()) : (null);
-            var queryEndDate = (endDate != null) ? (endDate.toISOString()) : (null);
+        startDate = startDate.toJSDate();
+        endDate = endDate.toJSDate();
+        endDate.setDate(endDate.getDate() + 1);
+        storeStartDate = startDate;
+        storeEndDate = endDate;
+        var queryStartDate = (startDate != null) ? (startDate.toISOString()) : (null);
+        var queryEndDate = (endDate != null) ? (endDate.toISOString()) : (null);
 
-            // Abort previous request and create abort controller for new request
-            controller.abort();
-            controller = new AbortController();
-            signal = controller.signal;
+        // Abort previous request and create abort controller for new request
+        controller.abort();
+        controller = new AbortController();
+        signal = controller.signal;
 
-            $("#spinner").show();
-            Promise.all([
-                // Fetch time series data
-                fetch(dataPath + '/chart_data/?event_starts_after=' + queryStartDate + '&event_ends_before=' + queryEndDate, {
-                    method: "GET",
-                    headers: {"Content-Type": "application/json"},
-                    signal: signal,
-                })
-                .then(function(response) { return response.json(); }),
+        $("#spinner").show();
+        Promise.all([
+            // Fetch time series data
+            fetch(dataPath + '/chart_data/?event_starts_after=' + queryStartDate + '&event_ends_before=' + queryEndDate, {
+                method: "GET",
+                headers: {"Content-Type": "application/json"},
+                signal: signal,
+            })
+            .then(function(response) { return response.json(); }),
 
-                /**
-                // Fetch annotations
-                fetch(dataPath + '/chart_annotations/?event_starts_after=' + queryStartDate + '&event_ends_before=' + queryEndDate, {
-                    method: "GET",
-                    headers: {"Content-Type": "application/json"},
-                      signal: signal,
-                })
-                .then(function(response) { return response.json(); }),
-                */
+            /**
+            // Fetch annotations
+            fetch(dataPath + '/chart_annotations/?event_starts_after=' + queryStartDate + '&event_ends_before=' + queryEndDate, {
+                method: "GET",
+                headers: {"Content-Type": "application/json"},
+                  signal: signal,
+            })
+            .then(function(response) { return response.json(); }),
+            */
 
-                // Embed chart
-                embedAndLoad(chartSpecsPath + 'event_starts_after=' + queryStartDate + '&event_ends_before=' + queryEndDate + '&', elementId, datasetName, previousResult, startDate, endDate),
-            ]).then(function(result) {
-                $("#spinner").hide();
-                vegaView.change(datasetName, vega.changeset().remove(vega.truthy).insert(result[0])).resize().run();
-                previousResult = result[0];
-                /**
-                vegaView.change(datasetName + '_annotations', vega.changeset().remove(vega.truthy).insert(result[1])).resize().run();
-                */
-            }).catch(console.error);
-        }
-        else {
-            firstLoadDone = true
-        }
+            // Embed chart
+            embedAndLoad(chartSpecsPath + 'event_starts_after=' + queryStartDate + '&event_ends_before=' + queryEndDate + '&', elementId, datasetName, previousResult, startDate, endDate),
+        ]).then(function(result) {
+            $("#spinner").hide();
+            vegaView.change(datasetName, vega.changeset().remove(vega.truthy).insert(result[0])).resize().run();
+            previousResult = result[0];
+            /**
+            vegaView.change(datasetName + '_annotations', vega.changeset().remove(vega.truthy).insert(result[1])).resize().run();
+            */
+        }).catch(console.error);
     });
 
     /** If the page is done loading, get data (for the time range stored in the session, or the default range),
@@ -370,11 +378,6 @@
         if (document.readyState === 'complete') {
             {% if event_starts_after and event_ends_before %}
                 // Initialize picker to the date selection specified in the session
-                var sessionStart = new Date('{{ event_starts_after }}');
-                var sessionEnd = new Date('{{ event_ends_before }}');
-                sessionEnd.setSeconds(sessionEnd.getSeconds() - 1); // -1 second in case most recent event ends at midnight
-                sessionStart.setHours(0,0,0,0); // get start of first day
-                sessionEnd.setHours(0,0,0,0); // get start of last day
                 $("#spinner").show();
                 let fetchedInitialData = await Promise.all([
                     initialData,
@@ -383,10 +386,6 @@
                 $("#spinner").hide();
                 vegaView.change(datasetName, vega.changeset().remove(vega.truthy).insert(fetchedInitialData)).resize().run();
                 previousResult = fetchedInitialData;
-                picker.setDateRange(
-                    sessionStart,
-                    sessionEnd,
-                );
                 var timerangeNotSetYet = false
             {% else %}
                 var timerangeNotSetYet = true

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -239,6 +239,7 @@
     let queryEndDate;
     let storeStartDate;
     let storeEndDate;
+    let firstLoadDone = false
 
     async function embedAndLoad(chartSpecsPath, elementId, datasetName, previousResult, startDate, endDate) {
 
@@ -266,6 +267,13 @@
     {% endif %}
     var elementId = 'sensorchart';
     var chartSpecsPath = dataPath + '/chart?';
+
+    const initialData = fetch(dataPath + '/chart_data/?event_starts_after=' + '{{ event_starts_after }}' + '&event_ends_before=' + '{{ event_ends_before }}', {
+        method: "GET",
+        headers: {"Content-Type": "application/json"},
+        signal: signal,
+    })
+    .then(function(response) { return response.json(); });
 
     // Set up abort controller to cancel requests
     var controller = new AbortController();
@@ -299,56 +307,60 @@
         format: 'YYYY-MM-DD\\T00:00:00',
     });
     picker.on('selected', (startDate, endDate) => {
+        if (firstLoadDone) {
+            // Stop replay
+            let toggle = document.querySelector('#replay');
+            toggle.classList.remove('playing');
+            toggle.classList.remove('paused');
+            toggle.classList.add('stopped');
 
-        // Stop replay
-        let toggle = document.querySelector('#replay');
-        toggle.classList.remove('playing');
-        toggle.classList.remove('paused');
-        toggle.classList.add('stopped');
+            startDate = startDate.toJSDate();
+            endDate = endDate.toJSDate();
+            endDate.setDate(endDate.getDate() + 1);
+            storeStartDate = startDate;
+            storeEndDate = endDate;
+            var queryStartDate = (startDate != null) ? (startDate.toISOString()) : (null);
+            var queryEndDate = (endDate != null) ? (endDate.toISOString()) : (null);
 
-        startDate = startDate.toJSDate();
-        endDate = endDate.toJSDate();
-        endDate.setDate(endDate.getDate() + 1);
-        storeStartDate = startDate;
-        storeEndDate = endDate;
-        var queryStartDate = (startDate != null) ? (startDate.toISOString()) : (null);
-        var queryEndDate = (endDate != null) ? (endDate.toISOString()) : (null);
+            // Abort previous request and create abort controller for new request
+            controller.abort();
+            controller = new AbortController();
+            signal = controller.signal;
 
-        // Abort previous request and create abort controller for new request
-        controller.abort();
-        controller = new AbortController();
-        signal = controller.signal;
+            $("#spinner").show();
+            Promise.all([
+                // Fetch time series data
+                fetch(dataPath + '/chart_data/?event_starts_after=' + queryStartDate + '&event_ends_before=' + queryEndDate, {
+                    method: "GET",
+                    headers: {"Content-Type": "application/json"},
+                    signal: signal,
+                })
+                .then(function(response) { return response.json(); }),
 
-        $("#spinner").show();
-        Promise.all([
-            // Fetch time series data
-            fetch(dataPath + '/chart_data/?event_starts_after=' + queryStartDate + '&event_ends_before=' + queryEndDate, {
-                method: "GET",
-                headers: {"Content-Type": "application/json"},
-                signal: signal,
-            })
-            .then(function(response) { return response.json(); }),
+                /**
+                // Fetch annotations
+                fetch(dataPath + '/chart_annotations/?event_starts_after=' + queryStartDate + '&event_ends_before=' + queryEndDate, {
+                    method: "GET",
+                    headers: {"Content-Type": "application/json"},
+                      signal: signal,
+                })
+                .then(function(response) { return response.json(); }),
+                */
 
-            /**
-            // Fetch annotations
-            fetch(dataPath + '/chart_annotations/?event_starts_after=' + queryStartDate + '&event_ends_before=' + queryEndDate, {
-                method: "GET",
-                headers: {"Content-Type": "application/json"},
-                  signal: signal,
-            })
-            .then(function(response) { return response.json(); }),
-            */
-
-            // Embed chart
-            embedAndLoad(chartSpecsPath + 'event_starts_after=' + queryStartDate + '&event_ends_before=' + queryEndDate + '&', elementId, datasetName, previousResult, startDate, endDate),
-        ]).then(function(result) {
-            $("#spinner").hide();
-            vegaView.change(datasetName, vega.changeset().remove(vega.truthy).insert(result[0])).resize().run();
-            previousResult = result[0];
-            /**
-            vegaView.change(datasetName + '_annotations', vega.changeset().remove(vega.truthy).insert(result[1])).resize().run();
-            */
-        }).catch(console.error);
+                // Embed chart
+                embedAndLoad(chartSpecsPath + 'event_starts_after=' + queryStartDate + '&event_ends_before=' + queryEndDate + '&', elementId, datasetName, previousResult, startDate, endDate),
+            ]).then(function(result) {
+                $("#spinner").hide();
+                vegaView.change(datasetName, vega.changeset().remove(vega.truthy).insert(result[0])).resize().run();
+                previousResult = result[0];
+                /**
+                vegaView.change(datasetName + '_annotations', vega.changeset().remove(vega.truthy).insert(result[1])).resize().run();
+                */
+            }).catch(console.error);
+        }
+        else {
+            firstLoadDone = true
+        }
     });
 
     /** If the page is done loading, get data (for the time range stored in the session, or the default range),
@@ -363,6 +375,15 @@
                 sessionEnd.setSeconds(sessionEnd.getSeconds() - 1); // -1 second in case most recent event ends at midnight
                 sessionStart.setHours(0,0,0,0); // get start of first day
                 sessionEnd.setHours(0,0,0,0); // get start of last day
+                $("#spinner").show();
+                Promise.all([
+                    initialData,
+                    embedAndLoad(chartSpecsPath + 'event_starts_after=' + '{{ event_starts_after }}' + '&event_ends_before=' + '{{ event_ends_before }}' + '&', elementId, datasetName, previousResult, sessionStart, sessionEnd),
+                ]).then(function(result) {
+                    $("#spinner").hide();
+                    vegaView.change(datasetName, vega.changeset().remove(vega.truthy).insert(result[0])).resize().run();
+                    previousResult = result[0];
+                }).catch(console.error);
                 picker.setDateRange(
                     sessionStart,
                     sessionEnd,


### PR DESCRIPTION
This PR makes data load faster on the asset (and sensor) page. Most commonly, the time range is already set as session data, so we shouldn't have to wait for finishing a potentially slow query to the database that determines the full timerange of shown sensors.

Also, the date range selection on the calendar is now set much earlier, when initializing the calendar, instead of when the charts are done loading. This means that, when you navigate the calendar while charts are still loading, you don't annoyingly pop back to the initial selection when the charts are done loading.

Closes #515.