### PR TITLE
400 support passing a custom duration to /schedules/trigger [POST]

### DIFF
--- a/documentation/api/change_log.rst
+++ b/documentation/api/change_log.rst
@@ -21,6 +21,7 @@ v3.0-5 | 2022-12-30
     - ``production-price-sensor`` -> send in ``flex-context`` instead
     - ``inflexible-device-sensors`` -> send in ``flex-context`` instead
 
+- Allow posting ``soc-targets`` to `/sensors/<id>/schedules/trigger` (POST) that exceed the default planning horizon, but not the max planning horizon.
 - Added a subsection on deprecating and sunsetting to the Introduction section.
 - Added a subsection on describing flexibility to the Notation section.
 

--- a/documentation/api/change_log.rst
+++ b/documentation/api/change_log.rst
@@ -13,6 +13,7 @@ v3.0-5 | 2022-12-30
     - ``soc-at-start`` -> send in ``flex-model`` instead
     - ``soc-min`` -> send in ``flex-model`` instead
     - ``soc-max`` -> send in ``flex-model`` instead
+    - ``soc-targets`` -> send in ``flex-model`` instead
     - ``soc-unit`` -> send in ``flex-model`` instead
     - ``roundtrip-efficiency`` -> send in ``flex-model`` instead
     - ``prefer-charging-sooner`` -> send in ``flex-model`` instead

--- a/documentation/api/change_log.rst
+++ b/documentation/api/change_log.rst
@@ -21,6 +21,7 @@ v3.0-5 | 2022-12-30
     - ``production-price-sensor`` -> send in ``flex-context`` instead
     - ``inflexible-device-sensors`` -> send in ``flex-context`` instead
 
+- Introduced the ``duration``field to `/sensors/<id>/schedules/trigger` (POST) for setting a planning horizon explicitly.
 - Allow posting ``soc-targets`` to `/sensors/<id>/schedules/trigger` (POST) that exceed the default planning horizon, but not the max planning horizon.
 - Added a subsection on deprecating and sunsetting to the Introduction section.
 - Added a subsection on describing flexibility to the Notation section.

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -48,6 +48,7 @@ Infrastructure / Support
 * Clean up table formatting for ``flexmeasures show`` CLI commands [see `PR #540 <http://www.github.com/FlexMeasures/flexmeasures/pull/540>`_]
 * Add  ``"Deprecation"`` and ``"Sunset"`` response headers for API users of deprecated API versions, and log warnings for FlexMeasures hosts when users still use them [see `PR #554 <http://www.github.com/FlexMeasures/flexmeasures/pull/554>`_ and `PR #565 <http://www.github.com/FlexMeasures/flexmeasures/pull/565>`_]
 * Explain how to avoid potential ``SMTPRecipientsRefused`` errors when using FlexMeasures in combination with a mail server [see `PR #558 <http://www.github.com/FlexMeasures/flexmeasures/pull/558>`_]
+* Set a limit to the allowed planning window for API users, using the ``FLEXMEASURES_MAX_PLANNING_HORIZON`` setting [see `PR #568 <http://www.github.com/FlexMeasures/flexmeasures/pull/568>`_]
 
 .. warning:: The API endpoint (`[POST] /sensors/(id)/schedules/trigger <api/v3_0.html#post--api-v3_0-sensors-(id)-schedules-trigger>`_) to make new schedules will (in v0.13) sunset the storage flexibility parameters (they move to the ``flex-model`` parameter group), as well as the parameters describing other sensors (they move to ``flex-context``).
 

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -23,6 +23,7 @@ New features
 * Improved import of time series data from CSV file: 1) drop duplicate records with warning, 2) allow configuring which column contains explicit recording times for each data point (use case: import forecasts) [see `PR #501 <http://www.github.com/FlexMeasures/flexmeasures/pull/501>`_], 3) localize timezone naive data, 4) support reading in datetime and timedelta values, 5) remove rows with NaN values, and 6) filter by values in specific columns [see `PR #521 <http://www.github.com/FlexMeasures/flexmeasures/pull/521>`_]
 * Filter data by source in the API endpoint `/sensors/data` (GET) [see `PR #543 <http://www.github.com/FlexMeasures/flexmeasures/pull/543>`_]
 * Allow posting ``null`` values to `/sensors/data` (POST) to correctly space time series that include missing values (the missing values are not stored) [see `PR #549 <http://www.github.com/FlexMeasures/flexmeasures/pull/549>`_]
