### PR TITLE
feat: set default `event_resolution` to fetch input data for the `Reporter`

### DIFF
--- a/flexmeasures/data/models/reporting/__init__.py
+++ b/flexmeasures/data/models/reporting/__init__.py
@@ -108,6 +108,9 @@ class Reporter(DataGeneratorMixin):
         if self.reporter_config is None:
             self.deserialize_config()
 
+        if input_resolution is None:
+            input_resolution = self.sensor.event_resolution
+
         # fetch data
         self.fetch_data(start, end, input_resolution, belief_time)
 

--- a/flexmeasures/data/models/reporting/tests/test_tibber_reporter.py
+++ b/flexmeasures/data/models/reporting/tests/test_tibber_reporter.py
@@ -250,7 +250,6 @@ def test_tibber_reporter(tibber_test_data):
     result = tibber_reporter.compute(
         start=datetime(2023, 4, 13, tzinfo=utc),
         end=datetime(2023, 4, 14, tzinfo=utc),
-        input_resolution=timedelta(hours=1),
     )
 
     # check that we got a result for 24 hours


### PR DESCRIPTION
Use the `event_resolution` of the report sensor as the default value to be used in the fetching step.

This is useful, among other cases, for the *Tibber Price Reporter* as we want to get hourly resolution VAT, Energy Tax and Tibber Tariff from yearly sensors.