### PR TITLE
Modern type annotations

### DIFF
--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -248,3 +248,5 @@ fsdomain
 filepath
 Changelog
 Bugfixes
+Dockerfile
+―

--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -246,3 +246,5 @@ deserializing
 kwargs
 fsdomain
 filepath
+Changelog
+Bugfixes

--- a/documentation/_static/css/custom.css
+++ b/documentation/_static/css/custom.css
@@ -1,6 +1,9 @@
 div section {
     text-align: justify;
 }
+#table-of-contents {
+    text-align: left;
+}
 
 div .toctree-wrapper > ul {
     column-count: 2;

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -15,6 +15,8 @@ Bugfixes
 Infrastructure / Support
 ----------------------
 
+.. warning:: The setting `FLEXMEASURES_PLUGIN_PATHS` has been sunset. It had been deprecated since v0.7.
+
 
 v0.13.0 | May 1, 2023
 ============================

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -15,7 +15,9 @@ Bugfixes
 Infrastructure / Support
 ----------------------
 
-.. warning:: The setting `FLEXMEASURES_PLUGIN_PATHS` has been sunset. It had been deprecated since v0.7.
+* The setting FLEXMEASURES_PLUGINS can be set as environment variable now (as a comma-separated list) [see `PR #660 <https://www.github.com/FlexMeasures/flexmeasures/pull/660>`_]
+
+.. warning:: The setting `FLEXMEASURES_PLUGIN_PATHS` has been deprecated since v0.7. It has now been sunset. Please replace it with :ref:`plugin-config`.
 
 
 v0.13.0 | May 1, 2023

--- a/documentation/configuration.rst
+++ b/documentation/configuration.rst
@@ -26,6 +26,8 @@ Level above which log messages are added to the log file. See the ``logging`` pa
 
 Default: ``logging.WARNING``
 
+.. note:: This setting is also recognized as environment variable.
+
 
 .. _modes-config:
 
@@ -72,6 +74,7 @@ FLEXMEASURES_PLUGINS
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A list of plugins you want FlexMeasures to load (e.g. for custom views or CLI functions). 
+This can be a Python list (e.g. ``["plugin1", "plugin2"]``) or a comma-separated string (e.g. ``"plugin1, plugin2"``).
 
 Two types of entries are possible here:
 
@@ -80,8 +83,9 @@ Two types of entries are possible here:
 
 Added functionality in plugins needs to be based on Flask Blueprints. See :ref:`plugins` for more information and examples.
 
-
 Default: ``[]``
+
+.. note:: This setting is also recognized as environment variable.
 
 
 FLEXMEASURES_DB_BACKUP_PATH
@@ -299,6 +303,8 @@ Token for accessing the MapBox API (for displaying maps on the dashboard and ass
 
 Default: ``None``
 
+.. note:: This setting is also recognized as environment variable.
+
 .. _sentry_access_token:
 
 SENTRY_SDN
@@ -308,6 +314,8 @@ Set tokenized URL, so errors will be sent to Sentry when ``app.env`` is not in `
 E.g.: ``https://<examplePublicKey>@o<something>.ingest.sentry.io/<project-Id>``
 
 Default: ``None``
+
+.. note:: This setting is also recognized as environment variable.
 
 
 SQLAlchemy
@@ -322,6 +330,9 @@ SQLALCHEMY_DATABASE_URI (**)
 Connection string to the postgres database, format: ``postgresql://<user>:<password>@<host-address>[:<port>]/<db>``
 
 Default: ``None``
+
+.. note:: This setting is also recognized as environment variable.
+
 
 SQLALCHEMY_ENGINE_OPTIONS
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -431,6 +442,8 @@ For FlexMeasures to be able to send email to users (e.g. for resetting passwords
 
 This is only a selection of the most important settings.
 See `the Flask-Mail Docs <https://flask-mail.readthedocs.io/en/latest/#configuring-flask-mail>`_ for others.
+
+.. note:: The mail settings are also recognized as environment variables.
 
 MAIL_SERVER (*)
 ^^^^^^^^^^^^^^^
@@ -542,6 +555,9 @@ Redis
 -----
 
 FlexMeasures uses the Redis database to support our forecasting and scheduling job queues.
+
+.. note:: The redis settings are also recognized as environment variables.
+
 
 FLEXMEASURES_REDIS_URL (*)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/documentation/configuration.rst
+++ b/documentation/configuration.rst
@@ -6,7 +6,7 @@ Configuration
 The following configurations are used by FlexMeasures.
 
 Required settings (e.g. postgres db) are marked with a double star (**).
-To enable easier quickstart tutorials, these required settings can be set by environment variables.
+To enable easier quickstart tutorials, continuous integration use cases and basic usage of FlexMeasures within other projects, these required settings, as well as a few others, can be set by environment variables ― this is also noted per setting.
 Recommended settings (e.g. mail, redis) are marked by one star (*).
 
 .. note:: FlexMeasures is best configured via a config file. The config file for FlexMeasures can be placed in one of two locations: 
@@ -85,7 +85,7 @@ Added functionality in plugins needs to be based on Flask Blueprints. See :ref:`
 
 Default: ``[]``
 
-.. note:: This setting is also recognized as environment variable.
+.. note:: This setting is also recognized as environment variable (since v0.14, which is also the version required to pass this setting as a string).
 
 
 FLEXMEASURES_DB_BACKUP_PATH

--- a/documentation/plugin/customisation.rst
+++ b/documentation/plugin/customisation.rst
@@ -230,7 +230,6 @@ We demonstrate this here, and also show how you can add your own custom field sc
 .. code-block:: python
 
     from datetime import datetime
-    from typing import Optional
 
     import click
     from flexmeasures.data.schemas import AwareDateTimeField
@@ -258,7 +257,7 @@ We demonstrate this here, and also show how you can add your own custom field sc
     )
     def schedule_meeting(
         where: str,
-        when: Optional[datetime] = None,
+        when: datetime | None = None,
     ):
         print(f"Okay, see you {where} on {when}.")
 

--- a/documentation/plugin/customisation.rst
+++ b/documentation/plugin/customisation.rst
@@ -81,6 +81,35 @@ get computed by your custom function! For later lookup, the data will be linked 
 .. todo:: We're planning to use a similar approach to allow for custom forecasting algorithms, as well.
 
 
+Deploying your plugin via Docker
+----------------------------------
+
+You can extend the FlexMeasures Docker image with your plugin's logic.
+
+Imagine your package (with an ``__init__.py`` file, one of the setups we discussed in :ref:`plugin_showcase`) is called ``flexmeasures_testplugin``.
+Then, this is a minimal possible Dockerfile:
+
+.. code-block:: docker
+
+    FROM lfenergy/flexmeasures
+
+    COPY flexmeasures_testplugin/ /app/flexmeasures_testplugin
+    ENV FLEXMEASURES_PLUGINS="/app/flexmeasures_testplugin"
+
+
+If you also want to install your requirements, you could for instance add these layers:
+
+.. code-block:: docker
+
+    COPY requirements/app.in /app/requirements/flexmeasures_testplugin.txt
+    RUN pip3 install --no-cache-dir -r requirements/flexmeasures_testplugin.txt
+
+.. note:: No need to install flexmeasures here, as the Docker image we are based on already installed FlexMeasures from code. If you pip3-install your plugin here (assuming it's on Pypi), check if it recongizes that FlexMeasures installation as it should.
+
+.. warning:: Using the :ref:`plugin-config` setting like this depends on FlexMeasures version v0.14.
+
+
+
 Adding your own style sheets
 ----------------------------
 

--- a/documentation/plugin/customisation.rst
+++ b/documentation/plugin/customisation.rst
@@ -16,7 +16,7 @@ but in the background your custom scheduling algorithm is being used.
 Let's walk through an example!
 
 First, we need to write a a class (inhering from the Base Scheduler) with a `schedule` function which accepts arguments just like the in-built schedulers (their code is `here <https://github.com/FlexMeasures/flexmeasures/tree/main/flexmeasures/data/models/planning>`_).
-The following minimal example gives you an idea of some meta information you can add for labelling your data, as well as the inputs and outputs of such a scheduling function:
+The following minimal example gives you an idea of some meta information you can add for labeling your data, as well as the inputs and outputs of such a scheduling function:
 
 .. code-block:: python
 
@@ -86,8 +86,8 @@ Deploying your plugin via Docker
 
 You can extend the FlexMeasures Docker image with your plugin's logic.
 
-Imagine your package (with an ``__init__.py`` file, one of the setups we discussed in :ref:`plugin_showcase`) is called ``flexmeasures_testplugin``.
-Then, this is a minimal possible Dockerfile:
+Imagine your plugin package (with an ``__init__.py`` file, one of the setups we discussed in :ref:`plugin_showcase`) is called ``flexmeasures_testplugin``.
+Then, this is a minimal possible Dockerfile ― containers based on this will serve FlexMeasures (see the original Dockerfile in the FlexMeasures repository) with the plugin logic, like endpoints:
 
 .. code-block:: docker
 
@@ -96,6 +96,7 @@ Then, this is a minimal possible Dockerfile:
     COPY flexmeasures_testplugin/ /app/flexmeasures_testplugin
     ENV FLEXMEASURES_PLUGINS="/app/flexmeasures_testplugin"
 
+You can of course also add multiple plugins this way.
 
 If you also want to install your requirements, you could for instance add these layers:
 

--- a/documentation/plugin/customisation.rst
+++ b/documentation/plugin/customisation.rst
@@ -104,9 +104,7 @@ If you also want to install your requirements, you could for instance add these 
     COPY requirements/app.in /app/requirements/flexmeasures_testplugin.txt
     RUN pip3 install --no-cache-dir -r requirements/flexmeasures_testplugin.txt
 
-.. note:: No need to install flexmeasures here, as the Docker image we are based on already installed FlexMeasures from code. If you pip3-install your plugin here (assuming it's on Pypi), check if it recongizes that FlexMeasures installation as it should.
-
-.. warning:: Using the :ref:`plugin-config` setting like this depends on FlexMeasures version v0.14.
+.. note:: No need to install flexmeasures here, as the Docker image we are based on already installed FlexMeasures from code. If you pip3-install your plugin here (assuming it's on Pypi), check if it recognizes that FlexMeasures installation as it should.
 
 
 

--- a/flexmeasures/api/common/schemas/sensor_data.py
+++ b/flexmeasures/api/common/schemas/sensor_data.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from datetime import timedelta
-from typing import List, Union
 
 from flask_login import current_user
 from isodate import datetime_isoformat
@@ -33,16 +34,16 @@ from flexmeasures.auth.policy import check_access
 class SingleValueField(fields.Float):
     """Field that both de-serializes and serializes a single value to a list of floats (length 1)."""
 
-    def _deserialize(self, value, attr, obj, **kwargs) -> List[float]:
+    def _deserialize(self, value, attr, obj, **kwargs) -> list[float]:
         return [self._validated(value)]
 
-    def _serialize(self, value, attr, data, **kwargs) -> List[float]:
+    def _serialize(self, value, attr, data, **kwargs) -> list[float]:
         return [self._validated(value)]
 
 
 def select_schema_to_ensure_list_of_floats(
-    values: Union[List[float], float], _
-) -> Union[fields.List, SingleValueField]:
+    values: list[float] | float, _
+) -> fields.List | SingleValueField:
     """Allows both a single float and a list of floats. Always returns a list of floats.
 
     Meant to improve user experience by not needing to make a list out of a single item, such that:

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
-from typing import Optional
 
 from flask import current_app
 from flask_classful import FlaskView, route
@@ -213,9 +214,9 @@ class SensorAPI(FlaskView):
         sensor: Sensor,
         start_of_schedule: datetime,
         duration: timedelta,
-        belief_time: Optional[datetime] = None,
-        flex_model: Optional[dict] = None,
-        flex_context: Optional[dict] = None,
+        belief_time: datetime | None = None,
+        flex_model: dict | None = None,
+        flex_context: dict | None = None,
         **kwargs,
     ):
         """

--- a/flexmeasures/app.py
+++ b/flexmeasures/app.py
@@ -1,7 +1,5 @@
-# flake8: noqa: E402
 from __future__ import annotations
 
-import os
 import time
 
 from flask import Flask, g, request
@@ -15,7 +13,7 @@ from redis import Redis
 from rq import Queue
 
 
-def create(
+def create(  # noqa C901
     env: str | None = None,
     path_to_config: str | None = None,
     plugins: list[str] | None = None,
@@ -57,12 +55,12 @@ def create(
     if plugins:
         app.config["FLEXMEASURES_PLUGINS"] += plugins
     add_basic_error_handlers(app)
-    if not app.env in ("development", "documentation") and not app.testing:
+    if app.env not in ("development", "documentation") and not app.testing:
         init_sentry(app)
 
     app.mail = Mail(app)
     FlaskJSON(app)
-    cors = CORS(app)
+    CORS(app)
 
     # configure Redis (for redis queue)
     if app.testing:
@@ -92,7 +90,7 @@ def create(
     set_secret_key(app)
     if app.config.get("SECURITY_PASSWORD_SALT", None) is None:
         app.config["SECURITY_PASSWORD_SALT"] = app.config["SECRET_KEY"]
-    if not app.env in ("documentation", "development"):
+    if app.env not in ("documentation", "development"):
         SSLify(app)
 
     # Register database and models, including user auth security handlers

--- a/flexmeasures/app.py
+++ b/flexmeasures/app.py
@@ -1,7 +1,8 @@
 # flake8: noqa: E402
+from __future__ import annotations
+
 import os
 import time
-from typing import Optional, List
 
 from flask import Flask, g, request
 from flask.cli import load_dotenv
@@ -15,9 +16,9 @@ from rq import Queue
 
 
 def create(
-    env: Optional[str] = None,
-    path_to_config: Optional[str] = None,
-    plugins: Optional[List[str]] = None,
+    env: str | None = None,
+    path_to_config: str | None = None,
+    plugins: list[str] | None = None,
 ) -> Flask:
     """
     Create a Flask app and configure it.

--- a/flexmeasures/auth/decorators.py
+++ b/flexmeasures/auth/decorators.py
@@ -1,4 +1,6 @@
-from typing import Callable, Optional
+from __future__ import annotations
+
+from typing import Callable
 from functools import wraps
 from flask import current_app
 from flask_json import as_json
@@ -99,9 +101,9 @@ def account_roles_required(*account_roles):
 
 def permission_required_for_context(
     permission: str,
-    arg_pos: Optional[int] = None,
-    arg_name: Optional[str] = None,
-    arg_loader: Optional[Callable] = None,
+    arg_pos: int | None = None,
+    arg_name: str | None = None,
+    arg_loader: Callable | None = None,
 ):
     """
     This decorator can be used to make sure that the current user has the necessary permission to access the context.

--- a/flexmeasures/auth/error_handling.py
+++ b/flexmeasures/auth/error_handling.py
@@ -5,9 +5,9 @@ Beware: There is a historical confusion of naming between authentication and aut
         Names of Responses have to be kept as they were called in original W3 protocols.
         See explanation below.
 """
+from __future__ import annotations
 
-
-from typing import Optional, Callable, List
+from typing import Callable
 
 from flask import request, jsonify, current_app
 
@@ -45,9 +45,7 @@ def unauthorized_handler_e(e):
     return unauthorized_handler()
 
 
-def unauthorized_handler(
-    func: Optional[Callable] = None, params: Optional[List] = None
-):
+def unauthorized_handler(func: Callable | None = None, params: list | None = None):
     """
     Handler for authorization problems.
     :param func: the Flask-Security-Too decorator, if relevant, and params are its parameters.
@@ -75,7 +73,7 @@ def unauthenticated_handler_e(e):
 
 
 def unauthenticated_handler(
-    mechanisms: Optional[List] = None, headers: Optional[dict] = None
+    mechanisms: list | None = None, headers: dict | None = None
 ):
     """
     Handler for authentication problems.

--- a/flexmeasures/auth/policy.py
+++ b/flexmeasures/auth/policy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Union  # Use | instead of Union when FM stops supporting Python 3.9
+# Use | instead of Union when FM stops supporting Python 3.9 (https://github.com/python/cpython/issues/86399)
+from typing import Union
 
 from flask import current_app
 from flask_security import current_user

--- a/flexmeasures/auth/policy.py
+++ b/flexmeasures/auth/policy.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-# Use | instead of Union when FM stops supporting Python 3.9 (https://github.com/python/cpython/issues/86399)
+# Use | instead of Union when FM stops supporting Python 3.9 (because of https://github.com/python/cpython/issues/86399)
 from typing import Union
 
 from flask import current_app

--- a/flexmeasures/auth/policy.py
+++ b/flexmeasures/auth/policy.py
@@ -1,4 +1,6 @@
-from typing import Dict, Union, Tuple, List
+from __future__ import annotations
+
+from typing import Union  # Use | instead of Union when FM stops supporting Python 3.9
 
 from flask import current_app
 from flask_security import current_user
@@ -13,13 +15,13 @@ ADMIN_READER_ROLE = "admin-reader"
 # constants to allow access to certain groups
 EVERY_LOGGED_IN_USER = "every-logged-in-user"
 
-PRINCIPALS_TYPE = Union[str, Tuple[str], List[Union[str, Tuple[str]]]]
+PRINCIPALS_TYPE = Union[str, tuple[str], list[Union[str, tuple[str]]]]
 
 
 class AuthModelMixin(object):
-    def __acl__(self) -> Dict[str, PRINCIPALS_TYPE]:
+    def __acl__(self) -> dict[str, PRINCIPALS_TYPE]:
         """
-        This function returns an access control list (ACL) for a instance of a model which is relevant for authorization.
+        This function returns an access control list (ACL) for an instance of a model which is relevant for authorization.
 
         ACLs in FlexMeasures are inspired by Pyramid's resource ACLs.
         In an ACL, we list which principal (security contexts, see below) allow certain kinds of actions

--- a/flexmeasures/auth/tests/test_principal_matching.py
+++ b/flexmeasures/auth/tests/test_principal_matching.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 import pytest
 
@@ -8,7 +8,7 @@ from flexmeasures.auth.policy import user_matches_principals
 class MockAccount:
 
     id: int
-    account_roles: List[str]
+    account_roles: list[str]
 
     def __init__(self, id, roles):
         self.id = id
@@ -21,7 +21,7 @@ class MockAccount:
 class MockUser:
 
     id: int
-    roles: List[str]
+    roles: list[str]
     account: MockAccount
 
     def __init__(self, id, username, roles, account):
@@ -35,7 +35,7 @@ class MockUser:
 
 
 def make_mock_user(
-    user_id: int, user_roles: List[str], account_id: int, account_roles: List[str]
+    user_id: int, user_roles: list[str], account_id: int, account_roles: list[str]
 ) -> MockUser:
     account = MockAccount(account_id, account_roles)
     return MockUser(id=user_id, username="Tester", roles=user_roles, account=account)

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Tuple
 import json
 
 from marshmallow import validate
@@ -134,8 +133,8 @@ def new_user(
     username: str,
     email: str,
     account_id: int,
-    roles: List[str],
-    timezone_optional: Optional[str],
+    roles: list[str],
+    timezone_optional: str | None,
 ):
     """
     Create a FlexMeasures user.
@@ -485,25 +484,25 @@ def add_beliefs(
     file: str,
     sensor: Sensor,
     source: str,
-    filter_columns: List[int],
-    filter_values: List[int],
-    unit: Optional[str] = None,
-    horizon: Optional[int] = None,
-    cp: Optional[float] = None,
+    filter_columns: list[int],
+    filter_values: list[int],
+    unit: str | None = None,
+    horizon: int | None = None,
+    cp: float | None = None,
     resample: bool = True,
     allow_overwrite: bool = False,
     skiprows: int = 1,
     na_values: list[str] | None = None,
     keep_default_na: bool = False,
-    nrows: Optional[int] = None,
+    nrows: int | None = None,
     datecol: int = 0,
     valuecol: int = 1,
-    beliefcol: Optional[int] = None,
-    timezone: Optional[str] = None,
+    beliefcol: int | None = None,
+    timezone: str | None = None,
     delimiter: str = ",",
     decimal: str = ".",
-    thousands: Optional[str] = None,
-    sheet_number: Optional[int] = None,
+    thousands: str | None = None,
+    sheet_number: int | None = None,
     **kwargs,  # in-code calls to this CLI command can set additional kwargs for use in pandas.read_csv or pandas.read_excel
 ):
     """Add sensor data from a csv file (also accepts xls or xlsx).
@@ -652,10 +651,10 @@ def add_beliefs(
 def add_annotation(
     content: str,
     start_str: str,
-    end_str: Optional[str],
-    account_ids: List[int],
-    generic_asset_ids: List[int],
-    sensor_ids: List[int],
+    end_str: str | None,
+    account_ids: list[int],
+    generic_asset_ids: list[int],
+    sensor_ids: list[int],
     user_id: int,
 ):
     """Add annotation to accounts, assets and/or sensors."""
@@ -737,9 +736,9 @@ def add_annotation(
 )
 def add_holidays(
     year: int,
-    countries: List[str],
-    generic_asset_ids: List[int],
-    account_ids: List[int],
+    countries: list[str],
+    generic_asset_ids: list[int],
+    account_ids: list[int],
 ):
     """Add holiday annotations to accounts and/or assets."""
     calendars = workalendar_registry.get_calendars(countries)
@@ -831,11 +830,11 @@ def add_holidays(
     "To process the job, run a worker (on any computer, but configured to the same databases) to process the 'forecasting' queue. Defaults to False.",
 )
 def create_forecasts(
-    sensor_ids: List[int],
+    sensor_ids: list[int],
     from_date_str: str = "2015-02-08",
     to_date_str: str = "2015-12-31",
-    horizons_as_hours: List[str] = ["1"],
-    resolution: Optional[int] = None,
+    horizons_as_hours: list[str] = ["1"],
+    resolution: int | None = None,
     as_job: bool = False,
 ):
     """
@@ -859,7 +858,7 @@ def create_forecasts(
         timezone
     )
 
-    event_resolution: Optional[timedelta]
+    event_resolution: timedelta | None
     if resolution is not None:
         event_resolution = timedelta(minutes=resolution)
     else:
@@ -1026,10 +1025,10 @@ def add_schedule_for_storage(
     start: datetime,
     duration: timedelta,
     soc_at_start: ur.Quantity,
-    soc_target_strings: List[Tuple[ur.Quantity, str]],
-    soc_min: Optional[ur.Quantity] = None,
-    soc_max: Optional[ur.Quantity] = None,
-    roundtrip_efficiency: Optional[ur.Quantity] = None,
+    soc_target_strings: list[tuple[ur.Quantity, str]],
+    soc_min: ur.Quantity | None = None,
+    soc_max: ur.Quantity | None = None,
+    roundtrip_efficiency: ur.Quantity | None = None,
     as_job: bool = False,
 ):
     """Create a new schedule for a storage asset.
@@ -1253,7 +1252,7 @@ def check_timezone(timezone):
         raise click.Abort()
 
 
-def check_errors(errors: Dict[str, List[str]]):
+def check_errors(errors: dict[str, list[str]]):
     if errors:
         click.secho(
             f"Please correct the following errors:\n{errors}.\n Use the --help flag to learn more.",

--- a/flexmeasures/cli/data_delete.py
+++ b/flexmeasures/cli/data_delete.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 from datetime import timedelta
 from itertools import chain
-from typing import Optional
 
 import click
 from flask import current_app as app
@@ -165,7 +166,7 @@ def delete_structure(force):
 )
 def delete_measurements(
     force: bool,
-    sensor_id: Optional[int] = None,
+    sensor_id: int | None = None,
 ):
     """Delete measurements (ex-post beliefs, i.e. with belief_horizon <= 0)."""
     if not force:
@@ -187,7 +188,7 @@ def delete_measurements(
 )
 def delete_prognoses(
     force: bool,
-    sensor_id: Optional[int] = None,
+    sensor_id: int | None = None,
 ):
     """Delete forecasts and schedules (ex-ante beliefs, i.e. with belief_horizon > 0)."""
     if not force:
@@ -217,7 +218,7 @@ def delete_prognoses(
     help="Use the --keep-measurements flag to keep beliefs with a zero or negative belief horizon (measurements, nowcasts and backcasts).",
 )
 def delete_unchanged_beliefs(
-    sensor_id: Optional[int] = None,
+    sensor_id: int | None = None,
     delete_unchanged_forecasts: bool = True,
     delete_unchanged_measurements: bool = True,
 ):
@@ -285,7 +286,7 @@ def delete_unchanged_beliefs(
     type=int,
     help="Delete NaN time series data for a single sensor only. Follow up with the sensor's ID.",
 )
-def delete_nan_beliefs(sensor_id: Optional[int] = None):
+def delete_nan_beliefs(sensor_id: int | None = None):
     """Delete NaN beliefs."""
     q = db.session.query(TimedBelief)
     if sensor_id is not None:

--- a/flexmeasures/cli/data_edit.py
+++ b/flexmeasures/cli/data_edit.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from datetime import timedelta
-from typing import Union, List, Optional
 
 import click
 import pandas as pd
@@ -83,13 +84,13 @@ def fm_edit_data():
 )
 def edit_attribute(
     attribute_key: str,
-    assets: List[GenericAsset],
-    sensors: List[Sensor],
+    assets: list[GenericAsset],
+    sensors: list[Sensor],
     attribute_null_value: bool,
-    attribute_float_value: Optional[float] = None,
-    attribute_bool_value: Optional[bool] = None,
-    attribute_str_value: Optional[str] = None,
-    attribute_int_value: Optional[int] = None,
+    attribute_float_value: float | None = None,
+    attribute_bool_value: bool | None = None,
+    attribute_str_value: str | None = None,
+    attribute_int_value: int | None = None,
 ):
     """Edit (or add) an asset attribute or sensor attribute."""
 
@@ -152,10 +153,10 @@ def edit_attribute(
     " and resampled data will be shown for manual approval.",
 )
 def resample_sensor_data(
-    sensor_ids: List[int],
+    sensor_ids: list[int],
     event_resolution_in_minutes: int,
-    start_str: Optional[str] = None,
-    end_str: Optional[str] = None,
+    start_str: str | None = None,
+    end_str: str | None = None,
     skip_integrity_check: bool = False,
 ):
     """Assign a new event resolution to an existing sensor and resample its data accordingly."""
@@ -208,11 +209,11 @@ app.cli.add_command(fm_edit_data)
 
 def parse_attribute_value(
     attribute_null_value: bool,
-    attribute_float_value: Optional[float] = None,
-    attribute_bool_value: Optional[bool] = None,
-    attribute_str_value: Optional[str] = None,
-    attribute_int_value: Optional[int] = None,
-) -> Union[float, int, bool, str, None]:
+    attribute_float_value: float | None = None,
+    attribute_bool_value: bool | None = None,
+    attribute_str_value: str | None = None,
+    attribute_int_value: int | None = None,
+) -> float | int | bool | str | None:
     """Parse attribute value."""
     if not single_true(
         [attribute_null_value]

--- a/flexmeasures/cli/data_show.py
+++ b/flexmeasures/cli/data_show.py
@@ -1,6 +1,7 @@
 """CLI Tasks for listing database contents - most useful in development"""
 
-from typing import Optional, List
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 
 import click
@@ -286,14 +287,14 @@ def list_data_sources():
     help="Set a filepath to store the beliefs as a CSV file.",
 )
 def plot_beliefs(
-    sensors: List[Sensor],
+    sensors: list[Sensor],
     start: datetime,
     duration: timedelta,
-    resolution: Optional[timedelta],
-    timezone: Optional[str],
-    belief_time_before: Optional[datetime],
-    source: Optional[DataSource],
-    filepath: Optional[str],
+    resolution: timedelta | None,
+    timezone: str | None,
+    belief_time_before: datetime | None,
+    source: DataSource | None,
+    filepath: str | None,
 ):
     """
     Show a simple plot of belief data directly in the terminal, and optionally, save the data to a CSV file.

--- a/flexmeasures/cli/jobs.py
+++ b/flexmeasures/cli/jobs.py
@@ -1,4 +1,5 @@
-from typing import List, Optional
+from __future__ import annotations
+
 import random
 import string
 
@@ -32,7 +33,7 @@ def fm_jobs():
     required=False,
     help="Give your worker a recognizable name. Defaults to random string. Defaults to fm-worker-<randomstring>",
 )
-def run_worker(queue: str, name: Optional[str]):
+def run_worker(queue: str, name: str | None):
     """
     Start a worker process for forecasting and/or scheduling jobs.
 
@@ -160,7 +161,7 @@ def handle_worker_exception(job, exc_type, exc_value, traceback):
     job.save_meta()
 
 
-def parse_queue_list(queue_names_str: str) -> List[Queue]:
+def parse_queue_list(queue_names_str: str) -> list[Queue]:
     """Parse a | separated string of queue names against the app.queues dict.
 
     The app.queues dict is expected to have queue names as keys, and rq.Queue objects as values.

--- a/flexmeasures/cli/monitor.py
+++ b/flexmeasures/cli/monitor.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
-from typing import Optional, List
 
 import click
 from flask import current_app as app
@@ -24,8 +25,8 @@ def fm_monitor():
 def send_task_monitoring_alert(
     task_name: str,
     msg: str,
-    latest_run: Optional[LatestTaskRun] = None,
-    custom_msg: Optional[str] = None,
+    latest_run: LatestTaskRun | None = None,
+    custom_msg: str | None = None,
 ):
     """
     Send any monitoring message per Sentry and per email. Also log an error.
@@ -138,11 +139,11 @@ def monitor_latest_run(task, custom_message):
 
 
 def send_lastseen_monitoring_alert(
-    users: List[User],
+    users: list[User],
     last_seen_delta: timedelta,
     alerted_users: bool,
-    account_role: Optional[str] = None,
-    user_role: Optional[str] = None,
+    account_role: str | None = None,
+    user_role: str | None = None,
 ):
     """
     Tell monitoring recipients and Sentry about user(s) we haven't seen in a while.
@@ -226,9 +227,9 @@ def send_lastseen_monitoring_alert(
 def monitor_last_seen(
     maximum_minutes_since_last_seen: int,
     alert_users: bool = False,
-    account_role: Optional[str] = None,
-    user_role: Optional[str] = None,
-    custom_user_message: Optional[str] = None,
+    account_role: str | None = None,
+    user_role: str | None = None,
+    custom_user_message: str | None = None,
 ):
     """
     Check if given users last contact (via a request) happened less than the allowed time ago.
@@ -242,7 +243,7 @@ def monitor_last_seen(
     last_seen_delta = timedelta(minutes=maximum_minutes_since_last_seen)
 
     # find users we haven't seen in the given time window
-    users: List[User] = User.query.filter(
+    users: list[User] = User.query.filter(
         User.last_seen_at < datetime.utcnow() - last_seen_delta
     ).all()
 

--- a/flexmeasures/cli/testing.py
+++ b/flexmeasures/cli/testing.py
@@ -1,5 +1,6 @@
 # flake8: noqa: E402
-from typing import List, Optional
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 import os
 
@@ -99,8 +100,8 @@ def test_making_forecasts():
     "--training", default=30, help="Number of days in the training and testing period."
 )
 def test_generic_model(
-    generic_asset_type_names: List[str],
-    sensor_name: Optional[str] = None,
+    generic_asset_type_names: list[str],
+    sensor_name: str | None = None,
     from_date: str = "2015-03-10",
     period: int = 3,
     horizon_hours: int = 1,

--- a/flexmeasures/cli/tests/utils.py
+++ b/flexmeasures/cli/tests/utils.py
@@ -1,4 +1,6 @@
-from typing import List, Callable
+from __future__ import annotations
+
+from typing import Callable
 
 from click.core import Command as ClickCommand
 
@@ -25,7 +27,7 @@ def to_flags(cli_input: dict) -> list:
     ]
 
 
-def get_click_commands(module) -> List[Callable]:
+def get_click_commands(module) -> list[Callable]:
     return [
         getattr(module, attr)
         for attr in dir(module)

--- a/flexmeasures/conftest.py
+++ b/flexmeasures/conftest.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 from contextlib import contextmanager
 import pytest
 from random import random
 from datetime import datetime, timedelta
-from typing import List, Dict
 import pytz
 
 from isodate import parse_duration
@@ -113,16 +114,16 @@ def create_test_db(app):
 
 
 @pytest.fixture(scope="module")
-def setup_accounts(db) -> Dict[str, Account]:
+def setup_accounts(db) -> dict[str, Account]:
     return create_test_accounts(db)
 
 
 @pytest.fixture(scope="function")
-def setup_accounts_fresh_db(fresh_db) -> Dict[str, Account]:
+def setup_accounts_fresh_db(fresh_db) -> dict[str, Account]:
     return create_test_accounts(fresh_db)
 
 
-def create_test_accounts(db) -> Dict[str, Account]:
+def create_test_accounts(db) -> dict[str, Account]:
     prosumer_account_role = AccountRole(name="Prosumer", description="A Prosumer")
     prosumer_account = Account(
         name="Test Prosumer Account", account_roles=[prosumer_account_role]
@@ -162,18 +163,18 @@ def create_test_accounts(db) -> Dict[str, Account]:
 
 
 @pytest.fixture(scope="module")
-def setup_roles_users(db, setup_accounts) -> Dict[str, User]:
+def setup_roles_users(db, setup_accounts) -> dict[str, User]:
     return create_roles_users(db, setup_accounts)
 
 
 @pytest.fixture(scope="function")
-def setup_roles_users_fresh_db(fresh_db, setup_accounts_fresh_db) -> Dict[str, User]:
+def setup_roles_users_fresh_db(fresh_db, setup_accounts_fresh_db) -> dict[str, User]:
     return create_roles_users(fresh_db, setup_accounts_fresh_db)
 
 
-def create_roles_users(db, test_accounts) -> Dict[str, User]:
+def create_roles_users(db, test_accounts) -> dict[str, User]:
     """Create a minimal set of roles and users"""
-    new_users: List[User] = []
+    new_users: list[User] = []
     # Two Prosumer users
     new_users.append(
         create_user(
@@ -230,16 +231,16 @@ def create_roles_users(db, test_accounts) -> Dict[str, User]:
 
 
 @pytest.fixture(scope="module")
-def setup_markets(db) -> Dict[str, Market]:
+def setup_markets(db) -> dict[str, Market]:
     return create_test_markets(db)
 
 
 @pytest.fixture(scope="function")
-def setup_markets_fresh_db(fresh_db) -> Dict[str, Market]:
+def setup_markets_fresh_db(fresh_db) -> dict[str, Market]:
     return create_test_markets(fresh_db)
 
 
-def create_test_markets(db) -> Dict[str, Market]:
+def create_test_markets(db) -> dict[str, Market]:
     """Create the epex_da market."""
 
     day_ahead = MarketType(
@@ -262,16 +263,16 @@ def create_test_markets(db) -> Dict[str, Market]:
 
 
 @pytest.fixture(scope="module")
-def setup_sources(db) -> Dict[str, DataSource]:
+def setup_sources(db) -> dict[str, DataSource]:
     return create_sources(db)
 
 
 @pytest.fixture(scope="function")
-def setup_sources_fresh_db(fresh_db) -> Dict[str, DataSource]:
+def setup_sources_fresh_db(fresh_db) -> dict[str, DataSource]:
     return create_sources(fresh_db)
 
 
-def create_sources(db) -> Dict[str, DataSource]:
+def create_sources(db) -> dict[str, DataSource]:
     seita_source = DataSource(name="Seita", type="demo script")
     db.session.add(seita_source)
     entsoe_source = DataSource(name="ENTSO-E", type="demo script")
@@ -280,19 +281,19 @@ def create_sources(db) -> Dict[str, DataSource]:
 
 
 @pytest.fixture(scope="module")
-def setup_asset_types(db) -> Dict[str, AssetType]:
+def setup_asset_types(db) -> dict[str, AssetType]:
     return create_test_asset_types(db)
 
 
 @pytest.fixture(scope="function")
-def setup_asset_types_fresh_db(fresh_db) -> Dict[str, AssetType]:
+def setup_asset_types_fresh_db(fresh_db) -> dict[str, AssetType]:
     return create_test_asset_types(fresh_db)
 
 
 @pytest.fixture(scope="module")
 def setup_generic_assets(
     db, setup_generic_asset_types, setup_accounts
-) -> Dict[str, AssetType]:
+) -> dict[str, AssetType]:
     """Make some generic assets used throughout."""
     return create_generic_assets(db, setup_generic_asset_types, setup_accounts)
 
@@ -300,7 +301,7 @@ def setup_generic_assets(
 @pytest.fixture(scope="function")
 def setup_generic_assets_fresh_db(
     fresh_db, setup_generic_asset_types_fresh_db, setup_accounts_fresh_db
-) -> Dict[str, AssetType]:
+) -> dict[str, AssetType]:
     """Make some generic assets used throughout."""
     return create_generic_assets(
         fresh_db, setup_generic_asset_types_fresh_db, setup_accounts_fresh_db
@@ -334,13 +335,13 @@ def create_generic_assets(db, setup_generic_asset_types, setup_accounts):
 
 
 @pytest.fixture(scope="module")
-def setup_generic_asset_types(db) -> Dict[str, AssetType]:
+def setup_generic_asset_types(db) -> dict[str, AssetType]:
     """Make some generic asset types used throughout."""
     return create_generic_asset_types(db)
 
 
 @pytest.fixture(scope="function")
-def setup_generic_asset_types_fresh_db(fresh_db) -> Dict[str, AssetType]:
+def setup_generic_asset_types_fresh_db(fresh_db) -> dict[str, AssetType]:
     """Make some generic asset types used throughout."""
     return create_generic_asset_types(fresh_db)
 
@@ -371,7 +372,7 @@ def create_generic_asset_types(db):
     )
 
 
-def create_test_asset_types(db) -> Dict[str, AssetType]:
+def create_test_asset_types(db) -> dict[str, AssetType]:
     """Make some asset types used throughout.
     Deprecated. Remove with Asset model."""
 
@@ -397,7 +398,7 @@ def create_test_asset_types(db) -> Dict[str, AssetType]:
 @pytest.fixture(scope="module")
 def setup_assets(
     db, setup_roles_users, setup_markets, setup_sources, setup_asset_types
-) -> Dict[str, Asset]:
+) -> dict[str, Asset]:
     """Add assets to known test users.
     Deprecated. Remove with Asset model."""
 
@@ -508,7 +509,7 @@ def create_beliefs(db: SQLAlchemy, setup_markets, setup_sources) -> int:
 @pytest.fixture(scope="module")
 def add_market_prices(
     db: SQLAlchemy, setup_assets, setup_markets, setup_sources
-) -> Dict[str, Sensor]:
+) -> dict[str, Sensor]:
     """Add two days of market prices for the EPEX day-ahead market."""
 
     # one day of test data (one complete sine curve)
@@ -556,14 +557,14 @@ def add_market_prices(
 @pytest.fixture(scope="module")
 def add_battery_assets(
     db: SQLAlchemy, setup_roles_users, setup_markets
-) -> Dict[str, Asset]:
+) -> dict[str, Asset]:
     return create_test_battery_assets(db, setup_roles_users, setup_markets)
 
 
 @pytest.fixture(scope="function")
 def add_battery_assets_fresh_db(
     fresh_db, setup_roles_users_fresh_db, setup_markets_fresh_db
-) -> Dict[str, Asset]:
+) -> dict[str, Asset]:
     return create_test_battery_assets(
         fresh_db, setup_roles_users_fresh_db, setup_markets_fresh_db
     )
@@ -571,7 +572,7 @@ def add_battery_assets_fresh_db(
 
 def create_test_battery_assets(
     db: SQLAlchemy, setup_roles_users, setup_markets
-) -> Dict[str, Asset]:
+) -> dict[str, Asset]:
     """
     Add two battery assets, set their capacity values and their initial SOC.
     """
@@ -632,14 +633,14 @@ def create_test_battery_assets(
 @pytest.fixture(scope="module")
 def add_charging_station_assets(
     db: SQLAlchemy, setup_roles_users, setup_markets
-) -> Dict[str, Asset]:
+) -> dict[str, Asset]:
     return create_charging_station_assets(db, setup_roles_users, setup_markets)
 
 
 @pytest.fixture(scope="function")
 def add_charging_station_assets_fresh_db(
     fresh_db: SQLAlchemy, setup_roles_users_fresh_db, setup_markets_fresh_db
-) -> Dict[str, Asset]:
+) -> dict[str, Asset]:
     return create_charging_station_assets(
         fresh_db, setup_roles_users_fresh_db, setup_markets_fresh_db
     )
@@ -647,7 +648,7 @@ def add_charging_station_assets_fresh_db(
 
 def create_charging_station_assets(
     db: SQLAlchemy, setup_roles_users, setup_markets
-) -> Dict[str, Asset]:
+) -> dict[str, Asset]:
     """Add uni- and bi-directional charging station assets, set their capacity value and their initial SOC."""
     db.session.add(
         AssetType(
@@ -716,18 +717,18 @@ def create_charging_station_assets(
 
 
 @pytest.fixture(scope="module")
-def add_weather_sensors(db, setup_generic_asset_types) -> Dict[str, Sensor]:
+def add_weather_sensors(db, setup_generic_asset_types) -> dict[str, Sensor]:
     return create_weather_sensors(db, setup_generic_asset_types)
 
 
 @pytest.fixture(scope="function")
 def add_weather_sensors_fresh_db(
     fresh_db, setup_generic_asset_types_fresh_db
-) -> Dict[str, Sensor]:
+) -> dict[str, Sensor]:
     return create_weather_sensors(fresh_db, setup_generic_asset_types_fresh_db)
 
 
-def create_weather_sensors(db: SQLAlchemy, generic_asset_types) -> Dict[str, Sensor]:
+def create_weather_sensors(db: SQLAlchemy, generic_asset_types) -> dict[str, Sensor]:
     """Add a weather station asset with two weather sensors."""
 
     weather_station = GenericAsset(

--- a/flexmeasures/data/models/annotations.py
+++ b/flexmeasures/data/models/annotations.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from datetime import timedelta
-from typing import List
 
 import pandas as pd
 
@@ -55,7 +56,7 @@ class Annotation(db.Model):
         allow_overwrite: bool = False,
         bulk_save_objects: bool = False,
         commit_transaction: bool = False,
-    ) -> List["Annotation"]:
+    ) -> list["Annotation"]:
         """Add a data frame describing annotations to the database and return the Annotation objects.
 
         :param df:                  Data frame describing annotations.
@@ -203,7 +204,7 @@ def get_or_create_annotation(
     return existing_annotation
 
 
-def to_annotation_frame(annotations: List[Annotation]) -> pd.DataFrame:
+def to_annotation_frame(annotations: list[Annotation]) -> pd.DataFrame:
     """Transform a list of annotations into a DataFrame.
 
     We don't use a BeliefsDataFrame here, because they are designed for quantitative data only.

--- a/flexmeasures/data/models/data_sources.py
+++ b/flexmeasures/data/models/data_sources.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from typing import Optional, TYPE_CHECKING
+
+from typing import TYPE_CHECKING
 
 import timely_beliefs as tb
 
@@ -33,9 +34,9 @@ class DataSource(db.Model, tb.BeliefSourceDBMixin):
 
     def __init__(
         self,
-        name: Optional[str] = None,
-        type: Optional[str] = None,
-        user: Optional[User] = None,
+        name: str | None = None,
+        type: str | None = None,
+        user: User | None = None,
         **kwargs,
     ):
         if user is not None:

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -1,4 +1,6 @@
-from typing import Any, List, Dict, Optional, Union, Type, Tuple
+from __future__ import annotations
+
+from typing import Any, Type
 from datetime import datetime as datetime_type, timedelta
 import json
 from flask import current_app
@@ -70,9 +72,9 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
     def __init__(
         self,
         name: str,
-        generic_asset: Optional[GenericAsset] = None,
-        generic_asset_id: Optional[int] = None,
-        attributes: Optional[dict] = None,
+        generic_asset: GenericAsset | None = None,
+        generic_asset_id: int | None = None,
+        attributes: dict | None = None,
         **kwargs,
     ):
         assert (generic_asset is None) ^ (
@@ -125,7 +127,7 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
             return "no entity address available"
 
     @property
-    def location(self) -> Optional[Tuple[float, float]]:
+    def location(self) -> tuple[float, float] | None:
         location = (self.get_attribute("latitude"), self.get_attribute("longitude"))
         if None not in location:
             return location
@@ -180,7 +182,7 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
 
     def check_required_attributes(
         self,
-        attributes: List[Union[str, Tuple[str, Union[Type, Tuple[Type, ...]]]]],
+        attributes: list[str | tuple[str, Type | tuple[Type, ...]]],
     ):
         """Raises if any attribute in the list of attributes is missing, or has the wrong type.
 
@@ -191,9 +193,13 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
 
     def latest_state(
         self,
-        source: Optional[
-            Union[DataSource, List[DataSource], int, List[int], str, List[str]]
-        ] = None,
+        source: DataSource
+        | list[DataSource]
+        | int
+        | list[int]
+        | str
+        | list[str]
+        | None = None,
     ) -> tb.BeliefsDataFrame:
         """Search the most recent event for this sensor, and return the most recent ex-post belief.
 
@@ -209,17 +215,21 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
 
     def search_annotations(
         self,
-        annotation_starts_after: Optional[datetime_type] = None,  # deprecated
-        annotations_after: Optional[datetime_type] = None,
-        annotation_ends_before: Optional[datetime_type] = None,  # deprecated
-        annotations_before: Optional[datetime_type] = None,
-        source: Optional[
-            Union[DataSource, List[DataSource], int, List[int], str, List[str]]
-        ] = None,
+        annotation_starts_after: datetime_type | None = None,  # deprecated
+        annotations_after: datetime_type | None = None,
+        annotation_ends_before: datetime_type | None = None,  # deprecated
+        annotations_before: datetime_type | None = None,
+        source: DataSource
+        | list[DataSource]
+        | int
+        | list[int]
+        | str
+        | list[str]
+        | None = None,
         include_asset_annotations: bool = False,
         include_account_annotations: bool = False,
         as_frame: bool = False,
-    ) -> Union[List[Annotation], pd.DataFrame]:
+    ) -> list[Annotation] | pd.DataFrame:
         """Return annotations assigned to this sensor, and optionally, also those assigned to the sensor's asset and the asset's account.
 
         :param annotations_after: only return annotations that end after this datetime (exclusive)
@@ -279,23 +289,27 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
 
     def search_beliefs(
         self,
-        event_starts_after: Optional[datetime_type] = None,
-        event_ends_before: Optional[datetime_type] = None,
-        beliefs_after: Optional[datetime_type] = None,
-        beliefs_before: Optional[datetime_type] = None,
-        horizons_at_least: Optional[timedelta] = None,
-        horizons_at_most: Optional[timedelta] = None,
-        source: Optional[
-            Union[DataSource, List[DataSource], int, List[int], str, List[str]]
-        ] = None,
+        event_starts_after: datetime_type | None = None,
+        event_ends_before: datetime_type | None = None,
+        beliefs_after: datetime_type | None = None,
+        beliefs_before: datetime_type | None = None,
+        horizons_at_least: timedelta | None = None,
+        horizons_at_most: timedelta | None = None,
+        source: DataSource
+        | list[DataSource]
+        | int
+        | list[int]
+        | str
+        | list[str]
+        | None = None,
         most_recent_beliefs_only: bool = True,
         most_recent_events_only: bool = False,
         most_recent_only: bool = None,  # deprecated
         one_deterministic_belief_per_event: bool = False,
         one_deterministic_belief_per_event_per_source: bool = False,
-        resolution: Union[str, timedelta] = None,
+        resolution: str | timedelta = None,
         as_json: bool = False,
-    ) -> Union[tb.BeliefsDataFrame, str]:
+    ) -> tb.BeliefsDataFrame | str:
         """Search all beliefs about events for this sensor.
 
         If you don't set any filters, you get the most recent beliefs about all events.
@@ -348,19 +362,23 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
     def chart(
         self,
         chart_type: str = "bar_chart",
-        event_starts_after: Optional[datetime_type] = None,
-        event_ends_before: Optional[datetime_type] = None,
-        beliefs_after: Optional[datetime_type] = None,
-        beliefs_before: Optional[datetime_type] = None,
-        source: Optional[
-            Union[DataSource, List[DataSource], int, List[int], str, List[str]]
-        ] = None,
+        event_starts_after: datetime_type | None = None,
+        event_ends_before: datetime_type | None = None,
+        beliefs_after: datetime_type | None = None,
+        beliefs_before: datetime_type | None = None,
+        source: DataSource
+        | list[DataSource]
+        | int
+        | list[int]
+        | str
+        | list[str]
+        | None = None,
         most_recent_beliefs_only: bool = True,
         include_data: bool = False,
         include_sensor_annotations: bool = False,
         include_asset_annotations: bool = False,
         include_account_annotations: bool = False,
-        dataset_name: Optional[str] = None,
+        dataset_name: str | None = None,
         **kwargs,
     ) -> dict:
         """Create a vega-lite chart showing sensor data.
@@ -452,7 +470,7 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
         return chart_specs
 
     @property
-    def timerange(self) -> Dict[str, datetime_type]:
+    def timerange(self) -> dict[str, datetime_type]:
         """Time range for which sensor data exists.
 
         :returns: dictionary with start and end, for example:
@@ -495,7 +513,7 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
     @classmethod
     def find_closest(
         cls, generic_asset_type_name: str, sensor_name: str, n: int = 1, **kwargs
-    ) -> Union["Sensor", List["Sensor"], None]:
+    ) -> "Sensor" | list["Sensor"] | None:
         """Returns the closest n sensors within a given asset type (as a list if n > 1).
         Parses latitude and longitude values stated in kwargs.
 
@@ -573,28 +591,32 @@ class TimedBelief(db.Model, tb.TimedBeliefDBMixin):
     @classmethod
     def search(
         cls,
-        sensors: Union[Sensor, int, str, List[Union[Sensor, int, str]]],
+        sensors: Sensor | int | str | list[Sensor | int | str],
         sensor: Sensor = None,  # deprecated
-        event_starts_after: Optional[datetime_type] = None,
-        event_ends_before: Optional[datetime_type] = None,
-        beliefs_after: Optional[datetime_type] = None,
-        beliefs_before: Optional[datetime_type] = None,
-        horizons_at_least: Optional[timedelta] = None,
-        horizons_at_most: Optional[timedelta] = None,
-        source: Optional[
-            Union[DataSource, List[DataSource], int, List[int], str, List[str]]
-        ] = None,
-        user_source_ids: Optional[Union[int, List[int]]] = None,
-        source_types: Optional[List[str]] = None,
-        exclude_source_types: Optional[List[str]] = None,
+        event_starts_after: datetime_type | None = None,
+        event_ends_before: datetime_type | None = None,
+        beliefs_after: datetime_type | None = None,
+        beliefs_before: datetime_type | None = None,
+        horizons_at_least: timedelta | None = None,
+        horizons_at_most: timedelta | None = None,
+        source: DataSource
+        | list[DataSource]
+        | int
+        | list[int]
+        | str
+        | list[str]
+        | None = None,
+        user_source_ids: int | list[int] | None = None,
+        source_types: list[str] | None = None,
+        exclude_source_types: list[str] | None = None,
         most_recent_beliefs_only: bool = True,
         most_recent_events_only: bool = False,
         most_recent_only: bool = None,  # deprecated
         one_deterministic_belief_per_event: bool = False,
         one_deterministic_belief_per_event_per_source: bool = False,
-        resolution: Union[str, timedelta] = None,
+        resolution: str | timedelta = None,
         sum_multiple: bool = True,
-    ) -> Union[tb.BeliefsDataFrame, Dict[str, tb.BeliefsDataFrame]]:
+    ) -> tb.BeliefsDataFrame | dict[str, tb.BeliefsDataFrame]:
         """Search all beliefs about events for the given sensors.
 
         If you don't set any filters, you get the most recent beliefs about all events.
@@ -798,20 +820,20 @@ class TimedValue(object):
     @classmethod
     def make_query(
         cls,
-        old_sensor_names: Tuple[str],
-        query_window: Tuple[Optional[datetime_type], Optional[datetime_type]],
-        belief_horizon_window: Tuple[Optional[timedelta], Optional[timedelta]] = (
+        old_sensor_names: tuple[str],
+        query_window: tuple[datetime_type | None, datetime_type | None],
+        belief_horizon_window: tuple[timedelta | None, timedelta | None] = (
             None,
             None,
         ),
-        belief_time_window: Tuple[Optional[datetime_type], Optional[datetime_type]] = (
+        belief_time_window: tuple[datetime_type | None, datetime_type | None] = (
             None,
             None,
         ),
-        belief_time: Optional[datetime_type] = None,
-        user_source_ids: Optional[Union[int, List[int]]] = None,
-        source_types: Optional[List[str]] = None,
-        exclude_source_types: Optional[List[str]] = None,
+        belief_time: datetime_type | None = None,
+        user_source_ids: int | list[int] | None = None,
+        source_types: list[str] | None = None,
+        exclude_source_types: list[str] | None = None,
         session: Session = None,
     ) -> Query:
         """
@@ -847,21 +869,21 @@ class TimedValue(object):
     @classmethod
     def search(
         cls,
-        old_sensor_names: Union[str, List[str]],
-        event_starts_after: Optional[datetime_type] = None,
-        event_ends_before: Optional[datetime_type] = None,
-        horizons_at_least: Optional[timedelta] = None,
-        horizons_at_most: Optional[timedelta] = None,
-        beliefs_after: Optional[datetime_type] = None,
-        beliefs_before: Optional[datetime_type] = None,
-        user_source_ids: Union[
-            int, List[int]
-        ] = None,  # None is interpreted as all sources
-        source_types: Optional[List[str]] = None,
-        exclude_source_types: Optional[List[str]] = None,
-        resolution: Union[str, timedelta] = None,
+        old_sensor_names: str | list[str],
+        event_starts_after: datetime_type | None = None,
+        event_ends_before: datetime_type | None = None,
+        horizons_at_least: timedelta | None = None,
+        horizons_at_most: timedelta | None = None,
+        beliefs_after: datetime_type | None = None,
+        beliefs_before: datetime_type | None = None,
+        user_source_ids: int
+        | list[int]
+        | None = None,  # None is interpreted as all sources
+        source_types: list[str] | None = None,
+        exclude_source_types: list[str] | None = None,
+        resolution: str | timedelta = None,
         sum_multiple: bool = True,
-    ) -> Union[tb.BeliefsDataFrame, Dict[str, tb.BeliefsDataFrame]]:
+    ) -> tb.BeliefsDataFrame | dict[str, tb.BeliefsDataFrame]:
         """Basically a convenience wrapper for services.collect_time_series_data,
         where time series data collection is implemented.
         """

--- a/flexmeasures/data/queries/annotations.py
+++ b/flexmeasures/data/queries/annotations.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List, Optional
 
 from sqlalchemy.orm import Query
 
@@ -14,9 +13,9 @@ from flexmeasures.data.models.data_sources import DataSource
 
 def query_asset_annotations(
     asset_id: int,
-    annotations_after: Optional[datetime] = None,
-    annotations_before: Optional[datetime] = None,
-    sources: Optional[List[DataSource]] = None,
+    annotations_after: datetime | None = None,
+    annotations_before: datetime | None = None,
+    sources: list[DataSource] | None = None,
     annotation_type: str | None = None,
 ) -> Query:
     """Match annotations assigned to the given asset."""

--- a/flexmeasures/data/queries/data_sources.py
+++ b/flexmeasures/data/queries/data_sources.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Union, Optional
-
 from flexmeasures import User
 from flexmeasures.utils.coding_utils import deprecated
 from flexmeasures.data.models.data_sources import DataSource
@@ -15,9 +13,9 @@ from flexmeasures.data.services.data_sources import (
 
 @deprecated(get_or_create_source_new, "0.14")
 def get_or_create_source(
-    source: Union[User, str],
-    source_type: Optional[str] = None,
-    model: Optional[str] = None,
+    source: User | str,
+    source_type: str | None = None,
+    model: str | None = None,
     flush: bool = True,
 ) -> DataSource:
     return get_or_create_source_new(source, source_type, model, flush)

--- a/flexmeasures/data/schemas/times.py
+++ b/flexmeasures/data/schemas/times.py
@@ -1,4 +1,5 @@
-from typing import Union, Optional
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 
 from flask import current_app
@@ -20,7 +21,7 @@ class DurationField(MarshmallowClickMixin, fields.Str):
 
     def _deserialize(
         self, value, attr, obj, **kwargs
-    ) -> Union[timedelta, isodate.Duration]:
+    ) -> timedelta | isodate.Duration:
         """
         Use the isodate library to turn an ISO8601 string into a timedelta.
         For some non-obvious cases, it will become an isodate.Duration, see
@@ -44,7 +45,7 @@ class DurationField(MarshmallowClickMixin, fields.Str):
 
     @staticmethod
     def ground_from(
-        duration: Union[timedelta, isodate.Duration], start: Optional[datetime]
+        duration: timedelta | isodate.Duration, start: datetime | None
     ) -> timedelta:
         """
         For some valid duration strings (such as "P1M", a month),

--- a/flexmeasures/data/schemas/times.py
+++ b/flexmeasures/data/schemas/times.py
@@ -19,9 +19,7 @@ class DurationField(MarshmallowClickMixin, fields.Str):
     """Field that deserializes to a ISO8601 Duration
     and serializes back to a string."""
 
-    def _deserialize(
-        self, value, attr, obj, **kwargs
-    ) -> timedelta | isodate.Duration:
+    def _deserialize(self, value, attr, obj, **kwargs) -> timedelta | isodate.Duration:
         """
         Use the isodate library to turn an ISO8601 string into a timedelta.
         For some non-obvious cases, it will become an isodate.Duration, see

--- a/flexmeasures/data/schemas/units.py
+++ b/flexmeasures/data/schemas/units.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from marshmallow import fields, validate, ValidationError
 
@@ -9,7 +9,7 @@ from flexmeasures.utils.unit_utils import is_valid_unit, ur
 class QuantityValidator(validate.Validator):
     """Validator which succeeds if the value passed to it is a valid quantity."""
 
-    def __init__(self, *, error: Optional[str] = None):
+    def __init__(self, *, error: str | None = None):
         self.error = error
 
     def __call__(self, value):

--- a/flexmeasures/data/services/accounts.py
+++ b/flexmeasures/data/services/accounts.py
@@ -1,12 +1,12 @@
-from typing import List, Optional
+from __future__ import annotations
 
 from flexmeasures.data.models.user import Account, AccountRole
 from flexmeasures.data.models.generic_assets import GenericAsset
 
 
 def get_accounts(
-    role_name: Optional[str] = None,
-) -> List[Account]:
+    role_name: str | None = None,
+) -> list[Account]:
     """Return a list of Account objects.
     The role_name parameter allows to filter by role.
     """
@@ -30,7 +30,7 @@ def get_number_of_assets_in_account(account_id: int) -> int:
     return number_of_assets_in_account
 
 
-def get_account_roles(account_id: int) -> List[AccountRole]:
+def get_account_roles(account_id: int) -> list[AccountRole]:
     account = Account.query.filter_by(id=account_id).one_or_none()
     if account is None:
         return []

--- a/flexmeasures/data/services/data_sources.py
+++ b/flexmeasures/data/services/data_sources.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import Optional, Union
 
 from flask import current_app
 
@@ -10,10 +9,10 @@ from flexmeasures.data.models.user import is_user
 
 
 def get_or_create_source(
-    source: Union[User, str],
-    source_type: Optional[str] = None,
-    model: Optional[str] = None,
-    version: Optional[str] = None,
+    source: User | str,
+    source_type: str | None = None,
+    model: str | None = None,
+    version: str | None = None,
     flush: bool = True,
 ) -> DataSource:
     if is_user(source):

--- a/flexmeasures/data/services/forecasting.py
+++ b/flexmeasures/data/services/forecasting.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
-from typing import List
 
 from flask import current_app
 import click
@@ -47,11 +48,11 @@ def create_forecasting_jobs(
     start_of_roll: datetime,
     end_of_roll: datetime,
     resolution: timedelta = None,
-    horizons: List[timedelta] = None,
+    horizons: list[timedelta] = None,
     model_search_term="linear-OLS",
     custom_model_params: dict = None,
     enqueue: bool = True,
-) -> List[Job]:
+) -> list[Job]:
     """Create forecasting jobs by rolling through a time window, for a number of given forecast horizons.
     Start and end of the forecasting jobs are equal to the time window (start_of_roll, end_of_roll) plus the horizon.
 
@@ -91,7 +92,7 @@ def create_forecasting_jobs(
                 "Cannot create forecasting jobs - set either horizons or resolution."
             )
         horizons = forecast_horizons_for(resolution)
-    jobs: List[Job] = []
+    jobs: list[Job] = []
     for horizon in horizons:
         job = Job.create(
             make_rolling_viewpoint_forecasts,

--- a/flexmeasures/data/services/time_series.py
+++ b/flexmeasures/data/services/time_series.py
@@ -1,4 +1,7 @@
-from typing import Any, List, Dict, Optional, Tuple, Union, Callable
+from __future__ import annotations
+
+# Use | instead of Union when FM stops supporting Python 3.9 (because of https://github.com/python/cpython/issues/86399)
+from typing import Any, Callable, Optional, Union
 from datetime import datetime, timedelta
 
 import inflect
@@ -19,35 +22,35 @@ p = inflect.engine()
 # Signature of a callable that build queries
 QueryCallType = Callable[
     [
-        Tuple[str],
-        Tuple[datetime, datetime],
-        Tuple[Optional[timedelta], Optional[timedelta]],
-        Tuple[Optional[datetime], Optional[datetime]],
+        tuple[str],
+        tuple[datetime, datetime],
+        tuple[Optional[timedelta], Optional[timedelta]],
+        tuple[Optional[datetime], Optional[datetime]],
         Optional[datetime],
-        Optional[Union[int, List[int]]],
-        Optional[List[str]],
-        Optional[List[str]],
+        Optional[Union[int, list[int]]],
+        Optional[list[str]],
+        Optional[list[str]],
     ],
     Query,
 ]
 
 
 def collect_time_series_data(
-    old_sensor_names: Union[str, List[str]],
+    old_sensor_names: str | list[str],
     make_query: QueryCallType,
-    query_window: Tuple[Optional[datetime], Optional[datetime]] = (None, None),
-    belief_horizon_window: Tuple[Optional[timedelta], Optional[timedelta]] = (
+    query_window: tuple[datetime | None, datetime | None] = (None, None),
+    belief_horizon_window: tuple[timedelta | None, timedelta | None] = (
         None,
         None,
     ),
-    belief_time_window: Tuple[Optional[datetime], Optional[datetime]] = (None, None),
-    belief_time: Optional[datetime] = None,
-    user_source_ids: Union[int, List[int]] = None,  # None is interpreted as all sources
-    source_types: Optional[List[str]] = None,
-    exclude_source_types: Optional[List[str]] = None,
-    resolution: Union[str, timedelta] = None,
+    belief_time_window: tuple[datetime | None, datetime | None] = (None, None),
+    belief_time: datetime | None = None,
+    user_source_ids: int | list[int] = None,  # None is interpreted as all sources
+    source_types: list[str] | None = None,
+    exclude_source_types: list[str] | None = None,
+    resolution: str | timedelta | None = None,
     sum_multiple: bool = True,
-) -> Union[tb.BeliefsDataFrame, Dict[str, tb.BeliefsDataFrame]]:
+) -> tb.BeliefsDataFrame | dict[str, tb.BeliefsDataFrame]:
     """Get time series data from one or more old sensor models and rescale and re-package it to order.
 
     We can (lazily) look up by pickle, or load from the database.
@@ -89,20 +92,20 @@ def collect_time_series_data(
 
 
 def query_time_series_data(
-    old_sensor_names: Tuple[str],
+    old_sensor_names: tuple[str],
     make_query: QueryCallType,
-    query_window: Tuple[Optional[datetime], Optional[datetime]] = (None, None),
-    belief_horizon_window: Tuple[Optional[timedelta], Optional[timedelta]] = (
+    query_window: tuple[datetime | None, datetime | None] = (None, None),
+    belief_horizon_window: tuple[timedelta | None, timedelta | None] = (
         None,
         None,
     ),
-    belief_time_window: Tuple[Optional[datetime], Optional[datetime]] = (None, None),
-    belief_time: Optional[datetime] = None,
-    user_source_ids: Optional[Union[int, List[int]]] = None,
-    source_types: Optional[List[str]] = None,
-    exclude_source_types: Optional[List[str]] = None,
-    resolution: Union[str, timedelta] = None,
-) -> Dict[str, tb.BeliefsDataFrame]:
+    belief_time_window: tuple[datetime | None, datetime | None] = (None, None),
+    belief_time: datetime | None = None,
+    user_source_ids: int | list[int] | None = None,
+    source_types: list[str] | None = None,
+    exclude_source_types: list[str] | None = None,
+    resolution: str | timedelta | None = None,
+) -> dict[str, tb.BeliefsDataFrame]:
     """
     Run a query for time series data on the database for a tuple of assets.
     Here, we need to know that postgres only stores naive datetimes and we keep them as UTC.
@@ -132,7 +135,7 @@ def query_time_series_data(
     df_all_assets = pd.DataFrame(
         query.all(), columns=[col["name"] for col in query.column_descriptions]
     )
-    bdf_dict: Dict[str, tb.BeliefsDataFrame] = {}
+    bdf_dict: dict[str, tb.BeliefsDataFrame] = {}
     for old_sensor_model_name in old_sensor_names:
 
         # Select data for the given asset
@@ -223,8 +226,8 @@ def find_sensor_by_name(name: str):
 
 
 def drop_non_unique_ids(
-    a: Union[int, List[int]], b: Union[int, List[int]]
-) -> List[int]:
+    a: int | list[int], b: int | list[int]
+) -> list[int]:
     """Removes all elements from B that are already in A."""
     a_l = a if type(a) == list else [a]
     b_l = b if type(b) == list else [b]
@@ -232,8 +235,8 @@ def drop_non_unique_ids(
 
 
 def convert_query_window_for_demo(
-    query_window: Tuple[datetime, datetime]
-) -> Tuple[datetime, datetime]:
+    query_window: tuple[datetime, datetime]
+) -> tuple[datetime, datetime]:
     demo_year = current_app.config.get("FLEXMEASURES_DEMO_YEAR", None)
     if demo_year is None:
         return query_window
@@ -259,7 +262,7 @@ def convert_query_window_for_demo(
     return start, end
 
 
-def aggregate_values(bdf_dict: Dict[Any, tb.BeliefsDataFrame]) -> tb.BeliefsDataFrame:
+def aggregate_values(bdf_dict: dict[Any, tb.BeliefsDataFrame]) -> tb.BeliefsDataFrame:
 
     # todo: test this function rigorously, e.g. with empty bdfs in bdf_dict
     # todo: consider 1 bdf with beliefs from source A, plus 1 bdf with beliefs from source B -> 1 bdf with sources A+B
@@ -271,7 +274,7 @@ def aggregate_values(bdf_dict: Dict[Any, tb.BeliefsDataFrame]) -> tb.BeliefsData
     if len(bdf_dict) == 1:
         return list(bdf_dict.values())[0]
 
-    unique_source_ids: List[int] = []
+    unique_source_ids: list[int] = []
     for bdf in bdf_dict.values():
         unique_source_ids.extend(bdf.lineage.sources)
         if not bdf.lineage.unique_beliefs_per_event_per_source:

--- a/flexmeasures/data/services/time_series.py
+++ b/flexmeasures/data/services/time_series.py
@@ -225,9 +225,7 @@ def find_sensor_by_name(name: str):
     return sensor
 
 
-def drop_non_unique_ids(
-    a: int | list[int], b: int | list[int]
-) -> list[int]:
+def drop_non_unique_ids(a: int | list[int], b: int | list[int]) -> list[int]:
     """Removes all elements from B that are already in A."""
     a_l = a if type(a) == list else [a]
     b_l = b if type(b) == list else [b]

--- a/flexmeasures/data/services/users.py
+++ b/flexmeasures/data/services/users.py
@@ -1,4 +1,5 @@
-from typing import Dict, List, Union, Optional
+from __future__ import annotations
+
 import random
 import string
 
@@ -32,11 +33,11 @@ def get_user(id: str) -> User:
 
 
 def get_users(
-    account_name: Optional[str] = None,
-    role_name: Optional[str] = None,
-    account_role_name: Optional[str] = None,
+    account_name: str | None = None,
+    role_name: str | None = None,
+    account_role_name: str | None = None,
     only_active: bool = True,
-) -> List[User]:
+) -> list[User]:
     """Return a list of User objects.
     The role_name parameter allows to filter by role.
     Set only_active to False if you also want non-active users.
@@ -76,9 +77,9 @@ def find_user_by_email(user_email: str, keep_in_session: bool = True) -> User:
 
 def create_user(  # noqa: C901
     password: str = None,
-    user_roles: Union[Dict[str, str], List[Dict[str, str]], str, List[str]] = None,
+    user_roles: dict[str, str] | list[dict[str, str]] | str | list[str] | None = None,
     check_email_deliverability: bool = True,
-    account_name: Optional[str] = None,
+    account_name: str | None = None,
     **kwargs,
 ) -> User:
     """

--- a/flexmeasures/data/tests/conftest.py
+++ b/flexmeasures/data/tests/conftest.py
@@ -1,7 +1,6 @@
 import pytest
 from datetime import datetime, timedelta
 from random import random
-from typing import Dict
 
 from isodate import parse_duration
 import pandas as pd
@@ -166,7 +165,7 @@ def add_failing_test_model(db):
 
 
 @pytest.fixture(scope="module")
-def add_nearby_weather_sensors(db, add_weather_sensors) -> Dict[str, Sensor]:
+def add_nearby_weather_sensors(db, add_weather_sensors) -> dict[str, Sensor]:
     temp_sensor_location = add_weather_sensors["temperature"].generic_asset.location
     weather_station_type = GenericAssetType.query.filter(
         GenericAssetType.name == "weather station"

--- a/flexmeasures/data/tests/test_forecasting_jobs.py
+++ b/flexmeasures/data/tests/test_forecasting_jobs.py
@@ -1,5 +1,6 @@
 # flake8: noqa: E402
-from typing import Optional, List
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 import os
 
@@ -130,8 +131,8 @@ def test_forecasting_two_hours_of_solar_at_edge_of_data_set(
 
 def check_failures(
     redis_queue,
-    failure_search_words: Optional[List[str]] = None,
-    model_identifiers: Optional[List[str]] = None,
+    failure_search_words: list[str] | None = None,
+    model_identifiers: list[str] | None = None,
 ):
     """Check that there was at least one failure.
     For each failure, the exception message can be checked for a search word

--- a/flexmeasures/data/transactional.py
+++ b/flexmeasures/data/transactional.py
@@ -2,8 +2,9 @@
 These, and only these, functions should help you with treating your own code
 in the context of one database transaction. Which makes our lives easier.
 """
+from __future__ import annotations
+
 import sys
-from typing import Optional
 
 import click
 from flask import current_app
@@ -76,7 +77,7 @@ class PartialTaskCompletionException(Exception):
 
 
 @optional_arg_decorator
-def task_with_status_report(task_function, task_name: Optional[str] = None):
+def task_with_status_report(task_function, task_name: str | None = None):
     """Decorator for tasks which should report their runtime and status in the db (as LatestTaskRun entries).
     Tasks decorated with this endpoint should also leave committing or rolling back the session to this
     decorator (for the reasons that it is nice to centralise that but also practically, this decorator

--- a/flexmeasures/ui/crud/api_wrapper.py
+++ b/flexmeasures/ui/crud/api_wrapper.py
@@ -1,4 +1,6 @@
-from typing import Optional, List, Dict, Any
+from __future__ import annotations
+
+from typing import Any
 
 from flask import current_app, request
 from flask_security import current_user
@@ -28,7 +30,7 @@ class InternalApi(object):
         }
 
     def _maybe_raise(
-        self, response: requests.Response, do_not_raise_for: Optional[List] = None
+        self, response: requests.Response, do_not_raise_for: list | None = None
     ):
         """
         Raise an error in the API (4xx, 5xx) if the error code is not in the list of codes
@@ -42,8 +44,8 @@ class InternalApi(object):
     def get(
         self,
         url: str,
-        query: Optional[Dict[str, Any]] = None,
-        do_not_raise_for: Optional[List] = None,
+        query: dict[str, Any] | None = None,
+        do_not_raise_for: list | None = None,
     ) -> requests.Response:
         current_app.logger.debug(
             f"{self._log_prefix} GETting {url} with query {query} ..."
@@ -59,8 +61,8 @@ class InternalApi(object):
     def post(
         self,
         url: str,
-        args: Optional[dict] = None,
-        do_not_raise_for: Optional[List] = None,
+        args: dict | None = None,
+        do_not_raise_for: list | None = None,
     ) -> requests.Response:
         current_app.logger.debug(
             f"{self._log_prefix} POSTing {url} with json data {args} ..."
@@ -76,8 +78,8 @@ class InternalApi(object):
     def patch(
         self,
         url: str,
-        args: Optional[dict] = None,
-        do_not_raise_for: Optional[List] = None,
+        args: dict | None = None,
+        do_not_raise_for: list | None = None,
     ) -> requests.Response:
         current_app.logger.debug(
             f"{self._log_prefix} PATCHing {url} with json data {args} ..."
@@ -93,7 +95,7 @@ class InternalApi(object):
     def delete(
         self,
         url: str,
-        do_not_raise_for: Optional[List] = None,
+        do_not_raise_for: list | None = None,
     ) -> requests.Response:
         current_app.logger.debug(f"{self._log_prefix} DELETEing {url} ...")
         response = requests.delete(

--- a/flexmeasures/ui/crud/assets.py
+++ b/flexmeasures/ui/crud/assets.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from typing import Union, Optional, List, Tuple
 import copy
 import json
 
@@ -101,9 +100,7 @@ class NewAssetForm(AssetForm):
     account_id = SelectField("Account", coerce=int)
 
 
-def with_options(
-    form: Union[AssetForm, NewAssetForm]
-) -> Union[AssetForm, NewAssetForm]:
+def with_options(form: AssetForm | NewAssetForm) -> AssetForm | NewAssetForm:
     if "generic_asset_type_id" in form:
         form.generic_asset_type_id.choices = [(-1, "--Select type--")] + [
             (atype.id, atype.name) for atype in GenericAssetType.query.all()
@@ -116,8 +113,8 @@ def with_options(
 
 
 def process_internal_api_response(
-    asset_data: dict, asset_id: Optional[int] = None, make_obj=False
-) -> Union[GenericAsset, dict]:
+    asset_data: dict, asset_id: int | None = None, make_obj=False
+) -> GenericAsset | dict:
     """
     Turn data from the internal API into something we can use to further populate the UI.
     Either as an asset object or a dict for form filling.
@@ -171,7 +168,7 @@ def user_can_delete(asset) -> bool:
     return True
 
 
-def get_assets_by_account(account_id: int | str | None) -> List[GenericAsset]:
+def get_assets_by_account(account_id: int | str | None) -> list[GenericAsset]:
     if account_id is not None:
         get_assets_response = InternalApi().get(
             url_for("AssetAPI:index"), query={"account_id": account_id}
@@ -397,7 +394,7 @@ class AssetCrudUI(FlaskView):
         )
 
 
-def _set_account(asset_form: NewAssetForm) -> Tuple[Optional[Account], Optional[str]]:
+def _set_account(asset_form: NewAssetForm) -> tuple[Account | None, str | None]:
     """Set an account for the to-be-created asset.
     Return the account (if available) and an error message"""
     account_error = None
@@ -419,7 +416,7 @@ def _set_account(asset_form: NewAssetForm) -> Tuple[Optional[Account], Optional[
 
 def _set_asset_type(
     asset_form: NewAssetForm,
-) -> Tuple[Optional[GenericAssetType], Optional[str]]:
+) -> tuple[GenericAssetType | None, str | None]:
     """Set an asset type for the to-be-created asset.
     Return the asset type (if available) and an error message."""
     asset_type = None

--- a/flexmeasures/ui/crud/users.py
+++ b/flexmeasures/ui/crud/users.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional, Union
 from datetime import datetime
 
 from flask import request, url_for
@@ -51,8 +50,8 @@ def render_user(user: User | None, asset_count: int = 0, msg: str | None = None)
 
 
 def process_internal_api_response(
-    user_data: dict, user_id: Optional[int] = None, make_obj=False
-) -> Union[User, dict]:
+    user_data: dict, user_id: int | None = None, make_obj=False
+) -> User | dict:
     """
     Turn data from the internal API into something we can use to further populate the UI.
     Either as a user object or a dict for form filling.

--- a/flexmeasures/ui/tests/utils.py
+++ b/flexmeasures/ui/tests/utils.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import copy
-from typing import List, Union
 
 from flask import url_for
 
@@ -23,7 +24,7 @@ def mock_asset_response(
     account_id: int = 1,
     as_list: bool = True,
     multiple: bool = False,
-) -> Union[dict, List[dict]]:
+) -> dict | list[dict]:
     asset = dict(
         id=asset_id,
         name="TestAsset",
@@ -49,7 +50,7 @@ def mock_user_response(
     active: bool = True,
     as_list: bool = True,
     multiple: bool = False,
-) -> Union[dict, List[dict]]:
+) -> dict | list[dict]:
     user = dict(
         id=user_id,
         username=username,
@@ -83,7 +84,7 @@ def mock_account_response(
     account_roles: list = [{"id": 1, "name": "Prosumer"}],
     as_list: bool = True,
     multiple: bool = False,
-) -> Union[dict, List[dict]]:
+) -> dict | list[dict]:
     account = dict(
         id=account_id,
         name=account_name,

--- a/flexmeasures/ui/utils/view_utils.py
+++ b/flexmeasures/ui/utils/view_utils.py
@@ -1,8 +1,9 @@
 """Utilities for views"""
+from __future__ import annotations
+
 import json
 import os
 import subprocess
-from typing import Tuple, List, Optional
 from datetime import datetime
 
 from flask import render_template, request, session, current_app
@@ -175,9 +176,9 @@ def set_time_range_for_session():
 
 
 def ensure_timing_vars_are_set(
-    time_window: Tuple[Optional[datetime], Optional[datetime]],
-    resolution: Optional[str],
-) -> Tuple[Tuple[datetime, datetime], str]:
+    time_window: tuple[datetime | None, datetime | None],
+    resolution: str | None,
+) -> tuple[tuple[datetime, datetime], str]:
     """
     Ensure that time window and resolution variables are set,
     even if we don't have them available ― in that case,
@@ -219,7 +220,7 @@ def set_session_market(resource: Resource) -> Market:
 
 
 def set_session_sensor_type(
-    accepted_sensor_types: List[WeatherSensorType],
+    accepted_sensor_types: list[WeatherSensorType],
 ) -> WeatherSensorType:
     """Set session["sensor_type"] to something, based on the available sensor types or the request.
     Returns the selected sensor type, or None."""
@@ -253,8 +254,8 @@ def set_session_sensor_type(
 
 
 def set_session_resource(
-    assets: List[Asset], groups_with_assets: List[str]
-) -> Optional[Resource]:
+    assets: list[Asset], groups_with_assets: list[str]
+) -> Resource | None:
     """
     Set session["resource"] to something, based on the available asset groups or the request.
 
@@ -295,7 +296,7 @@ def set_individual_traces_for_session():
         session[var_name] = request.values[var_name]
 
 
-def get_git_description() -> Tuple[str, int, str]:
+def get_git_description() -> tuple[str, int, str]:
     """
     Get information about the SCM (git) state if possible (if a .git directory exists).
 

--- a/flexmeasures/utils/app_utils.py
+++ b/flexmeasures/utils/app_utils.py
@@ -1,4 +1,5 @@
-from typing import Union, Tuple, List, Optional
+from __future__ import annotations
+
 import os
 import sys
 
@@ -121,8 +122,8 @@ def root_dispatcher():
 
 
 def find_first_applicable_config_entry(
-    configs: list, setting_name: str, app: Optional[Flask] = None
-) -> Optional[str]:
+    configs: list, setting_name: str, app: Flask | None = None
+) -> str | None:
     if app is None:
         app = current_app
     if isinstance(configs, str):
@@ -135,14 +136,14 @@ def find_first_applicable_config_entry(
 
 
 def parse_config_entry_by_account_roles(
-    config: Union[str, Tuple[str, List[str]]],
+    config: str | tuple[str, list[str]],
     setting_name: str,
-    app: Optional[Flask] = None,
-) -> Optional[str]:
+    app: Flask | None = None,
+) -> str | None:
     """
     Parse a config entry (which can be a string, e.g. "dashboard" or a tuple, e.g. ("dashboard", ["MDC"])).
     In the latter case, return the first item (a string) only if the current user's account roles match with the
-    list of roles in the second item. Otherwise return None.
+    list of roles in the second item. Otherwise, return None.
     """
     if app is None:
         app = current_app

--- a/flexmeasures/utils/coding_utils.py
+++ b/flexmeasures/utils/coding_utils.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import functools
 import time
 import inspect
-from typing import Union
 from flask import current_app
 
 
@@ -152,7 +151,7 @@ def timeit(func):
     return new_func
 
 
-def deprecated(alternative, version: Union[str, None] = None):
+def deprecated(alternative, version: str | None = None):
     """Decorator for printing a warning error.
     alternative: importable object to use as an alternative to the function/method decorated
     version: version in which the function will be sunset

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -95,7 +95,7 @@ class Config(object):
     # This setting contains the domain on which FlexMeasures runs
     # and the first month when the domain was under the current owner's administration
     FLEXMEASURES_HOSTS_AND_AUTH_START: dict = {"flexmeasures.io": "2021-01"}
-    FLEXMEASURES_PLUGINS: List[str] = []
+    FLEXMEASURES_PLUGINS: Union[List[str], str] = []  # str will be checked for commas
     FLEXMEASURES_PROFILE_REQUESTS: bool = False
     FLEXMEASURES_DB_BACKUP_PATH: str = "migrations/dumps"
     FLEXMEASURES_MENU_LOGO_PATH: str = ""

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -54,7 +54,6 @@ class Config(object):
     SECURITY_FORGOT_PASSWORD_TEMPLATE: str = "admin/forgot_password.html"
     SECURITY_RECOVERABLE: bool = True
     SECURITY_RESET_PASSWORD_TEMPLATE: str = "admin/reset_password.html"
-    SECURITY_RECOVERABLE: bool = True
     SECURITY_TOKEN_AUTHENTICATION_HEADER: str = "Authorization"
     SECURITY_TOKEN_MAX_AGE: int = 60 * 60 * 6  # six hours
     SECURITY_TRACKABLE: bool = False  # this is more in line with modern privacy law

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from datetime import timedelta
 import logging
-from typing import List, Optional, Union, Dict, Tuple
 
 """
 This lays out our configuration requirements and allows to set trivial defaults, per environment adjustable.
@@ -19,9 +18,9 @@ class Config(object):
 
     DEBUG: bool = False
     LOGGING_LEVEL: int = logging.WARNING
-    SECRET_KEY: Optional[str] = None
+    SECRET_KEY: str | None = None
 
-    SQLALCHEMY_DATABASE_URI: Optional[str] = None
+    SQLALCHEMY_DATABASE_URI: str | None = None
     # https://stackoverflow.com/questions/33738467/how-do-i-know-if-i-can-disable-sqlalchemy-track-modifications
     SQLALCHEMY_TRACK_MODIFICATIONS: bool = False
     SQLALCHEMY_ENGINE_OPTIONS: dict = {
@@ -33,41 +32,41 @@ class Config(object):
         },  # https://stackoverflow.com/a/59932909/13775459
     }
 
-    MAIL_SERVER: Optional[str] = "localhost"
-    MAIL_PORT: Optional[int] = 25
-    MAIL_USE_TLS: Optional[bool] = False
-    MAIL_USE_SSL: Optional[bool] = False
-    MAIL_USERNAME: Optional[str] = None
+    MAIL_SERVER: str | None = "localhost"
+    MAIL_PORT: int | None = 25
+    MAIL_USE_TLS: bool | None = False
+    MAIL_USE_SSL: bool | None = False
+    MAIL_USERNAME: str | None = None
     MAIL_DEFAULT_SENDER = (
         "FlexMeasures",
         "no-reply@example.com",
     )  # tuple of name and email address
-    MAIL_PASSWORD: Optional[str] = None
+    MAIL_PASSWORD: str | None = None
 
-    SECURITY_REGISTERABLE = False
-    SECURITY_LOGIN_USER_TEMPLATE = "admin/login_user.html"
-    SECURITY_EMAIL_SUBJECT_PASSWORD_RESET = (
+    SECURITY_REGISTERABLE: bool = False
+    SECURITY_LOGIN_USER_TEMPLATE: str = "admin/login_user.html"
+    SECURITY_EMAIL_SUBJECT_PASSWORD_RESET: str = (
         "Password reset instructions for your FlexMeasures account."
     )
-    SECURITY_EMAIL_SUBJECT_PASSWORD_NOTICE = (
+    SECURITY_EMAIL_SUBJECT_PASSWORD_NOTICE: str = (
         "Your FlexMeasures password has been reset."
     )
-    SECURITY_FORGOT_PASSWORD_TEMPLATE = "admin/forgot_password.html"
-    SECURITY_RECOVERABLE = True
-    SECURITY_RESET_PASSWORD_TEMPLATE = "admin/reset_password.html"
-    SECURITY_RECOVERABLE = True
-    SECURITY_TOKEN_AUTHENTICATION_HEADER = "Authorization"
-    SECURITY_TOKEN_MAX_AGE = 60 * 60 * 6  # six hours
-    SECURITY_TRACKABLE = False  # this is more in line with modern privacy law
-    SECURITY_PASSWORD_SALT: Optional[str] = None
+    SECURITY_FORGOT_PASSWORD_TEMPLATE: str = "admin/forgot_password.html"
+    SECURITY_RECOVERABLE: bool = True
+    SECURITY_RESET_PASSWORD_TEMPLATE: str = "admin/reset_password.html"
+    SECURITY_RECOVERABLE: bool = True
+    SECURITY_TOKEN_AUTHENTICATION_HEADER: str = "Authorization"
+    SECURITY_TOKEN_MAX_AGE: int = 60 * 60 * 6  # six hours
+    SECURITY_TRACKABLE: bool = False  # this is more in line with modern privacy law
+    SECURITY_PASSWORD_SALT: str | None = None
 
     # Allowed cross-origins. Set to "*" to allow all. For development (e.g. javascript on localhost) you might use "null" here
-    CORS_ORIGINS: Union[List[str], str] = []
+    CORS_ORIGINS: list[str] | str = []
     # this can be a dict with all possible options as value per regex, see https://flask-cors.readthedocs.io/en/latest/configuration.html
-    CORS_RESOURCES: Union[dict, list, str] = [r"/api/*"]
+    CORS_RESOURCES: dict | list | str = [r"/api/*"]
     CORS_SUPPORTS_CREDENTIALS: bool = True
 
-    MAPBOX_ACCESS_TOKEN: Optional[str] = None
+    MAPBOX_ACCESS_TOKEN: str | None = None
 
     JSONIFY_PRETTYPRINT_REGULAR: bool = False
 
@@ -75,37 +74,35 @@ class Config(object):
         3000  # Web interface poll period for updates in ms
     )
 
-    SENTRY_DSN: Optional[str] = None
+    SENTRY_DSN: str | None = None
     # Place additional Sentry config here.
     # traces_sample_rate is for performance monitoring across all transactions,
     # you probably want to adjust this.
     FLEXMEASURES_SENTRY_CONFIG: dict = dict(traces_sample_rate=0.33)
-    FLEXMEASURES_MONITORING_MAIL_RECIPIENTS: List[str] = []
+    FLEXMEASURES_MONITORING_MAIL_RECIPIENTS: list[str] = []
 
-    FLEXMEASURES_PLATFORM_NAME: Union[
-        str, List[Union[str, Tuple[str, List[str]]]]
-    ] = "FlexMeasures"
+    FLEXMEASURES_PLATFORM_NAME: str | list[str | tuple[str, list[str]]] = "FlexMeasures"
     FLEXMEASURES_MODE: str = ""
     FLEXMEASURES_ALLOW_DATA_OVERWRITE: bool = False
     FLEXMEASURES_TIMEZONE: str = "Asia/Seoul"
     FLEXMEASURES_HIDE_NAN_IN_UI: bool = False
-    FLEXMEASURES_PUBLIC_DEMO_CREDENTIALS: Optional[Tuple] = None
-    FLEXMEASURES_DEMO_YEAR: Optional[int] = None
+    FLEXMEASURES_PUBLIC_DEMO_CREDENTIALS: tuple | None = None
+    FLEXMEASURES_DEMO_YEAR: int | None = None
     # Configuration used for entity addressing:
     # This setting contains the domain on which FlexMeasures runs
     # and the first month when the domain was under the current owner's administration
-    FLEXMEASURES_HOSTS_AND_AUTH_START: dict = {"flexmeasures.io": "2021-01"}
-    FLEXMEASURES_PLUGINS: List[str] | str = []  # str will be checked for commas
+    FLEXMEASURES_HOSTS_AND_AUTH_START: dict[str, str] = {"flexmeasures.io": "2021-01"}
+    FLEXMEASURES_PLUGINS: list[str] | str = []  # str will be checked for commas
     FLEXMEASURES_PROFILE_REQUESTS: bool = False
     FLEXMEASURES_DB_BACKUP_PATH: str = "migrations/dumps"
     FLEXMEASURES_MENU_LOGO_PATH: str = ""
     FLEXMEASURES_EXTRA_CSS_PATH: str = ""
-    FLEXMEASURES_ROOT_VIEW: Union[str, List[Union[str, Tuple[str, List[str]]]]] = []
-    FLEXMEASURES_MENU_LISTED_VIEWS: List[Union[str, Tuple[str, List[str]]]] = [
+    FLEXMEASURES_ROOT_VIEW: str | list[str | tuple[str, list[str]]] = []
+    FLEXMEASURES_MENU_LISTED_VIEWS: list[str | tuple[str, list[str]]] = [
         "dashboard",
     ]
-    FLEXMEASURES_MENU_LISTED_VIEW_ICONS: Dict[str, str] = {}
-    FLEXMEASURES_MENU_LISTED_VIEW_TITLES: Dict[str, str] = {}
+    FLEXMEASURES_MENU_LISTED_VIEW_ICONS: dict[str, str] = {}
+    FLEXMEASURES_MENU_LISTED_VIEW_TITLES: dict[str, str] = {}
     FLEXMEASURES_ASSET_TYPE_GROUPS = {
         "renewables": ["solar", "wind"],
         "EVSE": ["one-way_evse", "two-way_evse"],
@@ -118,11 +115,11 @@ class Config(object):
         days=7
     )  # Time to live for UDI event ids of successful scheduling jobs. Set a negative timedelta to persist forever.
     FLEXMEASURES_JOB_CACHE_TTL: int = 3600  # Time to live for the job caching keys in seconds. Set a negative timedelta to persist forever.
-    FLEXMEASURES_TASK_CHECK_AUTH_TOKEN: Optional[str] = None
+    FLEXMEASURES_TASK_CHECK_AUTH_TOKEN: str | None = None
     FLEXMEASURES_REDIS_URL: str = "localhost"
     FLEXMEASURES_REDIS_PORT: int = 6379
     FLEXMEASURES_REDIS_DB_NR: int = 0  # Redis per default has 16 databases, [0-15]
-    FLEXMEASURES_REDIS_PASSWORD: Optional[str] = None
+    FLEXMEASURES_REDIS_PASSWORD: str | None = None
     FLEXMEASURES_JS_VERSIONS: dict = dict(
         vega="5.22.1",
         vegaembed="6.21.0",
@@ -138,12 +135,12 @@ class Config(object):
 
 #  names of settings which cannot be None
 #  SECRET_KEY is also required but utils.app_utils.set_secret_key takes care of this better.
-required: List[str] = ["SQLALCHEMY_DATABASE_URI"]
+required: list[str] = ["SQLALCHEMY_DATABASE_URI"]
 
 #  settings whose absence should trigger a warning
 mail_warning = "Without complete mail settings, FlexMeasures will not be able to send mails to users, e.g. for password resets!"
 redis_warning = "Without complete redis connection settings, FlexMeasures will not be able to run forecasting and scheduling job queues."
-warnable: Dict[str, str] = {
+warnable: dict[str, str] = {
     "MAIL_SERVER": mail_warning,
     "MAIL_PORT": mail_warning,
     "MAIL_USE_TLS": mail_warning,
@@ -159,48 +156,48 @@ warnable: Dict[str, str] = {
 
 
 class ProductionConfig(Config):
-    DEBUG = False
-    LOGGING_LEVEL = logging.ERROR
+    DEBUG: bool = False
+    LOGGING_LEVEL: int = logging.ERROR
 
 
 class StagingConfig(Config):
-    DEBUG = False
-    LOGGING_LEVEL = logging.WARNING
+    DEBUG: bool = False
+    LOGGING_LEVEL: int = logging.WARNING
 
 
 class DevelopmentConfig(Config):
-    DEBUG = True
-    LOGGING_LEVEL = logging.DEBUG
-    SQLALCHEMY_ECHO = False
-    PROPAGATE_EXCEPTIONS = True
-    # PRESERVE_CONTEXT_ON_EXCEPTION = False  # might need this to make our transaction handling work in debug mode
-    JSONIFY_PRETTYPRINT_REGULAR = True
-    FLEXMEASURES_MODE = "development"
+    DEBUG: bool = True
+    LOGGING_LEVEL: int = logging.DEBUG
+    SQLALCHEMY_ECHO: bool = False
+    PROPAGATE_EXCEPTIONS: bool = True
+    # PRESERVE_CONTEXT_ON_EXCEPTION: bool = False  # might need this to make our transaction handling work in debug mode
+    JSONIFY_PRETTYPRINT_REGULAR: bool = True
+    FLEXMEASURES_MODE: str = "development"
     FLEXMEASURES_PROFILE_REQUESTS: bool = True
 
 
 class TestingConfig(Config):
-    DEBUG = True  # this seems to be important for logging in, not sure why
-    LOGGING_LEVEL = logging.INFO
-    WTF_CSRF_ENABLED = False  # also necessary for logging in during tests
+    DEBUG: bool = True  # this seems to be important for logging in, not sure why
+    LOGGING_LEVEL: int = logging.INFO
+    WTF_CSRF_ENABLED: bool = False  # also necessary for logging in during tests
 
-    SECRET_KEY = "dummy-key-for-testing"
-    SECURITY_PASSWORD_SALT = "$2b$19$abcdefghijklmnopqrstuv"
-    SQLALCHEMY_DATABASE_URI = (
+    SECRET_KEY: str = "dummy-key-for-testing"
+    SECURITY_PASSWORD_SALT: str = "$2b$19$abcdefghijklmnopqrstuv"
+    SQLALCHEMY_DATABASE_URI: str = (
         "postgresql://flexmeasures_test:flexmeasures_test@localhost/flexmeasures_test"
     )
     # SQLALCHEMY_ECHO = True
-    FLEXMEASURES_TASK_CHECK_AUTH_TOKEN = "test-task-check-token"
+    FLEXMEASURES_TASK_CHECK_AUTH_TOKEN: str = "test-task-check-token"
 
     # These can speed up tests due to less hashing work (I saw ~165s -> ~100s)
     # (via https://github.com/mattupstate/flask-security/issues/731#issuecomment-362186021)
-    SECURITY_HASHING_SCHEMES = ["hex_md5"]
-    SECURITY_DEPRECATED_HASHING_SCHEMES: List[str] = []
-    FLEXMEASURES_MODE = "test"
-    FLEXMEASURES_PLANNING_HORIZON = timedelta(
+    SECURITY_HASHING_SCHEMES: list[str] = ["hex_md5"]
+    SECURITY_DEPRECATED_HASHING_SCHEMES: list[str] = []
+    FLEXMEASURES_MODE: str = "test"
+    FLEXMEASURES_PLANNING_HORIZON: timedelta = timedelta(
         hours=2 * 24
     )  # if more than 2 days, consider setting up more days of price data for tests
 
 
 class DocumentationConfig(Config):
-    SECRET_KEY = "dummy-key-for-documentation"
+    SECRET_KEY: str = "dummy-key-for-documentation"

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -95,7 +95,7 @@ class Config(object):
     # This setting contains the domain on which FlexMeasures runs
     # and the first month when the domain was under the current owner's administration
     FLEXMEASURES_HOSTS_AND_AUTH_START: dict = {"flexmeasures.io": "2021-01"}
-    FLEXMEASURES_PLUGINS: Union[List[str], str] = []  # str will be checked for commas
+    FLEXMEASURES_PLUGINS: List[str] | str = []  # str will be checked for commas
     FLEXMEASURES_PROFILE_REQUESTS: bool = False
     FLEXMEASURES_DB_BACKUP_PATH: str = "migrations/dumps"
     FLEXMEASURES_MENU_LOGO_PATH: str = ""

--- a/flexmeasures/utils/config_utils.py
+++ b/flexmeasures/utils/config_utils.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import os
 import sys
 import logging
-from typing import Optional, List, Tuple
 from datetime import datetime
 from logging.config import dictConfig as loggingDictConfig
 from pathlib import Path
@@ -50,7 +51,7 @@ def configure_logging():
     loggingDictConfig(flexmeasures_logging_config)
 
 
-def check_app_env(env: Optional[str]):
+def check_app_env(env: str | None):
     if env not in (
         "documentation",
         "development",
@@ -64,7 +65,7 @@ def check_app_env(env: Optional[str]):
         sys.exit(2)
 
 
-def read_config(app: Flask, custom_path_to_config: Optional[str]):
+def read_config(app: Flask, custom_path_to_config: str | None):
     """Read configuration from various expected sources, complain if not setup correctly."""
 
     check_app_env(app.env)
@@ -185,7 +186,7 @@ def are_required_settings_complete(app) -> bool:
     return True
 
 
-def get_config_warnings(app) -> Tuple[List[str], List[str]]:
+def get_config_warnings(app) -> tuple[list[str], list[str]]:
     """return missing settings and the warnings for them."""
     missing_settings = []
     config_warnings = []
@@ -197,7 +198,7 @@ def get_config_warnings(app) -> Tuple[List[str], List[str]]:
     return missing_settings, config_warnings
 
 
-def get_configuration_keys(app) -> List[str]:
+def get_configuration_keys(app) -> list[str]:
     """
     Collect all members of DefaultConfig who are not in-built fields or callables.
     """

--- a/flexmeasures/utils/config_utils.py
+++ b/flexmeasures/utils/config_utils.py
@@ -163,7 +163,7 @@ def read_env_vars(app: Flask):
     for var in (
         required
         + list(warnable.keys())
-        + ["LOGGING_LEVEL", "MAPBOX_ACCESS_TOKEN", "SENTRY_SDN"]
+        + ["LOGGING_LEVEL", "MAPBOX_ACCESS_TOKEN", "SENTRY_SDN", "FLEXMEASURES_PLUGINS"]
     ):
         app.config[var] = os.getenv(var, app.config.get(var, None))
     # DEBUG in env can come in as a string ("True") so make sure we don't trip here

--- a/flexmeasures/utils/entity_address_utils.py
+++ b/flexmeasures/utils/entity_address_utils.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import logging
-from typing import Optional, Union
 from urllib.parse import urlparse
 
 import re
@@ -44,7 +45,7 @@ def get_host() -> str:
 def build_entity_address(
     entity_info: dict,
     entity_type: str,
-    host: Optional[str] = None,
+    host: str | None = None,
     fm_scheme: str = FM1_ADDR_SCHEME,
 ) -> str:
     """
@@ -298,7 +299,7 @@ def parse_entity_address(  # noqa: C901
 
 
 def build_ea_scheme_and_naming_authority(
-    host: str, host_auth_start_month: Optional[str] = None
+    host: str, host_auth_start_month: str | None = None
 ) -> str:
     """
     This function creates the host identification part of
@@ -344,7 +345,7 @@ def build_ea_scheme_and_naming_authority(
     return f"{ADDR_SCHEME}.{host_auth_start_month}.{reversed_domain_name}"
 
 
-def reverse_domain_name(domain: Union[str, TldExtractResult]) -> str:
+def reverse_domain_name(domain: str | TldExtractResult) -> str:
     """
     Returns the reverse notation of the domain.
     You can pass in a string domain or an extraction result from tldextract

--- a/flexmeasures/utils/geo_utils.py
+++ b/flexmeasures/utils/geo_utils.py
@@ -1,4 +1,5 @@
-from typing import Tuple, Union
+from __future__ import annotations
+
 import math
 
 
@@ -15,7 +16,7 @@ def rad_lng(longitude: float) -> float:
 
 
 def earth_distance(
-    location: Tuple[float, float], other_location: Tuple[float, float]
+    location: tuple[float, float], other_location: tuple[float, float]
 ) -> float:
     """Great circle distance in km between two locations on Earth."""
     r = 6371  # Radius of Earth in kilometres
@@ -34,7 +35,7 @@ def earth_distance(
     )
 
 
-def parse_lat_lng(kwargs) -> Union[Tuple[float, float], Tuple[None, None]]:
+def parse_lat_lng(kwargs) -> tuple[float, float] | tuple[None, None]:
     """Parses latitude and longitude values stated in kwargs.
 
     Can be called with an object that has latitude and longitude properties, for example:

--- a/flexmeasures/utils/grid_cells.py
+++ b/flexmeasures/utils/grid_cells.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List
+from __future__ import annotations
 
 
 class LatLngGrid(object):
@@ -16,15 +16,15 @@ class LatLngGrid(object):
     In those case, these locations are closer to one side of the cell.
     """
 
-    top_left: Tuple[float, float]
-    bottom_right: Tuple[float, float]
+    top_left: tuple[float, float]
+    bottom_right: tuple[float, float]
     num_cells_lat: int
     num_cells_lng: int
 
     def __init__(
         self,
-        top_left: Tuple[float, float],
-        bottom_right: Tuple[float, float],
+        top_left: tuple[float, float],
+        bottom_right: tuple[float, float],
         num_cells_lat: int,
         num_cells_lng: int,
     ):
@@ -61,7 +61,7 @@ class LatLngGrid(object):
             + f"num_lat:{self.num_cells_lat}, num_lng:{self.num_cells_lng}>"
         )
 
-    def get_locations(self, method: str) -> List[Tuple[float, float]]:
+    def get_locations(self, method: str) -> list[tuple[float, float]]:
         """Get locations by method ("square" or "hex")"""
 
         if method == "hex":
@@ -97,7 +97,7 @@ class LatLngGrid(object):
         else:
             return (self.bottom_right[1] - self.top_left[1]) * 2
 
-    def locations_square(self) -> List[Tuple[float, float]]:
+    def locations_square(self) -> list[tuple[float, float]]:
         """square pattern"""
         locations = []
 
@@ -145,7 +145,7 @@ class LatLngGrid(object):
 
         return locations
 
-    def locations_hex(self) -> List[Tuple[float, float]]:
+    def locations_hex(self) -> list[tuple[float, float]]:
         """The hexagonal pattern - actually leaves out one cell for every even row."""
         locations = []
 
@@ -206,8 +206,8 @@ class LatLngGrid(object):
 
 
 def get_cell_nums(
-    tl: Tuple[float, float], br: Tuple[float, float], num_cells: int = 9
-) -> Tuple[int, int]:
+    tl: tuple[float, float], br: tuple[float, float], num_cells: int = 9
+) -> tuple[int, int]:
     """
     Compute the number of cells in both directions, latitude and longitude.
     By default, a square grid with N=9 cells is computed, so 3 by 3.

--- a/flexmeasures/utils/plugin_utils.py
+++ b/flexmeasures/utils/plugin_utils.py
@@ -24,6 +24,8 @@ def register_plugins(app: Flask):
     (last part of the path).
     """
     plugins = app.config.get("FLEXMEASURES_PLUGINS", [])
+    if isinstance(plugins, str):
+        plugins = [plugin.strip() for plugin in plugins.split(",")]
     if not isinstance(plugins, list):
         app.logger.error(
             f"The value of FLEXMEASURES_PLUGINS is not a list: {plugins}. Cannot install plugins ..."

--- a/flexmeasures/utils/plugin_utils.py
+++ b/flexmeasures/utils/plugin_utils.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import importlib.util
 import os
 import sys
 from importlib.abc import Loader
 from types import ModuleType
-from typing import Dict
 
 import sentry_sdk
 from flask import Flask, Blueprint
@@ -104,7 +105,7 @@ def register_plugins(app: Flask):
     sentry_sdk.set_context("plugins", app.config.get("LOADED_PLUGINS", {}))
 
 
-def check_config_settings(app, settings: Dict[str, dict]):
+def check_config_settings(app, settings: dict[str, dict]):
     """Make sure expected config settings exist.
 
     For example:

--- a/flexmeasures/utils/plugin_utils.py
+++ b/flexmeasures/utils/plugin_utils.py
@@ -24,6 +24,9 @@ def register_plugins(app: Flask):
     (last part of the path).
     """
     plugins = app.config.get("FLEXMEASURES_PLUGINS", [])
+    if not plugins and "FLEXMEASURES_PLUGIN_PATHS" in app.config:
+        app.logger.warning("Plugins found via FLEXMEASURES_PLUGIN_PATHS. This setting will be sunset in v0.14. Please switch to FLEXMEASURES_PLUGINS."
+        plugins = app.config.get("FLEXMEASURES_PLUGIN_PATHS", [])
     if isinstance(plugins, str):
         plugins = [plugin.strip() for plugin in plugins.split(",")]
     if not isinstance(plugins, list):

--- a/flexmeasures/utils/plugin_utils.py
+++ b/flexmeasures/utils/plugin_utils.py
@@ -28,7 +28,7 @@ def register_plugins(app: Flask):
         app.logger.warning("Plugins found via FLEXMEASURES_PLUGIN_PATHS. This setting will be sunset in v0.14. Please switch to FLEXMEASURES_PLUGINS."
         plugins = app.config.get("FLEXMEASURES_PLUGIN_PATHS", [])
     if isinstance(plugins, str):
-        plugins = [plugin.strip() for plugin in plugins.split(",")]
+        plugins = [plugin.strip() for plugin in plugins.split(",") if len(plugin.strip()) > 0]
     if not isinstance(plugins, list):
         app.logger.error(
             f"The value of FLEXMEASURES_PLUGINS is not a list: {plugins}. Cannot install plugins ..."

--- a/flexmeasures/utils/plugin_utils.py
+++ b/flexmeasures/utils/plugin_utils.py
@@ -24,12 +24,6 @@ def register_plugins(app: Flask):
     (last part of the path).
     """
     plugins = app.config.get("FLEXMEASURES_PLUGINS", [])
-    if not plugins:
-        # this is deprecated behaviour which we should remove in version 1.0
-        app.logger.debug(
-            "No plugins configured. Attempting deprecated setting FLEXMEASURES_PLUGIN_PATHS ..."
-        )
-        plugins = app.config.get("FLEXMEASURES_PLUGIN_PATHS", [])
     if not isinstance(plugins, list):
         app.logger.error(
             f"The value of FLEXMEASURES_PLUGINS is not a list: {plugins}. Cannot install plugins ..."

--- a/flexmeasures/utils/plugin_utils.py
+++ b/flexmeasures/utils/plugin_utils.py
@@ -25,10 +25,14 @@ def register_plugins(app: Flask):
     """
     plugins = app.config.get("FLEXMEASURES_PLUGINS", [])
     if not plugins and "FLEXMEASURES_PLUGIN_PATHS" in app.config:
-        app.logger.warning("Plugins found via FLEXMEASURES_PLUGIN_PATHS. This setting will be sunset in v0.14. Please switch to FLEXMEASURES_PLUGINS."
+        app.logger.warning(
+            "Plugins found via FLEXMEASURES_PLUGIN_PATHS. This setting will be sunset in v0.14. Please switch to FLEXMEASURES_PLUGINS."
+        )
         plugins = app.config.get("FLEXMEASURES_PLUGIN_PATHS", [])
     if isinstance(plugins, str):
-        plugins = [plugin.strip() for plugin in plugins.split(",") if len(plugin.strip()) > 0]
+        plugins = [
+            plugin.strip() for plugin in plugins.split(",") if len(plugin.strip()) > 0
+        ]
     if not isinstance(plugins, list):
         app.logger.error(
             f"The value of FLEXMEASURES_PLUGINS is not a list: {plugins}. Cannot install plugins ..."

--- a/flexmeasures/utils/time_utils.py
+++ b/flexmeasures/utils/time_utils.py
@@ -61,7 +61,7 @@ def naive_utc_from(dt: datetime) -> datetime:
 
 
 def tz_index_naively(
-    data: pd.DataFrame | pd.Series | pd.DatetimeIndex
+    data: pd.DataFrame | pd.Series | pd.DatetimeIndex,
 ) -> pd.DataFrame | pd.Series | pd.DatetimeIndex:
     """Turn any DatetimeIndex into a tz-naive one, then return. Useful for bokeh, for instance."""
     if isinstance(data, pd.DatetimeIndex):
@@ -87,9 +87,7 @@ def localized_datetime_str(dt: datetime, dt_format: str = "%Y-%m-%d %I:%M %p") -
     return local_dt.strftime(dt_format)
 
 
-def naturalized_datetime_str(
-    dt: datetime | None, now: datetime | None = None
-) -> str:
+def naturalized_datetime_str(dt: datetime | None, now: datetime | None = None) -> str:
     """
     Naturalise a datetime object (into a human-friendly string).
     The dt parameter (as well as the now parameter if you use it)
@@ -268,9 +266,7 @@ def freq_label_to_human_readable_label(freq_label: str) -> str:
     return f2h_map.get(freq_label, freq_label)
 
 
-def forecast_horizons_for(
-    resolution: str | timedelta
-) -> list[str] | list[timedelta]:
+def forecast_horizons_for(resolution: str | timedelta) -> list[str] | list[timedelta]:
     """Return a list of horizons that are supported per resolution.
     Return values or of the same type as the input."""
     if isinstance(resolution, timedelta):

--- a/flexmeasures/utils/time_utils.py
+++ b/flexmeasures/utils/time_utils.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 from datetime import datetime, timedelta
-from typing import List, Union, Tuple, Optional
 
 from flask import current_app
 from flask_security.core import current_user
@@ -19,8 +18,8 @@ def server_now() -> datetime:
 
 
 def ensure_local_timezone(
-    dt: Union[pd.Timestamp, datetime], tz_name: str = "Europe/Amsterdam"
-) -> Union[pd.Timestamp, datetime]:
+    dt: pd.Timestamp | datetime, tz_name: str = "Europe/Amsterdam"
+) -> pd.Timestamp | datetime:
     """If no timezone is given, assume the datetime is in the given timezone and make it explicit.
     Otherwise, if a timezone is given, convert to that timezone."""
     if isinstance(dt, datetime):
@@ -62,8 +61,8 @@ def naive_utc_from(dt: datetime) -> datetime:
 
 
 def tz_index_naively(
-    data: Union[pd.DataFrame, pd.Series, pd.DatetimeIndex]
-) -> Union[pd.DataFrame, pd.Series, pd.DatetimeIndex]:
+    data: pd.DataFrame | pd.Series | pd.DatetimeIndex
+) -> pd.DataFrame | pd.Series | pd.DatetimeIndex:
     """Turn any DatetimeIndex into a tz-naive one, then return. Useful for bokeh, for instance."""
     if isinstance(data, pd.DatetimeIndex):
         return data.tz_localize(tz=None)
@@ -89,7 +88,7 @@ def localized_datetime_str(dt: datetime, dt_format: str = "%Y-%m-%d %I:%M %p") -
 
 
 def naturalized_datetime_str(
-    dt: Optional[datetime], now: Optional[datetime] = None
+    dt: datetime | None, now: datetime | None = None
 ) -> str:
     """
     Naturalise a datetime object (into a human-friendly string).
@@ -128,7 +127,7 @@ def naturalized_datetime_str(
         return naturaldate(local_dt)
 
 
-def resolution_to_hour_factor(resolution: Union[str, timedelta]) -> float:
+def resolution_to_hour_factor(resolution: str | timedelta) -> float:
     """Return the factor with which a value needs to be multiplied in order to get the value per hour,
     e.g. 10 MW at a resolution of 15min are 2.5 MWh per time step.
 
@@ -139,7 +138,7 @@ def resolution_to_hour_factor(resolution: Union[str, timedelta]) -> float:
     return pd.Timedelta(resolution).to_pytimedelta() / timedelta(hours=1)
 
 
-def decide_resolution(start: Optional[datetime], end: Optional[datetime]) -> str:
+def decide_resolution(start: datetime | None, end: datetime | None) -> str:
     """
     Decide on a practical resolution given the length of the selected time period.
     Useful for querying or plotting.
@@ -202,9 +201,9 @@ def get_most_recent_hour() -> datetime:
 
 def get_most_recent_clocktime_window(
     window_size_in_minutes: int,
-    now: Optional[datetime] = None,
-    grace_period_in_seconds: Optional[int] = 0,
-) -> Tuple[datetime, datetime]:
+    now: datetime | None = None,
+    grace_period_in_seconds: int | None = 0,
+) -> tuple[datetime, datetime]:
     """
     Calculate a recent time window, returning a start and end minute so that
     a full hour can be filled with such windows, e.g.:
@@ -270,8 +269,8 @@ def freq_label_to_human_readable_label(freq_label: str) -> str:
 
 
 def forecast_horizons_for(
-    resolution: Union[str, timedelta]
-) -> Union[List[str], List[timedelta]]:
+    resolution: str | timedelta
+) -> list[str] | list[timedelta]:
     """Return a list of horizons that are supported per resolution.
     Return values or of the same type as the input."""
     if isinstance(resolution, timedelta):
@@ -293,7 +292,7 @@ def forecast_horizons_for(
         return horizons
 
 
-def supported_horizons() -> List[timedelta]:
+def supported_horizons() -> list[timedelta]:
     return [
         timedelta(hours=1),
         timedelta(hours=6),

--- a/flexmeasures/utils/unit_utils.py
+++ b/flexmeasures/utils/unit_utils.py
@@ -11,7 +11,6 @@ Percentages can be converted to units of some physical capacity if a capacity is
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import List, Optional, Union
 
 from moneyed import list_all_currencies
 import numpy as np
@@ -87,7 +86,7 @@ def is_valid_unit(unit: str) -> bool:
 
 
 def determine_unit_conversion_multiplier(
-    from_unit: str, to_unit: str, duration: Optional[timedelta] = None
+    from_unit: str, to_unit: str, duration: timedelta | None = None
 ):
     """Determine the value multiplier for a given unit conversion.
     If needed, requires a duration to convert from units of stock change to units of flow, or vice versa.
@@ -209,7 +208,7 @@ def is_energy_price_unit(unit: str) -> bool:
 
 
 def _convert_time_units(
-    data: Union[tb.BeliefsSeries, pd.Series, List[Union[int, float]], int, float],
+    data: tb.BeliefsSeries | pd.Series | list[int | float] | int | float,
     from_unit: str,
     to_unit: str,
 ):
@@ -229,12 +228,12 @@ def _convert_time_units(
 
 
 def convert_units(
-    data: Union[tb.BeliefsSeries, pd.Series, List[Union[int, float]], int, float],
+    data: tb.BeliefsSeries | pd.Series | list[int | float] | int | float,
     from_unit: str,
     to_unit: str,
-    event_resolution: Optional[timedelta] = None,
-    capacity: Optional[str] = None,
-) -> Union[pd.Series, List[Union[int, float]], int, float]:
+    event_resolution: timedelta | None = None,
+    capacity: str | None = None,
+) -> pd.Series | list[int | float] | int | float:
     """Updates data values to reflect the given unit conversion."""
     if from_unit in ("datetime", "timedelta"):
         return _convert_time_units(data, from_unit, to_unit)


### PR DESCRIPTION
Move to modern type annotations, but only in modules that are not seeing active development or are expected to be deprecated soon.

Also stops justify aligning TOC contents, for which we use a double-column layout, and hence, there is less width available to accommodate justify aligning.

(Quite a devilish PR...)