### PR TITLE
feat: 674 let the GitHub action test pipeline also use the latest dependency versions

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -49,7 +49,6 @@ jobs:
       - name: Install FlexMeasures & dependencies for tests
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          make install-pip-tools
           make install-for-test
           pip install coveralls
       - name: Run all tests except those marked to be skipped by GitHub

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Note: use tabs
 # actions which are virtual, i.e. not a script
-.PHONY: install install-for-dev install-deps install-flexmeasures run-local test freeze-deps upgrade-deps update-docs update-docs-pdf show-file-space show-data-model clean-db
+.PHONY: install install-for-dev install-for-test install-deps install-flexmeasures run-local test freeze-deps upgrade-deps update-docs update-docs-pdf show-file-space show-data-model clean-db
 
 
 # ---- Development ---
@@ -39,13 +39,27 @@ install-for-dev:
 	make install-flexmeasures
 
 install-for-test:
+	make install-pip-tools
+# Pass pinned=no if you want to test against latest stable packages, default is our pinned dependency set
+ifneq ($(pinned), no)
 	pip-sync requirements/app.txt requirements/dev.txt requirements/test.txt
+else
+	# cutting off the -c inter-layer dependency (that's pip-tools specific)
+	tail -n +3 requirements/test.in >> temp-test.in
+	pip install --upgrade -r requirements/app.in -r temp-test.in
+	rm temp-test.in
+endif
 	make install-flexmeasures
 
 install-deps:
 	make install-pip-tools
 	make freeze-deps
+# Pass pinned=no if you want to test against latest stable packages, default is our pinned dependency set
+ifneq ($(pinned), no)
 	pip-sync requirements/app.txt
+else
+	pip install --upgrade -r requirements/app.in
+endif
 
 install-flexmeasures:
 	pip install -e .

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ install-for-test:
 	make install-pip-tools
 # Pass pinned=no if you want to test against latest stable packages, default is our pinned dependency set
 ifneq ($(pinned), no)
-	pip-sync requirements/app.txt requirements/dev.txt requirements/test.txt
+	pip-sync requirements/app.txt requirements/test.txt
 else
 	# cutting off the -c inter-layer dependency (that's pip-tools specific)
 	tail -n +3 requirements/test.in >> temp-test.in


### PR DESCRIPTION
We want to test latest dependencies *sometimes*, a good moment is on approval of a pull request.

As a side effect, this PR should stop the situation of running two test pipelines on all pushes in PRs.