### PR TITLE
fix: relax constraint for overlaying plot traces for sensors with various resolutions

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -27,6 +27,7 @@ Bugfixes
 * Relax constraint validation of `StorageScheduler` to accommodate violations caused by floating point precision [see `PR #731 <https://www.github.com/FlexMeasures/flexmeasures/pull/731>`_]
 * Avoid saving any :abbr:`NaN (not a number)` values to the database, when calling ``flexmeasures add report`` [see `PR #735 <https://www.github.com/FlexMeasures/flexmeasures/pull/735>`_]
 * Fix browser console error when loading asset or sensor page with only a single data point [see `PR #732 <https://www.github.com/FlexMeasures/flexmeasures/pull/732>`_]
+* Relax constraint for overlaying plot traces for sensors with various resolutions, making it possible to show e.g. two price sensors in one chart, where one of them records hourly prices and the other records quarter-hourly prices [see `PR #743 <https://www.github.com/FlexMeasures/flexmeasures/pull/743>`_]
 
 
 v0.14.0 | June 15, 2023

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -271,9 +271,9 @@ def create_line_layer(
     event_value_field_definition: dict,
 ):
     event_resolutions = list(set([sensor.event_resolution for sensor in sensors]))
-    assert (
-        len(event_resolutions) == 1
-    ), "Sensors shown within one row must share the same event resolution."
+    assert all(res == timedelta(0) for res in event_resolutions) or all(
+        res != timedelta(0) for res in event_resolutions
+    ), "Sensors shown within one row must all be instantaneous (zero event resolution) or all be non-instantatneous (non-zero event resolution)."
     event_resolution = event_resolutions[0]
     line_layer = {
         "mark": {


### PR DESCRIPTION
This PR makes it possible to show e.g. two price sensors in one chart, where one of them records hourly prices and the other records quarterhourly prices.

Follow-up:

- [ ] The assertion error is just a server error now, but should be communicated back to the user in the UI.