### PR TITLE
Move over deprecated soc-targets field

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -1,3 +1,4 @@
+
 **********************
 FlexMeasures Changelog
 **********************
@@ -40,7 +41,7 @@ Infrastructure / Support
 * Remove bokeh dependency and obsolete UI views [see `PR #476 <http://www.github.com/FlexMeasures/flexmeasures/pull/476>`_]
 * Fix ``flexmeasures db-ops dump`` and ``flexmeasures db-ops restore`` not working in docker containers [see `PR #530 <http://www.github.com/FlexMeasures/flexmeasures/pull/530>`_] and incorrectly reporting a success when `pg_dump` and `pg_restore` are not installed [see `PR #526 <http://www.github.com/FlexMeasures/flexmeasures/pull/526>`_]
 * Plugins can save BeliefsSeries, too, instead of just BeliefsDataFrames [see `PR #523 <http://www.github.com/FlexMeasures/flexmeasures/pull/523>`_]
-* Improve documentation and code w.r.t. storage flexibility modelling ― prepare for handling other schedulers & merge battery and car charging schedulers [see `PR #511 <http://www.github.com/FlexMeasures/flexmeasures/pull/511>`_ and `PR #537 <http://www.github.com/FlexMeasures/flexmeasures/pull/537>`_]
+* Improve documentation and code w.r.t. storage flexibility modelling ― prepare for handling other schedulers & merge battery and car charging schedulers [see `PR #511 <http://www.github.com/FlexMeasures/flexmeasures/pull/511>`_, `PR #537 <http://www.github.com/FlexMeasures/flexmeasures/pull/537>`_ and `PR #566 <http://www.github.com/FlexMeasures/flexmeasures/pull/566>`_]
 * Revised strategy for removing unchanged beliefs when saving data: retain the oldest measurement (ex-post belief), too [see `PR #518 <http://www.github.com/FlexMeasures/flexmeasures/pull/518>`_]
 * Scheduling test for maximizing self-consumption, and improved time series db queries for fixed tariffs (and other long-term constants) [see `PR #532 <http://www.github.com/FlexMeasures/flexmeasures/pull/532>`_]
 * Clean up table formatting for ``flexmeasures show`` CLI commands [see `PR #540 <http://www.github.com/FlexMeasures/flexmeasures/pull/540>`_]

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -241,7 +241,7 @@ class SensorAPI(FlaskView):
                 ),
             ),  # todo: allow unit to be set per field, using QuantityField("%", validate=validate.Range(min=0, max=1))
             "targets": fields.List(
-                fields.Nested(SOCTargetSchema), data_key="soc-targets"
+                fields.Dict, data_key="soc-targets"
             ),
             "prefer_charging_sooner": fields.Bool(
                 data_key="prefer-charging-sooner", required=False
@@ -401,6 +401,7 @@ class SensorAPI(FlaskView):
             (soc_min, "soc-min"),
             (soc_max, "soc-max"),
             (unit, "soc-unit"),
+            (kwargs.get("targets"), "soc-targets"),
             (roundtrip_efficiency, "roundtrip-efficiency"),
             (
                 prefer_charging_sooner,

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -36,7 +36,6 @@ from flexmeasures.data.queries.utils import simplify_index
 from flexmeasures.data.schemas.sensors import SensorSchema, SensorIdField
 from flexmeasures.data.schemas.times import AwareDateTimeField
 from flexmeasures.data.schemas.units import QuantityField
-from flexmeasures.data.schemas.scheduling.storage import SOCTargetSchema
 from flexmeasures.data.schemas.scheduling import FlexContextSchema
 from flexmeasures.data.services.sensors import get_sensors
 from flexmeasures.data.services.scheduling import (
@@ -240,9 +239,7 @@ class SensorAPI(FlaskView):
                     ]
                 ),
             ),  # todo: allow unit to be set per field, using QuantityField("%", validate=validate.Range(min=0, max=1))
-            "targets": fields.List(
-                fields.Dict, data_key="soc-targets"
-            ),
+            "targets": fields.List(fields.Dict, data_key="soc-targets"),
             "prefer_charging_sooner": fields.Bool(
                 data_key="prefer-charging-sooner", required=False
             ),

