### PR TITLE
docs: unindex the sunset API versions from documentation

### DIFF
--- a/documentation/api/introduction.rst
+++ b/documentation/api/introduction.rst
@@ -45,7 +45,7 @@ Let's see what the ``/api`` endpoint returns:
     {'flexmeasures_version': '0.9.0',
      'message': 'For these API versions endpoints are available. An authentication token can be requested at: /api/requestAuthToken. For a list of services, see https://flexmeasures.readthedocs.io',
      'status': 200,
-     'versions': ['v1', 'v1_1', 'v1_2', 'v1_3', 'v2_0', 'v3_0']
+     'versions': ['v3_0']
     }
 
 So this tells us which API versions exist. For instance, we know that the latest API version is available at:
@@ -56,6 +56,9 @@ So this tells us which API versions exist. For instance, we know that the latest
 
 
 Also, we can see that a list of endpoints is available on https://flexmeasures.readthedocs.io for each of these versions.
+
+.. note:: Sunset API versions are still documented there, simply select an older version.
+
 
 .. _api_auth:
 

--- a/documentation/api/notation.rst
+++ b/documentation/api/notation.rst
@@ -145,10 +145,8 @@ Technically, this is equal to:
 
 This intuitive convention allows us to reduce communication by sending univariate timeseries as arrays.
 
-Notation for v1, v2 and v3
-""""""""""""""""""""""""""
 
-For version 1, 2 and 3 of the API, only equidistant timeseries data is expected to be communicated. Therefore:
+In all current versions of the FlexMeasures API, only equidistant timeseries data is expected to be communicated. Therefore:
 
 - only the array notation should be used (first notation from above),
 - "start" should be a timestamp on the hour or a multiple of the sensor resolution thereafter (e.g. "16:10" works if the resolution is 5 minutes), and

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -200,11 +200,6 @@ The platform operator of FlexMeasures can be an Aggregator.
     api/introduction
     api/notation
     api/v3_0
-    api/v2_0
-    api/v1_3
-    api/v1_2
-    api/v1_1
-    api/v1
     api/dev
     api/change_log
 


### PR DESCRIPTION
The latest version of the RTD docs don't need to show the sunset version in the menu anymore.

Older versions of the docs will always be available and show them in the menu.