### PR TITLE
fix: deprecated decorator wasn't returning the value of the moved cal…

### DIFF
--- a/flexmeasures/utils/coding_utils.py
+++ b/flexmeasures/utils/coding_utils.py
@@ -166,7 +166,7 @@ def deprecated(alternative, version: str | None = None):
                 f"The method or function {func.__name__} is deprecated and it is expected to be sunset in version {version}. Please, switch to using {inspect.getmodule(alternative).__name__}:{alternative.__name__} to suppress this warning."
             )
 
-            func(*args, **kwargs)
+            return func(*args, **kwargs)
 
         return wrapper
 

--- a/flexmeasures/utils/tests/test_coding_utils.py
+++ b/flexmeasures/utils/tests/test_coding_utils.py
@@ -2,7 +2,7 @@ from flexmeasures.utils.coding_utils import deprecated
 
 
 def other_function():
-    pass
+    return 1
 
 
 def test_deprecated_decorator(caplog, app):
@@ -10,11 +10,11 @@ def test_deprecated_decorator(caplog, app):
     # defining a function that is deprecated
     @deprecated(other_function, "v14")
     def deprecated_function():
-        pass
+        return other_function()
 
     caplog.clear()
 
-    deprecated_function()  # calling a deprecated function
+    value = deprecated_function()  # calling a deprecated function
     print(caplog.records)
     assert len(caplog.records) == 1  # only 1 warning being printed
 
@@ -25,3 +25,7 @@ def test_deprecated_decorator(caplog, app):
     assert "v14" in str(
         caplog.records[0].message
     )  # checking that the message is correct
+
+    assert (
+        value == 1
+    )  # check that the decorator is returning the value of `other_function`


### PR DESCRIPTION
While trying to the decorator `@deprecated` to refactor a function signature, I realized that is not returning the value of the function, just calling it. 

This bug affects the following functions:

* `flexmeasures.data.queries.data_sources:get_or_create_source`
* `flexmeasures.data.queries.data_sources:get_source_or_none`
* `flexmeasures.data.services.asset_grouping:get_asset_group_queries`

and methods:

* `flexmeasures.data.models.planning:Scheduler.compute_schedule`
* `flexmeasures.data.models.planning:storage:StorageScheduler.compute_schedule`

This is specially concerning for code extending from `Scheduler`.