+* Allow setting a custom planning horizon when calling `/sensors/<id>/schedules/trigger` (POST), using the new ``duration`` field [see `PR #568 <http://www.github.com/FlexMeasures/flexmeasures/pull/568>`_]
 * New resampling functionality for instantaneous sensor data: 1) ``flexmeasures show beliefs`` can now handle showing (and saving) instantaneous sensor data and non-instantaneous sensor data together, and 2) the API endpoint `/sensors/data` (GET) now allows fetching instantaneous sensor data in a custom frequency, by using the "resolution" field [see `PR #542 <http://www.github.com/FlexMeasures/flexmeasures/pull/542>`_]
 
 Bugfixes

--- a/documentation/configuration.rst
+++ b/documentation/configuration.rst
@@ -253,9 +253,20 @@ Default: ``timedelta(days=7)``
 FLEXMEASURES_PLANNING_HORIZON
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The horizon to use when making schedules.
+The default horizon for making schedules.
+API users can set a custom duration if they need to.
 
-Default: ``timedelta(hours=2 * 24)``
+Default: ``timedelta(days=2)``
+
+
+FLEXMEASURES_MAX_PLANNING_HORIZON
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The maximum horizon for making schedules.
+API users are not able to request longer schedules.
+Set to ``None`` to forgo this limitation.
+
+Default: ``timedelta(days=7, hours=1)``
 
 
 Access Tokens

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -306,6 +306,7 @@ class SensorAPI(FlaskView):
         Otherwise, it is set by the config setting :ref:`planning_horizon_config`, which defaults to 48 hours.
         If the flex-model contains targets that lie beyond the planning horizon, the length of the schedule is extended to accommodate them.
         Finally, the schedule length is limited by :ref:`max_planning_horizon_config`, which defaults to 169 hours.
+        Targets that exceed the max planning horizon are not accepted.
 
         The appropriate algorithm is chosen by FlexMeasures (based on asset type).
         It's also possible to use custom schedulers and custom flexibility models, see :ref:`plugin_customization`.

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -449,6 +449,15 @@ class SensorAPI(FlaskView):
             )
         # -- end deprecation logic
 
