### PR TITLE
fix: relax decimal resolution in constraint validation

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -16,6 +16,15 @@ Infrastructure / Support
 ----------------------
 
 
+v0.14.1 | June XX, 2023
+============================
+
+Bugfixes
+-----------
+
+* Relax constraint validation of `StorageScheduler` to accommodate violations caused by floating point precision [see `PR #731 <https://www.github.com/FlexMeasures/flexmeasures/pull/731>`_]
+
+
 v0.14.0 | June 15, 2023
 ============================
 

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -724,11 +724,16 @@ def validate_constraint(
 ) -> list[dict]:
     """Validate the feasibility of a given set of constraints.
 
-    :param constraints_df: DataFrame with the constraints
-    :param constraint_expression: inequality expression following pd.eval format.
-                                  No need to use the syntax `column` to reference
-                                  column, just use the column name.
-    :return: List of constraint violations, specifying their time, constraint and violation.
+    :param constraints_df:      DataFrame with the constraints
+    :param lhs_expression:      left-hand side of the inequality expression following pd.eval format.
+                                No need to use the syntax `column` to reference
+                                column, just use the column name.
+    :param inequality:          inequality operator, one of ('<=', '<', '>=', '>', '==', '!=').
+    :param rhs_expression:      right-hand side of the inequality expression following pd.eval format.
+                                No need to use the syntax `column` to reference
+                                column, just use the column name.
+    :param round_to_decimals:   Number of decimals to round off to before validating constraints.
+    :return:                    List of constraint violations, specifying their time, constraint and violation.
     """
 
     constraint_expression = f"{lhs_expression} {inequality} {rhs_expression}"

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import re
 import copy
 from datetime import datetime, timedelta
-from typing import List, Dict, Optional
 
 import pandas as pd
 import numpy as np
@@ -407,7 +406,7 @@ def create_constraint_violations_message(constraint_violations: list) -> str:
 
 
 def build_device_soc_values(
-    soc_values: List[Dict[str, datetime | float]] | pd.Series,
+    soc_values: list[dict[str, datetime | float]] | pd.Series,
     soc_at_start: float,
     start_of_schedule: datetime,
     end_of_schedule: datetime,
@@ -476,9 +475,9 @@ def add_storage_constraints(
     end: datetime,
     resolution: timedelta,
     soc_at_start: float,
-    soc_targets: List[Dict[str, datetime | float]] | pd.Series | None,
-    soc_maxima: List[Dict[str, datetime | float]] | pd.Series | None,
-    soc_minima: List[Dict[str, datetime | float]] | pd.Series | None,
+    soc_targets: list[dict[str, datetime | float]] | pd.Series | None,
+    soc_maxima: list[dict[str, datetime | float]] | pd.Series | None,
+    soc_minima: list[dict[str, datetime | float]] | pd.Series | None,
     soc_max: float,
     soc_min: float,
 ) -> pd.DataFrame:
@@ -695,7 +694,7 @@ def get_pattern_match_word(word: str) -> str:
     return regex + re.escape(word) + regex
 
 
-def sanitize_expression(expression: str, columns: list) -> tuple(str, list):
+def sanitize_expression(expression: str, columns: list) -> tuple[str, list]:
     """Wrap column in commas to accept arbitrary column names (e.g. with spaces).
 
     :param expression: expression to sanitize
@@ -721,7 +720,7 @@ def validate_constraint(
     lhs_expression: str,
     inequality: str,
     rhs_expression: str,
-    round_to_decimals: Optional[int] = 6,
+    round_to_decimals: int | None = 6,
 ) -> list[dict]:
     """Validate the feasibility of a given set of constraints.
 
@@ -814,7 +813,7 @@ def prepend_serie(serie: pd.Series, value) -> pd.Series:
 ####################
 @deprecated(build_device_soc_values, "0.14")
 def build_device_soc_targets(
-    targets: List[Dict[str, datetime | float]] | pd.Series,
+    targets: list[dict[str, datetime | float]] | pd.Series,
     soc_at_start: float,
     start_of_schedule: datetime,
     end_of_schedule: datetime,

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -187,7 +187,9 @@ class StorageScheduler(Scheduler):
 
             if len(constraint_violations) > 0:
                 # TODO: include hints from constraint_violations into the error message
-                message = create_constraint_violations_message(constraint_violations)
+                message = create_constraint_violations_message(
+                    constraint_violations, self.round_to_decimals
+                )
                 raise ValueError(
                     "The input data yields an infeasible problem. Constraint validation has found the following issues:\n"
                     + message

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -640,6 +640,26 @@ def test_add_storage_constraints(
 @pytest.mark.parametrize(
     "value_min1, value_equals1, value_max1, value_min2, value_equals2, value_max2, expected_constraint_type_violations",
     [
+        (1, np.nan, 9, 1, np.nan, 9, []),  # base case
+        (1, np.nan, 10, 1, np.nan, 10, []),  # exact equality
+        (
+            1,
+            np.nan,
+            10 + 0.5e-6,
+            1,
+            np.nan,
+            10,
+            [],
+        ),  # equality considering the precision (6 decimal figures)
+        (
+            1,
+            np.nan,
+            10 + 1e-5,
+            1,
+            np.nan,
+            10,
+            ["max(t) <= soc_max(t)"],
+        ),  # difference of 0.5e-5 > 1e-6
         (1, np.nan, 9, 2, np.nan, 20, ["max(t) <= soc_max(t)"]),
         (-1, np.nan, 9, 1, np.nan, 9, ["soc_min(t) <= min(t)"]),
         (1, 10, 9, 1, np.nan, 9, ["equals(t) <= max(t)"]),


### PR DESCRIPTION
This PR fixes the following bug fix request by @Flix6x:

-----
I have the below bug fix request for 0.14.1. Would you have time to take it up?

```
File "/home/felix/PycharmProjects/flexmeasures/flexmeasures/data/models/planning/storage.py", line 191, in compute
    raise ValueError("The input data yields an infeasible problem.")
```

I'm also seeing this error in production. I'll probably reinstall `fm==0.13.3` for now.

On inspection, line 191 has a comment preceding it with a todo. Let's first implement the todo. Secondly, upon printing the constraint_violations, I get (locally):

```
[{'dt': datetime.datetime(2023, 5, 1, 21, 45, tzinfo=<UTC>), 'condition': 'equals(t) <= max(t)', 'violation': 'equals(t) [1.6500000000000004]<=max(t) [1.65]'}]
```

This leads me to believe we should relax the constraint validation by some margin. Perhaps the default margin should correspond to the margin we use for rounding schedules:

See the Scheduler class In **data/models/planning/__init__.py**:

round_to_decimals: Optional[int] = 6,

----

The workaround is to split the *LHS*, *RHS* and inequality sign into different arguments arguments of the `validate_constraint` function. Then, use that to evaluate each expressions, rounding it. 