### PR TITLE
Upgrade dependencies after 0.12

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -71,7 +71,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/flexmeasures/api/__init__.py
+++ b/flexmeasures/api/__init__.py
@@ -54,7 +54,7 @@ def request_auth_token():
                 )
 
             if "password" not in request.json:
-                return {"errors": ["Please provide the 'password' parameter."]}
+                return {"errors": ["Please provide the 'password' parameter."]}, 400
             if not verify_password(request.json["password"], user.password):
                 return {"errors": ["User password does not match."]}, 401
         token = user.get_auth_token()

--- a/flexmeasures/api/tests/test_task_runs.py
+++ b/flexmeasures/api/tests/test_task_runs.py
@@ -60,6 +60,7 @@ def test_api_task_run_get_nonexistent_task(client):
 
 def test_api_task_run_post_no_name(client):
     task_run = post_task_run(client, "")
+    task_run = post_task_run(client, "")
     assert task_run.status_code == 400
     assert task_run.json["status"] == "ERROR"
     assert task_run.json["reason"] == "No task name given."

--- a/flexmeasures/api/tests/test_task_runs.py
+++ b/flexmeasures/api/tests/test_task_runs.py
@@ -60,7 +60,6 @@ def test_api_task_run_get_nonexistent_task(client):
 
 def test_api_task_run_post_no_name(client):
     task_run = post_task_run(client, "")
-    task_run = post_task_run(client, "")
     assert task_run.status_code == 400
     assert task_run.json["status"] == "ERROR"
     assert task_run.json["reason"] == "No task name given."

--- a/flexmeasures/templates/security/email/reset_instructions.html
+++ b/flexmeasures/templates/security/email/reset_instructions.html
@@ -1,1 +1,1 @@
-<p><a href="{{ reset_link }}">{{ _('You can now choose a new FlexMeasures password.') }} {{ _('Click here to reset your password') }}.</a></p>
+<p><a href="{{ reset_link }}">{{ _fsdomain('You can now choose a new FlexMeasures password.') }} {{ _fsdomain('Click here to reset your password') }}.</a></p>

--- a/flexmeasures/templates/security/email/reset_instructions.txt
+++ b/flexmeasures/templates/security/email/reset_instructions.txt
@@ -1,5 +1,5 @@
-{{ _('You can now choose a new FlexMeasures password.') }}
+{{ _fsdomain('You can now choose a new FlexMeasures password.') }}
 
-{{ _('Click the link below to reset your password:') }}
+{{ _fsdomain('Click the link below to reset your password:') }}
 
 {{ reset_link }}

--- a/flexmeasures/ui/templates/admin/forgot_password.html
+++ b/flexmeasures/ui/templates/admin/forgot_password.html
@@ -13,7 +13,7 @@
             <div class="forgot-pwd-form col-sm-12">
                 {% include "security/_messages.html" %}
 
-                <h1>{{ _('Send password reset instructions') }}</h1>
+                <h1>{{ _fsdomain('Send password reset instructions') }}</h1>
                 <form action="{{ url_for_security('forgot_password') }}" method="POST" name="forgot_password_form">
                     {{ forgot_password_form.hidden_tag() }}
                     {{ render_field_with_errors(forgot_password_form.email) }}

--- a/flexmeasures/ui/templates/admin/login_user.html
+++ b/flexmeasures/ui/templates/admin/login_user.html
@@ -15,7 +15,7 @@
             {% include "security/_messages.html" %}
         </div>
         <div class="login-form col-sm-4">
-            <h1>{{ _('Login') }}</h1>
+            <h1>{{ _fsdomain('Login') }}</h1>
             <form action="{{ url_for_security('login') }}" method="POST" name="login_user_form">
                 {{ login_user_form.hidden_tag() }}
                 {{ render_field_with_errors(login_user_form.email) }}

--- a/flexmeasures/ui/templates/admin/reset_password.html
+++ b/flexmeasures/ui/templates/admin/reset_password.html
@@ -15,7 +15,7 @@
             <div class="forgot-pwd-form col-sm-12">
                 {% include "security/_messages.html" %}
 
-                <h1>{{ _('Reset password') }}</h1>
+                <h1>{{ _fsdomain('Reset password') }}</h1>
                 <form action="{{ url_for_security('reset_password', token=reset_password_token) }}" method="POST" name="reset_password_form">
                     {{ reset_password_form.hidden_tag() }}
                     {{ render_field_with_errors(reset_password_form.password) }}

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -33,6 +33,7 @@ timely-beliefs[forecast]>=1.18
 python-dotenv
 # a backport, not needed in Python3.8
 importlib_metadata
+# see GH#607 for issue on this pin
 sqlalchemy>=1.4.0, <2
 Flask-SSLify
 Flask_JSON
@@ -52,7 +53,7 @@ marshmallow-sqlalchemy>=0.23.1
 webargs
 # Minimum version that correctly aligns time series that include NaN values
 uniplot>=0.7.0
-# Maximum constraints here due to Flask-Classful not supporting Werkzeug 2.2.0 yet, see https://github.com/teracyhq/flask-classful/pull/145
+# Maximum constraints here due to Flask-Classful not supporting Werkzeug 2.2.0 yet, see GH#595 and https://github.com/teracyhq/flask-classful/pull/145
 Flask-SQLAlchemy>=2.4.3,<3
 # flask should be after all the flask plugins, because setup might find they ARE flask
 flask>=1.0,<=2.1.2

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -38,11 +38,10 @@ Flask-SSLify
 Flask_JSON
 Flask-Migrate
 Flask-WTF
-# This should be looked at together with Security (see below). We get 401's with 0.6
-Flask-Login <= 0.5
 Flask-Mail
-# We wait a little with upgrading to 5, until it's less fresh (Aug 2022)
-Flask-Security-Too>=4.0, <5.0
+Flask-Security-Too>=5.0
+# This pin is tough to debug, but logging in (in API) stops working at 0.6.2. Maybe Flask 2.2 will help resolve this.
+Flask-Login <= 0.6.1
 Flask-Classful
 Flask-Marshmallow
 Flask-Cors

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -24,7 +24,7 @@ rq-dashboard
 # the following uses environment markers (see PEP 496)
 rq-win; os_name == 'nt' or os_name == 'win'
 # This limit resolves a conflict with test.in. The culprit is fakeredis (check their pyproject.toml)
