### PR TITLE
fix: limit numpy version to fix ReadTheDocs build

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -24,6 +24,7 @@ jobs:
         include:
           - python-version: "3.9"
             coverage: yes
+            upgrade: yes
     name: "Test (on Python ${{ matrix.py_version }})"
     steps:
       - uses: actions/setup-python@v4
@@ -59,6 +60,12 @@ jobs:
         run: pytest -v -m "not skip_github" --cov=flexmeasures --cov-branch
         if: ${{ matrix.coverage == 'yes' }}
       - run: coveralls --service=github
+      - name: Upgrade dependencies
+        run: pip install --upgrade --upgrade-strategy eager --no-cache-dir .
+        if: ${{ matrix.upgrade == 'yes' }}
+      - name: Run all tests except those marked to be skipped by GitHub
+        run: pytest -m "not skip_github"
+        if: ${{ matrix.upgrade == 'yes' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ matrix.coverage == 'yes' }}

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -24,7 +24,6 @@ jobs:
         include:
           - python-version: "3.9"
             coverage: yes
-            upgrade: yes
     name: "Test (on Python ${{ matrix.py_version }})"
     steps:
       - uses: actions/setup-python@v4
@@ -60,12 +59,6 @@ jobs:
         run: pytest -v -m "not skip_github" --cov=flexmeasures --cov-branch
         if: ${{ matrix.coverage == 'yes' }}
       - run: coveralls --service=github
-      - name: Upgrade dependencies
-        run: pip install --upgrade --upgrade-strategy eager --no-cache-dir .
-        if: ${{ matrix.upgrade == 'yes' }}
-      - name: Run all tests except those marked to be skipped by GitHub
-        run: pytest -m "not skip_github"
-        if: ${{ matrix.upgrade == 'yes' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ matrix.coverage == 'yes' }}

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -14,7 +14,8 @@ humanize
 psycopg2-binary
 bcrypt
 pytz
-numpy
+# limit the numpy version to make it compatible with numba==0.56.4
+numpy<1.24
 isodate
 click
 click-default-group

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -14,7 +14,7 @@ humanize
 psycopg2-binary
 bcrypt
 pytz
-# limit the numpy version to make it compatible with numba==0.56.4
+# limit the numpy version to make it compatible with numba==0.56.4, which timely-beliefs >=1.18 depends on (library sktime).
 numpy<1.24
 isodate
 click

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -14,7 +14,7 @@ humanize
 psycopg2-binary
 bcrypt
 pytz
-numpy
+numpy<1.24
 isodate
 click
 click-default-group

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -14,7 +14,7 @@ humanize
 psycopg2-binary
 bcrypt
 pytz
-numpy<1.24
+numpy
 isodate
 click
 click-default-group


### PR DESCRIPTION
Closes #681 

This PR limits the numpy version to <0.1.24 to make it compatible with `numba==0.56.4`.

Please, let me know your thoughts on this :D