### PR TITLE
feat: create the CLI command `flexmeasures show reporters`

### DIFF
--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -246,8 +246,8 @@ deserializing
 kwargs
 fsdomain
 filepath
+spellright
 Changelog
 Bugfixes
 Dockerfile
-―
 nt

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -10,6 +10,7 @@ New features
 -------------
 
 * Introduction of the classes `Reporter` and `PandasReporter` [see `PR #641 <https://www.github.com/FlexMeasures/flexmeasures/pull/641>`_]
+* Add CLI command ``flexmeasures show reporters`` [see `PR #686 <https://www.github.com/FlexMeasures/flexmeasures/pull/686>`_]
 
 
 Bugfixes

--- a/documentation/cli/commands.rst
+++ b/documentation/cli/commands.rst
@@ -53,6 +53,7 @@ of which some are referred to in this documentation.
 ``flexmeasures show roles``                       List available account- and user roles.
 ``flexmeasures show data-sources``                List available data sources.
 ``flexmeasures show beliefs``                     Plot time series data.
+``flexmeasures show reporters``                   List available reporters.
 ================================================= =======================================
 
 

--- a/documentation/dev/introduction.rst
+++ b/documentation/dev/introduction.rst
@@ -1,6 +1,7 @@
 .. _developing:
 
 
+
 Developing for FlexMeasures
 ===========================
 
@@ -35,8 +36,6 @@ Clone the `FlexMeasures repository <https://github.com/FlexMeasures/flexmeasures
 .. code-block:: bash
 
    $ git clone https://github.com/FlexMeasures/flexmeasures.git
-
-.. note:: Are you using Visual Studio Code? Then the code you just cloned also contains the editor configuration (part of) our team is using!
 
 
 Dependencies
@@ -209,6 +208,23 @@ This is also what happens automatically server-side when code is committed to a 
 
 If ``flake8``, ``black`` or ``mypy`` propose changes to any file, the commit is aborted (saying that it "failed"). 
 The changes proposed by ``black`` are implemented automatically (you can review them with `git diff`). Some of them might even resolve the ``flake8`` warnings :)
+
+
+Using Visual Studio, including spell checking
+----------------------------------------------
+
+Are you using Visual Studio Code? Then the code you just cloned also contains the editor configuration (part of) our team is using (see `.vscode`)!
+
+We recommend installing the flake8 and spellright extensions.
+
+For spellright, the FlexMeasures repository contains the project dictionary. Here are steps to link main dictionaries, which usually work on a Linux system:
+
+.. code-block:: bash
+
+   $ mkdir $HOME/.config/Code/Dictionaries
+   $ ln -s /usr/share/hunspell/* ~/.config/Code/Dictionaries
+
+Consult the extension's Readme for other systems.
 
 
 

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -1133,7 +1133,8 @@ def add_schedule_for_storage(
     default="PandasReporter",
     required=True,
     type=click.STRING,
-    help="Reporter class registered in flexmeasures.data.models.reporting or in an available flexmeasures plugin.",
+    help="Reporter class registered in flexmeasures.data.models.reporting or in an available flexmeasures plugin."
+    " Use the command `flexmeasures show reporters` to list all the available reporters.",
 )
 @click.option(
     "--sensor-id",

--- a/flexmeasures/cli/data_show.py
+++ b/flexmeasures/cli/data_show.py
@@ -376,4 +376,27 @@ def plot_beliefs(
         click.secho("Data saved to file.", **MsgStyle.SUCCESS)
 
 
+@fm_show_data.command("reporters")
+@with_appcontext
+def list_reporters():
+    """
+    Show available reporters.
+    """
+
+    click.echo("Reporters:\n")
+    click.echo(
+        tabulate(
+            [
+                (
+                    reporter_name,
+                    reporter_class.__version__,
+                    str(reporter_class.__author__),
+                )
+                for reporter_name, reporter_class in app.reporters.items()
+            ],
+            headers=["name", "version", "author"],
+        )
+    )
+
+
 app.cli.add_command(fm_show_data)

--- a/flexmeasures/cli/data_show.py
+++ b/flexmeasures/cli/data_show.py
@@ -388,13 +388,14 @@ def list_reporters():
         tabulate(
             [
                 (
+                    reporter_class.__module__,
                     reporter_name,
                     reporter_class.__version__,
-                    str(reporter_class.__author__),
+                    reporter_class.__author__,
                 )
                 for reporter_name, reporter_class in app.reporters.items()
             ],
-            headers=["name", "version", "author"],
+            headers=["module", "name", "version", "author"],
         )
     )
 

--- a/flexmeasures/cli/data_show.py
+++ b/flexmeasures/cli/data_show.py
@@ -388,14 +388,14 @@ def list_reporters():
         tabulate(
             [
                 (
-                    reporter_class.__module__,
                     reporter_name,
                     reporter_class.__version__,
                     reporter_class.__author__,
+                    reporter_class.__module__,
                 )
                 for reporter_name, reporter_class in app.reporters.items()
             ],
-            headers=["module", "name", "version", "author"],
+            headers=["name", "version", "author", "module"],
         )
     )
 


### PR DESCRIPTION
An interesting feature after the `flexmeasures add report` is the possibility to show all the available reporters. This PR creates a new command that list all the reporter classes that can be used: all the classes in `flexmeasures.data.models.reporting` and in the main file of every plugin (__init__.py) that subclass `Reporter`.

## Usage

```terminal
$ flexmeasures show reporters
```
## Output example
```
Reporters:

name              version  author
--------------  ---------  --------
PandasReporter          1  None
```