-redis < 4.5
+redis >4.5, <5
 tldextract
 pyomo>=5.6
 tabulate
@@ -33,7 +33,7 @@ timely-beliefs[forecast]>=1.18
 python-dotenv
 # a backport, not needed in Python3.8
 importlib_metadata
-sqlalchemy>=1.4.0
+sqlalchemy>=1.4.0, <2
 Flask-SSLify
 Flask_JSON
 Flask-Migrate

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -56,5 +56,5 @@ uniplot>=0.7.0
 # Maximum constraints here due to Flask-Classful not supporting Werkzeug 2.2.0 yet, see https://github.com/teracyhq/flask-classful/pull/145
 Flask-SQLAlchemy>=2.4.3,<3
 # flask should be after all the flask plugins, because setup might find they ARE flask
-flask>=1.0,<2.1.2
+flask>=1.0,<=2.1.2
 werkzeug <2.1

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -38,7 +38,8 @@ Flask-SSLify
 Flask_JSON
 Flask-Migrate
 Flask-WTF
-Flask-Login
+# This should be looked at together with Security (see below). We get 401's with 0.6
+Flask-Login <= 0.5
 Flask-Mail
 # We wait a little with upgrading to 5, until it's less fresh (Aug 2022)
 Flask-Security-Too>=4.0, <5.0

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -23,8 +23,8 @@ rq
 rq-dashboard
 # the following uses environment markers (see PEP 496)
 rq-win; os_name == 'nt' or os_name == 'win'
-# This limit resolves a conflict with test.in. The culprit is fakeredis (check their setup.cfg)
-redis < 4.4.0
+# This limit resolves a conflict with test.in. The culprit is fakeredis (check their pyproject.toml)
+redis < 4.5
 tldextract
 pyomo>=5.6
 tabulate
@@ -36,7 +36,6 @@ importlib_metadata
 sqlalchemy>=1.4.0
 Flask-SSLify
 Flask_JSON
-Flask-SQLAlchemy>=2.4.3
 Flask-Migrate
 Flask-WTF
 Flask-Login
@@ -53,8 +52,8 @@ marshmallow-sqlalchemy>=0.23.1
 webargs
 # Minimum version that correctly aligns time series that include NaN values
 uniplot>=0.7.0
+# Maximum constraints here due to Flask-Classful not supporting Werkzeug 2.2.0 yet, see https://github.com/teracyhq/flask-classful/pull/145
+Flask-SQLAlchemy>=2.4.3,<3
 # flask should be after all the flask plugins, because setup might find they ARE flask
-# Minimum here due to Flask-Classful not supporting Werkzeug 2.2.0 yet, see https://github.com/teracyhq/flask-classful/pull/145
-flask>=1.0, <=2.1.2
-# remove if flask max constraint (see above) is removed 
+flask>=1.0,<2.1.2
 werkzeug <2.1

--- a/requirements/app.txt
+++ b/requirements/app.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/app.txt requirements/app.in
 #
-alembic==1.9.1
+alembic==1.9.2
     # via flask-migrate
 altair==4.2.0
     # via -r requirements/app.in
@@ -28,7 +28,7 @@ certifi==2022.12.7
     # via
     #   requests
     #   sentry-sdk
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
 click==8.1.3
     # via
@@ -40,7 +40,7 @@ click-default-group==1.2.2
     # via -r requirements/app.in
 colour==0.1.5
     # via -r requirements/app.in
-contourpy==1.0.6
+contourpy==1.0.7
     # via matplotlib
 convertdate==2.4.0
     # via workalendar
@@ -50,7 +50,7 @@ deprecated==1.2.13
     # via sktime
 dill==0.3.6
     # via openturns
-dnspython==2.2.1
+dnspython==2.3.0
     # via email-validator
 email-validator==1.3.0
     # via
@@ -103,7 +103,7 @@ flask-sqlalchemy==2.5.1
     #   flask-migrate
 flask-sslify==0.1.5
     # via -r requirements/app.in
-flask-wtf==1.0.1
+flask-wtf==1.1.1
     # via
     #   -r requirements/app.in
     #   flask-security-too
@@ -153,7 +153,7 @@ lunardate==0.2.0
     # via workalendar
 mako==1.2.4
     # via alembic
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via
     #   jinja2
     #   mako
@@ -169,7 +169,7 @@ marshmallow-polyfield==5.11
     # via -r requirements/app.in
 marshmallow-sqlalchemy==0.28.1
     # via -r requirements/app.in
-matplotlib==3.6.2
+matplotlib==3.6.3
     # via timetomodel
 numba==0.56.4
     # via sktime
@@ -250,25 +250,25 @@ python-dateutil==2.8.2
     #   workalendar
 python-dotenv==0.21.0
     # via -r requirements/app.in
-pytz==2022.7
+pytz==2022.7.1
     # via
     #   -r requirements/app.in
     #   babel
     #   pandas
     #   timely-beliefs
     #   timetomodel
-redis==4.4.1
+redis==4.4.2
     # via
     #   -r requirements/app.in
     #   rq
     #   rq-dashboard
-requests==2.28.1
+requests==2.28.2
     # via
     #   requests-file
     #   tldextract
 requests-file==1.5.1
     # via tldextract
-rq==1.11.1
+rq==1.12.0
     # via
     #   -r requirements/app.in
     #   rq-dashboard
@@ -284,7 +284,7 @@ scipy==1.10.0
     #   statsmodels
     #   timely-beliefs
     #   timetomodel
-sentry-sdk[flask]==1.12.1
+sentry-sdk[flask]==1.13.0
     # via -r requirements/app.in
 six==1.16.0
     # via
@@ -296,7 +296,7 @@ six==1.16.0
     #   requests-file
 sklearn==0.0.post1
     # via timetomodel
-sktime==0.15.0
+sktime==0.15.1
     # via timely-beliefs
 sqlalchemy==1.4.46
     # via
