### PR TITLE
fix: forwarding arguments in deprecated util function

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -29,6 +29,14 @@ Infrastructure / Support
 .. warning:: The setting `FLEXMEASURES_PLUGIN_PATHS` has been deprecated since v0.7. It has now been sunset. Please replace it with :ref:`plugin-config`.
 
 
+v0.13.3 | June 10, 2023
+=======================
+
+Bugfixes
+---------
+* Fix forwarding arguments in deprecated util function [see `PR #719 <https://github.com/FlexMeasures/flexmeasures/pull/719>`_]
+
+
 v0.13.2 | June 9, 2023
 =======================
 

--- a/flexmeasures/data/queries/data_sources.py
+++ b/flexmeasures/data/queries/data_sources.py
@@ -18,7 +18,7 @@ def get_or_create_source(
     model: str | None = None,
     flush: bool = True,
 ) -> DataSource:
-    return get_or_create_source_new(source, source_type, model, flush)
+    return get_or_create_source_new(source, source_type, model, flush=flush)
 
 
 @deprecated(get_source_or_none_new, "0.14")


### PR DESCRIPTION
The new function that replaced `get_or_create_source` introduced an extra `version` parameter before the `flush` parameter. I see this as a nice illustration that we should prefer kwargs over args.