### PR TITLE
fix: drop NaN values when saving the report to the database

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -23,6 +23,7 @@ Bugfixes
 -----------
 
 * Relax constraint validation of `StorageScheduler` to accommodate violations caused by floating point precision [see `PR #731 <https://www.github.com/FlexMeasures/flexmeasures/pull/731>`_]
+* Avoid saving any NaN values to the database, when calling ``flexmeasures add report`` [see `PR #735 <https://www.github.com/FlexMeasures/flexmeasures/pull/735>`_]
 
 
 v0.14.0 | June 15, 2023

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -23,7 +23,7 @@ Bugfixes
 -----------
 
 * Relax constraint validation of `StorageScheduler` to accommodate violations caused by floating point precision [see `PR #731 <https://www.github.com/FlexMeasures/flexmeasures/pull/731>`_]
-* Avoid saving any NaN values to the database, when calling ``flexmeasures add report`` [see `PR #735 <https://www.github.com/FlexMeasures/flexmeasures/pull/735>`_]
+* Avoid saving any :abbr:`NaN (not a number)` values to the database, when calling ``flexmeasures add report`` [see `PR #735 <https://www.github.com/FlexMeasures/flexmeasures/pull/735>`_]
 
 
 v0.14.0 | June 15, 2023

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -4,6 +4,11 @@
 FlexMeasures CLI Changelog
 **********************
 
+since v0.14.1 | June XX, 2023
+=================================
+
+* Avoid saving any :abbr:`NaN (not a number)` values to the database, when calling ``flexmeasures add report``.
+
 since v0.14.0 | June 15, 2023
 =================================
 

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -1347,10 +1347,10 @@ def add_report(  # noqa: C901
             "Report computation done, but the report is empty.", **MsgStyle.WARN
         )
 
-    # save the report it's not running in dry mode
+    # save the report if it's not running in dry mode
     if not dry_run:
         click.echo("Saving report to the database...")
-        save_to_db(result)
+        save_to_db(result.dropna())
         db.session.commit()
         click.secho(
             "Success. The report has been saved to the database.",


### PR DESCRIPTION
I'm actually considering moving this logic (of dropping NaNs before saving the data to the database) into `save_to_db`, but I feel that might constitute a more impactful change then needed for this fix. What do you think, @victorgarcia98? Do you see any use for supporting saving NaN values to the database?

For anyone impacted by this: there already exists a CLI command for removing NaN values from the database: see `flexmeasures delete nan-beliefs`.