@@ -314,7 +314,7 @@ tabulate==0.9.0
     # via -r requirements/app.in
 threadpoolctl==3.1.0
     # via scikit-learn
-timely-beliefs[forecast]==1.18.0
+timely-beliefs[forecast]==1.19.0
     # via -r requirements/app.in
 timetomodel==0.7.1
     # via -r requirements/app.in
@@ -328,7 +328,7 @@ typing-extensions==4.4.0
     #   pydantic
 uniplot==0.8.1
     # via -r requirements/app.in
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   requests
     #   sentry-sdk

--- a/requirements/app.txt
+++ b/requirements/app.txt
@@ -83,7 +83,7 @@ flask-cors==3.0.10
     # via -r requirements/app.in
 flask-json==0.3.5
     # via -r requirements/app.in
-flask-login==0.5.0
+flask-login==0.6.1
     # via
     #   -r requirements/app.in
     #   flask-security-too
@@ -95,7 +95,7 @@ flask-migrate==4.0.4
     # via -r requirements/app.in
 flask-principal==0.4.0
     # via flask-security-too
-flask-security-too==4.1.6
+flask-security-too==5.1.2
     # via -r requirements/app.in
 flask-sqlalchemy==2.5.1
     # via
@@ -336,12 +336,15 @@ werkzeug==2.0.3
     # via
     #   -r requirements/app.in
     #   flask
+    #   flask-login
 workalendar==17.0.0
     # via -r requirements/app.in
 wrapt==1.15.0
     # via deprecated
 wtforms==3.0.1
-    # via flask-wtf
+    # via
+    #   flask-security-too
+    #   flask-wtf
 xlrd==2.0.1
     # via -r requirements/app.in
 zipp==3.15.0

--- a/requirements/app.txt
+++ b/requirements/app.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --output-file=requirements/app.txt requirements/app.in
 #
-alembic==1.9.2
+alembic==1.10.2
     # via flask-migrate
-altair==4.2.0
+altair==4.2.2
     # via -r requirements/app.in
 arrow==1.2.3
     # via rq-dashboard
@@ -14,7 +14,7 @@ async-timeout==4.0.2
     # via redis
 attrs==22.2.0
     # via jsonschema
-babel==2.11.0
+babel==2.12.1
     # via py-moneyed
 bcrypt==4.0.1
     # via -r requirements/app.in
@@ -28,7 +28,7 @@ certifi==2022.12.7
     # via
     #   requests
     #   sentry-sdk
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via
@@ -52,13 +52,13 @@ dill==0.3.6
     # via openturns
 dnspython==2.3.0
     # via email-validator
-email-validator==1.3.0
+email-validator==1.3.1
     # via
     #   -r requirements/app.in
     #   flask-security-too
 entrypoints==0.4
     # via altair
-filelock==3.9.0
+filelock==3.10.0
     # via tldextract
 flask==2.1.2
     # via
@@ -91,11 +91,11 @@ flask-mail==0.9.1
     # via -r requirements/app.in
 flask-marshmallow==0.14.0
     # via -r requirements/app.in
-flask-migrate==4.0.1
+flask-migrate==4.0.4
     # via -r requirements/app.in
 flask-principal==0.4.0
     # via flask-security-too
-flask-security-too==4.1.5
+flask-security-too==4.1.6
     # via -r requirements/app.in
 flask-sqlalchemy==2.5.1
     # via
@@ -107,18 +107,18 @@ flask-wtf==1.1.1
     # via
     #   -r requirements/app.in
     #   flask-security-too
-fonttools==4.38.0
+fonttools==4.39.2
     # via matplotlib
-greenlet==2.0.1
+greenlet==2.0.2
     # via sqlalchemy
-humanize==4.4.0
+humanize==4.6.0
     # via -r requirements/app.in
 idna==3.4
     # via
     #   email-validator
     #   requests
     #   tldextract
-importlib-metadata==6.0.0
+importlib-metadata==6.1.0
     # via
     #   -r requirements/app.in
     #   timely-beliefs
@@ -167,9 +167,9 @@ marshmallow==3.19.0
     #   webargs
 marshmallow-polyfield==5.11
     # via -r requirements/app.in
-marshmallow-sqlalchemy==0.28.1
+marshmallow-sqlalchemy==0.29.0
     # via -r requirements/app.in
-matplotlib==3.6.3
+matplotlib==3.7.1
     # via timetomodel
 numba==0.56.4
     # via sktime
@@ -199,7 +199,7 @@ packaging==23.0
     #   matplotlib
     #   statsmodels
     #   webargs
-pandas==1.5.2
+pandas==1.5.3
     # via
     #   -r requirements/app.in
     #   altair
@@ -229,13 +229,13 @@ psycopg2-binary==2.9.5
     #   timely-beliefs
 py-moneyed==3.0
     # via -r requirements/app.in
-pydantic==1.10.4
+pydantic==1.10.6
     # via inflect
-pyluach==2.0.2
+pyluach==2.2.0
     # via workalendar
 pymeeus==0.5.12
     # via convertdate
-pyomo==6.4.4
+pyomo==6.5.0
     # via -r requirements/app.in
 pyparsing==3.0.9
     # via matplotlib
@@ -248,16 +248,15 @@ python-dateutil==2.8.2
     #   pandas
     #   timetomodel
     #   workalendar
-python-dotenv==0.21.0
+python-dotenv==1.0.0
     # via -r requirements/app.in
 pytz==2022.7.1
     # via
     #   -r requirements/app.in
-    #   babel
     #   pandas
     #   timely-beliefs
     #   timetomodel
-redis==4.4.2
+redis==4.5.1
     # via
     #   -r requirements/app.in
     #   rq
@@ -268,15 +267,15 @@ requests==2.28.2
     #   tldextract
 requests-file==1.5.1
     # via tldextract
-rq==1.12.0
+rq==1.13.0
     # via
     #   -r requirements/app.in
     #   rq-dashboard
 rq-dashboard==0.6.1
     # via -r requirements/app.in
-scikit-learn==1.2.0
+scikit-learn==1.2.2
     # via sktime
