### PR TITLE
Move test using fresh_db to separate test module

### DIFF
--- a/flexmeasures/conftest.py
+++ b/flexmeasures/conftest.py
@@ -633,6 +633,21 @@ def create_test_battery_assets(
 def add_charging_station_assets(
     db: SQLAlchemy, setup_roles_users, setup_markets
 ) -> Dict[str, Asset]:
+    return create_charging_station_assets(db, setup_roles_users, setup_markets)
+
+
+@pytest.fixture(scope="function")
+def add_charging_station_assets_fresh_db(
+    fresh_db: SQLAlchemy, setup_roles_users_fresh_db, setup_markets_fresh_db
+) -> Dict[str, Asset]:
+    return create_charging_station_assets(
+        fresh_db, setup_roles_users_fresh_db, setup_markets_fresh_db
+    )
+
+
+def create_charging_station_assets(
+    db: SQLAlchemy, setup_roles_users, setup_markets
+) -> Dict[str, Asset]:
     """Add uni- and bi-directional charging station assets, set their capacity value and their initial SOC."""
     db.session.add(
         AssetType(

--- a/flexmeasures/data/tests/test_scheduling_repeated_jobs.py
+++ b/flexmeasures/data/tests/test_scheduling_repeated_jobs.py
@@ -13,25 +13,6 @@ from flexmeasures.data.models.time_series import Sensor
 from flexmeasures.data.tests.utils import work_on_rq, exception_reporter
 from flexmeasures.data.services.scheduling import create_scheduling_job
 from flexmeasures.data.services.utils import hash_function_arguments, job_cache
-from flexmeasures.data.models.planning import Scheduler
-from flexmeasures.data.services.scheduling import load_custom_scheduler
-
-
-class FailingScheduler(Scheduler):
-
-    __author__ = "Test Organization"
-    __version__ = "1"
-
-    def compute_schedule(self):
-        """
-        This is a schedule that fails
-        """
-
-        raise Exception()
-
-    def deserialize_config(self):
-        """Do not care about any config sent in."""
-        self.config_deserialized = True
 
 
 @pytest.mark.parametrize(
@@ -330,68 +311,3 @@ def test_force_new_job_creation(db, app, add_charging_station_assets, setup_test
 
     # check that `force_new_job_creation=True` actually triggers a new job creation
     assert job2.id != job3.id
-
-
-def test_requeue_failing_job(
-    fresh_db, app, add_charging_station_assets, setup_test_data
-):
-    """
-    Testing that failing jobs are requeued.
-    This test is called with a fresh db so that previous schedules don't interfere.
-    """
-
-    tz = pytz.timezone("Europe/Amsterdam")
-    start = tz.localize(datetime(2016, 1, 2))
-    end = tz.localize(datetime(2016, 1, 3))
-    resolution = timedelta(minutes=15)
-
-    charging_station = Sensor.query.filter(
-        Sensor.name == "Test charging station"
-    ).one_or_none()
-
-    custom_scheduler = {
-        "module": "flexmeasures.data.tests.test_scheduling_repeated_jobs",
-        "class": "FailingScheduler",
-    }
-
-    # test if we can fetch the right scheduler class
-    scheduler = load_custom_scheduler(custom_scheduler)(
-        charging_station, start, end, resolution
-    )
-    assert isinstance(scheduler, FailingScheduler)
-
-    # assigning scheduler to the sensor "Test charging station"
-    charging_station.attributes["custom-scheduler"] = custom_scheduler
-
-    # clean queue
-    app.queues["scheduling"].empty()
-
-    # calling the job twice, with the requeue argument to true
-    jobs = []
-
-    for _ in range(2):
-        job = create_scheduling_job(
-            sensor=charging_station,
-            start=start,
-            end=end,
-            resolution=resolution,
-            enqueue=True,
-            requeue=True,
-        )
-
-        work_on_rq(app.queues["scheduling"], exc_handler=exception_reporter)
-        jobs.append(job)
-
-    job1, job2 = jobs
-
-    print(job1.failed_job_registry, len(job1.failed_job_registry))
-
-    assert job1.id == job2.id  # equal job IDs
-    assert job1.is_failed
-    assert job2.is_failed
-
-    print("JOB2: ", job2.enqueued_at)
-    print("JOB1: ", job1.enqueued_at)
-
-    # check if job2 has actually been requeued
-    assert job1.enqueued_at < job2.enqueued_at

--- a/flexmeasures/data/tests/test_scheduling_repeated_jobs_fresh_db.py
+++ b/flexmeasures/data/tests/test_scheduling_repeated_jobs_fresh_db.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytz
+
+from flexmeasures.data.models.time_series import Sensor
+from flexmeasures.data.tests.utils import work_on_rq, exception_reporter
+from flexmeasures.data.services.scheduling import create_scheduling_job
+from flexmeasures.data.models.planning import Scheduler
+from flexmeasures.data.services.scheduling import load_custom_scheduler
+
+
+class FailingScheduler(Scheduler):
+
+    __author__ = "Test Organization"
+    __version__ = "1"
+
+    def compute_schedule(self):
+        """
+        This is a schedule that fails
+        """
+
+        raise Exception()
+
+    def deserialize_config(self):
+        """Do not care about any config sent in."""
+        self.config_deserialized = True
+
+
+def test_requeue_failing_job(
+    fresh_db, app, add_charging_station_assets_fresh_db, setup_fresh_test_data
+):
+    """
+    Testing that failing jobs are requeued.
+    This test is called with a fresh db so that previous schedules don't interfere.
+    """
+
+    tz = pytz.timezone("Europe/Amsterdam")
+    start = tz.localize(datetime(2016, 1, 2))
+    end = tz.localize(datetime(2016, 1, 3))
+    resolution = timedelta(minutes=15)
+
+    charging_station = Sensor.query.filter(
+        Sensor.name == "Test charging station"
+    ).one_or_none()
+
+    custom_scheduler = {
+        "module": "flexmeasures.data.tests.test_scheduling_repeated_jobs_fresh_db",
+        "class": "FailingScheduler",
+    }
+
+    # test if we can fetch the right scheduler class
+    scheduler = load_custom_scheduler(custom_scheduler)(
+        charging_station, start, end, resolution
+    )
+    assert isinstance(scheduler, FailingScheduler)
+
+    # assigning scheduler to the sensor "Test charging station"
+    charging_station.attributes["custom-scheduler"] = custom_scheduler
+
+    # clean queue
+    app.queues["scheduling"].empty()
+
+    # calling the job twice, with the requeue argument to true
+    jobs = []
+
+    for _ in range(2):
+        job = create_scheduling_job(
+            sensor=charging_station,
+            start=start,
+            end=end,
+            resolution=resolution,
+            enqueue=True,
+            requeue=True,
+        )
+
+        work_on_rq(app.queues["scheduling"], exc_handler=exception_reporter)
+        jobs.append(job)
+
+    job1, job2 = jobs
+
+    print(job1.failed_job_registry, len(job1.failed_job_registry))
+
+    assert job1.id == job2.id  # equal job IDs
+    assert job1.is_failed
+    assert job2.is_failed
+
+    print("JOB2: ", job2.enqueued_at)
+    print("JOB1: ", job1.enqueued_at)
+
+    # check if job2 has actually been requeued
+    assert job1.enqueued_at < job2.enqueued_at

--- a/flexmeasures/data/tests/test_scheduling_repeated_jobs_fresh_db.py
+++ b/flexmeasures/data/tests/test_scheduling_repeated_jobs_fresh_db.py
@@ -16,7 +16,7 @@ class FailingScheduler(Scheduler):
     __author__ = "Test Organization"
     __version__ = "1"
 
-    def compute_schedule(self):
+    def compute(self):
         """
         This is a schedule that fails
         """


### PR DESCRIPTION
If you exclusively run the test associated with the `FailingScheduler`, it will fail.

```
pytest -k test_requeue_failing_job
```

This has to do with mixing the `fresh_db` and `db` fixtures in a single test. To resolve this, I've moved `test_requeue_failing_job` to a new module named `test_scheduling_repeated_jobs_fresh_db.py` and have it use equivalent fixtures that use the fresh db instead.