### PR TITLE
Rate limiting for scheduling triggers

### DIFF
--- a/flexmeasures/api/v3_0/__init__.py
+++ b/flexmeasures/api/v3_0/__init__.py
@@ -18,7 +18,14 @@ def register_at(app: Flask):
         return 0
 
     # Apply rate limit: a schedule can be triggered once per 5 minutes per sensor per account
-    SensorAPI.decorators.append(app.limiter.limit("1 per 5 minutes", key_func=lambda: str(current_user.account_id) + request.view_args.get("id", ""), cost=cost_function))
+    SensorAPI.decorators.append(
+        app.limiter.limit(
+            "1 per 5 minutes",
+            key_func=lambda: str(current_user.account_id)
+            + request.view_args.get("id", ""),
+            cost=cost_function,
+        )
+    )
 
     SensorAPI.register(app, route_prefix=v3_0_api_prefix)
     UserAPI.register(app, route_prefix=v3_0_api_prefix)

--- a/flexmeasures/api/v3_0/__init__.py
+++ b/flexmeasures/api/v3_0/__init__.py
@@ -1,4 +1,5 @@
-from flask import Flask
+from flask import Flask, request
+from flask_security import current_user
 
 from flexmeasures.api.v3_0.sensors import SensorAPI
 from flexmeasures.api.v3_0.users import UserAPI
@@ -10,6 +11,14 @@ def register_at(app: Flask):
     """This can be used to register this blueprint together with other api-related things"""
 
     v3_0_api_prefix = "/api/v3_0"
+
+    def cost_function() -> int:
+        if request.endpoint == "SensorAPI:trigger_schedule":
+            return 1
+        return 0
+
+    # Apply rate limit: a schedule can be triggered once per 5 minutes per sensor per account
+    SensorAPI.decorators.append(app.limiter.limit("1 per 5 minutes", key_func=lambda: str(current_user.account_id) + request.view_args.get("id", ""), cost=cost_function))
 
     SensorAPI.register(app, route_prefix=v3_0_api_prefix)
     UserAPI.register(app, route_prefix=v3_0_api_prefix)

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -1,10 +1,10 @@
 from datetime import datetime, timedelta
 from typing import Optional
 
-from flask import current_app
+from flask import current_app, Flask, request
 from flask_classful import FlaskView, route
 from flask_json import as_json
-from flask_security import auth_required
+from flask_security import auth_required, current_user
 import isodate
 from marshmallow import fields, ValidationError
 from rq.job import Job, NoSuchJobError
@@ -53,6 +53,15 @@ class SensorAPI(FlaskView):
     route_base = "/sensors"
     trailing_slash = False
     decorators = [auth_required()]
