### PR TITLE
Pandas reporter schema output event resolution

### DIFF
--- a/flexmeasures/data/models/reporting/__init__.py
+++ b/flexmeasures/data/models/reporting/__init__.py
@@ -75,7 +75,7 @@ class Reporter(DataGeneratorMixin):
             )
 
             # store data source as local variable
-            for source in bdf.sources.unique():
+            for source in bdf.sources.unique().dropna():
                 self.data[f"source_{source.id}"] = source
 
             # store BeliefsDataFrame as local variable

--- a/flexmeasures/data/models/reporting/pandas_reporter.py
+++ b/flexmeasures/data/models/reporting/pandas_reporter.py
@@ -30,6 +30,9 @@ class PandasReporter(Reporter):
         # extract PandasReporter specific fields
         self.transformations = self.reporter_config.get("transformations")
         self.final_df_output = self.reporter_config.get("final_df_output")
+        self.output_event_resolution = self.reporter_config.get(
+            "output_event_resolution"
+        )
 
     def _compute(
         self,
@@ -83,6 +86,9 @@ class PandasReporter(Reporter):
                 for event_start, event_value in final_output.iteritems()
             ]
             final_output = tb.BeliefsDataFrame(timed_beliefs)
+
+        if self.output_event_resolution:
+            final_output.event_resolution = self.output_event_resolution
 
         return final_output
 

--- a/flexmeasures/data/schemas/reporting/pandas_reporter.py
+++ b/flexmeasures/data/schemas/reporting/pandas_reporter.py
@@ -5,6 +5,8 @@ from flexmeasures.data.schemas.reporting import ReporterConfigSchema
 
 from timely_beliefs import BeliefsDataFrame
 
+from flexmeasures.data.schemas import DurationField
+
 
 class PandasMethodCall(Schema):
 
@@ -74,6 +76,7 @@ class PandasReporterConfigSchema(ReporterConfigSchema):
 
     transformations = fields.List(fields.Nested(PandasMethodCall()), required=True)
     final_df_output = fields.Str(required=True)
+    output_event_resolution = DurationField(required=False)
 
     @validates_schema
     def validate_chaining(self, data, **kwargs):


### PR DESCRIPTION
Add the field `output_event_resolution` field to `PandasReporterConfigSchema` used to set the `event_resolution` of the `final_df_output`. This is useful for cases in which we want to modify the `event_resolution` using methods that are not part of  timely-beliefs (e.g: resample).

In addition, this PR solves the issue of having NaN DataSources in the returned timely-beliefs.