### PR TITLE
feat: CLI can delete multiple sensors at once

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -9,6 +9,8 @@ v0.15.0 | July XX, 2023
 New features
 -------------
 
+* Allow deleting multiple sensors with a single call to ``flexmeasures delete sensor`` by passing the ``--id`` option multiple times [see `PR #734 <https://www.github.com/FlexMeasures/flexmeasures/pull/734>`_]
+
 Bugfixes
 -----------
 

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -4,6 +4,11 @@
 FlexMeasures CLI Changelog
 **********************
 
+since v0.15.0 | July XX, 2023
+=================================
+
+* Allow deleting multiple sensors with a single call to ``flexmeasures delete sensor`` by passing the ``--id`` option multiple times. 
+
 since v0.14.0 | June 15, 2023
 =================================
 

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -7,7 +7,7 @@ FlexMeasures CLI Changelog
 since v0.15.0 | July XX, 2023
 =================================
 
-* Allow deleting multiple sensors with a single call to ``flexmeasures delete sensor`` by passing the ``--id`` option multiple times. 
+* Allow deleting multiple sensors with a single call to ``flexmeasures delete sensor`` by passing the ``--id`` option multiple times.
 
 since v0.14.0 | June 15, 2023
 =================================

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -374,7 +374,7 @@ def add_source(name: str, model: str, version: str, source_type: str):
     "sensor",
     required=True,
     type=SensorIdField(),
-    help="Sensor to which the beliefs pertain.",
+    help="Record the beliefs under this sensor. Follow up with the sensor's ID. ",
 )
 @click.option(
     "--source",
@@ -1165,7 +1165,7 @@ def add_schedule_for_storage(
     "sensor",
     type=SensorIdField(),
     required=True,
-    help="ID of the sensor used to save the report."
+    help="Sensor used to save the report. Follow up with the sensor's ID. "
     " If needed, use `flexmeasures add sensor` to create a new sensor first.",
 )
 @click.option(


### PR DESCRIPTION
This PR let's you delete multiple sensors with a single call to `flexmeasures delete sensor` by passing the `--id` option multiple times. I also tried to streamline the help messages a bit for CLI usages of the `SensorIDField`.