-scipy==1.10.0
+scipy==1.10.1
     # via
     #   properscoring
     #   scikit-learn
@@ -284,7 +283,7 @@ scipy==1.10.0
     #   statsmodels
     #   timely-beliefs
     #   timetomodel
-sentry-sdk[flask]==1.13.0
+sentry-sdk[flask]==1.17.0
     # via -r requirements/app.in
 six==1.16.0
     # via
@@ -296,9 +295,9 @@ six==1.16.0
     #   requests-file
 sklearn==0.0.post1
     # via timetomodel
-sktime==0.15.1
+sktime==0.16.1
     # via timely-beliefs
-sqlalchemy==1.4.46
+sqlalchemy==1.4.47
     # via
     #   -r requirements/app.in
     #   alembic
@@ -307,9 +306,7 @@ sqlalchemy==1.4.46
     #   timely-beliefs
     #   timetomodel
 statsmodels==0.13.5
-    # via
-    #   sktime
-    #   timetomodel
+    # via timetomodel
 tabulate==0.9.0
     # via -r requirements/app.in
 threadpoolctl==3.1.0
@@ -322,13 +319,14 @@ tldextract==3.4.0
     # via -r requirements/app.in
 toolz==0.12.0
     # via altair
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
+    #   alembic
     #   py-moneyed
     #   pydantic
-uniplot==0.8.1
+uniplot==0.10.0
     # via -r requirements/app.in
-urllib3==1.26.14
+urllib3==1.26.15
     # via
     #   requests
     #   sentry-sdk
@@ -340,13 +338,13 @@ werkzeug==2.0.3
     #   flask
 workalendar==17.0.0
     # via -r requirements/app.in
-wrapt==1.14.1
+wrapt==1.15.0
     # via deprecated
 wtforms==3.0.1
     # via flask-wtf
 xlrd==2.0.1
     # via -r requirements/app.in
-zipp==3.11.0
+zipp==3.15.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/app.txt
+++ b/requirements/app.txt
@@ -4,17 +4,19 @@
 #
 #    pip-compile --output-file=requirements/app.txt requirements/app.in
 #
-alembic==1.8.1
+alembic==1.9.1
     # via flask-migrate
 altair==4.2.0
     # via -r requirements/app.in
-arrow==1.2.2
+arrow==1.2.3
     # via rq-dashboard
-attrs==22.1.0
+async-timeout==4.0.2
+    # via redis
+attrs==22.2.0
     # via jsonschema
-babel==2.10.3
+babel==2.11.0
     # via py-moneyed
-bcrypt==4.0.0
+bcrypt==4.0.1
     # via -r requirements/app.in
 blinker==1.5
     # via
@@ -22,7 +24,7 @@ blinker==1.5
     #   flask-principal
     #   flask-security-too
     #   sentry-sdk
-certifi==2022.6.15
+certifi==2022.12.7
     # via
     #   requests
     #   sentry-sdk
@@ -38,25 +40,25 @@ click-default-group==1.2.2
     # via -r requirements/app.in
 colour==0.1.5
     # via -r requirements/app.in
+contourpy==1.0.6
+    # via matplotlib
 convertdate==2.4.0
     # via workalendar
 cycler==0.11.0
     # via matplotlib
 deprecated==1.2.13
-    # via
-    #   redis
-    #   sktime
-dill==0.3.5.1
+    # via sktime
+dill==0.3.6
     # via openturns
 dnspython==2.2.1
     # via email-validator
-email-validator==1.2.1
+email-validator==1.3.0
     # via
     #   -r requirements/app.in
     #   flask-security-too
 entrypoints==0.4
     # via altair
-filelock==3.8.0
+filelock==3.9.0
     # via tldextract
 flask==2.1.2
     # via
@@ -79,7 +81,7 @@ flask-classful==0.14.2
     # via -r requirements/app.in
 flask-cors==3.0.10
     # via -r requirements/app.in
-flask-json==0.3.4
+flask-json==0.3.5
     # via -r requirements/app.in
 flask-login==0.5.0
     # via
@@ -89,7 +91,7 @@ flask-mail==0.9.1
     # via -r requirements/app.in
 flask-marshmallow==0.14.0
     # via -r requirements/app.in
-flask-migrate==3.1.0
+flask-migrate==4.0.1
     # via -r requirements/app.in
 flask-principal==0.4.0
     # via flask-security-too
@@ -105,26 +107,26 @@ flask-wtf==1.0.1
     # via
     #   -r requirements/app.in
     #   flask-security-too
-fonttools==4.37.1
+fonttools==4.38.0
     # via matplotlib
-greenlet==1.1.3
+greenlet==2.0.1
     # via sqlalchemy
-humanize==4.3.0
+humanize==4.4.0
     # via -r requirements/app.in
-idna==3.3
+idna==3.4
     # via
     #   email-validator
     #   requests
     #   tldextract
-importlib-metadata==4.12.0
+importlib-metadata==6.0.0
     # via
     #   -r requirements/app.in
     #   timely-beliefs
-inflect==6.0.0
+inflect==6.0.2
     # via -r requirements/app.in
 inflection==0.5.1
     # via -r requirements/app.in
-iso8601==1.0.2
+iso8601==1.1.0
     # via -r requirements/app.in
 isodate==0.6.1
     # via
@@ -139,9 +141,9 @@ jinja2==3.1.2
     # via
     #   altair
     #   flask
-joblib==1.1.0
+joblib==1.2.0
     # via scikit-learn
-jsonschema==4.15.0
+jsonschema==4.17.3
     # via altair
 kiwisolver==1.4.4
     # via matplotlib
@@ -149,32 +151,33 @@ llvmlite==0.39.1
     # via numba
 lunardate==0.2.0
     # via workalendar
-mako==1.2.2
+mako==1.2.4
     # via alembic
 markupsafe==2.1.1
     # via
     #   jinja2
     #   mako
     #   wtforms
-marshmallow==3.17.1
+marshmallow==3.19.0
     # via
     #   -r requirements/app.in
     #   flask-marshmallow
     #   marshmallow-polyfield
     #   marshmallow-sqlalchemy
     #   webargs
