### PR TITLE
Fix copybutton

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -20,6 +20,7 @@ New features
 Bugfixes
 -----------
 
+* Fix copy button on tutorials and other documentation, so that only commands are copied and no output or comments [see `PR #636 <https://www.github.com/FlexMeasures/flexmeasures/pull/636>`_]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/dev/api.rst
+++ b/documentation/dev/api.rst
@@ -14,7 +14,7 @@ This is a small guide for creating new versions of the API and its docs.
     :depth: 2
 
 
-Introducting a new API version
+Introducing a new API version
 ---------------------
 
 Larger changes to the API, other than fixes and refactoring, should be done by creating a new API version.

--- a/documentation/dev/api.rst
+++ b/documentation/dev/api.rst
@@ -101,8 +101,8 @@ Test the entire api or just your new version:
 
 .. code-block:: bash
 
-   pytest -k api
-   pytest -k v1_1
+   $ pytest -k api
+   $ pytest -k v1_1
 
 UI Crud
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/documentation/dev/docker-compose.rst
+++ b/documentation/dev/docker-compose.rst
@@ -19,7 +19,7 @@ Run this:
 
 .. code-block:: bash
 
-    docker-compose build
+    $ docker-compose build
 
 This pulls the images you need, and re-builds the FlexMeasures ones from code. If you change code, re-running this will re-build that image.
 
@@ -36,16 +36,16 @@ Start the stack like this:
 
 .. code-block:: bash
 
-    docker-compose up
+    $ docker-compose up
 
 .. warning:: This might fail if ports 5000 (Flask) or 6379 (Redis) are in use on your system. Stop these processes before you continue.
 
 Check ``docker ps`` or ``docker-compose ps`` to see if your containers are running:
 
 
-.. code-block:: console
+.. code-block:: bash
 
-    ± docker ps
+    $ docker ps
     CONTAINER ID   IMAGE                 COMMAND                  CREATED          STATUS                             PORTS                    NAMES
     beb9bf567303   flexmeasures_server   "bash -c 'flexmeasur…"   44 seconds ago   Up 38 seconds (health: starting)   0.0.0.0:5000->5000/tcp   flexmeasures-server-1
     e36cd54a7fd5   flexmeasures_worker   "flexmeasures jobs r…"   44 seconds ago   Up 5 seconds                       5000/tcp                 flexmeasures-worker-1
@@ -86,23 +86,23 @@ The `flexmeasures-server` container already creates the toy account when it star
 
 Let's go into the `flexmeasures-worker` container:
 
-.. code-block:: console
+.. code-block:: bash
 
-    docker exec -it flexmeasures-worker-1 bash
+    $ docker exec -it flexmeasures-worker-1 bash
 
 There, we add the price data, as described in :ref:`tut_toy_schedule_price_data`. Create the prices and add them to the FlexMeasures DB in the container's bash session.
 
 Next, we put a scheduling job in the worker's queue. This only works because we have the Redis container running ― the toy tutorial doesn't have it. The difference is that we're adding ``--as-job``:
 
-.. code-block:: console
+.. code-block:: bash
 
-    flexmeasures add schedule for-storage --sensor-id 2 --consumption-price-sensor 3 \
+    $ flexmeasures add schedule for-storage --sensor-id 2 --consumption-price-sensor 3 \
         --start ${TOMORROW}T07:00+01:00 --duration PT12H --soc-at-start 50% \
         --roundtrip-efficiency 90% --as-job
 
 We should now see in the output of ``docker logs flexmeasures-worker-1`` something like the following:
 
-.. code-block:: console
+.. code-block:: bash
 
     Running Scheduling Job d3e10f6d-31d2-46c6-8308-01ede48f8fdd: <Sensor 2: charging, unit: MW res.: 0:15:00>, from 2022-07-06 07:00:00+01:00 to 2022-07-06 19:00:00+01:00
 
@@ -110,14 +110,14 @@ So the job had been queued in Redis, was then picked up by the worker process, a
 
 We'll not go into the server container this time, but simply send a command:
 
-.. code-block:: console
+.. code-block:: bash
 
-    TOMORROW=$(date --date="next day" '+%Y-%m-%d')
-    docker exec -it flexmeasures-server-1 bash -c "flexmeasures show beliefs --sensor-id 2 --start ${TOMORROW}T07:00:00+01:00 --duration PT12H"
+    $ TOMORROW=$(date --date="next day" '+%Y-%m-%d')
+    $ docker exec -it flexmeasures-server-1 bash -c "flexmeasures show beliefs --sensor-id 2 --start ${TOMORROW}T07:00:00+01:00 --duration PT12H"
 
 The charging/discharging schedule should be there:
 
-.. code-block:: console
+.. code-block:: bash
 
     ┌────────────────────────────────────────────────────────────┐
     │   ▐                      ▐▀▀▌                           ▛▀▀│ 
@@ -167,8 +167,8 @@ You can run tests in the flexmeasures docker container, using the database servi
 
 After you've started the compose stack with ``docker-compose up``, run:
 
-.. code-block:: console
+.. code-block:: bash
 
-    docker exec -it -e SQLALCHEMY_TEST_DATABASE_URI="postgresql://fm-test-db-user:fm-test-db-pass@test-db:5432/fm-test-db" flexmeasures-server-1 pytest
+    $ docker exec -it -e SQLALCHEMY_TEST_DATABASE_URI="postgresql://fm-test-db-user:fm-test-db-pass@test-db:5432/fm-test-db" flexmeasures-server-1 pytest
 
 This rounds up the dev experience offered by running FlexMeasures in Docker. Now you can develop FlexMeasures and also run your tests. If you develop plugins, you could extend the command being used, e.g. ``bash -c "cd /path/to/my/plugin && pytest"``. 

