### PR TITLE
docs(dev): update developer documentation

### DIFF
--- a/documentation/dev/introduction.rst
+++ b/documentation/dev/introduction.rst
@@ -23,18 +23,34 @@ Virtual environment
 Using a virtual environment is best practice for Python developers. We also strongly recommend using a dedicated one for your work on FlexMeasures, as our make target (see below) will use ``pip-sync`` to install dependencies, which could interfere with some libraries you already have installed.
 
 
-* Make a virtual environment: ``python3.8 -m venv flexmeasures-venv`` or use a different tool like ``mkvirtualenv`` or virtualenvwrapper. You can also use
-  an `Anaconda distribution <https://conda.io/docs/user-guide/tasks/manage-environments.html>`_ as base with ``conda create -n flexmeasures-venv python=3.8``.
+* Make a virtual environment: ``python3.10 -m venv flexmeasures-venv`` or use a different tool like ``mkvirtualenv`` or virtualenvwrapper. You can also use
+  an `Anaconda distribution <https://conda.io/docs/user-guide/tasks/manage-environments.html>`_ as base with ``conda create -n flexmeasures-venv python=3.10``.
 * Activate it, e.g.: ``source flexmeasures-venv/bin/activate``
+
+Download Flexmeasures
+^^^^^^^^^^^^^^^^^^^^^^^
+Clone the `Flexmeasures repository <https://github.com/FlexMeasures/flexmeasures.git>`_ from Github.
+
+.. code-block:: console
+
+   git clone https://github.com/FlexMeasures/flexmeasures.git
+
 
 Dependencies
 ^^^^^^^^^^^^^^^^^^^^
 
-Install all dependencies including the ones needed for development:
+Go into the ``flexmeasures`` folder and install all dependencies including the ones needed for development:
 
 .. code-block:: console
 
+   cd flexmeasures
    make install-for-dev
+
+:ref:`Install the LP solver <install-lp-solver>`. On Unix the Cbc LP solver can be installed with:
+
+.. code-block:: console
+
+   apt-get install coinor-cbc
 
 
 Configuration

--- a/documentation/tut/installation.rst
+++ b/documentation/tut/installation.rst
@@ -225,6 +225,8 @@ Set mail settings
 
 For FlexMeasures to be able to send email to users (e.g. for resetting passwords), you need an email account which can do that (e.g. GMail). Set the MAIL_* settings in your configuration, see :ref:`mail-config`.
 
+.. _install-lp-solver:
+
 Install an LP solver
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/documentation/tut/toy-example-from-scratch.rst
+++ b/documentation/tut/toy-example-from-scratch.rst
@@ -51,6 +51,8 @@ Install Flexmeasures and the database
             $ docker run --rm --name flexmeasures-tutorial-fm --env SQLALCHEMY_DATABASE_URI=postgresql://postgres:fm-db-passwd@flexmeasures-tutorial-db:5432/flexmeasures-db --env SECRET_KEY=notsecret --env FLASK_ENV=development --env LOGGING_LEVEL=INFO -d --network=flexmeasures_network -p 5000:5000 lfenergy/flexmeasures
             $ docker exec flexmeasures-tutorial-fm bash -c "flexmeasures db upgrade"
 
+        .. note:: A tip on Linux/macOS ― You might have the ``docker`` command, but need `sudo` rights to execute it. ``alias docker='sudo docker'`` enables you to still run this tutorial.
+
         Now - what's *very important* to remember is this: The rest of this tutorial will happen *inside* the ``flexmeasures-tutorial-fm`` container! This is how you hop inside the container and run a terminal there:
 
         .. code-block:: console
@@ -66,7 +68,12 @@ Install Flexmeasures and the database
             $ docker stop flexmeasures-tutorial-db
             $ docker stop flexmeasures-tutorial-fm
 
-        .. note:: A tip on Linux/macOS ― You might have the ``docker`` command, but need `sudo` rights to execute it. ``alias docker='sudo docker'`` enables you to still run this tutorial.
+        To start the containers again, do this (note that re-running the `docker run` commands above *deletes and re-creates* all data!):
+        
+        .. code-block:: console
+        
+            $ docker start flexmeasures-tutorial-db
+            $ docker start flexmeasures-tutorial-fm
 
         .. note:: For newer versions of MacOS, port 5000 is in use by default by Control Center. You can turn this off by going to System Preferences > Sharing and untick the "Airplay Receiver" box. If you don't want to do this for some reason, you can change the host port in the ``docker run`` command to some other port, for example 5001. To do this, change ``-p 5000:5000`` in the command to ``-p 5001:5000``. If you do this, remember that you will have to go to ``localhost:5001`` in your browser when you want to inspect the FlexMeasures UI.
 


### PR DESCRIPTION
updated the following parts of the documentation
- python version to use update to 3.10
- add instruction to clone the repository
- clearer instructions for installing dependencies
- install Cbc LP solver as part of the dependencies
- link to Cbc LP solver install instructions in developer documentation