-marshmallow-polyfield==5.10
+marshmallow-polyfield==5.11
     # via -r requirements/app.in
 marshmallow-sqlalchemy==0.28.1
     # via -r requirements/app.in
-matplotlib==3.5.3
+matplotlib==3.6.2
     # via timetomodel
-numba==0.56.3
+numba==0.56.4
     # via sktime
-numpy==1.22.4
+numpy==1.23.5
     # via
     #   -r requirements/app.in
     #   altair
+    #   contourpy
     #   matplotlib
     #   numba
     #   pandas
@@ -187,17 +190,16 @@ numpy==1.22.4
     #   timely-beliefs
     #   timetomodel
     #   uniplot
-openturns==1.19.post1
+openturns==1.20.post3
     # via timely-beliefs
-packaging==21.3
+packaging==23.0
     # via
     #   marshmallow
     #   marshmallow-sqlalchemy
     #   matplotlib
-    #   redis
     #   statsmodels
     #   webargs
-pandas==1.5.1
+pandas==1.5.2
     # via
     #   -r requirements/app.in
     #   altair
@@ -207,11 +209,11 @@ pandas==1.5.1
     #   timetomodel
 passlib==1.7.4
     # via flask-security-too
-patsy==0.5.2
+patsy==0.5.3
     # via statsmodels
-pillow==9.2.0
+pillow==9.4.0
     # via matplotlib
-pint==0.19.2
+pint==0.20.1
     # via -r requirements/app.in
 ply==3.11
     # via pyomo
@@ -219,27 +221,25 @@ properscoring==0.1
     # via timely-beliefs
 pscript==0.7.7
     # via -r requirements/app.in
-psutil==5.9.1
+psutil==5.9.4
     # via openturns
-psycopg2-binary==2.9.3
+psycopg2-binary==2.9.5
     # via
     #   -r requirements/app.in
     #   timely-beliefs
-py-moneyed==2.0
+py-moneyed==3.0
     # via -r requirements/app.in
-pydantic==1.10.0
+pydantic==1.10.4
     # via inflect
-pyluach==2.0.1
+pyluach==2.0.2
     # via workalendar
-pymeeus==0.5.11
+pymeeus==0.5.12
     # via convertdate
-pyomo==6.4.2
+pyomo==6.4.4
     # via -r requirements/app.in
 pyparsing==3.0.9
-    # via
-    #   matplotlib
-    #   packaging
-pyrsistent==0.18.1
+    # via matplotlib
+pyrsistent==0.19.3
     # via jsonschema
 python-dateutil==2.8.2
     # via
@@ -248,16 +248,16 @@ python-dateutil==2.8.2
     #   pandas
     #   timetomodel
     #   workalendar
-python-dotenv==0.20.0
+python-dotenv==0.21.0
     # via -r requirements/app.in
-pytz==2022.2.1
+pytz==2022.7
     # via
     #   -r requirements/app.in
     #   babel
     #   pandas
     #   timely-beliefs
     #   timetomodel
-redis==4.1.4
+redis==4.4.1
     # via
     #   -r requirements/app.in
     #   rq
@@ -268,17 +268,15 @@ requests==2.28.1
     #   tldextract
 requests-file==1.5.1
     # via tldextract
-rq==1.11.0
+rq==1.11.1
     # via
     #   -r requirements/app.in
     #   rq-dashboard
 rq-dashboard==0.6.1
     # via -r requirements/app.in
-scikit-learn==1.1.2
-    # via
-    #   sklearn
-    #   sktime
-scipy==1.8.1
+scikit-learn==1.2.0
+    # via sktime
+scipy==1.10.0
     # via
     #   properscoring
     #   scikit-learn
@@ -286,7 +284,7 @@ scipy==1.8.1
     #   statsmodels
     #   timely-beliefs
     #   timetomodel
-sentry-sdk[flask]==1.9.5
+sentry-sdk[flask]==1.12.1
     # via -r requirements/app.in
 six==1.16.0
     # via
@@ -296,11 +294,11 @@ six==1.16.0
     #   patsy
     #   python-dateutil
     #   requests-file
-sklearn==0.0
+sklearn==0.0.post1
     # via timetomodel
-sktime==0.13.4
+sktime==0.15.0
     # via timely-beliefs
-sqlalchemy==1.4.40
+sqlalchemy==1.4.46
     # via
     #   -r requirements/app.in
     #   alembic
@@ -308,11 +306,11 @@ sqlalchemy==1.4.40
     #   marshmallow-sqlalchemy
     #   timely-beliefs
     #   timetomodel
-statsmodels==0.13.2
+statsmodels==0.13.5
     # via
     #   sktime
     #   timetomodel
-tabulate==0.8.10
+tabulate==0.9.0
     # via -r requirements/app.in
 threadpoolctl==3.1.0
     # via scikit-learn
@@ -320,17 +318,17 @@ timely-beliefs[forecast]==1.18.0
     # via -r requirements/app.in
 timetomodel==0.7.1
     # via -r requirements/app.in
-tldextract==3.3.1
+tldextract==3.4.0
     # via -r requirements/app.in
 toolz==0.12.0
     # via altair
-typing-extensions==4.3.0
+typing-extensions==4.4.0
     # via
     #   py-moneyed
     #   pydantic
-uniplot==0.7.0
+uniplot==0.8.1
     # via -r requirements/app.in
-urllib3==1.26.12
+urllib3==1.26.13
     # via
     #   requests
     #   sentry-sdk
@@ -340,7 +338,7 @@ werkzeug==2.0.3
     # via
     #   -r requirements/app.in
     #   flask
-workalendar==16.3.0
+workalendar==17.0.0
     # via -r requirements/app.in
 wrapt==1.14.1
     # via deprecated
@@ -348,7 +346,7 @@ wtforms==3.0.1
     # via flask-wtf
 xlrd==2.0.1
     # via -r requirements/app.in
-zipp==3.8.1
+zipp==3.11.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/app.txt
+++ b/requirements/app.txt
@@ -256,7 +256,7 @@ pytz==2022.7.1
     #   pandas
     #   timely-beliefs
     #   timetomodel
