### PR TITLE
fix validation of deprecated roundtrip-efficiency field in trigger-schedules endpoint

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -7,6 +7,14 @@ v0.13.0 | February XX, 2023
 ============================
 
 
+v0.12.1 | January XX, 2023
+============================
+
+Bugfixes
+-----------
+* Fix validation of (deprecated) API parameter ``roundtrip-efficiency`` [see `PR #582 <https://www.github.com/FlexMeasures/flexmeasures/pull/582>`_]
+
+
 
 v0.12.0 | January 4, 2023
 ============================

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -223,7 +223,7 @@ class SensorAPI(FlaskView):
             ),
             "flex_model": fields.Dict(data_key="flex-model"),
             "soc_sensor_id": fields.Str(data_key="soc-sensor", required=False),
-            "roundtrip_efficiency": fields.Str(data_key="roundtrip-efficiency"),
+            "roundtrip_efficiency": fields.Raw(data_key="roundtrip-efficiency"),
             "start_value": fields.Float(data_key="soc-at-start"),
             "soc_min": fields.Float(data_key="soc-min"),
             "soc_max": fields.Float(data_key="soc-max"),


### PR DESCRIPTION
Fixes #581 