### PR TITLE
Upgrade classifiers in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,13 +35,19 @@ setup(
     },
     license="Apache2.0",
     classifiers=[
+        "Environment :: Console",
+        "Environment :: Web Environment",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
-        "Development Status :: 3 - Alpha",
+        "Programming Language :: Python :: 3.10",
+        "Framework :: Flask",
+        "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
+        "Operating System :: POSIX :: Linux",
+        "Operating System :: MacOS :: MacOS X",
     ],
     long_description="""\
 The *FlexMeasures Platform* is the intelligent backend to support real-time energy flexibility apps, rapidly and scalable.

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,9 @@ setup(
         "Framework :: Flask",
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: Apache Software License",
-        "Operating System :: OS Independent",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",
+        "Natural Language :: English",
     ],
     long_description="""\
 The *FlexMeasures Platform* is the intelligent backend to support real-time energy flexibility apps, rapidly and scalable.


### PR DESCRIPTION
- make clear we are not supporting Windows right now
- Python 3.10
- dev status stable
- environment: Console & Web