--- a/documentation/dev/docker-compose.rst
+++ b/documentation/dev/docker-compose.rst
@@ -96,7 +96,7 @@ Next, we put a scheduling job in the worker's queue. This only works because we 
 
 .. code-block:: bash
 
-    $ flexmeasures add schedule for-storage --sensor-id 2 --consumption-price-sensor 3 \
+    $ flexmeasures add schedule for-storage --sensor-id 1 --consumption-price-sensor 2 \
         --start ${TOMORROW}T07:00+01:00 --duration PT12H --soc-at-start 50% \
         --roundtrip-efficiency 90% --as-job
 
@@ -113,35 +113,35 @@ We'll not go into the server container this time, but simply send a command:
 .. code-block:: bash
 
     $ TOMORROW=$(date --date="next day" '+%Y-%m-%d')
-    $ docker exec -it flexmeasures-server-1 bash -c "flexmeasures show beliefs --sensor-id 2 --start ${TOMORROW}T07:00:00+01:00 --duration PT12H"
+    $ docker exec -it flexmeasures-server-1 bash -c "flexmeasures show beliefs --sensor-id 1 --start ${TOMORROW}T07:00:00+01:00 --duration PT12H"
 
 The charging/discharging schedule should be there:
 
 .. code-block:: bash
 
     ┌────────────────────────────────────────────────────────────┐
-    │   ▐                      ▐▀▀▌                           ▛▀▀│ 
-    │   ▞▌                     ▞  ▐                           ▌  │ 0.4MW
-    │   ▌▌                     ▌  ▐                          ▐   │ 
-    │  ▗▘▌                     ▌  ▐                          ▐   │ 
-    │  ▐ ▐                    ▗▘  ▝▖                         ▐   │ 
-    │  ▞ ▐                    ▐    ▌                         ▌   │ 0.2MW
-    │ ▗▘ ▐                    ▐    ▌                         ▌   │ 
-    │ ▐  ▝▖                   ▌    ▚                        ▞    │ 
-    │▀▘───▀▀▀▀▀▀▀▀▀▀▀▀▀▀▌────▐─────▝▀▀▀▀▀▀▀▀▜─────▐▀▀▀▀▀▀▀▀▀─────│ 0MW
-    │                   ▌    ▞              ▐    ▗▘              │ 
-    │                   ▚    ▌              ▐    ▐               │ 
-    │                   ▐   ▗▘              ▝▖   ▌               │ -0.2MW
-    │                   ▐   ▐                ▌   ▌               │ 
-    │                   ▐   ▐                ▌  ▗▘               │ 
-    │                    ▌  ▞                ▌  ▐                │ 
-    │                    ▌  ▌                ▐  ▐                │ -0.4MW
-    │                    ▙▄▄▌                ▐▄▄▞                │ 
+    │   ▐            ▐▀▀▌                                     ▛▀▀│ 0.5MW
+    │   ▞▌           ▌  ▌                                     ▌  │
+    │   ▌▌           ▌  ▐                                    ▗▘  │
+    │   ▌▌           ▌  ▐                                    ▐   │
+    │  ▐ ▐          ▐   ▐                                    ▐   │
+    │  ▐ ▐          ▐   ▝▖                                   ▞   │
+    │  ▌ ▐          ▐    ▌                                   ▌   │
+    │ ▐  ▝▖         ▌    ▌                                   ▌   │
+    │▀▘───▀▀▀▀▖─────▌────▀▀▀▀▀▀▀▀▀▌─────▐▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▘───│ 0.0MW
+    │         ▌    ▐              ▚     ▌                        │
+    │         ▌    ▞              ▐    ▗▘                        │
+    │         ▌    ▌              ▐    ▞                         │
+    │         ▐   ▐               ▝▖   ▌                         │
+    │         ▐   ▐                ▌  ▗▘                         │
+    │         ▐   ▌                ▌  ▐                          │
+    │         ▝▖  ▌                ▌  ▞                          │
+    │          ▙▄▟                 ▐▄▄▌                          │ -0.5MW
     └────────────────────────────────────────────────────────────┘
-            10           20           30          40
-                         ██ charging
+               10           20           30          40
+                            ██ discharging
 
-Like in the original toy tutorial, we can also check in the server container's `web UI <http://localhost:5000/sensors/2/>`_ (username is "toy-user@flexmeasures.io", password is "toy-password"):
+Like in the original toy tutorial, we can also check in the server container's `web UI <http://localhost:5000/sensors/1/>`_ (username is "toy-user@flexmeasures.io", password is "toy-password"):
 
 .. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/sensor-data-charging.png
     :align: center

--- a/documentation/dev/introduction.rst
+++ b/documentation/dev/introduction.rst
@@ -31,9 +31,9 @@ Download FlexMeasures
 ^^^^^^^^^^^^^^^^^^^^^^^
 Clone the `FlexMeasures repository <https://github.com/FlexMeasures/flexmeasures.git>`_ from GitHub.
 
-.. code-block:: console
+.. code-block:: bash
 
-   git clone https://github.com/FlexMeasures/flexmeasures.git
+   $ git clone https://github.com/FlexMeasures/flexmeasures.git
 
 .. note:: Are you using Visual Studio Code? Then the code you just cloned also contains the editor configuration (part of) our team is using!
 