-redis==4.5.1
+redis==4.5.2
     # via
     #   -r requirements/app.in
     #   rq
@@ -274,7 +274,9 @@ rq==1.13.0
 rq-dashboard==0.6.1
     # via -r requirements/app.in
 scikit-learn==1.2.2
-    # via sktime
+    # via
+    #   sktime
+    #   timetomodel
 scipy==1.10.1
     # via
     #   properscoring
@@ -293,8 +295,6 @@ six==1.16.0
     #   patsy
     #   python-dateutil
     #   requests-file
-sklearn==0.0.post1
-    # via timetomodel
 sktime==0.16.1
     # via timely-beliefs
 sqlalchemy==1.4.47
@@ -313,7 +313,7 @@ threadpoolctl==3.1.0
     # via scikit-learn
 timely-beliefs[forecast]==1.19.0
     # via -r requirements/app.in
-timetomodel==0.7.1
+timetomodel==0.7.2
     # via -r requirements/app.in
 tldextract==3.4.0
     # via -r requirements/app.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -15,7 +15,7 @@ click==8.1.3
     #   black
 distlib==0.3.6
     # via virtualenv
-filelock==3.9.0
+filelock==3.10.0
     # via
     #   -c requirements/app.txt
     #   virtualenv
@@ -23,13 +23,13 @@ flake8==4.0.1
     # via -r requirements/dev.in
 flake8-blind-except==0.2.1
     # via -r requirements/dev.in
-identify==2.5.13
+identify==2.5.21
     # via pre-commit
 mccabe==0.6.1
     # via flake8
-mypy==0.991
+mypy==1.1.1
     # via -r requirements/dev.in
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
@@ -40,13 +40,13 @@ packaging==23.0
     #   -c requirements/app.txt
     #   -c requirements/test.txt
     #   setuptools-scm
-pathspec==0.10.3
+pathspec==0.11.1
     # via black
-platformdirs==2.6.2
+platformdirs==3.1.1
     # via
     #   black
     #   virtualenv
-pre-commit==2.21.0
+pre-commit==3.2.0
     # via -r requirements/dev.in
 pycodestyle==2.8.0
     # via flake8
@@ -64,14 +64,14 @@ tomli==2.0.1
     #   black
     #   mypy
     #   setuptools-scm
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   -c requirements/app.txt
     #   mypy
     #   setuptools-scm
-virtualenv==20.17.1
+virtualenv==20.21.0
     # via pre-commit
-watchdog==2.2.1
+watchdog==2.3.1
     # via -r requirements/dev.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -71,7 +71,7 @@ typing-extensions==4.5.0
     #   setuptools-scm
 virtualenv==20.21.0
     # via pre-commit
-watchdog==2.3.1
+watchdog==3.0.0
     # via -r requirements/dev.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -23,7 +23,7 @@ flake8==4.0.1
     # via -r requirements/dev.in
 flake8-blind-except==0.2.1
     # via -r requirements/dev.in
-identify==2.5.12
+identify==2.5.13
     # via pre-commit
 mccabe==0.6.1
     # via flake8

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -15,7 +15,7 @@ click==8.1.3
     #   black
 distlib==0.3.6
     # via virtualenv
-filelock==3.8.0
+filelock==3.9.0
     # via
     #   -c requirements/app.txt
     #   virtualenv
@@ -23,11 +23,11 @@ flake8==4.0.1
     # via -r requirements/dev.in
 flake8-blind-except==0.2.1
     # via -r requirements/dev.in
-identify==2.5.3
+identify==2.5.12
     # via pre-commit
 mccabe==0.6.1
     # via flake8
-mypy==0.971
+mypy==0.991
     # via -r requirements/dev.in
 mypy-extensions==0.4.3
     # via
@@ -35,50 +35,43 @@ mypy-extensions==0.4.3
     #   mypy
 nodeenv==1.7.0
     # via pre-commit
-packaging==21.3
+packaging==23.0
     # via
     #   -c requirements/app.txt
     #   -c requirements/test.txt
     #   setuptools-scm
-pathspec==0.10.0
+pathspec==0.10.3
     # via black
-platformdirs==2.5.2
+platformdirs==2.6.2
     # via
     #   black
     #   virtualenv
-pre-commit==2.20.0
+pre-commit==2.21.0
     # via -r requirements/dev.in
 pycodestyle==2.8.0
     # via flake8
 pyflakes==2.4.0
     # via flake8
-pyparsing==3.0.9
-    # via
-    #   -c requirements/app.txt
-    #   -c requirements/test.txt
-    #   packaging
 pytest-runner==6.0.0
     # via -r requirements/dev.in
 pyyaml==6.0
     # via pre-commit
-setuptools-scm==7.0.5
+setuptools-scm==7.1.0
     # via -r requirements/dev.in
-toml==0.10.2
-    # via pre-commit
 tomli==2.0.1
     # via
     #   -c requirements/test.txt
     #   black
     #   mypy
     #   setuptools-scm
-typing-extensions==4.3.0
+typing-extensions==4.4.0
     # via
     #   -c requirements/app.txt
     #   mypy
     #   setuptools-scm
-virtualenv==20.16.4
+virtualenv==20.17.1
     # via pre-commit
-watchdog==2.1.9
+watchdog==2.2.1
     # via -r requirements/dev.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -1,8 +1,9 @@
 -c app.txt
 
-sphinx
+# these pins are waiting for rtd-theme 1.2 which allows higher docutils version
+sphinx<4.5
+sphinx-tabs<3.4
 sphinx-rtd-theme 
 sphinxcontrib.httpdomain
 sphinx_fontawesome
 sphinx_copybutton
-sphinx-tabs

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -1,9 +1,8 @@
 -c app.txt
 
-# these pins are waiting for rtd-theme 1.2 which allows higher docutils version
-sphinx<4.5
-sphinx-tabs<3.4
-sphinx-rtd-theme 
+sphinx
+sphinx-rtd-theme >= 1.2
 sphinxcontrib.httpdomain
 sphinx_fontawesome
 sphinx_copybutton
+sphinx-tabs

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.13
     # via sphinx