+
+    @classmethod
+    def _rate_limiter(cls, app: Flask):
+        # a schedule can be triggered once per 5 minutes per account & sensor
+        return app.limiter.limit(
+            "1 per 5 minutes",
+            key_func=lambda: f"{current_user.account_id}-{request.view_args.get('id', '')}",
+            cost=lambda: 1 if request.endpoint == "SensorAPI:trigger_schedule" else 0,
+        )
 
     @route("", methods=["GET"])
     @use_kwargs(

--- a/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
+++ b/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
@@ -105,6 +105,15 @@ def test_trigger_and_get_schedule(
         assert trigger_schedule_response.status_code == 200
         job_id = trigger_schedule_response.json["schedule"]
 
+        # Check rate limiter kicks in when immediately reattempting to trigger a schedule
+        trigger_schedule_response = client.post(
+            url_for("SensorAPI:trigger_schedule", id=sensor.id),
+            json=message,
+            headers={"Authorization": auth_token},
+        )
+        print("Server responded with:\n%s" % trigger_schedule_response.json)
+        assert trigger_schedule_response.status_code == 429
+
     # look for scheduling jobs in queue
     assert (
         len(app.queues["scheduling"]) == 1
@@ -197,6 +206,16 @@ def test_trigger_and_get_schedule(
     )
     print("Server responded with:\n%s" % get_schedule_response.json)
     assert get_schedule_response.status_code == 200
+
+    # Check rate limiter does not kick in when immediately reattempting to fetch a schedule
+    get_schedule_response = client.get(
+        url_for("SensorAPI:get_schedule", id=sensor.id, uuid=job_id),
+        query_string=get_schedule_message,
+        headers={"content-type": "application/json", "Authorization": auth_token},
+    )
+    print("Server responded with:\n%s" % get_schedule_response.json)
+    assert get_schedule_response.status_code == 200  # not 429
+
     # assert get_schedule_response.json["type"] == "GetDeviceMessageResponse"
     assert len(get_schedule_response.json["values"]) == expected_length_of_schedule
 

--- a/flexmeasures/app.py
+++ b/flexmeasures/app.py
@@ -5,6 +5,8 @@ from typing import Optional, List
 
 from flask import Flask, g, request
 from flask.cli import load_dotenv
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 from flask_mail import Mail
 from flask_sslify import SSLify
 from flask_json import FlaskJSON
@@ -67,10 +69,7 @@ def create(
     if app.testing:
         from fakeredis import FakeStrictRedis
 
-        app.queues = dict(
-            forecasting=Queue(connection=FakeStrictRedis(), name="forecasting"),
-            scheduling=Queue(connection=FakeStrictRedis(), name="scheduling"),
-        )
+        redis_conn = FakeStrictRedis()
     else:
         redis_conn = Redis(
             app.config["FLEXMEASURES_REDIS_URL"],
@@ -83,10 +82,18 @@ def create(
             redis_conn = Redis("MY-DB-NAME", unix_socket_path="/tmp/my-redis.socket",
             )
         """
-        app.queues = dict(
-            forecasting=Queue(connection=redis_conn, name="forecasting"),
-            scheduling=Queue(connection=redis_conn, name="scheduling"),
-        )
+    app.queues = dict(
+        forecasting=Queue(connection=redis_conn, name="forecasting"),
+        scheduling=Queue(connection=redis_conn, name="scheduling"),
+    )
+
+    # Set up rate limiter
+    app.config["RATELIMIT_STORAGE_URI"] = "redis://"
+    app.config["RATELIMIT_STORAGE_OPTIONS"] = {"connection_pool": redis_conn.connection_pool}
+    app.limiter = Limiter(
+        get_remote_address,
+        app=app,
+    )
 
     # Some basic security measures
 

--- a/flexmeasures/app.py
+++ b/flexmeasures/app.py
@@ -89,7 +89,9 @@ def create(
 
     # Set up rate limiter
     app.config["RATELIMIT_STORAGE_URI"] = "redis://"
-    app.config["RATELIMIT_STORAGE_OPTIONS"] = {"connection_pool": redis_conn.connection_pool}
+    app.config["RATELIMIT_STORAGE_OPTIONS"] = {
+        "connection_pool": redis_conn.connection_pool
+    }
     app.limiter = Limiter(
         get_remote_address,
         app=app,

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -36,6 +36,7 @@ importlib_metadata
 sqlalchemy>=1.4.0
 Flask-SSLify
 Flask_JSON
+Flask-Limiter[redis]
 Flask-SQLAlchemy>=2.4.3
 Flask-Migrate
 Flask-WTF

--- a/requirements/app.txt
+++ b/requirements/app.txt
@@ -125,7 +125,6 @@ idna==3.3
 importlib-metadata==4.12.0
     # via
     #   -r requirements/app.in
-    #   flask
     #   timely-beliefs
 inflect==6.0.0
     # via -r requirements/app.in

--- a/requirements/app.txt
+++ b/requirements/app.txt
@@ -38,12 +38,15 @@ click-default-group==1.2.2
     # via -r requirements/app.in
 colour==0.1.5
     # via -r requirements/app.in
+commonmark==0.9.1
+    # via rich
 convertdate==2.4.0
     # via workalendar
 cycler==0.11.0
     # via matplotlib
 deprecated==1.2.13
     # via
+    #   limits
     #   redis
     #   sktime
 dill==0.3.5.1
@@ -64,6 +67,7 @@ flask==2.1.2
     #   flask-classful
     #   flask-cors
     #   flask-json
+    #   flask-limiter
     #   flask-login
     #   flask-mail
     #   flask-marshmallow
@@ -80,6 +84,8 @@ flask-classful==0.14.2
 flask-cors==3.0.10
     # via -r requirements/app.in
 flask-json==0.3.4
+    # via -r requirements/app.in
+flask-limiter[redis]==3.1.0
     # via -r requirements/app.in
 flask-login==0.5.0
     # via
@@ -119,6 +125,7 @@ idna==3.3
 importlib-metadata==4.12.0
     # via
     #   -r requirements/app.in
+    #   flask
     #   timely-beliefs
 inflect==6.0.0
     # via -r requirements/app.in
@@ -145,6 +152,8 @@ jsonschema==4.15.0
     # via altair
 kiwisolver==1.4.4
     # via matplotlib
+limits==3.1.6
+    # via flask-limiter
 llvmlite==0.39.1
     # via numba
 lunardate==0.2.0
@@ -189,8 +198,11 @@ numpy==1.22.4
     #   uniplot
 openturns==1.19.post1
     # via timely-beliefs
+ordered-set==4.1.0
+    # via flask-limiter
 packaging==21.3
     # via
+    #   limits
     #   marshmallow
     #   marshmallow-sqlalchemy
     #   matplotlib
@@ -229,6 +241,8 @@ py-moneyed==2.0
     # via -r requirements/app.in
 pydantic==1.10.0
     # via inflect
+pygments==2.14.0
+    # via rich
 pyluach==2.0.1
     # via workalendar
 pymeeus==0.5.11
@@ -268,6 +282,8 @@ requests==2.28.1
     #   tldextract
 requests-file==1.5.1
     # via tldextract
+rich==12.6.0
+    # via flask-limiter
 rq==1.11.0
     # via
     #   -r requirements/app.in
@@ -326,6 +342,8 @@ toolz==0.12.0
     # via altair
 typing-extensions==4.3.0
     # via
+    #   flask-limiter
+    #   limits
     #   py-moneyed
     #   pydantic
 uniplot==0.7.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -41,8 +41,9 @@ packaging==21.3
     # via
     #   -c requirements/app.txt
     #   sphinx
-pygments==2.11.2
+pygments==2.14.0
     # via
+    #   -c requirements/app.txt
     #   sphinx
     #   sphinx-tabs
 pyparsing==3.0.9


### PR DESCRIPTION
I completed my tech spike.

I couldn't (figure out how to) decorate only the trigger method of our FlaskView, so I worked around that by decorating the entire SensorAPI and using the cost function to only count towards the limit for the trigger method. It's not the most elegant solution, but it does look easily extensible this way.

We also discussed offline on what to apply the limit (using `key_func`): users or accounts. Here I decided to combine the account and the sensor id, just to let a test pass (`test_trigger_and_get_schedule` first schedules a battery and then schedules a charging station). But it might also make sense to apply a limit per sensor.