@@ -43,16 +43,16 @@ Dependencies
 
 Go into the ``flexmeasures`` folder and install all dependencies including the ones needed for development:
 
-.. code-block:: console
+.. code-block:: bash
 
-   cd flexmeasures
-   make install-for-dev
+   $ cd flexmeasures
+   $ make install-for-dev
 
 :ref:`Install the LP solver <install-lp-solver>`. On Unix the Cbc LP solver can be installed with:
 
-.. code-block:: console
+.. code-block:: bash
 
-   apt-get install coinor-cbc
+   $ apt-get install coinor-cbc
 
 
 Configuration
@@ -72,9 +72,9 @@ Loading data
 
 If you have a SQL Dump file, you can load that:
 
-.. code-block:: console
+.. code-block:: bash
 
-   psql -U {user_name} -h {host_name} -d {database_name} -f {file_path}
+   $ psql -U {user_name} -h {host_name} -d {database_name} -f {file_path}
 
 
 Run locally
@@ -82,16 +82,16 @@ Run locally
 
 Now, to start the web application, you can run:
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures run
+   $ flexmeasures run
 
 
 Or:
 
-.. code-block:: console
+.. code-block:: bash
 
-   python run-local.py
+   $ python run-local.py
 
 
 And access the server at http://localhost:5000
@@ -112,27 +112,27 @@ Tests
 
 You can run automated tests with:
 
-.. code-block:: console
+.. code-block:: bash
 
-   make test
+   $ make test
 
 
 which behind the curtains installs dependencies and calls pytest.
 
 A coverage report can be created like this:
 
-.. code-block:: console
+.. code-block:: bash
 
-   pytest --cov=flexmeasures --cov-config .coveragerc
+   $ pytest --cov=flexmeasures --cov-config .coveragerc
 
 
 You can add --cov-report=html after which a htmlcov/index.html is generated.
 
 It's also possible to use:
 
-.. code-block:: console
+.. code-block:: bash
 
-   python setup.py test
+   $ python setup.py test
 
 
 
@@ -159,10 +159,10 @@ We also run `mypy <http://mypy-lang.org/>`_ on many files to do some static type
 We do this so real problems are found faster and the discussion about formatting is limited.
 All of these can be installed by using ``pip``, but we recommend using them as a pre-commit hook. To activate that behaviour, do:
 
-.. code-block:: console
+.. code-block:: bash
 
-   pip install pre-commit
-   pre-commit install
+   $ pip install pre-commit
+   $ pre-commit install
 
 
 in your virtual environment.
@@ -182,10 +182,10 @@ A hint about using notebooks
 
 If you edit notebooks, make sure results do not end up in git:
 
-.. code-block:: console
+.. code-block:: bash
 