-babel==2.11.0
+babel==2.12.1
     # via
     #   -c requirements/app.txt
     #   sphinx
@@ -14,7 +14,7 @@ certifi==2022.12.7
     # via
     #   -c requirements/app.txt
     #   requests
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via
     #   -c requirements/app.txt
     #   requests
@@ -45,10 +45,6 @@ pygments==2.14.0
     # via
     #   sphinx
     #   sphinx-tabs
-pytz==2022.7.1
-    # via
-    #   -c requirements/app.txt
-    #   babel
 requests==2.28.2
     # via
     #   -c requirements/app.txt
@@ -67,29 +63,32 @@ sphinx==4.4.0
     #   sphinx-rtd-theme
     #   sphinx-tabs
     #   sphinxcontrib-httpdomain
+    #   sphinxcontrib-jquery
 sphinx-copybutton==0.5.1
     # via -r requirements/docs.in
 sphinx-fontawesome==0.0.6
     # via -r requirements/docs.in
-sphinx-rtd-theme==1.1.1
+sphinx-rtd-theme==1.2.0
     # via -r requirements/docs.in
 sphinx-tabs==3.3.1
     # via -r requirements/docs.in
-sphinxcontrib-applehelp==1.0.3
+sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-htmlhelp==2.0.1
     # via sphinx
 sphinxcontrib-httpdomain==1.8.1
     # via -r requirements/docs.in
+sphinxcontrib-jquery==4.1
+    # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-urllib3==1.26.14
+urllib3==1.26.15
     # via
     #   -c requirements/app.txt
     #   requests

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.1.0
     # via
     #   -c requirements/app.txt
     #   requests
-docutils==0.17.1
+docutils==0.18.1
     # via
     #   sphinx
     #   sphinx-rtd-theme
@@ -55,7 +55,7 @@ six==1.16.0
     #   sphinxcontrib-httpdomain
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.4.0
+sphinx==6.1.3
     # via
     #   -r requirements/docs.in
     #   sphinx-copybutton
@@ -70,7 +70,7 @@ sphinx-fontawesome==0.0.6
     # via -r requirements/docs.in
 sphinx-rtd-theme==1.2.0
     # via -r requirements/docs.in
-sphinx-tabs==3.3.1
+sphinx-tabs==3.4.1
     # via -r requirements/docs.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,11 +6,11 @@
 #
 alabaster==0.7.12
     # via sphinx
-babel==2.10.3
+babel==2.11.0
     # via
     #   -c requirements/app.txt
     #   sphinx
-certifi==2022.6.15
+certifi==2022.12.7
     # via
     #   -c requirements/app.txt
     #   requests
@@ -23,11 +23,11 @@ docutils==0.17.1
     #   sphinx
     #   sphinx-rtd-theme
     #   sphinx-tabs
-idna==3.3
+idna==3.4
     # via
     #   -c requirements/app.txt
     #   requests
-imagesize==1.3.0
+imagesize==1.4.1
     # via sphinx
 jinja2==3.1.2
     # via
@@ -37,19 +37,15 @@ markupsafe==2.1.1
     # via
     #   -c requirements/app.txt
     #   jinja2
-packaging==21.3
+packaging==23.0
     # via
     #   -c requirements/app.txt
     #   sphinx
-pygments==2.11.2
+pygments==2.14.0
     # via
     #   sphinx
     #   sphinx-tabs
-pyparsing==3.0.9
-    # via
-    #   -c requirements/app.txt
-    #   packaging
-pytz==2022.2.1
+pytz==2022.7
     # via
     #   -c requirements/app.txt
     #   babel
@@ -71,21 +67,21 @@ sphinx==4.4.0
     #   sphinx-rtd-theme
     #   sphinx-tabs
     #   sphinxcontrib-httpdomain
-sphinx-copybutton==0.5.0
+sphinx-copybutton==0.5.1
     # via -r requirements/docs.in
 sphinx-fontawesome==0.0.6
     # via -r requirements/docs.in
-sphinx-rtd-theme==1.0.0
+sphinx-rtd-theme==1.1.1
     # via -r requirements/docs.in
 sphinx-tabs==3.3.1
     # via -r requirements/docs.in
-sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-applehelp==1.0.3
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
 sphinxcontrib-htmlhelp==2.0.0
     # via sphinx
-sphinxcontrib-httpdomain==1.8.0
+sphinxcontrib-httpdomain==1.8.1
     # via -r requirements/docs.in
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
@@ -93,7 +89,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-urllib3==1.26.12
+urllib3==1.26.13
     # via
     #   -c requirements/app.txt
     #   requests

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/docs.txt requirements/docs.in
 #
-alabaster==0.7.12
+alabaster==0.7.13
     # via sphinx
 babel==2.11.0
     # via
@@ -14,7 +14,7 @@ certifi==2022.12.7
     # via
     #   -c requirements/app.txt
     #   requests
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via
     #   -c requirements/app.txt
     #   requests
@@ -33,7 +33,7 @@ jinja2==3.1.2
     # via
     #   -c requirements/app.txt
     #   sphinx
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via
     #   -c requirements/app.txt
     #   jinja2
@@ -45,11 +45,11 @@ pygments==2.14.0
     # via
     #   sphinx
     #   sphinx-tabs
-pytz==2022.7
+pytz==2022.7.1
     # via
     #   -c requirements/app.txt
     #   babel
-requests==2.28.1
+requests==2.28.2
     # via
     #   -c requirements/app.txt
     #   sphinx
@@ -89,7 +89,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   -c requirements/app.txt
     #   requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -16,7 +16,7 @@ certifi==2022.12.7
     # via
     #   -c requirements/app.txt
     #   requests
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via
     #   -c requirements/app.txt
     #   requests
@@ -50,7 +50,7 @@ jinja2==3.1.2
     #   flask
 lupa==1.14.1
     # via -r requirements/test.in
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via
     #   -c requirements/app.txt
     #   jinja2
@@ -61,7 +61,7 @@ packaging==23.0
     #   pytest-sugar
 pluggy==1.0.0
     # via pytest
