### PR TITLE
Fix/avoid duplicate sensor queries

### DIFF
--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -297,7 +297,8 @@ class GenericAsset(db.Model, AuthModelMixin):
         :param dataset_name: optionally name the dataset used in the chart (the default name is sensor_<id>)
         :returns: JSON string defining vega-lite chart specs
         """
-        sensors = flatten_unique(self.sensors_to_show)
+        sensors_to_show = self.sensors_to_show
+        sensors = flatten_unique(sensors_to_show)
         for sensor in sensors:
             sensor.sensor_type = sensor.get_attribute("sensor_type", sensor.name)
 
@@ -310,7 +311,7 @@ class GenericAsset(db.Model, AuthModelMixin):
             kwargs["event_ends_before"] = event_ends_before
         chart_specs = chart_type_to_chart_specs(
             chart_type,
-            sensors_to_show=self.sensors_to_show,
+            sensors_to_show=sensors_to_show,
             dataset_name=dataset_name,
             **kwargs,
         )

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from functools import cached_property
 from typing import Any, Dict, Optional, Tuple, List, Union
 import json
 
@@ -297,8 +298,7 @@ class GenericAsset(db.Model, AuthModelMixin):
         :param dataset_name: optionally name the dataset used in the chart (the default name is sensor_<id>)
         :returns: JSON string defining vega-lite chart specs
         """
-        sensors_to_show = self.sensors_to_show
-        sensors = flatten_unique(sensors_to_show)
+        sensors = flatten_unique(self.sensors_to_show)
         for sensor in sensors:
             sensor.sensor_type = sensor.get_attribute("sensor_type", sensor.name)
 
@@ -311,7 +311,7 @@ class GenericAsset(db.Model, AuthModelMixin):
             kwargs["event_ends_before"] = event_ends_before
         chart_specs = chart_type_to_chart_specs(
             chart_type,
-            sensors_to_show=sensors_to_show,
+            sensors_to_show=self.sensors_to_show,
             dataset_name=dataset_name,
             **kwargs,
         )
@@ -428,7 +428,7 @@ class GenericAsset(db.Model, AuthModelMixin):
             return df.to_json(orient="records")
         return bdf_dict
 
-    @property
+    @cached_property
     def sensors_to_show(self) -> list["Sensor" | list["Sensor"]]:  # noqa F821
         """Sensors to show, as defined by the sensors_to_show attribute.
 


### PR DESCRIPTION
This PR implements caching on the same sensor query that is otherwise executed 3 times upon loading the asset page. I was careful not to touch the original function signature, as I know a FlexMeasures plugin is using it. I don't think a deprecation of the original function is required, as it now just calls the internal (cached) method under the hood.

@victorgarcia98 please review this as a potential example for future work on caching methods in the `data.services` and `data.queries` packages. That is, with this PR I'm suggesting a possible recommendation for future issues on speeding up other methods:

- Let's not touch the original function signature.
- Let's not use a deprecation decorator, because there is no deprecation of the original method.
- Use the original method to convert arguments into hashable types.
- Move the original method implementation to an internal method (prefixing the method name with `_`)
- Apply the `lru_cache` decorator to the internal method.

Questions:

- I'm sure there are some limitations of using this caching mechanism. Maybe you have some considerations / guidance for when using `lru_cache` is or is not a good idea?
- Maybe the cache size should be as small as needed? In this case that could be 1 instead of the default 128, if we only wish to avoid duplicate queries within the same page load.
- Also, we want changes to sensor properties to show up with a page reload (e.g. when we allow the sensor name to be updated via API). Should we clear the cache when tearing down the last request, or just set the cache's [time to live](https://gist.github.com/qtalen/8f0323f9c9e3e550cab56c78fd8bd764#file-ttl_cache-py) to the expected time it takes to load the page?