### PR TITLE
548 allow sending null values when posting data

### DIFF
--- a/flexmeasures/api/common/schemas/sensor_data.py
+++ b/flexmeasures/api/common/schemas/sensor_data.py
@@ -59,7 +59,7 @@ def select_schema_to_ensure_list_of_floats(
     This ensures that we are not requiring the same flexibility from users who are retrieving data.
     """
     if isinstance(values, list):
-        return fields.List(fields.Float)
+        return fields.List(fields.Float(allow_none=True))
     else:
         return SingleValueField()
 

--- a/flexmeasures/api/common/schemas/tests/test_sensor_data_schema.py
+++ b/flexmeasures/api/common/schemas/tests/test_sensor_data_schema.py
@@ -57,6 +57,14 @@ def test_resolution_field_deserialization(
             [2.7],
             [2.7],
         ),
+        (
+            [1, None, 3],  # sending a None/null value as part of a list is allowed
+            [1, None, 3],
+        ),
+        (
+            [None],  # sending a None/null value as part of a list is allowed
+            [None],
+        ),
     ],
 )
 def test_value_field_deserialization(
@@ -102,6 +110,10 @@ def test_value_field_serialization(
         (
             "3, 4",
             "Not a valid number",
+        ),
+        (
+            None,
+            "may not be null",  # sending a single None/null value is not allowed
         ),
     ],
 )

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -138,12 +138,13 @@ class SensorAPI(FlaskView):
             }
 
         The above request posts four values for a duration of one hour, where the first
-        event start is at the given start time, and subsequent values start in 15 minute intervals throughout the one hour duration.
+        event start is at the given start time, and subsequent events start in 15 minute intervals throughout the one hour duration.
 
         The sensor is the one with ID=1.
         The unit has to be convertible to the sensor's unit.
         The resolution of the data has to match the sensor's required resolution, but
         FlexMeasures will attempt to upsample lower resolutions.
+        The list of values may include null values.
 
         :reqheader Authorization: The authentication token
         :reqheader Content-Type: application/json

--- a/flexmeasures/api/v3_0/tests/utils.py
+++ b/flexmeasures/api/v3_0/tests/utils.py
@@ -2,16 +2,22 @@ from flexmeasures import Sensor
 
 
 def make_sensor_data_request_for_gas_sensor(
-    num_values: int = 6, duration: str = "PT1H", unit: str = "m³"
+    num_values: int = 6,
+    duration: str = "PT1H",
+    unit: str = "m³",
+    include_a_null: bool = False,
 ) -> dict:
     """Creates request to post sensor data for a gas sensor.
     This particular gas sensor measures units of m³/h with a 10-minute resolution.
     """
     sensor = Sensor.query.filter(Sensor.name == "some gas sensor").one_or_none()
+    values = num_values * [-11.28]
+    if include_a_null:
+        values[0] = None
     message: dict = {
         "type": "PostSensorDataRequest",
         "sensor": f"ea1.2021-01.io.flexmeasures:fm1.{sensor.id}",
-        "values": num_values * [-11.28],
+        "values": values,
         "start": "2021-06-07T00:00:00+02:00",
         "duration": duration,
         "horizon": "PT0H",


### PR DESCRIPTION
Work in progress.

@nhoening Would you agree that the values should not enter the database as NaN values? That is, users may send null values in order to correctly 'space' their time series data, but we'd then throw them out before saving.