-pytest==7.2.0
+pytest==7.2.1
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -73,11 +73,11 @@ pytest-flask==1.2.0
     # via -r requirements/test.in
 pytest-sugar==0.9.6
     # via -r requirements/test.in
-redis==4.4.1
+redis==4.4.2
     # via
     #   -c requirements/app.txt
     #   fakeredis
-requests==2.28.1
+requests==2.28.2
     # via
     #   -c requirements/app.txt
     #   -r requirements/test.in
@@ -96,7 +96,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   -c requirements/app.txt
     #   requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,11 +4,15 @@
 #
 #    pip-compile --output-file=requirements/test.txt requirements/test.in
 #
-attrs==22.1.0
+async-timeout==4.0.2
+    # via
+    #   -c requirements/app.txt
+    #   redis
+attrs==22.2.0
     # via
     #   -c requirements/app.txt
     #   pytest
-certifi==2022.6.15
+certifi==2022.12.7
     # via
     #   -c requirements/app.txt
     #   requests
@@ -20,23 +24,21 @@ click==8.1.3
     # via
     #   -c requirements/app.txt
     #   flask
-coverage[toml]==6.4.4
+coverage[toml]==7.0.5
     # via pytest-cov
-deprecated==1.2.13
-    # via
-    #   -c requirements/app.txt
-    #   redis
-fakeredis==1.9.0
+exceptiongroup==1.1.0
+    # via pytest
+fakeredis==2.4.0
     # via -r requirements/test.in
 flask==2.1.2
     # via
     #   -c requirements/app.txt
     #   pytest-flask
-idna==3.3
+idna==3.4
     # via
     #   -c requirements/app.txt
     #   requests
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
 itsdangerous==2.1.2
     # via
@@ -46,39 +48,32 @@ jinja2==3.1.2
     # via
     #   -c requirements/app.txt
     #   flask
-lupa==1.13
+lupa==1.14.1
     # via -r requirements/test.in
 markupsafe==2.1.1
     # via
     #   -c requirements/app.txt
     #   jinja2
-packaging==21.3
+packaging==23.0
     # via
     #   -c requirements/app.txt
     #   pytest
     #   pytest-sugar
-    #   redis
 pluggy==1.0.0
     # via pytest
-py==1.11.0
-    # via pytest
-pyparsing==3.0.9
-    # via
-    #   -c requirements/app.txt
-    #   packaging
-pytest==7.1.2
+pytest==7.2.0
     # via
     #   -r requirements/test.in
     #   pytest-cov
     #   pytest-flask
     #   pytest-sugar
-pytest-cov==3.0.0
+pytest-cov==4.0.0
     # via -r requirements/test.in
 pytest-flask==1.2.0
     # via -r requirements/test.in
-pytest-sugar==0.9.5
+pytest-sugar==0.9.6
     # via -r requirements/test.in
-redis==4.1.4
+redis==4.4.1
     # via
     #   -c requirements/app.txt
     #   fakeredis
@@ -92,17 +87,16 @@ requests-mock==1.10.0
 six==1.16.0
     # via
     #   -c requirements/app.txt
-    #   fakeredis
     #   requests-mock
 sortedcontainers==2.4.0
     # via fakeredis
-termcolor==1.1.0
+termcolor==2.2.0
     # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage
     #   pytest
-urllib3==1.26.12
+urllib3==1.26.13
     # via
     #   -c requirements/app.txt
     #   requests
@@ -111,7 +105,3 @@ werkzeug==2.0.3
     #   -c requirements/app.txt
     #   flask
     #   pytest-flask
-wrapt==1.14.1
-    # via
-    #   -c requirements/app.txt
-    #   deprecated

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -16,7 +16,7 @@ certifi==2022.12.7
     # via
     #   -c requirements/app.txt
     #   requests
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via
     #   -c requirements/app.txt
     #   requests
@@ -24,11 +24,11 @@ click==8.1.3
     # via
     #   -c requirements/app.txt
     #   flask
-coverage[toml]==7.0.5
+coverage[toml]==7.2.2
     # via pytest-cov
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via pytest
-fakeredis==2.4.0
+fakeredis==2.10.1
     # via -r requirements/test.in
 flask==2.1.2
     # via
@@ -61,7 +61,7 @@ packaging==23.0
     #   pytest-sugar
 pluggy==1.0.0
     # via pytest
-pytest==7.2.1
+pytest==7.2.2
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -73,7 +73,7 @@ pytest-flask==1.2.0
     # via -r requirements/test.in
 pytest-sugar==0.9.6
     # via -r requirements/test.in
-redis==4.4.2
+redis==4.5.1
     # via
     #   -c requirements/app.txt
     #   fakeredis
@@ -96,7 +96,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-urllib3==1.26.14
+urllib3==1.26.15
     # via
     #   -c requirements/app.txt
     #   requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -73,7 +73,7 @@ pytest-flask==1.2.0
     # via -r requirements/test.in
 pytest-sugar==0.9.6
     # via -r requirements/test.in
-redis==4.5.1
+redis==4.5.2
     # via
     #   -c requirements/app.txt
     #   fakeredis


### PR DESCRIPTION
Bringing us back up to date with most of the awesome shoulders we stand upon.

Most important upgrade is Flask-Security (major version upgrade which needed some work, and some research leading to another pin), and maybe moving redis forward.

Also, I had to do research into larger problems, which I described better and postponed: Flask-Classful (#595) and SQLAlchemy (#607).

Note to self: Some of these issues (like the difficult-to-investigate fakeredis problem) resolve themselves once the authors of libraries get to work. Our art is to know for which ones to wait and which ones to fix ourselves ...


TODO:

- [x] Timely-beliefs doesn't like the numpy upgrade. I wonder if the `[forecast]` option is applied during `pip-compile`. 
- [x] Flask-Security 5 & Flask-Login 0.6 need to be looked at. Updating Flask-Login as first step, it already leads to tests failing due to 401 status in API endpoints.
- [x] Forecasting & scheduling jobs tests fail, not sure why as there are no errors in the logs
- [x] Wait for https://github.com/SeitaBV/timetomodel/pull/27 and a new timetomodel version to land. 