+        def possibly_expand_duration_given_future_most_target(duration: timedelta, start: datetime, soc_targets: Optional[List[Dict]]) -> timedelta:
+            if soc_targets is None:
+                return duration
+            target_datetimes = [isodate.parse_datetime(soc_target["datetime"]) for soc_target in soc_targets]
+            future_most_target_datetime = max(target_datetimes)
+            max_target_duration = future_most_target_datetime - start
+            return max(duration, max_target_duration)
+        duration = possibly_expand_duration_given_future_most_target(duration, start_of_schedule, flex_model.get("soc-targets"))
+
         end_of_schedule = start_of_schedule + duration
         scheduler_kwargs = dict(
             sensor=sensor,

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -302,7 +302,10 @@ class SensorAPI(FlaskView):
                   See https://github.com/FlexMeasures/flexmeasures/issues/485. Until then, it is possible to call this endpoint for one flexible endpoint at a time
                   (considering already scheduled sensors as inflexible).
 
-        The length of schedules is set by the duration field, or otherwise the config setting :ref:`planning_horizon_config`, defaulting to 12 hours.
+        The length of the schedule can be set explicitly through the 'duration' field.
+        Otherwise, it is set by the config setting :ref:`planning_horizon_config`, which defaults to 48 hours.
+        If the flex-model contains targets that lie beyond the planning horizon, the length of the schedule is extended to accommodate them.
+        Finally, the schedule length is limited by :ref:`max_planning_horizon_config`, which defaults to 169 hours.
 
         The appropriate algorithm is chosen by FlexMeasures (based on asset type).
         It's also possible to use custom schedulers and custom flexibility models, see :ref:`plugin_customization`.
@@ -325,8 +328,8 @@ class SensorAPI(FlaskView):
 
         **Example request B**
 
-        This message triggers a schedule for a storage asset, starting at 10.00am, at which the state of charge (soc) is 12.1 kWh,
-        with a target state of charge of 25 kWh at 4.00pm.
+        This message triggers a 24-hour schedule for a storage asset, starting at 10.00am,
+        at which the state of charge (soc) is 12.1 kWh, with a target state of charge of 25 kWh at 4.00pm.
         The minimum and maximum soc are set to 10 and 25 kWh, respectively.
         Roundtrip efficiency for use in scheduling is set to 98%.
         Aggregate consumption (of all devices within this EMS) should be priced by sensor 9,
@@ -339,6 +342,7 @@ class SensorAPI(FlaskView):
 
             {
                 "start": "2015-06-02T10:00:00+00:00",
+                "duration": "PT24H",
                 "flex-model": {
                     "soc-at-start": 12.1,
                     "soc-unit": "kWh",

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -449,15 +449,6 @@ class SensorAPI(FlaskView):
             )
         # -- end deprecation logic
 
-        def possibly_expand_duration_given_future_most_target(duration: timedelta, start: datetime, soc_targets: Optional[List[Dict]]) -> timedelta:
-            if soc_targets is None:
-                return duration
-            target_datetimes = [isodate.parse_datetime(soc_target["datetime"]) for soc_target in soc_targets]
-            future_most_target_datetime = max(target_datetimes)
-            max_target_duration = future_most_target_datetime - start
-            return max(duration, max_target_duration)
-        duration = possibly_expand_duration_given_future_most_target(duration, start_of_schedule, flex_model.get("soc-targets"))
-
         end_of_schedule = start_of_schedule + duration
         scheduler_kwargs = dict(
             sensor=sensor,

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -34,7 +34,7 @@ from flexmeasures.data.models.user import Account
 from flexmeasures.data.models.time_series import Sensor
 from flexmeasures.data.queries.utils import simplify_index
 from flexmeasures.data.schemas.sensors import SensorSchema, SensorIdField
-from flexmeasures.data.schemas.times import AwareDateTimeField, DurationField
+from flexmeasures.data.schemas.times import AwareDateTimeField, PlanningDurationField
 from flexmeasures.data.schemas.units import QuantityField
 from flexmeasures.data.schemas.scheduling.storage import SOCTargetSchema
 from flexmeasures.data.schemas.scheduling import FlexContextSchema
@@ -65,12 +65,6 @@ DEPRECATED_FLEX_CONFIGURATION_FIELDS = [
     "production-price-sensor",
     "inflexible-device-sensors",
 ]
-
-
-def get_default_planning_horizon():
-    return current_app.config.get(  # type: ignore
-        "FLEXMEASURES_PLANNING_HORIZON"
-    )
 
 
 class SensorAPI(FlaskView):
@@ -227,7 +221,9 @@ class SensorAPI(FlaskView):
                 data_key="start", format="iso", required=True
             ),
             "belief_time": AwareDateTimeField(format="iso", data_key="prior"),
-            "duration": DurationField(load_default=get_default_planning_horizon),
+            "duration": PlanningDurationField(
+                load_default=PlanningDurationField.load_default
+            ),
             "flex_model": fields.Dict(data_key="flex-model"),
             "soc_sensor_id": fields.Str(data_key="soc-sensor", required=False),
             "roundtrip_efficiency": QuantityField(

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -265,7 +265,7 @@ class SensorAPI(FlaskView):
         self,
         sensor: Sensor,
         start_of_schedule: datetime,
-        duration: Optional[timedelta] = None,
+        duration: timedelta,
         belief_time: Optional[datetime] = None,
         start_value: Optional[float] = None,
         soc_min: Optional[float] = None,

--- a/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
+++ b/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
@@ -92,6 +92,7 @@ def test_trigger_and_get_schedule(
     message["roundtrip-efficiency"] = 0.98
     message["soc-min"] = 0
     message["soc-max"] = 4
+    message["duration"] = "PT48H"
     assert len(app.queues["scheduling"]) == 0
 
     sensor = Sensor.query.filter(Sensor.name == asset_name).one_or_none()

--- a/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
+++ b/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
@@ -28,6 +28,14 @@ from flexmeasures.utils.calculations import integrate_time_series
             "Not a valid number",
         ),
         (message_for_trigger_schedule(), "soc-unit", "MWH", "Must be one of"),
+        (
+            message_for_trigger_schedule(
+                with_targets=True, too_far_into_the_future_targets=True
+            ),
+            "soc-targets",
+            None,
+            "Target datetime exceeds",
+        )
     ],
 )
 def test_trigger_schedule_with_invalid_flexmodel(

--- a/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
+++ b/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
@@ -35,7 +35,7 @@ from flexmeasures.utils.calculations import integrate_time_series
             "soc-targets",
             None,
             "Target datetime exceeds",
-        )
+        ),
     ],
 )
 def test_trigger_schedule_with_invalid_flexmodel(

--- a/flexmeasures/api/v3_0/tests/utils.py
+++ b/flexmeasures/api/v3_0/tests/utils.py
@@ -48,7 +48,7 @@ def message_for_trigger_schedule(
 ) -> dict:
     message = {
         "start": "2015-01-01T00:00:00+01:00",
-        "duration": "PT48H",
+        "duration": "PT47H",
     }
     if unknown_prices:
         message[

--- a/flexmeasures/api/v3_0/tests/utils.py
+++ b/flexmeasures/api/v3_0/tests/utils.py
@@ -48,7 +48,7 @@ def message_for_trigger_schedule(
 ) -> dict:
     message = {
         "start": "2015-01-01T00:00:00+01:00",
-        "duration": "PT47H",
+        "duration": "PT24H",  # Will be extended in case of targets that would otherwise lie beyond the schedule's end
     }
     if unknown_prices:
         message[

--- a/flexmeasures/api/v3_0/tests/utils.py
+++ b/flexmeasures/api/v3_0/tests/utils.py
@@ -44,6 +44,7 @@ def message_for_trigger_schedule(
     unknown_prices: bool = False,
     with_targets: bool = False,
     realistic_targets: bool = True,
+    too_far_into_the_future_targets: bool = False,
     deprecated_format_pre012: bool = False,
 ) -> dict:
     message = {
@@ -70,10 +71,16 @@ def message_for_trigger_schedule(
     if with_targets:
         if realistic_targets:
             # this target (in kWh, according to soc-unit) is well below the soc_max_in_mwh on the battery's sensor attributes
-            targets = [{"value": 25, "datetime": "2015-01-02T23:00:00+01:00"}]
+            target_value = 25
         else:
             # this target (in kWh, according to soc-unit) is actually higher than soc_max_in_mwh on the battery's sensor attributes
-            targets = [{"value": 25000, "datetime": "2015-01-02T23:00:00+01:00"}]
+            target_value = 25000
+        if too_far_into_the_future_targets:
+            # this target exceeds FlexMeasures' default max planning horizon
+            target_datetime = "2015-02-02T23:00:00+01:00"
+        else:
+            target_datetime = "2015-01-02T23:00:00+01:00"
+        targets = [{"value": target_value, "datetime": target_datetime}]
         if deprecated_format_pre012:
             message["soc-targets"] = targets
         else:

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -356,7 +356,7 @@ def build_device_soc_targets(
     TODO: this function could become the deserialization method of a new SOCTargetsSchema (targets, plural), which wraps SOCTargetSchema.
 
     """
-    if isinstance(targets, pd.Series):  # some teats prepare it this way
+    if isinstance(targets, pd.Series):  # some tests prepare it this way
         device_targets = targets
     else:
         device_targets = initialize_series(

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -262,6 +262,9 @@ class StorageScheduler(Scheduler):
         """Extend schedule period in case a target exceeds its end.
 
         The schedule's duration is possibly limited by the server config setting 'FLEXMEASURES_MAX_PLANNING_HORIZON'.
+
+        todo: when deserialize_flex_config becomes a single schema for the whole scheduler,
+              this function would become a class method with a @post_load decorator.
         """
         soc_targets = self.flex_model.get("soc_targets")
         if soc_targets:

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -333,7 +333,7 @@ class StorageScheduler(Scheduler):
 
 
 def build_device_soc_targets(
-    targets: List[Dict[datetime, float]] | pd.Series,
+    targets: List[Dict[str, datetime | float]] | pd.Series,
     soc_at_start: float,
     start_of_schedule: datetime,
     end_of_schedule: datetime,

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -253,7 +253,20 @@ class StorageScheduler(Scheduler):
         self.flex_model = StorageFlexModelSchema().load(self.flex_model)
         self.flex_context = FlexContextSchema().load(self.flex_context)
 
+        # Extend schedule period in case a target exceeds its end
+        self.possibly_extend_end()
+
         return self.flex_model
+
+    def possibly_extend_end(self):
+        """Extend schedule period in case a target exceeds its end."""
+        soc_targets = self.flex_model.get("soc_targets")
+        if soc_targets:
+            max_target_datetime = max(
+                [soc_target["datetime"] for soc_target in soc_targets]
+            )
+            if max_target_datetime > self.end:
+                self.end = max_target_datetime
 
     def get_min_max_targets(
         self, deserialized_names: bool = True

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -250,7 +250,7 @@ class StorageScheduler(Scheduler):
         self.ensure_soc_min_max()
 
         # Now it's time to check if our flex configurations holds up to schemas
-        self.flex_model = StorageFlexModelSchema().load(self.flex_model)
+        self.flex_model = StorageFlexModelSchema(self.start).load(self.flex_model)
         self.flex_context = FlexContextSchema().load(self.flex_context)
 
         # Extend schedule period in case a target exceeds its end

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -56,6 +56,8 @@ class StorageFlexModelSchema(Schema):
     def check_whether_targets_exceed_max_planning_horizon(
         self, soc_targets: list[dict[str, datetime | float]]
     ):
+        if not soc_targets:
+            return
         max_server_horizon = current_app.config.get("FLEXMEASURES_MAX_PLANNING_HORIZON")
         max_target_datetime = max([target["datetime"] for target in soc_targets])
         max_server_datetime = self.start + max_server_horizon

--- a/flexmeasures/data/schemas/times.py
+++ b/flexmeasures/data/schemas/times.py
@@ -1,6 +1,7 @@
 from typing import Union, Optional
 from datetime import datetime, timedelta
 
+from flask import current_app
 from marshmallow import fields
 import isodate
 from isodate.isoerror import ISO8601Error
@@ -62,6 +63,15 @@ class DurationField(MarshmallowClickMixin, fields.Str):
             )
             return (pd.Timestamp(start) + offset).to_pydatetime() - start
         return duration
+
+
+class PlanningDurationField(DurationField):
+    @classmethod
+    def load_default(cls):
+        """
+        Use this with the load_default arg to __init__ if you want the default FlexMeasures planning horizon.
+        """
+        return current_app.config.get("FLEXMEASURES_PLANNING_HORIZON")
 
 
 class AwareDateTimeField(MarshmallowClickMixin, fields.AwareDateTime):

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import timedelta
 import logging
 from typing import List, Optional, Union, Dict, Tuple
@@ -112,7 +114,8 @@ class Config(object):
     }  # how to group assets by asset types
     FLEXMEASURES_LP_SOLVER: str = "cbc"
     FLEXMEASURES_JOB_TTL: timedelta = timedelta(days=1)
-    FLEXMEASURES_PLANNING_HORIZON: timedelta = timedelta(hours=2 * 24)
+    FLEXMEASURES_PLANNING_HORIZON: timedelta = timedelta(days=2)
+    FLEXMEASURES_MAX_PLANNING_HORIZON: timedelta | None = timedelta(days=7, hours=1)
     FLEXMEASURES_PLANNING_TTL: timedelta = timedelta(
         days=7
     )  # Time to live for UDI event ids of successful scheduling jobs. Set a negative timedelta to persist forever.


### PR DESCRIPTION
- [x] Support passing a custom duration to /schedules/trigger [POST].
- [x] Allow SoC targets to exceed the default planning horizon, dynamically extending the planning window.
- [x] Introduce a new config setting: `FLEXMEASURES_MAX_PLANNING_HORIZON`.
- [x] Do not allow SoC targets to exceed the max planning horizon.
