### PR TITLE
fix: timerange for sensor with a single belief

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -23,6 +23,7 @@ Bugfixes
 -----------
 
 * Relax constraint validation of `StorageScheduler` to accommodate violations caused by floating point precision [see `PR #731 <https://www.github.com/FlexMeasures/flexmeasures/pull/731>`_]
+* Fix browser console error when loading asset or sensor page with only a single data point [see `PR #732 <https://www.github.com/FlexMeasures/flexmeasures/pull/732>`_]
 
 
 v0.14.0 | June 15, 2023

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -20,13 +20,11 @@ from flexmeasures.data.models.data_sources import DataSource
 from flexmeasures.data.models.parsing_utils import parse_source_arg
 from flexmeasures.data.models.user import User
 from flexmeasures.data.queries.annotations import query_asset_annotations
+from flexmeasures.data.services.timerange import get_timerange
 from flexmeasures.auth.policy import AuthModelMixin, EVERY_LOGGED_IN_USER
 from flexmeasures.utils import geo_utils
 from flexmeasures.utils.coding_utils import flatten_unique
-from flexmeasures.utils.time_utils import (
-    determine_minimum_resampling_resolution,
-    server_now,
-)
+from flexmeasures.utils.time_utils import determine_minimum_resampling_resolution
 
 
 class GenericAssetType(db.Model):
@@ -525,36 +523,9 @@ class GenericAsset(db.Model, AuthModelMixin):
                       'end': datetime.datetime(2020, 12, 3, 14, 30, tzinfo=pytz.utc)
                   }
         """
-        from flexmeasures.data.models.time_series import TimedBelief
-
         sensor_ids = [s.id for s in flatten_unique(sensors)]
-        least_recent_query = (
-            TimedBelief.query.filter(TimedBelief.sensor_id.in_(sensor_ids))
-            .order_by(TimedBelief.event_start.asc())
-            .limit(1)
-        )
-        most_recent_query = (
-            TimedBelief.query.filter(TimedBelief.sensor_id.in_(sensor_ids))
-            .order_by(TimedBelief.event_start.desc())
-            .limit(1)
-        )
-        results = least_recent_query.union_all(most_recent_query).all()
-        try:
-            # try the most common case first (sensor has more than 1 data point)
-            least_recent, most_recent = results
-        except ValueError as e:
-            if not results:
-                # return now in case there is no data for any of the sensors
-                now = server_now()
-                return dict(start=now, end=now)
-            elif len(results) == 1:
-                # return the start and end of the only data point found
-                least_recent = most_recent = results[0]
-            else:
-                # reraise this unlikely error
-                raise e
-
-        return dict(start=least_recent.event_start, end=most_recent.event_end)
+        start, end = get_timerange(sensor_ids)
+        return dict(start=start, end=end)
 
 
 def create_generic_asset(generic_asset_type: str, **kwargs) -> GenericAsset:

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -44,7 +44,6 @@ from flexmeasures.data.models.data_sources import DataSource
 from flexmeasures.data.models.generic_assets import GenericAsset
 from flexmeasures.data.models.validation_utils import check_required_attributes
 from flexmeasures.data.queries.sensors import query_sensors_by_proximity
-from flexmeasures.utils.time_utils import server_now
 from flexmeasures.utils.geo_utils import parse_lat_lng
 
 

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -19,6 +19,7 @@ from flexmeasures.auth.policy import AuthModelMixin, EVERY_LOGGED_IN_USER
 from flexmeasures.data import db
 from flexmeasures.data.models.parsing_utils import parse_source_arg
 from flexmeasures.data.services.annotations import prepare_annotations_for_chart
+from flexmeasures.data.services.timerange import get_timerange
 from flexmeasures.data.queries.utils import (
     create_beliefs_query,
     get_belief_timing_criteria,
@@ -480,23 +481,8 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
                       'end': datetime.datetime(2020, 12, 3, 14, 30, tzinfo=pytz.utc)
                   }
         """
-        least_recent_query = (
-            TimedBelief.query.filter(TimedBelief.sensor == self)
-            .order_by(TimedBelief.event_start.asc())
-            .limit(1)
-        )
-        most_recent_query = (
-            TimedBelief.query.filter(TimedBelief.sensor == self)
-            .order_by(TimedBelief.event_start.desc())
-            .limit(1)
-        )
-        results = least_recent_query.union_all(most_recent_query).all()
-        if not results:
-            # return now in case there is no data for the sensor
-            now = server_now()
-            return dict(start=now, end=now)
-        least_recent, most_recent = results
-        return dict(start=least_recent.event_start, end=most_recent.event_end)
+        start, end = get_timerange([self.id])
+        return dict(start=start, end=end)
 
     def __repr__(self) -> str:
         return f"<Sensor {self.id}: {self.name}, unit: {self.unit} res.: {self.event_resolution}>"

--- a/flexmeasures/data/services/timerange.py
+++ b/flexmeasures/data/services/timerange.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from flexmeasures.utils import time_utils
+
+
+def get_timerange(sensor_ids: list[int]) -> tuple[datetime, datetime]:
+    """Get the start and end of the least recent and most recent event, respectively."""
+    from flexmeasures.data.models.time_series import TimedBelief
+
+    least_recent_query = (
+        TimedBelief.query.filter(TimedBelief.sensor_id.in_(sensor_ids))
+        .order_by(TimedBelief.event_start.asc())
+        .limit(1)
+    )
+    most_recent_query = (
+        TimedBelief.query.filter(TimedBelief.sensor_id.in_(sensor_ids))
+        .order_by(TimedBelief.event_start.desc())
+        .limit(1)
+    )
+    results = least_recent_query.union_all(most_recent_query).all()
+    try:
+        # try the most common case first (sensor has more than 1 data point)
+        least_recent, most_recent = results
+    except ValueError as e:
+        if not results:
+            # return now in case there is no data for any of the sensors
+            now = time_utils.server_now()
+            return now, now
+        elif len(results) == 1:
+            # return the start and end of the only data point found
+            least_recent = most_recent = results[0]
+        else:
+            # reraise this unlikely error
+            raise e
+
+    return least_recent.event_start, most_recent.event_end


### PR DESCRIPTION
Loading the asset page or sensor page showed a 500 server error in the browser console, in case of finding out the timerange of a sensor with only a single data point. Pretty rare, but still a bug.

I had to fix this bug in two places, which prompted me to refactor. I wasn't able to put the util function into one of the existing modules in `data/services/`, because of circular imports, so I opted to create a new one, which currently just holds this one util new function.