### PR TITLE
fix: prevent mutating the original FIELD_DEFINITIONS dict

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -32,6 +32,7 @@ Bugfixes
 * Fix browser console error when loading asset or sensor page with only a single data point [see `PR #732 <https://www.github.com/FlexMeasures/flexmeasures/pull/732>`_]
 * Fix defaults for the ``--start-offset`` and ``--end-offset` options to ``flexmeasures add report``, which weren't being interpreted in the local timezone of the reporting sensor [see `PR #744 <https://www.github.com/FlexMeasures/flexmeasures/pull/744>`_]
 * Relax constraint for overlaying plot traces for sensors with various resolutions, making it possible to show e.g. two price sensors in one chart, where one of them records hourly prices and the other records quarter-hourly prices [see `PR #743 <https://www.github.com/FlexMeasures/flexmeasures/pull/743>`_]
+* Resolve bug where different page loads would potentially influence the time axis of each other's charts, by avoiding mutation of shared field definitions [see `PR #746 <https://www.github.com/FlexMeasures/flexmeasures/pull/746>`_]
 
 
 v0.14.0 | June 15, 2023

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -29,7 +29,7 @@ def bar_chart(
         stack=None,
         **FIELD_DEFINITIONS["event_value"],
     )
-    event_start_field_definition = FIELD_DEFINITIONS["event_start"]
+    event_start_field_definition = FIELD_DEFINITIONS["event_start"].copy()
     event_start_field_definition["timeUnit"] = {
         "unit": "yearmonthdatehoursminutesseconds",
         "step": sensor.event_resolution.total_seconds(),
@@ -98,7 +98,7 @@ def chart_for_multiple_sensors(
     minimum_non_zero_resolution = min(condition) if any(condition) else timedelta(0)
 
     # Set up field definition for event starts
-    event_start_field_definition = FIELD_DEFINITIONS["event_start"]
+    event_start_field_definition = FIELD_DEFINITIONS["event_start"].copy()
     event_start_field_definition["timeUnit"] = {
         "unit": "yearmonthdatehoursminutesseconds",
         "step": minimum_non_zero_resolution.total_seconds(),


### PR DESCRIPTION
> The `event_start_field_definition` kept the reference to the original data. In such case, we could encounter interference when multiple users are accessing.

_Adapted from @victorgarcia98 in https://github.com/FlexMeasures/flexmeasures/pull/742#discussion_r1238056664_

Again, great catch!