### PR TITLE
Bug in `flexmeasures show beliefs` in case of empty sensors

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -19,7 +19,7 @@ New features
 
 Bugfixes
 -----------
-* The CLI command ``flexmeasures show beliefs`` now supports plotting time series data that includes NaN values, and provides better support for plotting multiple sensors that do not share the same unit [see `PR #516 <http://www.github.com/FlexMeasures/flexmeasures/pull/516>`_]
+* The CLI command ``flexmeasures show beliefs`` now supports plotting time series data that includes NaN values, and provides better support for plotting multiple sensors that do not share the same unit [see `PR #516 <http://www.github.com/FlexMeasures/flexmeasures/pull/516>`_ and `PR #539 <http://www.github.com/FlexMeasures/flexmeasures/pull/539>`_]
 * Consistent CLI/UI support for asset lat/lng positions up to 7 decimal places (previously the UI rounded to 4 decimal places, whereas the CLI allowed more than 4) [see `PR #522 <http://www.github.com/FlexMeasures/flexmeasures/pull/522>`_]
 
 Infrastructure / Support

--- a/flexmeasures/cli/data_show.py
+++ b/flexmeasures/cli/data_show.py
@@ -310,11 +310,14 @@ def plot_beliefs(
         sum_multiple=False,
     )
     # only keep non-empty
+    empty_sensors = []
     for s in sensors:
         if beliefs_by_sensor[s.name].empty:
             click.echo(f"No data found for sensor '{s.name}' (Id: {s.id})")
             beliefs_by_sensor.pop(s.name)
-            sensors.remove(s)
+            empty_sensors.append(s)
+    for s in empty_sensors:
+        sensors.remove(s)
     if len(beliefs_by_sensor.keys()) == 0:
         click.echo("No data found!")
         raise click.Abort()


### PR DESCRIPTION
The dataframe handed over to uniplot cannot contain empty columns. Otherwise, you get:
```
ValueError: zero-size array to reduction operation maximum which has no identity
```
We knew that, and were already throwing out columns with no sensor data. But we did it with a bad loop, that removes items from the list while looping over that same list. In case of a list where the non-empty sensors aren't all at the back of the list, we still end up trying to show empty sensor data.