--- a/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
+++ b/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
@@ -161,12 +161,16 @@ def test_trigger_and_get_schedule(
         if not "flex-model" in message:
             start_soc = message["soc-at-start"] / 1000  # in MWh
             soc_targets = message["soc-targets"]
+            roundtrip_efficiency = message["roundtrip-efficiency"]
         else:
             start_soc = message["flex-model"]["soc-at-start"] / 1000  # in MWh
             soc_targets = message["flex-model"]["soc-targets"]
+            roundtrip_efficiency = message["flex-model"]["roundtrip-efficiency"]
         soc_schedule = integrate_time_series(
             consumption_schedule,
             start_soc,
+            up_efficiency=roundtrip_efficiency**0.5,
+            down_efficiency=roundtrip_efficiency**0.5,
             decimal_precision=6,
         )
         print(consumption_schedule)

--- a/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
+++ b/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
@@ -150,7 +150,7 @@ def test_trigger_and_get_schedule(
         == app.config.get("FLEXMEASURES_PLANNING_HORIZON") / resolution
     )
 
-    if not "flex-model" in message:
+    if "flex-model" not in message:
         start_soc = message["soc-at-start"] / 1000  # in MWh
         roundtrip_efficiency = message["roundtrip-efficiency"]
         soc_targets = message.get("soc-targets")

--- a/flexmeasures/api/v3_0/tests/utils.py
+++ b/flexmeasures/api/v3_0/tests/utils.py
@@ -57,7 +57,7 @@ def message_for_trigger_schedule(
     flex_model = {
         "soc-at-start": 12.1,  # in kWh, according to soc-unit
         "soc-min": 0,  # in kWh, according to soc-unit
-        "soc-max": 4,  # in kWh, according to soc-unit
+        "soc-max": 40,  # in kWh, according to soc-unit
         "soc-unit": "kWh",
         "roundtrip-efficiency": 0.98,
     }
@@ -69,7 +69,7 @@ def message_for_trigger_schedule(
     if with_targets:
         if realistic_targets:
             # this target (in kWh, according to soc-unit) is well below the soc_max_in_mwh on the battery's sensor attributes
-            targets = [{"value": 3500, "datetime": "2015-01-02T23:00:00+01:00"}]
+            targets = [{"value": 25, "datetime": "2015-01-02T23:00:00+01:00"}]
         else:
             # this target (in kWh, according to soc-unit) is actually higher than soc_max_in_mwh on the battery's sensor attributes
             targets = [{"value": 25000, "datetime": "2015-01-02T23:00:00+01:00"}]

--- a/flexmeasures/api/v3_0/tests/utils.py
+++ b/flexmeasures/api/v3_0/tests/utils.py
@@ -54,18 +54,24 @@ def message_for_trigger_schedule(
             "start"
         ] = "2040-01-01T00:00:00+01:00"  # We have no beliefs in our test database about 2040 prices
 
+    flex_model = {
+        "soc-at-start": 12.1,  # in kWh, according to soc-unit
+        "soc-min": 0,  # in kWh, according to soc-unit
+        "soc-max": 4,  # in kWh, according to soc-unit
+        "soc-unit": "kWh",
+        "roundtrip-efficiency": 0.98,
+    }
     if deprecated_format_pre012:
-        message["soc-at-start"] = 12.1
-        message["soc-unit"] = "kWh"
+        # unpack flex model directly as message fields
+        message = dict(**message, **flex_model)
     else:
-        message["flex-model"] = {}
-        message["flex-model"]["soc-at-start"] = 12.1
-        message["flex-model"]["soc-unit"] = "kWh"
+        message["flex-model"] = flex_model
     if with_targets:
         if realistic_targets:
+            # this target (in kWh, according to soc-unit) is well below the soc_max_in_mwh on the battery's sensor attributes
             targets = [{"value": 3500, "datetime": "2015-01-02T23:00:00+01:00"}]
         else:
-            # this target is actually higher than soc_max_in_mwh on the battery's sensor attributes
+            # this target (in kWh, according to soc-unit) is actually higher than soc_max_in_mwh on the battery's sensor attributes
             targets = [{"value": 25000, "datetime": "2015-01-02T23:00:00+01:00"}]
         if deprecated_format_pre012:
             message["soc-targets"] = targets

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -188,14 +188,17 @@ class StorageScheduler(Scheduler):
     def persist_flex_model(self):
         """Store new soc info as GenericAsset attributes"""
         self.sensor.generic_asset.set_attribute("soc_datetime", self.start.isoformat())
-        if self.flex_model.get("soc_unit") == "kWh":
+        soc_unit = self.flex_model.get("soc_unit")
+        if soc_unit == "kWh":
             self.sensor.generic_asset.set_attribute(
                 "soc_in_mwh", self.flex_model["soc_at_start"] / 1000
             )
-        else:
+        elif soc_unit == "MWh":
             self.sensor.generic_asset.set_attribute(
                 "soc_in_mwh", self.flex_model["soc_at_start"]
             )
+        else:
+            raise NotImplementedError(f"Unsupported SoC unit '{soc_unit}'.")
 
     def deserialize_flex_config(self):
         """

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -56,7 +56,7 @@ class StorageFlexModelSchema(Schema):
             if data.get("soc_targets"):
                 for target in data["soc_targets"]:
                     target["value"] /= 1000.0
-            data["soc_unit"] == "MWh"
+            data["soc_unit"] = "MWh"
 
         # Convert round-trip efficiency to dimensionless (to the (0,1] range)
         if data.get("roundtrip_efficiency") is not None:


### PR DESCRIPTION
Fixes the following bugs:
- `test_trigger_and_get_schedule` was not checking for soc-targets sent in the deprecated soc-targets field
- `test_trigger_and_get_schedule` was not taking into account efficiency losses when checking soc-targets
- `test_trigger_and_get_schedule` was not checking for soc-targets sent within the flex-model field
- `test_trigger_and_get_schedule` was assuming wrong units for the soc-max and soc-targets fields, thereby creating an unsolvable scheduling problem
- The deprecated soc-targets field was hidden in an unused `**kwargs` variable, and not moved over to become part of the flex-model field
- The deprecated soc-targets field was still being deserialized by the API endpoint rather than by the scheduler
- The SoC state was stored with the wrong units as an asset attribute