### PR TITLE
Revert some modern type annotations, to keep support for Python 3.8

### DIFF
--- a/flexmeasures/auth/policy.py
+++ b/flexmeasures/auth/policy.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-# Use | instead of Union when FM stops supporting Python 3.9 (because of https://github.com/python/cpython/issues/86399)
-from typing import Union
+# Use | instead of Union, list instead of List and tuple instead of Tuple when FM stops supporting Python 3.9 (because of https://github.com/python/cpython/issues/86399)
+from typing import List, Tuple, Union
 
 from flask import current_app
 from flask_security import current_user
@@ -16,7 +16,7 @@ ADMIN_READER_ROLE = "admin-reader"
 # constants to allow access to certain groups
 EVERY_LOGGED_IN_USER = "every-logged-in-user"
 
-PRINCIPALS_TYPE = Union[str, tuple[str], list[Union[str, tuple[str]]]]
+PRINCIPALS_TYPE = Union[str, Tuple[str], List[Union[str, Tuple[str]]]]
 
 
 class AuthModelMixin(object):

--- a/flexmeasures/data/services/time_series.py
+++ b/flexmeasures/data/services/time_series.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-# Use | instead of Union when FM stops supporting Python 3.9 (because of https://github.com/python/cpython/issues/86399)
-from typing import Any, Callable, Optional, Union
+# Use | instead of Union, list instead of List and tuple instead of Tuple when FM stops supporting Python 3.9 (because of https://github.com/python/cpython/issues/86399)
+from typing import Any, Callable, List, Optional, Tuple, Union
 from datetime import datetime, timedelta
 
 import inflect
@@ -22,14 +22,14 @@ p = inflect.engine()
 # Signature of a callable that build queries
 QueryCallType = Callable[
     [
-        tuple[str],
-        tuple[datetime, datetime],
-        tuple[Optional[timedelta], Optional[timedelta]],
-        tuple[Optional[datetime], Optional[datetime]],
+        Tuple[str],
+        Tuple[datetime, datetime],
+        Tuple[Optional[timedelta], Optional[timedelta]],
+        Tuple[Optional[datetime], Optional[datetime]],
         Optional[datetime],
-        Optional[Union[int, list[int]]],
-        Optional[list[str]],
-        Optional[list[str]],
+        Optional[Union[int, List[int]]],
+        Optional[List[str]],
+        Optional[List[str]],
     ],
     Query,
 ]


### PR DESCRIPTION
Closes https://github.com/FlexMeasures/flexmeasures/issues/684.