### PR TITLE
docs: mention the ongoing work on shifting algorithm in the API notation

### DIFF
--- a/documentation/api/notation.rst
+++ b/documentation/api/notation.rst
@@ -204,7 +204,7 @@ Here are the three types of flexibility models you can expect to be built-in:
 
 2) For **shiftable processes**
    
-   .. todo:: A simple algorithm exists, needs integration into FlexMeasures and asset type clarified.
+   .. todo:: A simple and proven algorithm exists, but is awaiting proper integration into FlexMeasures, see `PR 729 <https://github.com/FlexMeasures/flexmeasures/pull/729>`_.
 
 3) For **buffer devices** (e.g. thermal energy storage systems connected to heat pumps), use the same flexibility parameters described above for storage devices. Here are some tips to model a buffer with these parameters:
 

--- a/documentation/api/notation.rst
+++ b/documentation/api/notation.rst
@@ -211,6 +211,7 @@ Here are the three types of flexibility models you can expect to be built-in:
    - Describe the thermal energy content in kWh or MWh.
    - Set ``soc-minima`` to the accumulative usage forecast.
    - Set ``roundtrip-efficiency`` to the square of the conversion efficiency. [#]_
+   - Set ``storage-efficiency`` to a value below 100% to model (heat) loss.
 
     .. [#] Setting a roundtrip efficiency of higher than 1 is not supported. We plan to implement a separate field for :abbr:`COP (coefficient of performance)` values.
 


### PR DESCRIPTION
when discussing flex models

#729 should of course remove this and replace it with real docs.