### PR TITLE
feat: let CLI users pass a JSON list (as a string) to set an asset or sensor attribute

### DIFF
--- a/flexmeasures/cli/data_edit.py
+++ b/flexmeasures/cli/data_edit.py
@@ -10,6 +10,7 @@ import click
 import pandas as pd
 from flask import current_app as app
 from flask.cli import with_appcontext
+import json
 
 from flexmeasures import Sensor
 from flexmeasures.data import db
@@ -79,6 +80,13 @@ def fm_edit_data():
     help="Set the attribute to this integer value.",
 )
 @click.option(
+    "--list",
+    "attribute_list_value",
+    required=False,
+    type=str,
+    help="Set the attribute to this list value. Pass a string with a JSON-parse-able list representation, e.g. '[1,\"a\"]'.",
+)
+@click.option(
     "--null",
     "attribute_null_value",
     required=False,
@@ -95,6 +103,7 @@ def edit_attribute(
     attribute_bool_value: bool | None = None,
     attribute_str_value: str | None = None,
     attribute_int_value: int | None = None,
+    attribute_list_value: str | None = None,
 ):
     """Edit (or add) an asset attribute or sensor attribute."""
 
@@ -107,6 +116,7 @@ def edit_attribute(
         attribute_bool_value=attribute_bool_value,
         attribute_str_value=attribute_str_value,
         attribute_int_value=attribute_int_value,
+        attribute_list_value=attribute_list_value,
         attribute_null_value=attribute_null_value,
     )
 
@@ -217,6 +227,7 @@ def parse_attribute_value(
     attribute_bool_value: bool | None = None,
     attribute_str_value: str | None = None,
     attribute_int_value: int | None = None,
+    attribute_list_value: str | None = None,
 ) -> float | int | bool | str | None:
     """Parse attribute value."""
     if not single_true(
@@ -228,6 +239,7 @@ def parse_attribute_value(
                 attribute_bool_value,
                 attribute_str_value,
                 attribute_int_value,
+                attribute_list_value,
             ]
         ]
     ):
@@ -240,6 +252,14 @@ def parse_attribute_value(
         return bool(attribute_bool_value)
     elif attribute_int_value is not None:
         return int(attribute_int_value)
+    elif attribute_list_value is not None:
+        try:
+            val = json.loads(attribute_list_value)
+        except json.decoder.JSONDecodeError as jde:
+            raise ValueError(f"Error parsing list value: {jde}")
+        if not isinstance(val, list):
+            raise ValueError(f"{val} is not a list.")
+        return val
     return attribute_str_value
 
 


### PR DESCRIPTION
## Description

We have the `flexmeasures edit attribute` CLI command.

It allows to edit attribute values of several types on assets and sensors: float, bool, str, int.
We are handling lists as attribute values, as well (e.g. generic_asset.sensors_to_show), and are thinking about dictionaries.

This PR is about supporting these two types in the CLI command, as well.

## Look & Feel

flexmeasures edit attribute --asset-id 27 --attribute "sensors_to_show" --list '[14, 54, 55,56]'

## How to test

Edit an attribute and check in the CLI or SQL if the attribute has changed:

- flexmeasures show asset --id 27
- select * from generic_asset where id = 27

Also pass in wrong (non parseable) values

## Further Improvements

Still need to support dicts, but that could happen in the same way easily.
