### PR TITLE
Create command to show available Schedulers

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,6 +13,7 @@ New features
 * Introduction of the classes `Reporter` and `PandasReporter` [see `PR #641 <https://www.github.com/FlexMeasures/flexmeasures/pull/641>`_]
 * Add CLI command ``flexmeasures add report`` [see `PR #659 <https://www.github.com/FlexMeasures/flexmeasures/pull/659>`_]
 * Add CLI command ``flexmeasures show reporters`` [see `PR #686 <https://www.github.com/FlexMeasures/flexmeasures/pull/686>`_]
+* Add CLI command ``flexmeasures show schedulers`` [see `PR #708 <https://github.com/FlexMeasures/flexmeasures/pull/708>`_]
 
 Bugfixes
 -----------

--- a/documentation/cli/commands.rst
+++ b/documentation/cli/commands.rst
@@ -55,6 +55,7 @@ of which some are referred to in this documentation.
 ``flexmeasures show data-sources``                List available data sources.
 ``flexmeasures show beliefs``                     Plot time series data.
 ``flexmeasures show reporters``                   List available reporters.
+``flexmeasures show schedulers``                  List available schedulers.
 ================================================= =======================================
 
 

--- a/flexmeasures/app.py
+++ b/flexmeasures/app.py
@@ -99,16 +99,12 @@ def create(  # noqa C901
 
     register_db_at(app)
 
-    # Register Reporters
+    # Register Reporters and Schedulers
     from flexmeasures.utils.coding_utils import get_classes_module
-    from flexmeasures.data.models.reporting import Reporter
+    from flexmeasures.data.models import reporting, planning
 
-    app.reporters = get_classes_module("flexmeasures.data.models.reporting", Reporter)
-
-    # Register Schedulers
-    from flexmeasures.data.models.planning import Scheduler
-
-    app.schedulers = get_classes_module("flexmeasures.data.models.planning", Scheduler)
+    app.reporters = get_classes_module("flexmeasures.data.models", reporting.Reporter)
+    app.schedulers = get_classes_module("flexmeasures.data.models", planning.Scheduler)
 
     # add auth policy
 

--- a/flexmeasures/app.py
+++ b/flexmeasures/app.py
@@ -105,6 +105,11 @@ def create(  # noqa C901
 
     app.reporters = get_classes_module("flexmeasures.data.models.reporting", Reporter)
 
+    # Register Schedulers
+    from flexmeasures.data.models.planning import Scheduler
+
+    app.schedulers = get_classes_module("flexmeasures.data.models.planning", Scheduler)
+
     # add auth policy
 
     from flexmeasures.auth import register_at as register_auth_at

--- a/flexmeasures/cli/data_show.py
+++ b/flexmeasures/cli/data_show.py
@@ -400,4 +400,28 @@ def list_reporters():
     )
 
 
+@fm_show_data.command("schedulers")
+@with_appcontext
+def list_schedulers():
+    """
+    Show available schedulers.
+    """
+
+    click.echo("Schedulers:\n")
+    click.echo(
+        tabulate(
+            [
+                (
+                    scheduler_name,
+                    scheduler_class.__version__,
+                    scheduler_class.__author__,
+                    scheduler_class.__module__,
+                )
+                for scheduler_name, scheduler_class in app.schedulers.items()
+            ],
+            headers=["name", "version", "author", "module"],
+        )
+    )
+
+
 app.cli.add_command(fm_show_data)

--- a/flexmeasures/cli/data_show.py
+++ b/flexmeasures/cli/data_show.py
@@ -376,6 +376,28 @@ def plot_beliefs(
         click.secho("Data saved to file.", **MsgStyle.SUCCESS)
 
 
+def list_items(item_type):
+    """
+    Show available items of a specific type.
+    """
+
+    click.echo(f"{item_type.capitalize()}:\n")
+    click.echo(
+        tabulate(
+            [
+                (
+                    item_name,
+                    item_class.__version__,
+                    item_class.__author__,
+                    item_class.__module__,
+                )
+                for item_name, item_class in getattr(app, item_type).items()
+            ],
+            headers=["name", "version", "author", "module"],
+        )
+    )
+
+
 @fm_show_data.command("reporters")
 @with_appcontext
 def list_reporters():
@@ -383,21 +405,8 @@ def list_reporters():
     Show available reporters.
     """
 
-    click.echo("Reporters:\n")
-    click.echo(
-        tabulate(
-            [
-                (
-                    reporter_name,
-                    reporter_class.__version__,
-                    reporter_class.__author__,
-                    reporter_class.__module__,
-                )
-                for reporter_name, reporter_class in app.reporters.items()
-            ],
-            headers=["name", "version", "author", "module"],
-        )
-    )
+    with app.app_context():
+        list_items("reporters")
 
 
 @fm_show_data.command("schedulers")
@@ -407,21 +416,8 @@ def list_schedulers():
     Show available schedulers.
     """
 
-    click.echo("Schedulers:\n")
-    click.echo(
-        tabulate(
-            [
-                (
-                    scheduler_name,
-                    scheduler_class.__version__,
-                    scheduler_class.__author__,
-                    scheduler_class.__module__,
-                )
-                for scheduler_name, scheduler_class in app.schedulers.items()
-            ],
-            headers=["name", "version", "author", "module"],
-        )
-    )
+    with app.app_context():
+        list_items("schedulers")
 
 
 app.cli.add_command(fm_show_data)

--- a/flexmeasures/utils/coding_utils.py
+++ b/flexmeasures/utils/coding_utils.py
@@ -182,21 +182,20 @@ def find_classes_module(module, superclass, skiptest=True):
         if skiptest and ("test" in f"{module}.{submodule.name}"):
             continue
 
+        module_object = importlib.import_module(f"{module}.{submodule.name}")
+        module_classes = inspect.getmembers(module_object, inspect.isclass)
+        classes.extend(
+            [
+                (class_name, klass)
+                for class_name, klass in module_classes
+                if issubclass(klass, superclass) and klass != superclass
+            ]
+        )
         if submodule.ispkg:
             classes.extend(
                 find_classes_module(
                     f"{module}.{submodule.name}", superclass, skiptest=skiptest
                 )
-            )
-        else:
-            module_object = importlib.import_module(f"{module}.{submodule.name}")
-            module_classes = inspect.getmembers(module_object, inspect.isclass)
-            classes.extend(
-                [
-                    (class_name, klass)
-                    for class_name, klass in module_classes
-                    if issubclass(klass, superclass) and klass != superclass
-                ]
             )
 
     return classes

--- a/flexmeasures/utils/plugin_utils.py
+++ b/flexmeasures/utils/plugin_utils.py
@@ -102,10 +102,12 @@ def register_plugins(app: Flask):
             app.logger.debug(f"Registering {plugin_blueprint} ...")
             app.register_blueprint(plugin_blueprint)
 
-        # Loading reporters
+        # Load reporters and schedulers
         from flexmeasures.data.models.reporting import Reporter
+        from flexmeasures.data.models.planning import Scheduler
 
         app.reporters.update(get_classes_module(module.__name__, Reporter))
+        app.schedulers.update(get_classes_module(module.__name__, Scheduler))
 
         app.config["LOADED_PLUGINS"][plugin_name] = plugin_version
     app.logger.info(f"Loaded plugins: {app.config['LOADED_PLUGINS']}")


### PR DESCRIPTION
This PR builds upon the previous work done in PR #686, which introduced the command `flexmeasures show reporters`. Now, we extend this functionality to include the Scheduler class as well. The new command, `flexmeasures show schedulers`, allows users to view a comprehensive list of all available schedulers within flexmeasures.