### PR TITLE
Disregard targets that are too far into the future

### DIFF
--- a/documentation/api/change_log.rst
+++ b/documentation/api/change_log.rst
@@ -22,7 +22,7 @@ v3.0-5 | 2022-12-30
     - ``inflexible-device-sensors`` -> send in ``flex-context`` instead
 
 - Introduced the ``duration``field to `/sensors/<id>/schedules/trigger` (POST) for setting a planning horizon explicitly.
-- Allow posting ``soc-targets`` to `/sensors/<id>/schedules/trigger` (POST) that exceed the default planning horizon, but not the max planning horizon.
+- Allow posting ``soc-targets`` to `/sensors/<id>/schedules/trigger` (POST) that exceed the default planning horizon, and ignore posted targets that exceed the max planning horizon.
 - Added a subsection on deprecating and sunsetting to the Introduction section.
 - Added a subsection on describing flexibility to the Notation section.
 

--- a/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
+++ b/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
@@ -28,6 +28,7 @@ from flexmeasures.utils.calculations import integrate_time_series
             "Not a valid number",
         ),
         (message_for_trigger_schedule(), "soc-unit", "MWH", "Must be one of"),
+        # todo: add back test in case we stop grandfathering ignoring too-far-into-the-future targets, or amend otherwise
         # (
         #     message_for_trigger_schedule(
         #         with_targets=True, too_far_into_the_future_targets=True

--- a/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
+++ b/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
@@ -28,14 +28,14 @@ from flexmeasures.utils.calculations import integrate_time_series
             "Not a valid number",
         ),
         (message_for_trigger_schedule(), "soc-unit", "MWH", "Must be one of"),
-        (
-            message_for_trigger_schedule(
-                with_targets=True, too_far_into_the_future_targets=True
-            ),
-            "soc-targets",
-            None,
-            "Target datetime exceeds",
-        ),
+        # (
+        #     message_for_trigger_schedule(
+        #         with_targets=True, too_far_into_the_future_targets=True
+        #     ),
+        #     "soc-targets",
+        #     None,
+        #     "Target datetime exceeds",
+        # ),
     ],
 )
 def test_trigger_schedule_with_invalid_flexmodel(

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -376,9 +376,11 @@ def build_device_soc_targets(
                 device_targets.index.tzinfo
             )  # otherwise DST would be problematic
             if target_datetime > end_of_schedule:
-                raise ValueError(
-                    f'Target datetime exceeds {end_of_schedule}. Maximum scheduling horizon is {current_app.config.get("FLEXMEASURES_MAX_PLANNING_HORIZON")}.'
+                # Skip too-far-into-the-future target
+                current_app.logger.warning(
+                    f'Disregarding target datetime {target_datetime}, because it exceeds {end_of_schedule}. Maximum scheduling horizon is {current_app.config.get("FLEXMEASURES_MAX_PLANNING_HORIZON")}.'
                 )
+                continue
 
             device_targets.loc[target_datetime] = target_value
 

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from flask import current_app
 from marshmallow import Schema, post_load, validate, validates, fields
-from marshmallow.validate import OneOf, ValidationError
+from marshmallow.validate import OneOf
 
 from flexmeasures.data.schemas.times import AwareDateTimeField
 from flexmeasures.data.schemas.units import QuantityField

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -62,7 +62,7 @@ class StorageFlexModelSchema(Schema):
         max_target_datetime = max([target["datetime"] for target in soc_targets])
         max_server_datetime = self.start + max_server_horizon
         if max_target_datetime > max_server_datetime:
-            raise ValidationError(
+            current_app.logger.warning(
                 f'Target datetime exceeds {max_server_datetime}. Maximum scheduling horizon is {current_app.config.get("FLEXMEASURES_MAX_PLANNING_HORIZON")}.'
             )
 

--- a/flexmeasures/data/services/scheduling.py
+++ b/flexmeasures/data/services/scheduling.py
@@ -207,7 +207,7 @@ def load_custom_scheduler(scheduler_specs: dict) -> type:
         try:
             module = importlib.import_module(module_descr)
         except TypeError as te:
-            current_app.log.error(f"Cannot load {module_descr}: {te}.")
+            current_app.logger.error(f"Cannot load {module_descr}: {te}.")
             raise
         except ModuleNotFoundError:
             current_app.logger.error(


### PR DESCRIPTION
This PR stops raising a `ValidationError` on too-far-into-the-future targets, and disregards them instead.

The two options for me here are, either:
1. we allow too-far-into-the-future targets, but disregard them. We follow up (new ticket) by using the 'Warning' HTTP header, and add documentation that API users should monitor these (if they aren't already), or
2. we grandfather too-far-into-the-future targets for now, and will raise in the future. We follow up (new ticket) by using deprecation and sunset headers, and disallow such targets in the future.

With either option, this PR would be the first step imo.