### PR TITLE
FLEXMEASURES_PLUGINS configurable from env

### DIFF
--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -248,3 +248,5 @@ fsdomain
 filepath
 Changelog
 Bugfixes
+Dockerfile
+―

--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -246,3 +246,5 @@ deserializing
 kwargs
 fsdomain
 filepath
+Changelog
+Bugfixes

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -15,6 +15,8 @@ Bugfixes
 Infrastructure / Support
 ----------------------
 
+.. warning:: The setting `FLEXMEASURES_PLUGIN_PATHS` has been sunset. It had been deprecated since v0.7.
+
 
 v0.13.0 | May 1, 2023
 ============================

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -15,7 +15,9 @@ Bugfixes
 Infrastructure / Support
 ----------------------
 
-.. warning:: The setting `FLEXMEASURES_PLUGIN_PATHS` has been sunset. It had been deprecated since v0.7.
+* The setting FLEXMEASURES_PLUGINS can be set as environment variable now (as a comma-separated list) [see `PR #660 <https://www.github.com/FlexMeasures/flexmeasures/pull/660>`_]
+
+.. warning:: The setting `FLEXMEASURES_PLUGIN_PATHS` has been deprecated since v0.7. It has now been sunset. Please replace it with :ref:`plugin-config`.
 
 
 v0.13.0 | May 1, 2023

--- a/documentation/configuration.rst
+++ b/documentation/configuration.rst
@@ -26,6 +26,8 @@ Level above which log messages are added to the log file. See the ``logging`` pa
 
 Default: ``logging.WARNING``
 
+.. note:: This setting is also recognized as environment variable.
+
 
 .. _modes-config:
 
@@ -72,6 +74,7 @@ FLEXMEASURES_PLUGINS
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A list of plugins you want FlexMeasures to load (e.g. for custom views or CLI functions). 
+This can be a Python list (e.g. ``["plugin1", "plugin2"]``) or a comma-separated string (e.g. ``"plugin1, plugin2"``).
 
 Two types of entries are possible here:
 
@@ -80,8 +83,9 @@ Two types of entries are possible here:
 
 Added functionality in plugins needs to be based on Flask Blueprints. See :ref:`plugins` for more information and examples.
 
-
 Default: ``[]``
+
+.. note:: This setting is also recognized as environment variable.
 
 
 FLEXMEASURES_DB_BACKUP_PATH
