### PR TITLE
696 readthedocs build is eagerly installing dependencies leading to unpredictable builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,8 +20,10 @@ python:
   install:
     - requirements: requirements/app.txt
     - requirements: requirements/docs.txt
-    - method: pip
-      path: .
+
+jobs:
+  post_create_environment:
+    - pip install . --no-deps
 
 sphinx:
   fail_on_warning: true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,15 +15,15 @@ build:
   os: ubuntu-20.04
   tools:
     python: "3.9"
+  jobs:
+    post_create_environment:
+      - pip install . --no-deps
 
 python: 
   install:
     - requirements: requirements/app.txt
     - requirements: requirements/docs.txt
 
-jobs:
-  post_create_environment:
-    - pip install . --no-deps
 
 sphinx:
   fail_on_warning: true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,7 +17,7 @@ build:
     python: "3.9"
   jobs:
     post_create_environment:
-      - pip install . --no-deps
+      - pip install . --no-deps  # as python install step, RTD installs deps eagerly
 
 python: 
   install:


### PR DESCRIPTION
Closes #696 

I told RTD to build this branch (otherwise it only builds main), and it succeeded:

https://readthedocs.org/projects/flexmeasures/builds/20799757/