### PR TITLE
Fix bugs in tutorial and CLI scheduling trigger

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -40,7 +40,7 @@ A tiny, but complete example: Let's install FlexMeasures from scratch. Then, usi
     $ export SQLALCHEMY_DATABASE_URI="postgresql://postgres:docker@127.0.0.1:5433/flexmeasures-db" && export SECRET_KEY=notsecret 
     $ flexmeasures db upgrade  # create tables
     $ flexmeasures add toy-account --kind battery  # setup account & a user, a battery (Id 2) and a market (Id 3)
-    $ flexmeasures add beliefs --sensor-id 3 --source toy-user prices-tomorrow.csv --timezone Europe/Amsterdam  # load prices, also possible per API
+    $ flexmeasures add beliefs --sensor-id 3 --source toy-user prices-tomorrow.csv --timezone utc  # load prices, also possible per API
     $ flexmeasures add schedule --sensor-id 2 --consumption-price-sensor 3 \
         --start ${TOMORROW}T07:00+01:00 --duration PT12H \
         --soc-at-start 50% --roundtrip-efficiency 90%  # this is also possible per API

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -40,7 +40,7 @@ A tiny, but complete example: Let's install FlexMeasures from scratch. Then, usi
     $ export SQLALCHEMY_DATABASE_URI="postgresql://postgres:docker@127.0.0.1:5433/flexmeasures-db" && export SECRET_KEY=notsecret 
     $ flexmeasures db upgrade  # create tables
     $ flexmeasures add toy-account --kind battery  # setup account & a user, a battery (Id 2) and a market (Id 3)
-    $ flexmeasures add beliefs --sensor-id 3 --source toy-user prices-tomorrow.csv  # load prices, also possible per API
+    $ flexmeasures add beliefs --sensor-id 3 --source toy-user prices-tomorrow.csv --timezone Europe/Amsterdam  # load prices, also possible per API
     $ flexmeasures add schedule --sensor-id 2 --consumption-price-sensor 3 \
         --start ${TOMORROW}T07:00+01:00 --duration PT12H \
         --soc-at-start 50% --roundtrip-efficiency 90%  # this is also possible per API

--- a/documentation/tut/toy-example-from-scratch.rst
+++ b/documentation/tut/toy-example-from-scratch.rst
@@ -19,7 +19,7 @@ Below are the ``flexmeasures`` CLI commands we'll run, and which we'll explain s
     # setup an account with a user, a battery (Id 2) and a market (Id 3)
     $ flexmeasures add toy-account --kind battery
     # load prices to optimise the schedule against
-    $ flexmeasures add beliefs --sensor-id 3 --source toy-user prices-tomorrow.csv
+    $ flexmeasures add beliefs --sensor-id 3 --source toy-user prices-tomorrow.csv --timezone Europe/Amsterdam
     # make the schedule
     $ flexmeasures add schedule --sensor-id 2 --consumption-price-sensor 3 \
         --start ${TOMORROW}T07:00+01:00 --duration PT12H \

--- a/documentation/tut/toy-example-from-scratch.rst
+++ b/documentation/tut/toy-example-from-scratch.rst
@@ -19,7 +19,7 @@ Below are the ``flexmeasures`` CLI commands we'll run, and which we'll explain s
     # setup an account with a user, a battery (Id 2) and a market (Id 3)
     $ flexmeasures add toy-account --kind battery
     # load prices to optimise the schedule against
-    $ flexmeasures add beliefs --sensor-id 3 --source toy-user prices-tomorrow.csv --timezone Europe/Amsterdam
+    $ flexmeasures add beliefs --sensor-id 3 --source toy-user prices-tomorrow.csv --timezone utc
     # make the schedule
     $ flexmeasures add schedule --sensor-id 2 --consumption-price-sensor 3 \
         --start ${TOMORROW}T07:00+01:00 --duration PT12H \

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -1015,11 +1015,13 @@ def create_schedule(
             end=end,
             belief_time=server_now(),
             resolution=power_sensor.event_resolution,
-            soc_at_start=soc_at_start,
-            soc_targets=soc_targets,
-            soc_min=soc_min,
-            soc_max=soc_max,
-            roundtrip_efficiency=roundtrip_efficiency,
+            storage_specs=dict(
+                soc_at_start=soc_at_start,
+                soc_targets=soc_targets,
+                soc_min=soc_min,
+                soc_max=soc_max,
+                roundtrip_efficiency=roundtrip_efficiency,
+            ),
             consumption_price_sensor=consumption_price_sensor,
             production_price_sensor=production_price_sensor,
         )

--- a/flexmeasures/data/services/scheduling.py
+++ b/flexmeasures/data/services/scheduling.py
@@ -144,6 +144,8 @@ def make_schedule(
             % sensor.generic_asset.generic_asset_type
         )
 
+    storage_specs = ensure_storage_specs(storage_specs, sensor, start, end, resolution)
+
     consumption_schedule = scheduler().schedule(
         sensor,
         start,


### PR DESCRIPTION
I'd like your opinion on the extra call to `ensure_storage_specs` in `make_schedule`. If you go through the job route (with `create_scheduling_job`), it now gets called twice: once before creating the job (which makes sense to me, because you want to let the user know of any problems straight away), and another time when executing the job. Is that okay?