### PR TITLE
Stop trimming the planning window in response to price availability

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -21,6 +21,7 @@ Bugfixes
 -----------
 * The CLI command ``flexmeasures show beliefs`` now supports plotting time series data that includes NaN values, and provides better support for plotting multiple sensors that do not share the same unit [see `PR #516 <http://www.github.com/FlexMeasures/flexmeasures/pull/516>`_]
 * Consistent CLI/UI support for asset lat/lng positions up to 7 decimal places (previously the UI rounded to 4 decimal places, whereas the CLI allowed more than 4) [see `PR #522 <http://www.github.com/FlexMeasures/flexmeasures/pull/522>`_]
+* Stop trimming the planning window in response to price availability, which is a problem when SoC targets occur outside of the available price window, by making a simplistic assumption about future prices [see `PR #538 <http://www.github.com/FlexMeasures/flexmeasures/pull/538>`_]
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -55,7 +55,7 @@ class StorageScheduler(Scheduler):
             beliefs_before=belief_time,
             price_sensor=consumption_price_sensor,
             sensor=sensor,
-            allow_trimmed_query_window=True,
+            allow_trimmed_query_window=False,
         )
         down_deviation_prices, (start, end) = get_prices(
             (start, end),
@@ -63,7 +63,7 @@ class StorageScheduler(Scheduler):
             beliefs_before=belief_time,
             price_sensor=production_price_sensor,
             sensor=sensor,
-            allow_trimmed_query_window=True,
+            allow_trimmed_query_window=False,
         )
 
         start = pd.Timestamp(start).tz_convert("UTC")

--- a/flexmeasures/data/models/planning/utils.py
+++ b/flexmeasures/data/models/planning/utils.py
@@ -163,7 +163,13 @@ def get_prices(
     sensor: Optional[Sensor] = None,
     allow_trimmed_query_window: bool = True,
 ) -> Tuple[pd.DataFrame, Tuple[datetime, datetime]]:
-    """Check for known prices or price forecasts, trimming query window accordingly if allowed."""
+    """Check for known prices or price forecasts.
+
+    If so allowed, the query window is trimmed according to the available data.
+    If not allowed, prices are extended to the edges of the query window:
+    - The first available price serves as a naive backcast.
+    - The last available price serves as a naive forecast.
+    """
 
     # Look for the applicable price sensor
     if price_sensor is None:

--- a/flexmeasures/data/models/planning/utils.py
+++ b/flexmeasures/data/models/planning/utils.py
@@ -203,9 +203,22 @@ def get_prices(
             )
             query_window = (first_event_start, last_event_end)
         else:
-            raise UnknownPricesException(
-                f"Prices partially unknown for planning window (sensor {price_sensor.id})."
+            index = initialize_index(
+                start=query_window[0],
+                end=query_window[1],
+                resolution=resolution,
             )
+            price_df = price_df.reindex(index)
+            # or to also forward fill intermediate NaN values, use: price_df = price_df.ffill().bfill()
+            price_df[: price_df.first_valid_index()] = price_df[
+                price_df.index == price_df.first_valid_index()
+            ].values[0]
+            price_df[price_df.last_valid_index() :] = price_df[
+                price_df.index == price_df.last_valid_index()
+            ].values[0]
+            # raise UnknownPricesException(
+            #     f"Prices partially unknown for planning window (sensor {price_sensor.id})."
+            # )
     return price_df, query_window
 
 

--- a/flexmeasures/data/models/planning/utils.py
+++ b/flexmeasures/data/models/planning/utils.py
@@ -199,10 +199,16 @@ def get_prices(
             first_event_start = price_df.first_valid_index()
             last_event_end = price_df.last_valid_index() + resolution
             current_app.logger.warning(
-                f"Prices partially unknown for planning window (sensor {price_sensor.id}). Trimming planning window (from {query_window[0]} until {query_window[-1]}) to {first_event_start} until {last_event_end}."
+                f"Prices partially unknown for planning window (sensor {price_sensor.id}). "
+                f"Trimming planning window (from {query_window[0]} until {query_window[-1]}) to {first_event_start} until {last_event_end}."
             )
             query_window = (first_event_start, last_event_end)
         else:
+            current_app.logger.warning(
+                f"Prices partially unknown for planning window (sensor {price_sensor.id}). "
+                f"Assuming the first price is valid from the start of the planning window ({query_window[0]}), "
+                f"and the last price is valid until the end of the planning window ({query_window[-1]})."
+            )
             index = initialize_index(
                 start=query_window[0],
                 end=query_window[1],
@@ -216,9 +222,6 @@ def get_prices(
             price_df[price_df.last_valid_index() :] = price_df[
                 price_df.index == price_df.last_valid_index()
             ].values[0]
-            # raise UnknownPricesException(
-            #     f"Prices partially unknown for planning window (sensor {price_sensor.id})."
-            # )
     return price_df, query_window
 
 


### PR DESCRIPTION
~My initial reason to create this PR was to prevent the scheduler from emptying the storage at the end of the scheduling horizon. We now prevent this by~ making an assumption about the future beyond **the part of** the scheduling horizon **with available prices**. Specifically, we use the most naive forecasting (forward filling the last known price).

~Note that in case of a negative price, this would still result in emptying the battery; but e.g.~ switching to naive forecasting with a seasonal periodicity of 1 day or 1 week would give inconsistent results, because they will then depend on how long a price period has been loaded in the price BeliefsDataFrame.

Then I encountered a second reason for this PR. By stopping to trim the planning window in response to price availability, another bug is resolved as well. Namely, for cases when SoC targets occur outside of the available price window. The two choices I saw here were to either trim the SoC targets or to not trim the planning window. Trimming the SoC targets would lead to a schedule that might in the end lead violating the user's constraints, so that's not a good option. I'd rather make a simplistic assumption about future prices in order to not have to trim the planning window.