@@ -299,6 +303,8 @@ Token for accessing the MapBox API (for displaying maps on the dashboard and ass
 
 Default: ``None``
 
+.. note:: This setting is also recognized as environment variable.
+
 .. _sentry_access_token:
 
 SENTRY_SDN
@@ -308,6 +314,8 @@ Set tokenized URL, so errors will be sent to Sentry when ``app.env`` is not in `
 E.g.: ``https://<examplePublicKey>@o<something>.ingest.sentry.io/<project-Id>``
 
 Default: ``None``
+
+.. note:: This setting is also recognized as environment variable.
 
 
 SQLAlchemy
@@ -322,6 +330,9 @@ SQLALCHEMY_DATABASE_URI (**)
 Connection string to the postgres database, format: ``postgresql://<user>:<password>@<host-address>[:<port>]/<db>``
 
 Default: ``None``
+
+.. note:: This setting is also recognized as environment variable.
+
 
 SQLALCHEMY_ENGINE_OPTIONS
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -431,6 +442,8 @@ For FlexMeasures to be able to send email to users (e.g. for resetting passwords
 
 This is only a selection of the most important settings.
 See `the Flask-Mail Docs <https://flask-mail.readthedocs.io/en/latest/#configuring-flask-mail>`_ for others.
+
+.. note:: The mail settings are also recognized as environment variables.
 
 MAIL_SERVER (*)
 ^^^^^^^^^^^^^^^
@@ -542,6 +555,9 @@ Redis
 -----
 
 FlexMeasures uses the Redis database to support our forecasting and scheduling job queues.
+
+.. note:: The redis settings are also recognized as environment variables.
+
 
 FLEXMEASURES_REDIS_URL (*)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/documentation/configuration.rst
+++ b/documentation/configuration.rst
@@ -6,7 +6,7 @@ Configuration
 The following configurations are used by FlexMeasures.
 
 Required settings (e.g. postgres db) are marked with a double star (**).
-To enable easier quickstart tutorials, these required settings can be set by environment variables.
+To enable easier quickstart tutorials, continuous integration use cases and basic usage of FlexMeasures within other projects, these required settings, as well as a few others, can be set by environment variables ― this is also noted per setting.
 Recommended settings (e.g. mail, redis) are marked by one star (*).
 
 .. note:: FlexMeasures is best configured via a config file. The config file for FlexMeasures can be placed in one of two locations: 
@@ -85,7 +85,7 @@ Added functionality in plugins needs to be based on Flask Blueprints. See :ref:`
 
 Default: ``[]``
 
-.. note:: This setting is also recognized as environment variable.
+.. note:: This setting is also recognized as environment variable (since v0.14, which is also the version required to pass this setting as a string).
 
 
 FLEXMEASURES_DB_BACKUP_PATH

--- a/documentation/plugin/customisation.rst
+++ b/documentation/plugin/customisation.rst
@@ -81,6 +81,35 @@ get computed by your custom function! For later lookup, the data will be linked 
 .. todo:: We're planning to use a similar approach to allow for custom forecasting algorithms, as well.
 
 
+Deploying your plugin via Docker
+----------------------------------
+
+You can extend the FlexMeasures Docker image with your plugin's logic.
+
+Imagine your package (with an ``__init__.py`` file, one of the setups we discussed in :ref:`plugin_showcase`) is called ``flexmeasures_testplugin``.
+Then, this is a minimal possible Dockerfile:
+
+.. code-block:: docker
+
+    FROM lfenergy/flexmeasures
+
+    COPY flexmeasures_testplugin/ /app/flexmeasures_testplugin
+    ENV FLEXMEASURES_PLUGINS="/app/flexmeasures_testplugin"
+
+
+If you also want to install your requirements, you could for instance add these layers:
+
+.. code-block:: docker
+
+    COPY requirements/app.in /app/requirements/flexmeasures_testplugin.txt
+    RUN pip3 install --no-cache-dir -r requirements/flexmeasures_testplugin.txt
+
+.. note:: No need to install flexmeasures here, as the Docker image we are based on already installed FlexMeasures from code. If you pip3-install your plugin here (assuming it's on Pypi), check if it recongizes that FlexMeasures installation as it should.
+
+.. warning:: Using the :ref:`plugin-config` setting like this depends on FlexMeasures version v0.14.
+
+
+
 Adding your own style sheets
 ----------------------------
 

--- a/documentation/plugin/customisation.rst
+++ b/documentation/plugin/customisation.rst
@@ -16,7 +16,7 @@ but in the background your custom scheduling algorithm is being used.
 Let's walk through an example!
 
 First, we need to write a a class (inhering from the Base Scheduler) with a `schedule` function which accepts arguments just like the in-built schedulers (their code is `here <https://github.com/FlexMeasures/flexmeasures/tree/main/flexmeasures/data/models/planning>`_).
-The following minimal example gives you an idea of some meta information you can add for labelling your data, as well as the inputs and outputs of such a scheduling function:
+The following minimal example gives you an idea of some meta information you can add for labeling your data, as well as the inputs and outputs of such a scheduling function:
 
 .. code-block:: python
 
@@ -86,8 +86,8 @@ Deploying your plugin via Docker
 
 You can extend the FlexMeasures Docker image with your plugin's logic.
 
-Imagine your package (with an ``__init__.py`` file, one of the setups we discussed in :ref:`plugin_showcase`) is called ``flexmeasures_testplugin``.
-Then, this is a minimal possible Dockerfile:
+Imagine your plugin package (with an ``__init__.py`` file, one of the setups we discussed in :ref:`plugin_showcase`) is called ``flexmeasures_testplugin``.
+Then, this is a minimal possible Dockerfile ― containers based on this will serve FlexMeasures (see the original Dockerfile in the FlexMeasures repository) with the plugin logic, like endpoints:
 
 .. code-block:: docker
 
@@ -96,6 +96,7 @@ Then, this is a minimal possible Dockerfile:
     COPY flexmeasures_testplugin/ /app/flexmeasures_testplugin
     ENV FLEXMEASURES_PLUGINS="/app/flexmeasures_testplugin"
 
+You can of course also add multiple plugins this way.
 
 If you also want to install your requirements, you could for instance add these layers:
 

--- a/documentation/plugin/customisation.rst
+++ b/documentation/plugin/customisation.rst
@@ -104,9 +104,7 @@ If you also want to install your requirements, you could for instance add these 
     COPY requirements/app.in /app/requirements/flexmeasures_testplugin.txt
     RUN pip3 install --no-cache-dir -r requirements/flexmeasures_testplugin.txt
 
-.. note:: No need to install flexmeasures here, as the Docker image we are based on already installed FlexMeasures from code. If you pip3-install your plugin here (assuming it's on Pypi), check if it recongizes that FlexMeasures installation as it should.
-
-.. warning:: Using the :ref:`plugin-config` setting like this depends on FlexMeasures version v0.14.
+.. note:: No need to install flexmeasures here, as the Docker image we are based on already installed FlexMeasures from code. If you pip3-install your plugin here (assuming it's on Pypi), check if it recognizes that FlexMeasures installation as it should.
 
 
 

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -95,7 +95,7 @@ class Config(object):
     # This setting contains the domain on which FlexMeasures runs
     # and the first month when the domain was under the current owner's administration
     FLEXMEASURES_HOSTS_AND_AUTH_START: dict = {"flexmeasures.io": "2021-01"}
-    FLEXMEASURES_PLUGINS: List[str] = []
+    FLEXMEASURES_PLUGINS: Union[List[str], str] = []  # str will be checked for commas
     FLEXMEASURES_PROFILE_REQUESTS: bool = False
     FLEXMEASURES_DB_BACKUP_PATH: str = "migrations/dumps"
     FLEXMEASURES_MENU_LOGO_PATH: str = ""

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -95,7 +95,7 @@ class Config(object):
     # This setting contains the domain on which FlexMeasures runs
     # and the first month when the domain was under the current owner's administration
     FLEXMEASURES_HOSTS_AND_AUTH_START: dict = {"flexmeasures.io": "2021-01"}
-    FLEXMEASURES_PLUGINS: Union[List[str], str] = []  # str will be checked for commas
+    FLEXMEASURES_PLUGINS: List[str] | str = []  # str will be checked for commas
     FLEXMEASURES_PROFILE_REQUESTS: bool = False
     FLEXMEASURES_DB_BACKUP_PATH: str = "migrations/dumps"
     FLEXMEASURES_MENU_LOGO_PATH: str = ""

--- a/flexmeasures/utils/config_utils.py
+++ b/flexmeasures/utils/config_utils.py
@@ -163,7 +163,7 @@ def read_env_vars(app: Flask):
     for var in (
         required
         + list(warnable.keys())
-        + ["LOGGING_LEVEL", "MAPBOX_ACCESS_TOKEN", "SENTRY_SDN"]
+        + ["LOGGING_LEVEL", "MAPBOX_ACCESS_TOKEN", "SENTRY_SDN", "FLEXMEASURES_PLUGINS"]
     ):
         app.config[var] = os.getenv(var, app.config.get(var, None))
     # DEBUG in env can come in as a string ("True") so make sure we don't trip here

--- a/flexmeasures/utils/plugin_utils.py
+++ b/flexmeasures/utils/plugin_utils.py
@@ -24,6 +24,8 @@ def register_plugins(app: Flask):
     (last part of the path).
     """
     plugins = app.config.get("FLEXMEASURES_PLUGINS", [])
+    if isinstance(plugins, str):
+        plugins = [plugin.strip() for plugin in plugins.split(",")]
     if not isinstance(plugins, list):
         app.logger.error(
             f"The value of FLEXMEASURES_PLUGINS is not a list: {plugins}. Cannot install plugins ..."

--- a/flexmeasures/utils/plugin_utils.py
+++ b/flexmeasures/utils/plugin_utils.py
@@ -24,6 +24,9 @@ def register_plugins(app: Flask):
     (last part of the path).
     """
     plugins = app.config.get("FLEXMEASURES_PLUGINS", [])
+    if not plugins and "FLEXMEASURES_PLUGIN_PATHS" in app.config:
+        app.logger.warning("Plugins found via FLEXMEASURES_PLUGIN_PATHS. This setting will be sunset in v0.14. Please switch to FLEXMEASURES_PLUGINS."
+        plugins = app.config.get("FLEXMEASURES_PLUGIN_PATHS", [])
     if isinstance(plugins, str):
         plugins = [plugin.strip() for plugin in plugins.split(",")]
     if not isinstance(plugins, list):

--- a/flexmeasures/utils/plugin_utils.py
+++ b/flexmeasures/utils/plugin_utils.py
@@ -28,7 +28,7 @@ def register_plugins(app: Flask):
         app.logger.warning("Plugins found via FLEXMEASURES_PLUGIN_PATHS. This setting will be sunset in v0.14. Please switch to FLEXMEASURES_PLUGINS."
         plugins = app.config.get("FLEXMEASURES_PLUGIN_PATHS", [])
     if isinstance(plugins, str):
-        plugins = [plugin.strip() for plugin in plugins.split(",")]
+        plugins = [plugin.strip() for plugin in plugins.split(",") if len(plugin.strip()) > 0]
     if not isinstance(plugins, list):
         app.logger.error(
             f"The value of FLEXMEASURES_PLUGINS is not a list: {plugins}. Cannot install plugins ..."

--- a/flexmeasures/utils/plugin_utils.py
+++ b/flexmeasures/utils/plugin_utils.py
@@ -24,12 +24,6 @@ def register_plugins(app: Flask):
     (last part of the path).
     """
     plugins = app.config.get("FLEXMEASURES_PLUGINS", [])
-    if not plugins:
-        # this is deprecated behaviour which we should remove in version 1.0
-        app.logger.debug(
-            "No plugins configured. Attempting deprecated setting FLEXMEASURES_PLUGIN_PATHS ..."
-        )
-        plugins = app.config.get("FLEXMEASURES_PLUGIN_PATHS", [])
     if not isinstance(plugins, list):
         app.logger.error(
             f"The value of FLEXMEASURES_PLUGINS is not a list: {plugins}. Cannot install plugins ..."

--- a/flexmeasures/utils/plugin_utils.py
+++ b/flexmeasures/utils/plugin_utils.py
@@ -25,10 +25,14 @@ def register_plugins(app: Flask):
     """
     plugins = app.config.get("FLEXMEASURES_PLUGINS", [])
     if not plugins and "FLEXMEASURES_PLUGIN_PATHS" in app.config:
-        app.logger.warning("Plugins found via FLEXMEASURES_PLUGIN_PATHS. This setting will be sunset in v0.14. Please switch to FLEXMEASURES_PLUGINS."
+        app.logger.warning(
+            "Plugins found via FLEXMEASURES_PLUGIN_PATHS. This setting will be sunset in v0.14. Please switch to FLEXMEASURES_PLUGINS."
+        )
         plugins = app.config.get("FLEXMEASURES_PLUGIN_PATHS", [])
     if isinstance(plugins, str):
-        plugins = [plugin.strip() for plugin in plugins.split(",") if len(plugin.strip()) > 0]
+        plugins = [
+            plugin.strip() for plugin in plugins.split(",") if len(plugin.strip()) > 0
+        ]
     if not isinstance(plugins, list):
         app.logger.error(
             f"The value of FLEXMEASURES_PLUGINS is not a list: {plugins}. Cannot install plugins ..."


### PR DESCRIPTION
The FLEXMEASURES_PLUGINS settings should also be possible as an env var. This is handy for devs, who simply want to add their own logic, but are not busy with how FlexMeasures works or is deployed. For example, they use a docker-compose or Kubernetes setup and just add their logic.