-   conda install -c conda-forge nbstripout
-   nbstripout --install
+   $ conda install -c conda-forge nbstripout
+   $ nbstripout --install
 
 
 (on Windows, maybe you need to look closer at https://github.com/kynan/nbstripout)

--- a/documentation/dev/introduction.rst
+++ b/documentation/dev/introduction.rst
@@ -201,7 +201,7 @@ I added this to my ~/.bashrc, so I only need to type ``fm`` to get started and h
 
    addssh(){
        eval `ssh-agent -s`
-       ssh-add ~/.ssh/id_bitbucket
+       ssh-add ~/.ssh/id_github
    }
    fm(){
        addssh

--- a/documentation/host/data.rst
+++ b/documentation/host/data.rst
@@ -29,10 +29,10 @@ Install
 
 On Unix:
 
-.. code-block:: console
+.. code-block:: bash
 
-   sudo apt-get install postgresql-12
-   pip install psycopg2-binary
+   $ sudo apt-get install postgresql-12
+   $ pip install psycopg2-binary
 
 
 On Windows:
@@ -61,9 +61,9 @@ Find the ``timezone`` setting and set it to 'UTC'.
 
 Then restart the postgres server.
 
-.. code-block:: console
+.. code-block:: bash
 
-    service postgresql restart
+    $ service postgresql restart
 
 
 Setup the "flexmeasures" Unix user
@@ -71,9 +71,9 @@ Setup the "flexmeasures" Unix user
 
 This may in fact not be needed:
 
-.. code-block:: console
+.. code-block:: bash
 
-   sudo /usr/sbin/adduser flexmeasures
+   $ sudo /usr/sbin/adduser flexmeasures
 
 
 Create "flexmeasures" and "flexmeasures_test" databases and users
@@ -84,14 +84,14 @@ From the terminal:
 Open a console (use your Windows key and type ``cmd``\ ).
 Proceed to create a database as the postgres superuser (using your postgres user password):
 
-.. code-block:: console
+.. code-block:: bash
 
-   sudo -i -u postgres
-   createdb -U postgres flexmeasures
-   createdb -U postgres flexmeasures_test
-   createuser --pwprompt -U postgres flexmeasures      # enter your password
-   createuser --pwprompt -U postgres flexmeasures_test  # enter "flexmeasures_test" as password
-   exit
+   $ sudo -i -u postgres
+   $ createdb -U postgres flexmeasures
+   $ createdb -U postgres flexmeasures_test
+   $ createuser --pwprompt -U postgres flexmeasures      # enter your password
+   $ createuser --pwprompt -U postgres flexmeasures_test  # enter "flexmeasures_test" as password
+   $ exit
 
 
 Or, from within Postgres console:
@@ -106,9 +106,9 @@ Or, from within Postgres console:
 
 Finally, test if you can log in as the flexmeasures user:
 
-.. code-block:: console
+.. code-block:: bash
 
-   psql -U flexmeasures --password -h 127.0.0.1 -d flexmeasures
+   $ psql -U flexmeasures --password -h 127.0.0.1 -d flexmeasures
 
 .. code-block:: sql
 
@@ -121,9 +121,9 @@ Add Postgres Extensions to your database(s)
 To find the nearest sensors, FlexMeasures needs some extra Postgres support.
 Add the following extensions while logged in as the postgres superuser:
 
-.. code-block:: console
+.. code-block:: bash
 
-   sudo -u postgres psql
+   $ sudo -u postgres psql
 
 .. code-block:: sql
 
@@ -161,25 +161,25 @@ Here is a short recipe to import data from a FlexMeasures database (e.g. a demo 
 
 On the to-be-exported database:
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures db-ops dump
+   $ flexmeasures db-ops dump
 
 
 .. note:: Only the data gets dumped here.
 
 Then, we create the structure in our database anew, based on the data model given by the local codebase:
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures db-ops reset
+   $ flexmeasures db-ops reset
 
 
 Then we import the data dump we made earlier:
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures db-ops restore <DATABASE DUMP FILENAME>
+   $ flexmeasures db-ops restore <DATABASE DUMP FILENAME>
 
 
 A potential ``alembic_version`` error should not prevent other data tables from being restored.
@@ -192,40 +192,40 @@ Create data manually
 
 First, you can get the database structure with:
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures db upgrade
+   $ flexmeasures db upgrade
 
 
 .. note:: If you develop code (and might want to make changes to the data model), you should also check out the maintenance section about database migrations.
 
 You can create users with the ``add user`` command. Check it out:
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures add user --help
+   $ flexmeasures add user --help
 
 
 You can create some pre-determined asset types and data sources with this command:
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures add initial-structure
+   $ flexmeasures add initial-structure
 
 You can also create assets in the FlexMeasures UI.
 
 On the command line, you can add many things. Check what data you can add yourself:
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures add --help
+   $ flexmeasures add --help
 
 
 For instance, you can create forecasts for your existing metered data with this command:
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures add forecasts --help
+   $ flexmeasures add forecasts --help
 
 
 Check out it's ``--help`` content to learn more. You can set which assets and which time window you want to forecast. Of course, making forecasts takes a while for a larger dataset.
@@ -233,9 +233,9 @@ You can also simply queue a job with this command (and run a worker to process t
 
 Just to note, there are also commands to get rid of data. Check:
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures delete --help
+   $ flexmeasures delete --help
 
 Check out the :ref:`cli` documentation for more details.
 
@@ -246,9 +246,9 @@ Visualize the data model
 
 You can visualise the data model like this:
 
-.. code-block:: console
+.. code-block:: bash
 
-   make show-data-model
+   $ make show-data-model
 
 
 This will generate a picture based on the model code.
@@ -267,11 +267,11 @@ Make first migration
 
 Run these commands from the repository root directory (read below comments first):
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures db init
-   flexmeasures db migrate
-   flexmeasures db upgrade
+   $ flexmeasures db init
+   $ flexmeasures db migrate
+   $ flexmeasures db upgrade
 
 
 The first command (\ ``flexmeasures db init``\ ) is only needed here once, it initialises the alembic migration tool.
@@ -287,10 +287,10 @@ Make another migration
 
 Just to be clear that the ``db init`` command is needed only at the beginning - you usually do, if your model changed:
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures db migrate --message "Please explain what you did, it helps for later"
-   flexmeasures db upgrade
+   $ flexmeasures db migrate --message "Please explain what you did, it helps for later"
+   $ flexmeasures db upgrade
 
 
 Get database structure updated
@@ -298,9 +298,9 @@ Get database structure updated
 
 The goal is that on any other computer, you can always execute
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures db upgrade
+   $ flexmeasures db upgrade
 
 
 to have the database structure up-to-date with all migrations.
@@ -310,18 +310,18 @@ Working with the migration history
 
 The history of migrations is at your fingertips:
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures db current
-   flexmeasures db history
+   $ flexmeasures db current
+   $ flexmeasures db history
 
 
 You can move back and forth through the history:
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures db downgrade
-   flexmeasures db upgrade
+   $ flexmeasures db downgrade
+   $ flexmeasures db upgrade
 
 
 Both of these accept a specific revision id parameter, as well.
@@ -331,9 +331,9 @@ Check out database status
 
 Log in into the database:
 
-.. code-block:: console
+.. code-block:: bash
 
-   psql -U flexmeasures --password -h 127.0.0.1 -d flexmeasures
+   $ psql -U flexmeasures --password -h 127.0.0.1 -d flexmeasures
 
 
 with the password from flexmeasures/development_config.py. Check which tables are there:

--- a/documentation/host/deployment.rst
+++ b/documentation/host/deployment.rst
@@ -55,9 +55,9 @@ Cbc needs to be present on the server where FlexMeasures runs, under the ``cbc``
 
 You can install it on Debian like this:
 
-.. code-block:: console
+.. code-block:: bash
 
-   apt-get install coinor-cbc
+   $ apt-get install coinor-cbc
 
 
 If you can't use the package manager on your host, the solver has to be installed from source.

--- a/documentation/host/error-monitoring.rst
+++ b/documentation/host/error-monitoring.rst
@@ -19,9 +19,9 @@ The CLI task ``flexmeasures monitor last-seen`` lets you be alerted if a user ha
 
 Here is an example for illustration:
 
-.. code-block:: console
+.. code-block:: bash
 
-    flexmeasures monitor last-seen --account-role SubscriberToServiceXYZ --user-role bot --maximum-minutes-since-last-seen 100
+    $ flexmeasures monitor last-seen --account-role SubscriberToServiceXYZ --user-role bot --maximum-minutes-since-last-seen 100
 
 As you see, users are filtered by roles. You might need to add roles before this works as you want.
 
@@ -36,9 +36,9 @@ The alerts will come in via Sentry, but you can also send them to email addresse
 
 For illustration, here is one example of how we monitor the latest run times of tasks on a server ― the below is run in a cron script every hour and checks if every listed task ran 60, 6 or 1440 minutes ago, respectively:
 
-.. code-block:: console
+.. code-block:: bash
 
-    flexmeasures monitor latest-run --task get_weather_forecasts 60 --task get_recent_meter_data 6  --task import_epex_prices 1440
+    $ flexmeasures monitor latest-run --task get_weather_forecasts 60 --task get_recent_meter_data 6  --task import_epex_prices 1440
 
 The first task (get_weather_forecasts) is actually supported within FlexMeasures, while the other two sit in plugins we wrote.
 

--- a/documentation/host/queues.rst
+++ b/documentation/host/queues.rst
@@ -22,23 +22,23 @@ Run workers
 
 Here is how to run one worker for each kind of job (in separate terminals):
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures jobs run-worker --name our-only-worker --queue forecasting|scheduling
+   $ flexmeasures jobs run-worker --name our-only-worker --queue forecasting|scheduling
 
 Running multiple workers in parallel might be a great idea.
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures jobs run-worker --name forecaster --queue forecasting
-   flexmeasures jobs run-worker --name scheduler --queue scheduling
+   $ flexmeasures jobs run-worker --name forecaster --queue forecasting
+   $ flexmeasures jobs run-worker --name scheduler --queue scheduling
 
 You can also clear the job queues:
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures jobs clear-queue --queue forecasting
-   flexmeasures jobs clear-queue --queue scheduling
+   $ flexmeasures jobs clear-queue --queue forecasting
+   $ flexmeasures jobs clear-queue --queue scheduling
 
 
 When the main FlexMeasures process runs (e.g. by ``flexmeasures run``\ ), the queues of forecasting and scheduling jobs can be visited at ``http://localhost:5000/tasks/forecasting`` and ``http://localhost:5000/tasks/schedules``\ , respectively (by admins).
@@ -50,10 +50,10 @@ Inspect the queue and jobs
 
 The first option to inspect the state of the ``forecasting`` queue should be via the formidable `RQ dashboard <https://github.com/Parallels/rq-dashboard>`_. If you have admin rights, you can access it at ``your-flexmeasures-url/rq/``\ , so for instance ``http://localhost:5000/rq/``. You can also start RQ dashboard yourself (but you need to know the redis server credentials):
 
-.. code-block:: console
+.. code-block:: bash
 
-   pip install rq-dashboard
-   rq-dashboard --redis-host my.ip.addr.ess --redis-password secret --redis-database 0
+   $ pip install rq-dashboard
+   $ rq-dashboard --redis-host my.ip.addr.ess --redis-password secret --redis-database 0
 
 
 RQ dashboard shows you ongoing and failed jobs, and you can see the error messages of the latter, which is very useful.

--- a/documentation/tut/forecasting_scheduling.rst
+++ b/documentation/tut/forecasting_scheduling.rst
@@ -24,18 +24,18 @@ Here we assume you have access to a Redis server and configured it (see :ref:`re
 
 Start to run one worker for each kind of job (in a separate terminal):
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures jobs run-worker --queue forecasting
-   flexmeasures jobs run-worker --queue scheduling
+   $ flexmeasures jobs run-worker --queue forecasting
+   $ flexmeasures jobs run-worker --queue scheduling
 
 
 You can also clear the job queues:
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures jobs clear-queue --queue forecasting
-   flexmeasures jobs clear-queue --queue scheduling
+   $ flexmeasures jobs clear-queue --queue forecasting
+   $ flexmeasures jobs clear-queue --queue scheduling
 
 
 When the main FlexMeasures process runs (e.g. by ``flexmeasures run``\ ), the queues of forecasting and scheduling jobs can be visited at ``http://localhost:5000/tasks/forecasting`` and ``http://localhost:5000/tasks/schedules``\ , respectively (by admins).
@@ -73,9 +73,9 @@ If you host FlexMeasures yourself, we provide a CLI task for adding forecasts fo
 
 Here we request 6-hour forecasts to be made for two sensors, for a period of two days:
 
-.. code-block:: console
+.. code-block:: bash
 
-    flexmeasures add forecasts --sensor-id 2 --sensor-id 3 \
+    $ flexmeasures add forecasts --sensor-id 2 --sensor-id 3 \
         --from-date 2015-02-01 --to-date 2015-08-31 \
         --horizon 6 --as-job
 
@@ -129,9 +129,9 @@ If FlexMeasures receives this message, a scheduling job will be made and put int
 
 A second way to add scheduling jobs is via the CLI, so this is available for people who host FlexMeasures themselves:
 
-.. code-block:: console
+.. code-block:: bash
 
-    flexmeasures add schedule for-storage --sensor-id 2 --optimization-context-id 3 \
+    $ flexmeasures add schedule for-storage --sensor-id 2 --optimization-context-id 3 \
         --start 2022-07-05T07:00+01:00 --duration PT12H \
         --soc-at-start 50% --roundtrip-efficiency 90% --as-job
 

--- a/documentation/tut/forecasting_scheduling.rst
+++ b/documentation/tut/forecasting_scheduling.rst
@@ -131,7 +131,7 @@ A second way to add scheduling jobs is via the CLI, so this is available for peo
 
 .. code-block:: bash
 
-    $ flexmeasures add schedule for-storage --sensor-id 2 --optimization-context-id 3 \
+    $ flexmeasures add schedule for-storage --sensor-id 1 --consumption-price-sensor 2 \
         --start 2022-07-05T07:00+01:00 --duration PT12H \
         --soc-at-start 50% --roundtrip-efficiency 90% --as-job
 

--- a/documentation/tut/installation.rst
+++ b/documentation/tut/installation.rst
@@ -95,9 +95,9 @@ This suffices for a quick start.
 
 .. note:: For a more permanent configuration, you can create your FlexMeasures configuration file at ``~/.flexmeasures.cfg`` and add this:
 
-    .. code-block:: console
+    .. code-block:: python
 
-        SQLALCHEMY_DATABASE_URI="postgresql://<user>:<password>@<host-address>[:<port>]/<db>"
+        SQLALCHEMY_DATABASE_URI = "postgresql://<user>:<password>@<host-address>[:<port>]/<db>"
 
 
 Adding data

--- a/documentation/tut/installation.rst
+++ b/documentation/tut/installation.rst
@@ -21,9 +21,9 @@ Install FlexMeasures
 
 Install dependencies and the ``flexmeasures`` platform itself:
 
-.. code-block:: console
+.. code-block:: bash
 
-   pip install flexmeasures
+   $ pip install flexmeasures
 
 .. note:: With newer Python versions and Windows, some smaller dependencies (e.g. ``tables`` or ``rq-win``) might cause issues as support is often slower. You might overcome this with a little research, by `installing from wheels <http://www.pytables.org/usersguide/installation.html#prerequisitesbininst>`_ or `from the repo <https://github.com/michaelbrooks/rq-win#installation-and-use>`_, respectively.
 
@@ -33,9 +33,9 @@ Make a secret key for sessions and password salts
 
 Set a secret key which is used to sign user sessions and re-salt their passwords. The quickest way is with an environment variable, like this:
 
-.. code-block:: console
+.. code-block:: bash
 
-   export SECRET_KEY=something-secret
+   $ export SECRET_KEY=something-secret
 
 (on Windows, use ``set`` instead of ``export``\ )
 
@@ -43,9 +43,9 @@ This suffices for a quick start.
 
 If you want to consistently use FlexMeasures, we recommend you add this setting to your config file at ``~/.flexmeasures.cfg`` and use a truly random string. Here is a Pythonic way to generate a good secret key:
 
-.. code-block:: console
+.. code-block:: bash
 
-   python -c "import secrets; print(secrets.token_urlsafe())"
+   $ python -c "import secrets; print(secrets.token_urlsafe())"
 
 
 
@@ -54,17 +54,17 @@ Configure environment
 
 Set an environment variable to indicate in which environment you are operating (one out of development|testing|staging|production). We'll go with ``development`` here:
 
-.. code-block:: console
+.. code-block:: bash
 
-   export FLASK_ENV=development
+   $ export FLASK_ENV=development
 
 (on Windows, use ``set`` instead of ``export``\ )
 
 or:
 
-.. code-block:: console
+.. code-block:: bash
 
-   echo "FLASK_ENV=development" >> .env
+   $ echo "FLASK_ENV=development" >> .env
 
 .. note:: The default is ``production``\ , which will not work well on localhost due to SSL issues. 
 
@@ -77,9 +77,9 @@ Preparing the time series database
 * 
   Tell ``flexmeasures`` about it:
 
-   .. code-block:: console
+   .. code-block:: bash
 
-       export SQLALCHEMY_DATABASE_URI="postgresql://<user>:<password>@<host-address>[:<port>]/<db>"
+       $ export SQLALCHEMY_DATABASE_URI="postgresql://<user>:<password>@<host-address>[:<port>]/<db>"
 
   If you install this on localhost, ``host-address`` is ``127.0.0.1`` and the port can be left out.
   (on Windows, use ``set`` instead of ``export``\ )
@@ -87,9 +87,9 @@ Preparing the time series database
 * 
   Create the Postgres DB structure for FlexMeasures:
 
-   .. code-block:: console
+   .. code-block:: bash
 
-       flexmeasures db upgrade
+       $ flexmeasures db upgrade
 
 This suffices for a quick start.
 
@@ -109,17 +109,17 @@ Add an account & user
 
 FlexMeasures is a tenant-based platform ― multiple clients can enjoy its services on one server. Let's create a tenant account first: 
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures add account --name  "Some company"
+   $ flexmeasures add account --name  "Some company"
 
 This command will tell us the ID of this account. Let's assume it was ``2``.
 
 FlexMeasures is also a web-based platform, so we need to create a user to authenticate:
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures add user --username <your-username> --email <your-email-address> --account-id 2 --roles=admin
+   $ flexmeasures add user --username <your-username> --email <your-email-address> --account-id 2 --roles=admin
 
 
 * This will ask you to set a password for the user.
@@ -131,9 +131,9 @@ Add structure
 
 Populate the database with some standard asset types, user roles etc.: 
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures add initial-structure
+   $ flexmeasures add initial-structure
 
 
 Add your first asset
@@ -143,9 +143,9 @@ There are three ways to add assets:
 
 First, you can use the ``flexmeasures`` :ref:`cli`:
 
-.. code-block:: console
+.. code-block:: bash
 
-    flexmeasures add asset --name "my basement battery pack" --asset-type-id 3 --latitude 65 --longitude 123.76 --account-id 2
+    $ flexmeasures add asset --name "my basement battery pack" --asset-type-id 3 --latitude 65 --longitude 123.76 --account-id 2
 
 For the asset type ID, I consult ``flexmeasures show asset-types``.
 
@@ -161,9 +161,9 @@ Add your first sensor
 
 Usually, we are here because we want to measure something with respect to our assets. Each assets can have sensors for that, so let's add a power sensor to our new battery asset, using the ``flexmeasures`` :ref:`cli`:
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures add sensor --name power --unit MW --event-resolution 5 --timezone Europe/Amsterdam --asset-id 1 --attributes '{"capacity_in_mw": 7}'
+   $ flexmeasures add sensor --name power --unit MW --event-resolution 5 --timezone Europe/Amsterdam --asset-id 1 --attributes '{"capacity_in_mw": 7}'
 
 The asset ID I got from the last CLI command, or I could consult ``flexmeasures show account --account-id <my-account-id>``.
 
@@ -177,9 +177,9 @@ There are three ways to add data:
 
 First, you can load in data from a file (CSV or Excel) via the ``flexmeasures`` :ref:`cli`:
 
-.. code-block:: console
+.. code-block:: bash
    
-   flexmeasures add beliefs --file my-data.csv --skiprows 2 --delimiter ";" --source OurLegacyDatabase --sensor-id 1
+   $ flexmeasures add beliefs --file my-data.csv --skiprows 2 --delimiter ";" --source OurLegacyDatabase --sensor-id 1
 
 This assumes you have a file `my-data.csv` with measurements, which was exported from some legacy database, and that the data is about our sensor with ID 1. This command has many options, so do use its ``--help`` function.
 
@@ -187,9 +187,9 @@ Second, you can use the `POST /api/v3_0/sensors/data <api/v3_0.html#post--api-v3
 
 Finally, you can tell FlexMeasures to create forecasts for your meter data with the ``flexmeasures add forecasts`` command, here is an example:
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures add forecasts --from-date 2020-03-08 --to-date 2020-04-08 --asset-type Asset --asset my-solar-panel
+   $ flexmeasures add forecasts --from-date 2020-03-08 --to-date 2020-04-08 --asset-type Asset --asset my-solar-panel
 
 .. note:: You can also use the API to send forecast data.
 
@@ -203,9 +203,9 @@ Running the web service
 
 It's finally time to start running FlexMeasures:
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures run
+   $ flexmeasures run
 
 (This might print some warnings, see the next section where we go into more detail)
 
@@ -234,9 +234,9 @@ For planning balancing actions, the FlexMeasures platform uses a linear program 
 
 Installing Cbc can be done on Unix via:
 
-.. code-block:: console
+.. code-block:: bash
 
-   apt-get install coinor-cbc
+   $ apt-get install coinor-cbc
 
 
 (also available in different popular package managers).
@@ -253,10 +253,10 @@ To let FlexMeasures queue forecasting and scheduling jobs, install a `Redis <htt
 
 Then, start workers in a console (or some other method to keep a long-running process going):
 
-.. code-block:: console
+.. code-block:: bash
 
-   flexmeasures jobs run-worker --queue forecasting
-   flexmeasures jobs run-worker --queue scheduling
+   $ flexmeasures jobs run-worker --queue forecasting
+   $ flexmeasures jobs run-worker --queue scheduling
 
 
 Where to go from here?

--- a/documentation/tut/toy-example-from-scratch.rst
+++ b/documentation/tut/toy-example-from-scratch.rst
@@ -14,7 +14,7 @@ What do you need? Your own computer, with one of two situations: either you have
 
 Below are the ``flexmeasures`` CLI commands we'll run, and which we'll explain step by step. There are some other crucial steps for installation and setup, so this becomes a complete example from scratch, but this is the meat:
 
-.. code-block:: console
+.. code-block:: bash
 
     # setup an account with a user, battery (ID 1) and market (ID 2)
     $ flexmeasures add toy-account --kind battery
@@ -42,7 +42,7 @@ Install Flexmeasures and the database
 
         We start by installing the FlexMeasures platform, and then use Docker to run a postgres database and tell FlexMeasures to create all tables.
 
-        .. code-block:: console
+        .. code-block:: bash
 
             $ docker pull lfenergy/flexmeasures:latest
             $ docker pull postgres
@@ -55,7 +55,7 @@ Install Flexmeasures and the database
 
         Now - what's *very important* to remember is this: The rest of this tutorial will happen *inside* the ``flexmeasures-tutorial-fm`` container! This is how you hop inside the container and run a terminal there:
 
-        .. code-block:: console
+        .. code-block:: bash
 
             $ docker exec -it flexmeasures-tutorial-fm bash
 
@@ -63,14 +63,14 @@ Install Flexmeasures and the database
 
         To stop the containers, you can type
         
-        .. code-block:: console
+        .. code-block:: bash
         
             $ docker stop flexmeasures-tutorial-db
             $ docker stop flexmeasures-tutorial-fm
 
         To start the containers again, do this (note that re-running the `docker run` commands above *deletes and re-creates* all data!):
         
-        .. code-block:: console
+        .. code-block:: bash
         
             $ docker start flexmeasures-tutorial-db
             $ docker start flexmeasures-tutorial-fm
@@ -85,16 +85,16 @@ Install Flexmeasures and the database
 
         We'll create a database for FlexMeasures:
 
-        .. code-block:: console
+        .. code-block:: bash
 
-            sudo -i -u postgres
-            createdb -U postgres flexmeasures-db
-            createuser --pwprompt -U postgres flexmeasures-user      # enter your password, we'll use "fm-db-passwd"
-            exit
+            $ sudo -i -u postgres
+            $ createdb -U postgres flexmeasures-db
+            $ createuser --pwprompt -U postgres flexmeasures-user      # enter your password, we'll use "fm-db-passwd"
+            $ exit
 
         Then, we can install FlexMeasures itself, set some variables and tell FlexMeasures to create all tables:
 
-        .. code-block:: console
+        .. code-block:: bash
 
             $ pip install flexmeasures
             $ export SQLALCHEMY_DATABASE_URI="postgresql://flexmeasures-user:fm-db-passwd@localhost:5432/flexmeasures-db" SECRET_KEY=notsecret LOGGING_LEVEL="INFO" DEBUG=0
@@ -112,7 +112,7 @@ Let's create the structural data first.
 
 FlexMeasures offers a command to create a toy account with a battery:
 
-.. code-block:: console
+.. code-block:: bash
 
     $ flexmeasures add toy-account --kind battery
 
@@ -125,7 +125,7 @@ And with that, we're done with the structural data for this tutorial!
 
 If you want, you can inspect what you created:
 
-.. code-block:: console
+.. code-block:: bash
 
     $ flexmeasures show account --id 1                       
     
@@ -188,7 +188,7 @@ Add some price data
 
 Now to add price data. First, we'll create the csv file with prices (EUR/MWh, see the setup for sensor 2 above) for tomorrow.
 
-.. code-block:: console
+.. code-block:: bash
 
     $ TOMORROW=$(date --date="next day" '+%Y-%m-%d')
     $ echo "Hour,Price                                      
@@ -219,7 +219,7 @@ Now to add price data. First, we'll create the csv file with prices (EUR/MWh, se
 
 This is time series data, in FlexMeasures we call "beliefs". Beliefs can also be sent to FlexMeasures via API or imported from open data hubs like `ENTSO-E <https://github.com/SeitaBV/flexmeasures-entsoe>`_ or `OpenWeatherMap <https://github.com/SeitaBV/flexmeasures-openweathermap>`_. However, in this tutorial we'll show how you can read data in from a CSV file. Sometimes that's just what you need :)
 
-.. code-block:: console
+.. code-block:: bash
 
     $ flexmeasures add beliefs --sensor-id 2 --source toy-user prices-tomorrow.csv --timezone Europe/Amsterdam
     Successfully created beliefs
@@ -230,7 +230,7 @@ In FlexMeasures, all beliefs have a data source. Here, we use the username of th
 
 Let's look at the price data we just loaded:
 
-.. code-block:: console
+.. code-block:: bash
 
     $ flexmeasures show beliefs --sensor-id 2 --start ${TOMORROW}T00:00:00+01:00 --duration PT24H
     Beliefs for Sensor 'day-ahead prices' (ID 2).
@@ -276,7 +276,7 @@ Finally, we can create the schedule, which is the main benefit of FlexMeasures (
 We'll ask FlexMeasures for a schedule for our discharging sensor (ID 1). We also need to specify what to optimise against. Here we pass the Id of our market price sensor (3).
 To keep it short, we'll only ask for a 12-hour window starting at 7am. Finally, the scheduler should know what the state of charge of the battery is when the schedule starts (50%) and what its roundtrip efficiency is (90%).
 
-.. code-block:: console
+.. code-block:: bash
 
     $ flexmeasures add schedule for-storage --sensor-id 1 --consumption-price-sensor 2 \
         --start ${TOMORROW}T07:00+01:00 --duration PT12H \
@@ -285,7 +285,7 @@ To keep it short, we'll only ask for a 12-hour window starting at 7am. Finally, 
 
 Great. Let's see what we made:
 
-.. code-block:: console
+.. code-block:: bash
 
     $ flexmeasures show beliefs --sensor-id 1 --start ${TOMORROW}T07:00:00+01:00 --duration PT12H
     Beliefs for Sensor 'discharging' (ID 1).
@@ -334,7 +334,7 @@ So far we haven't taken into account any other devices that consume or produce e
 
 First, we'll create a new csv file with solar forecasts (MW, see the setup for sensor 3 above) for tomorrow.
 
-.. code-block:: console
+.. code-block:: bash
 
     $ TOMORROW=$(date --date="next day" '+%Y-%m-%d')
     $ echo "Hour,Price
@@ -370,7 +370,7 @@ Setting the data source type to "forecaster" helps FlexMeasures to visualize dis
 
 .. note:: The ``flexmeasures add source`` command also allows to set a model and version, so sources can be distinguished in more detail. But that is not the point of this tutorial. See ``flexmeasures add source --help``.
 
-.. code-block:: console
+.. code-block:: bash
 
     $ flexmeasures add source --name "toy-forecaster" --type forecaster
     Added source <Data source 4 (toy-forecaster)>
@@ -383,7 +383,7 @@ The one-hour CSV data is automatically resampled to the 15-minute resolution of 
 
 Now, we'll reschedule the battery while taking into account the solar production. This will have an effect on the available headroom for the battery.
 
-.. code-block:: console
+.. code-block:: bash
 
     $ flexmeasures add schedule for-storage --sensor-id 1 --consumption-price-sensor 2 \
         --inflexible-device-sensor 3 \


### PR DESCRIPTION
This PR fixes the copy button on tutorials and other documentation, so that only commands are copied and no output or comments.