### PR TITLE
Deprecation headers for old fields that moved to flex-model and flex-context 

### DIFF
--- a/flexmeasures/api/common/utils/deprecation_utils.py
+++ b/flexmeasures/api/common/utils/deprecation_utils.py
@@ -50,14 +50,7 @@ def deprecate_field(
     """
     if not isinstance(field, list):
         field = [field]
-    if deprecation_date:
-        deprecation = to_http_time(pd.Timestamp(deprecation_date) - pd.Timedelta("1s"))
-    else:
-        deprecation = "true"
-    if sunset_date:
-        sunset = to_http_time(pd.Timestamp(sunset_date) - pd.Timedelta("1s"))
-    else:
-        sunset = None
+    deprecation, sunset = _format_deprecation_and_sunset(deprecation_date, sunset_date)
 
     @after_this_request
     def _after_request_handler(response: Response) -> Response:
@@ -114,14 +107,7 @@ def deprecate_blueprint(
     - Deprecation header: https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-deprecation-header
     - Sunset header: https://www.rfc-editor.org/rfc/rfc8594
     """
-    if deprecation_date:
-        deprecation = to_http_time(pd.Timestamp(deprecation_date) - pd.Timedelta("1s"))
-    else:
-        deprecation = "true"
-    if sunset_date:
-        sunset = to_http_time(pd.Timestamp(sunset_date) - pd.Timedelta("1s"))
-    else:
-        sunset = None
+    deprecation, sunset = _format_deprecation_and_sunset(deprecation_date, sunset_date)
 
     def _after_request_handler(response: Response) -> Response:
         current_app.logger.warning(
@@ -162,3 +148,15 @@ def _add_link(response: Response, link: str, rel: str) -> Response:
     else:
         response.headers["Link"] = link_text
     return response
+
+
+def _format_deprecation_and_sunset(deprecation_date, sunset_date):
+    if deprecation_date:
+        deprecation = to_http_time(pd.Timestamp(deprecation_date) - pd.Timedelta("1s"))
+    else:
+        deprecation = "true"
+    if sunset_date:
+        sunset = to_http_time(pd.Timestamp(sunset_date) - pd.Timedelta("1s"))
+    else:
+        sunset = None
+    return deprecation, sunset

--- a/flexmeasures/api/common/utils/deprecation_utils.py
+++ b/flexmeasures/api/common/utils/deprecation_utils.py
@@ -30,9 +30,9 @@ def deprecate_field(
             deprecate_field(
                 "color",
                 deprecation_date="2022-12-14",
-                deprecation_link="https://flexmeasures.readthedocs.org/some-deprecation-notice",
+                deprecation_link="https://flexmeasures.readthedocs.io/some-deprecation-notice",
                 sunset_date="2023-02-01",
-                sunset_link="https://flexmeasures.readthedocs.org/some-sunset-notice",
+                sunset_link="https://flexmeasures.readthedocs.io/some-sunset-notice",
             )
 
     :param field:            The field (or fields, as a list of strings) to be deprecated
@@ -89,9 +89,9 @@ def deprecate_blueprint(
     >>> deprecate_blueprint(
             deprecated_bp,
             deprecation_date="2022-12-14",
-            deprecation_link="https://flexmeasures.readthedocs.org/some-deprecation-notice",
+            deprecation_link="https://flexmeasures.readthedocs.io/some-deprecation-notice",
             sunset_date="2023-02-01",
-            sunset_link="https://flexmeasures.readthedocs.org/some-sunset-notice",
+            sunset_link="https://flexmeasures.readthedocs.io/some-sunset-notice",
         )
 
     :param blueprint:        The blueprint to be deprecated

--- a/flexmeasures/api/common/utils/deprecation_utils.py
+++ b/flexmeasures/api/common/utils/deprecation_utils.py
@@ -7,8 +7,8 @@ import pandas as pd
 from flexmeasures.utils.time_utils import to_http_time
 
 
-def deprecate_field(
-    field: str | list[str],
+def deprecate_fields(
+    fields: str | list[str],
     deprecation_date: pd.Timestamp | str | None = None,
     deprecation_link: str | None = None,
     sunset_date: pd.Timestamp | str | None = None,
@@ -35,7 +35,7 @@ def deprecate_field(
                 sunset_link="https://flexmeasures.readthedocs.io/some-sunset-notice",
             )
 
-    :param field:            The field (or fields, as a list of strings) to be deprecated
+    :param fields:           The fields (as a list of strings) to be deprecated
     :param deprecation_date: date indicating when the field was deprecated, used for the "Deprecation" header
                              if no date is given, defaults to "true"
                              see https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-deprecation-header#section-2-1
@@ -48,13 +48,15 @@ def deprecate_field(
     - Deprecation header: https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-deprecation-header
     - Sunset header: https://www.rfc-editor.org/rfc/rfc8594
     """
-    if not isinstance(field, list):
-        field = [field]
+    if not isinstance(fields, list):
+        fields = [fields]
     deprecation, sunset = _format_deprecation_and_sunset(deprecation_date, sunset_date)
 
     @after_this_request
     def _after_request_handler(response: Response) -> Response:
-        deprecated_fields_used = set(field) & set(request.json.keys())  # sets intersect
+        deprecated_fields_used = set(fields) & set(
+            request.json.keys()
+        )  # sets intersect
 
         # If any deprecated field is used, log a warning and add deprecation and sunset headers
         if deprecated_fields_used:

--- a/flexmeasures/api/common/utils/deprecation_utils.py
+++ b/flexmeasures/api/common/utils/deprecation_utils.py
@@ -1,10 +1,81 @@
 from __future__ import annotations
 
-from flask import current_app, request, Blueprint, Response
+from flask import current_app, request, Blueprint, Response, after_this_request
 from flask_security.core import current_user
 import pandas as pd
 
 from flexmeasures.utils.time_utils import to_http_time
+
+
+def deprecate_field(
+    field: str | list[str],
+    deprecation_date: pd.Timestamp | str | None = None,
+    deprecation_link: str | None = None,
+    sunset_date: pd.Timestamp | str | None = None,
+    sunset_link: str | None = None,
+):
+    """Deprecates a field (or fields) on a route by adding the "Deprecation" header with a deprecation date.
+
+    Also logs a warning when a deprecated field is used.
+
+    >>> from flask_classful import route
+    >>> @route("/item/", methods=["POST"])
+        @use_kwargs(
+            {
+                "color": ColorField,
+                "length": LengthField,
+            }
+        )
+        def post_item(color, length):
+            deprecate_field(
+                "color",
+                deprecation_date="2022-12-14",
+                deprecation_link="https://flexmeasures.readthedocs.org/some-deprecation-notice",
+                sunset_date="2023-02-01",
+                sunset_link="https://flexmeasures.readthedocs.org/some-sunset-notice",
+            )
+
+    :param field:            The field (or fields, as a list of strings) to be deprecated
+    :param deprecation_date: date indicating when the field was deprecated, used for the "Deprecation" header
+                             if no date is given, defaults to "true"
+                             see https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-deprecation-header#section-2-1
+    :param deprecation_link: url providing more information about the deprecation
+    :param sunset_date:      date indicating when the field is likely to become unresponsive
+    :param sunset_link:      url providing more information about the sunset
+
+    References
+    ----------
+    - Deprecation header: https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-deprecation-header
+    - Sunset header: https://www.rfc-editor.org/rfc/rfc8594
+    """
+    if not isinstance(field, list):
+        field = [field]
+    if deprecation_date:
+        deprecation = to_http_time(pd.Timestamp(deprecation_date) - pd.Timedelta("1s"))
+    else:
+        deprecation = "true"
+    if sunset_date:
+        sunset = to_http_time(pd.Timestamp(sunset_date) - pd.Timedelta("1s"))
+    else:
+        sunset = None
+
+    @after_this_request
+    def _after_request_handler(response: Response) -> Response:
+        deprecated_fields_used = set(field) & set(request.json.keys())  # sets intersect
+
+        # If any deprecated field is used, log a warning and add deprecation and sunset headers
+        if deprecated_fields_used:
+            current_app.logger.warning(
+                f"Endpoint {request.endpoint} called by {current_user} with deprecated fields: {deprecated_fields_used}"
+            )
+            return _add_headers(
+                response,
+                deprecation,
+                deprecation_link,
+                sunset,
+                sunset_link,
+            )
+        return response
 
 
 def deprecate_blueprint(
@@ -15,6 +86,8 @@ def deprecate_blueprint(
     sunset_link: str | None = None,
 ):
     """Deprecates every route on a blueprint by adding the "Deprecation" header with a deprecation date.
+
+    Also logs a warning when a deprecated endpoint is called.
 
     >>> from flask import Flask, Blueprint
     >>> app = Flask('some_app')
@@ -38,8 +111,8 @@ def deprecate_blueprint(
 
     References
     ----------
-    - Deprecation field: https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-deprecation-header
-    - Sunset field: https://www.rfc-editor.org/rfc/rfc8594
+    - Deprecation header: https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-deprecation-header
+    - Sunset header: https://www.rfc-editor.org/rfc/rfc8594
     """
     if deprecation_date:
         deprecation = to_http_time(pd.Timestamp(deprecation_date) - pd.Timedelta("1s"))
@@ -47,8 +120,13 @@ def deprecate_blueprint(
         deprecation = "true"
     if sunset_date:
         sunset = to_http_time(pd.Timestamp(sunset_date) - pd.Timedelta("1s"))
+    else:
+        sunset = None
 
     def _after_request_handler(response: Response) -> Response:
+        current_app.logger.warning(
+            f"Deprecated endpoint {request.endpoint} called by {current_user}"
+        )
         return _add_headers(
             response,
             deprecation,
@@ -74,9 +152,6 @@ def _add_headers(
         response = _add_link(response, deprecation_link, "deprecation")
     if sunset_link:
         response = _add_link(response, sunset_link, "sunset")
-    current_app.logger.warning(
-        f"Deprecated endpoint {request.endpoint} called by {current_user}"
-    )
     return response
 
 

--- a/flexmeasures/api/tests/utils.py
+++ b/flexmeasures/api/tests/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 
 from flask import url_for, current_app, Response
@@ -104,10 +106,25 @@ def post_task_run(client, task_name: str, status: bool = True):
     )
 
 
-def check_deprecation(response: Response):
+def check_deprecation(
+    response: Response,
+    deprecation: str | None = "Tue, 13 Dec 2022 23:59:59 GMT",
+    sunset: str | None = "Tue, 31 Jan 2023 23:59:59 GMT",
+):
+    """Check deprecation and sunset headers.
+
+    Also make sure we link to some url for further info.
+    """
     print(response.headers)
-    assert "Tue, 13 Dec 2022 23:59:59 GMT" in response.headers["Deprecation"]
-    assert "Tue, 31 Jan 2023 23:59:59 GMT" in response.headers["Sunset"]
-    # Make sure we link to some url for both deprecation and sunset
-    assert 'rel="deprecation"' in response.headers["Link"]
-    assert 'rel="sunset"' in response.headers["Link"]
+    if deprecation:
+        assert deprecation in response.headers.get("Deprecation", [])
+        assert 'rel="deprecation"' in response.headers.get("Link", [])
+    else:
+        assert deprecation not in response.headers.get("Deprecation", [])
+        assert 'rel="deprecation"' not in response.headers.get("Link", [])
+    if sunset:
+        assert sunset in response.headers.get("Sunset", [])
+        assert 'rel="sunset"' in response.headers.get("Link", [])
+    else:
+        assert sunset not in response.headers.get("Sunset", [])
+        assert 'rel="sunset"' not in response.headers.get("Link", [])

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -18,6 +18,7 @@ from flexmeasures.api.common.responses import (
     unknown_schedule,
     invalid_flex_config,
 )
+from flexmeasures.api.common.utils.deprecation_utils import deprecate_field
 from flexmeasures.api.common.utils.validators import (
     optional_duration_accepted,
 )
@@ -51,6 +52,19 @@ from flexmeasures.utils.unit_utils import ur
 get_sensor_schema = GetSensorDataSchema()
 post_sensor_schema = PostSensorDataSchema()
 sensors_schema = SensorSchema(many=True)
+
+DEPRECATED_FLEX_CONFIGURATION_FIELDS = [
+    "soc-at-start",
+    "soc-min",
+    "soc-max",
+    "soc-unit",
+    "roundtrip-efficiency",
+    "prefer-charging-sooner",
+    "soc-targets",
+    "consumption-price-sensor",
+    "production-price-sensor",
+    "inflexible-device-sensors",
+]
 
 
 class SensorAPI(FlaskView):
@@ -372,6 +386,13 @@ class SensorAPI(FlaskView):
         :status 422: UNPROCESSABLE_ENTITY
         """
         # -- begin deprecation logic, can be removed after 0.13
+        deprecate_field(
+            DEPRECATED_FLEX_CONFIGURATION_FIELDS,
+            deprecation_date="2022-12-14",
+            deprecation_link="https://flexmeasures.readthedocs.org/some-deprecation-notice",
+            sunset_date="2023-02-01",
+            sunset_link="https://flexmeasures.readthedocs.org/some-sunset-notice",
+        )
         found_fields: Dict[str, List[str]] = dict(model=[], context=[])
         deprecation_message = ""
         # flex-model

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -18,7 +18,7 @@ from flexmeasures.api.common.responses import (
     unknown_schedule,
     invalid_flex_config,
 )
-from flexmeasures.api.common.utils.deprecation_utils import deprecate_field
+from flexmeasures.api.common.utils.deprecation_utils import deprecate_fields
 from flexmeasures.api.common.utils.validators import (
     optional_duration_accepted,
 )
@@ -386,12 +386,12 @@ class SensorAPI(FlaskView):
         :status 422: UNPROCESSABLE_ENTITY
         """
         # -- begin deprecation logic, can be removed after 0.13
-        deprecate_field(
+        deprecate_fields(
             DEPRECATED_FLEX_CONFIGURATION_FIELDS,
             deprecation_date="2022-12-14",
-            deprecation_link="https://flexmeasures.readthedocs.io/en/latest/api/change_log.html#v3-0-4-2022-12-08",
+            deprecation_link="https://flexmeasures.readthedocs.io/en/latest/api/change_log.html#v3-0-5-2022-12-30",
             sunset_date="2023-02-01",
-            sunset_link="https://flexmeasures.readthedocs.io/en/latest/api/change_log.html#v3-0-4-2022-12-08",
+            sunset_link="https://flexmeasures.readthedocs.io/en/latest/api/change_log.html#v3-0-5-2022-12-30",
         )
         found_fields: Dict[str, List[str]] = dict(model=[], context=[])
         deprecation_message = ""

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -389,9 +389,9 @@ class SensorAPI(FlaskView):
         deprecate_field(
             DEPRECATED_FLEX_CONFIGURATION_FIELDS,
             deprecation_date="2022-12-14",
-            deprecation_link="https://flexmeasures.readthedocs.org/some-deprecation-notice",
+            deprecation_link="https://flexmeasures.readthedocs.io/en/latest/api/change_log.html#v3-0-4-2022-12-08",
             sunset_date="2023-02-01",
-            sunset_link="https://flexmeasures.readthedocs.org/some-sunset-notice",
+            sunset_link="https://flexmeasures.readthedocs.io/en/latest/api/change_log.html#v3-0-4-2022-12-08",
         )
         found_fields: Dict[str, List[str]] = dict(model=[], context=[])
         deprecation_message = ""

--- a/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
+++ b/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
@@ -5,7 +5,7 @@ from isodate import parse_datetime
 import pandas as pd
 from rq.job import Job
 
-from flexmeasures.api.tests.utils import get_auth_token
+from flexmeasures.api.tests.utils import check_deprecation, get_auth_token
 from flexmeasures.api.v1_3.tests.utils import message_for_get_device_message
 from flexmeasures.api.v3_0.tests.utils import message_for_trigger_schedule
 from flexmeasures.data.models.time_series import Sensor, TimedBelief
@@ -51,6 +51,7 @@ def test_trigger_schedule_with_invalid_flexmodel(
             headers={"Authorization": auth_token},
         )
         print("Server responded with:\n%s" % trigger_schedule_response.json)
+        check_deprecation(trigger_schedule_response, deprecation=None, sunset=None)
         assert trigger_schedule_response.status_code == 422
         assert field in trigger_schedule_response.json["message"]["json"]
         if isinstance(trigger_schedule_response.json["message"]["json"], str):
@@ -105,6 +106,7 @@ def test_trigger_and_get_schedule(
             headers={"Authorization": auth_token},
         )
         print("Server responded with:\n%s" % trigger_schedule_response.json)
+        check_deprecation(trigger_schedule_response)
         assert trigger_schedule_response.status_code == 200
         assert (
             "soc-min" in trigger_schedule_response.json["message"]


### PR DESCRIPTION
Also tests whether:
- the deprecation and sunset headers are introduced when the old fields are used, and
- the headers are not introduced when the old fields aren't used.