### PR TITLE
fix: also re-attach a detached source to the TimedBelief object

### DIFF
--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -570,13 +570,15 @@ class TimedBelief(db.Model, tb.TimedBeliefDBMixin):
         source: tb.DBBeliefSource,
         **kwargs,
     ):
-        # get a Sensor instance attached to the database session (input sensor is detached)
+        # get a Sensor instance attached to the database session (if input sensor is detached)
         # check out Issue #683 for more details
         inspection_obj = inspect(sensor, raiseerr=False)
-        if (
-            inspection_obj and inspection_obj.detached
-        ):  # fetch Sensor only when it is detached
+        if inspection_obj and inspection_obj.detached:
             sensor = Sensor.query.get(sensor.id)
+        # do the same for DataSource
+        inspection_obj = inspect(source, raiseerr=False)
+        if inspection_obj and inspection_obj.detached:
+            source = DataSource.query.get(source.id)
 
         tb.TimedBeliefDBMixin.__init__(self, sensor, source, **kwargs)
         tb_utils.remove_class_init_kwargs(tb.TimedBeliefDBMixin, kwargs)


### PR DESCRIPTION
Just as in #709, which fixed the problem discussed in #683.
We saw a similar error happening in the real world now, only with the `DataSource`.