### PR TITLE
add Highs to requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,6 @@ WORKDIR /app
 # requirements - doing this earlier, so we don't install them each time. Use --no-cache to refresh them.
 COPY requirements /app/requirements
 
-
-
 # py dev tooling
 RUN python3 -m pip install --no-cache-dir  --upgrade pip && python3 --version && pip3 install --no-cache-dir --upgrade setuptools && pip3 install highspy && pip3 install --no-cache-dir -r requirements/app.txt -r requirements/dev.txt -r requirements/test.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,10 @@ WORKDIR /app
 # requirements - doing this earlier, so we don't install them each time. Use --no-cache to refresh them.
 COPY requirements /app/requirements
 
+
+
 # py dev tooling
-RUN python3 -m pip install --no-cache-dir  --upgrade pip && python3 --version && pip3 install --no-cache-dir --upgrade setuptools && pip3 install --no-cache-dir -r requirements/app.txt -r requirements/dev.txt -r requirements/test.txt
+RUN python3 -m pip install --no-cache-dir  --upgrade pip && python3 --version && pip3 install --no-cache-dir --upgrade setuptools && pip3 install highspy && pip3 install --no-cache-dir -r requirements/app.txt -r requirements/dev.txt -r requirements/test.txt
 
 # Copy code and meta/config data
 COPY setup.* .flaskenv wsgi.py /app/

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -27,7 +27,7 @@ Infrastructure / Support
 * Add support for profiling Flask API calls using ``pyinstrument`` (if installed). Can be enabled by setting the environment variable ``FLEXMEASURES_PROFILE_REQUESTS`` to ``True`` [see `PR #722 <https://www.github.com/FlexMeasures/flexmeasures/pull/722>`_]
 * The endpoint `[POST] /health/ready <api/v3_0.html#get--api-v3_0-health-ready>`_ returns the status of the Redis connection, if configured [see `PR #699 <https://www.github.com/FlexMeasures/flexmeasures/pull/699>`_]
 * Document the `device_scheduler` linear program [see `PR #764 <https://www.github.com/FlexMeasures/flexmeasures/pull/764>`_].
-* Add support for `Highs <https://highs.dev/>`_ solver [see `PR #766 <https://www.github.com/FlexMeasures/flexmeasures/pull/766>`_].
+* Add support for `HiGHS <https://highs.dev/>`_ solver [see `PR #766 <https://www.github.com/FlexMeasures/flexmeasures/pull/766>`_].
 
 v0.14.1 | June 26, 2023
 ============================

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -27,8 +27,7 @@ Infrastructure / Support
 * Add support for profiling Flask API calls using ``pyinstrument`` (if installed). Can be enabled by setting the environment variable ``FLEXMEASURES_PROFILE_REQUESTS`` to ``True`` [see `PR #722 <https://www.github.com/FlexMeasures/flexmeasures/pull/722>`_]
 * The endpoint `[POST] /health/ready <api/v3_0.html#get--api-v3_0-health-ready>`_ returns the status of the Redis connection, if configured [see `PR #699 <https://www.github.com/FlexMeasures/flexmeasures/pull/699>`_]
 * Document the `device_scheduler` linear program [see `PR #764 <https://www.github.com/FlexMeasures/flexmeasures/pull/764>`_].
-
-/api/v3_0/health/ready
+* Add support for `Highs <https://highs.dev/>`_ solver [see `PR #766 <https://www.github.com/FlexMeasures/flexmeasures/pull/766>`_].
 
 v0.14.1 | June 26, 2023
 ============================

--- a/documentation/configuration.rst
+++ b/documentation/configuration.rst
@@ -55,7 +55,7 @@ Default: ``False``
 FLEXMEASURES_LP_SOLVER
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The command to run the scheduling solver. This is the executable command which FlexMeasures calls via the `pyomo library <http://www.pyomo.org/>`_. Other values might be ``cplex``, ``glpk`` or ``appsi_highs`` for `Highs <https://highs.dev/>`_. Consult `their documentation <https://pyomo.readthedocs.io/en/stable/solving_pyomo_models.html#supported-solvers>`_ to learn more. 
+The command to run the scheduling solver. This is the executable command which FlexMeasures calls via the `pyomo library <http://www.pyomo.org/>`_. Other values might be ``cplex``, ``glpk`` or ``appsi_highs`` for `HiGHS <https://highs.dev/>`_. Consult `their documentation <https://pyomo.readthedocs.io/en/stable/solving_pyomo_models.html#supported-solvers>`_ to learn more. 
 
 Default: ``"cbc"``
 

--- a/documentation/configuration.rst
+++ b/documentation/configuration.rst
@@ -55,7 +55,7 @@ Default: ``False``
 FLEXMEASURES_LP_SOLVER
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The command to run the scheduling solver. This is the executable command which FlexMeasures calls via the `pyomo library <http://www.pyomo.org/>`_. Other values might be ``cplex`` or ``glpk``. Consult `their documentation <https://pyomo.readthedocs.io/en/stable/solving_pyomo_models.html#supported-solvers>`_ to learn more. 
+The command to run the scheduling solver. This is the executable command which FlexMeasures calls via the `pyomo library <http://www.pyomo.org/>`_. Other values might be ``cplex``, ``glpk`` or ``appsi_highs`` for `Highs <https://highs.dev/>`_. Consult `their documentation <https://pyomo.readthedocs.io/en/stable/solving_pyomo_models.html#supported-solvers>`_ to learn more. 
 
 Default: ``"cbc"``
 

--- a/documentation/dev/introduction.rst
+++ b/documentation/dev/introduction.rst
@@ -54,6 +54,11 @@ Go into the ``flexmeasures`` folder and install all dependencies including the o
 
    $ apt-get install coinor-cbc
 
+Alternatively, HiGHS solver can be installed with pip:
+
+.. code-block:: bash
+
+   $ pip install highspy
 
 Configuration
 ^^^^^^^^^^^^^^^^^^^^

--- a/documentation/host/deployment.rst
+++ b/documentation/host/deployment.rst
@@ -48,7 +48,7 @@ Keep in mind that FlexMeasures is based on `Flask <https://flask.palletsprojects
 Install the linear solver on the server
 ---------------------------------------
 
-To compute schedules, FlexMeasures uses the `Cbc <https://github.com/coin-or/Cbc>`_ mixed integer linear optimization solver.
+To compute schedules, FlexMeasures uses the `Cbc <https://github.com/coin-or/Cbc>`_ or `HiGHS <https://highs.dev/>`_ mixed integer linear optimization solvers.
 It is used through `Pyomo <http://www.pyomo.org>`_\ , so in principle supporting a `different solver <https://pyomo.readthedocs.io/en/stable/solving_pyomo_models.html#supported-solvers>`_ would be possible.
 
 Cbc needs to be present on the server where FlexMeasures runs, under the ``cbc`` command.
@@ -65,4 +65,11 @@ We provide an example script in ``ci/install-cbc-from-source.sh`` to do that, wh
 pass a directory for the installation.
 
 In case you want to install a later version, adapt the version in the script. 
+
+HiGHS can be installed using pip:
+
+.. code-block:: bash
+
+   $ pip install highspy
+
 

--- a/documentation/host/deployment.rst
+++ b/documentation/host/deployment.rst
@@ -48,10 +48,10 @@ Keep in mind that FlexMeasures is based on `Flask <https://flask.palletsprojects
 Install the linear solver on the server
 ---------------------------------------
 
-To compute schedules, FlexMeasures uses the `Cbc <https://github.com/coin-or/Cbc>`_ (FlexMeasures solver by default) or `HiGHS <https://highs.dev/>`_ mixed integer linear optimization solver.
+To compute schedules, FlexMeasures uses the `CBC <https://github.com/coin-or/Cbc>`_ (FlexMeasures solver by default) or `HiGHS <https://highs.dev/>`_ mixed integer linear optimization solver.
 Solvers are used through `Pyomo <http://www.pyomo.org>`_\ , so in principle supporting a `different solver <https://pyomo.readthedocs.io/en/stable/solving_pyomo_models.html#supported-solvers>`_ would be possible.
 
-Cbc needs to be present on the server where FlexMeasures runs, under the ``cbc`` command.
+CBC needs to be present on the server where FlexMeasures runs, under the ``cbc`` command.
 
 You can install it on Debian like this:
 

--- a/documentation/host/deployment.rst
+++ b/documentation/host/deployment.rst
@@ -48,8 +48,8 @@ Keep in mind that FlexMeasures is based on `Flask <https://flask.palletsprojects
 Install the linear solver on the server
 ---------------------------------------
 
-To compute schedules, FlexMeasures uses the `Cbc <https://github.com/coin-or/Cbc>`_ or `HiGHS <https://highs.dev/>`_ mixed integer linear optimization solvers.
-It is used through `Pyomo <http://www.pyomo.org>`_\ , so in principle supporting a `different solver <https://pyomo.readthedocs.io/en/stable/solving_pyomo_models.html#supported-solvers>`_ would be possible.
+To compute schedules, FlexMeasures uses the `Cbc <https://github.com/coin-or/Cbc>`_ (FlexMeasures solver by default) or `HiGHS <https://highs.dev/>`_ mixed integer linear optimization solver.
+Solvers are used through `Pyomo <http://www.pyomo.org>`_\ , so in principle supporting a `different solver <https://pyomo.readthedocs.io/en/stable/solving_pyomo_models.html#supported-solvers>`_ would be possible.
 
 Cbc needs to be present on the server where FlexMeasures runs, under the ``cbc`` command.
 

--- a/documentation/tut/installation.rst
+++ b/documentation/tut/installation.rst
@@ -226,12 +226,12 @@ For FlexMeasures to be able to send email to users (e.g. for resetting passwords
 Install an LP solver
 ^^^^^^^^^^^^^^^^^^^^
 
-For planning balancing actions, the FlexMeasures platform uses a linear program solver. Currently that is the Cbc or HiGHS solvers. See :ref:`solver-config` if you want to change to a different solver.
+For planning balancing actions, the FlexMeasures platform uses a linear program solver. Currently that is the CBC or HiGHS solvers. See :ref:`solver-config` if you want to change to a different solver.
 
 CBC
 *****
 
-Installing Cbc can be done on Unix via:
+Installing CBC can be done on Unix via:
 
 .. code-block:: bash
 
@@ -242,7 +242,7 @@ Installing Cbc can be done on Unix via:
 
 We provide a script for installing from source (without requiring ``sudo`` rights) in the `ci` folder.
 
-More information (e.g. for installing on Windows) on `the Cbc website <https://projects.coin-or.org/Cbc>`_.
+More information (e.g. for installing on Windows) on `the CBC website <https://projects.coin-or.org/Cbc>`_.
 
 HiGHS
 ******

--- a/documentation/tut/installation.rst
+++ b/documentation/tut/installation.rst
@@ -247,7 +247,7 @@ More information (e.g. for installing on Windows) on `the Cbc website <https://p
 HiGHS
 ******
 
-HiGHS is a modern LP solver that aims at solving large problems. It can installed using pip:
+HiGHS is a modern LP solver that aims at solving large problems. It can be installed using pip:
 
 .. code-block:: bash
 

--- a/documentation/tut/installation.rst
+++ b/documentation/tut/installation.rst
@@ -226,7 +226,10 @@ For FlexMeasures to be able to send email to users (e.g. for resetting passwords
 Install an LP solver
 ^^^^^^^^^^^^^^^^^^^^
 
-For planning balancing actions, the FlexMeasures platform uses a linear program solver. Currently that is the Cbc solver. See :ref:`solver-config` if you want to change to a different solver.
+For planning balancing actions, the FlexMeasures platform uses a linear program solver. Currently that is the Cbc or HiGHS solvers. See :ref:`solver-config` if you want to change to a different solver.
+
+CBC
+*****
 
 Installing Cbc can be done on Unix via:
 
@@ -240,6 +243,17 @@ Installing Cbc can be done on Unix via:
 We provide a script for installing from source (without requiring ``sudo`` rights) in the `ci` folder.
 
 More information (e.g. for installing on Windows) on `the Cbc website <https://projects.coin-or.org/Cbc>`_.
+
+HiGHS
+******
+
+HiGHS is a modern LP solver that aims at solving large problems. It can installed using pip:
+
+.. code-block:: bash
+
+   $ pip install highspy
+
+More information (e.g. for installing on Windows) on `the HiGHS website <https://highs.dev/>`_.
 
 
 Install and configure Redis

--- a/flexmeasures/data/models/planning/linear_optimization.py
+++ b/flexmeasures/data/models/planning/linear_optimization.py
@@ -340,7 +340,7 @@ def device_scheduler(  # noqa C901
 
     # Solve
 
-    # load_solutions=False to avoid a RuntimeError exceptions in HiGHS when solving and infeasible problem.
+    # load_solutions=False to avoid a RuntimeError exception in appsi solvers when solving an infeasible problem.
     results = SolverFactory(current_app.config.get("FLEXMEASURES_LP_SOLVER")).solve(
         model, load_solutions=False
     )

--- a/flexmeasures/data/models/planning/linear_optimization.py
+++ b/flexmeasures/data/models/planning/linear_optimization.py
@@ -345,7 +345,7 @@ def device_scheduler(  # noqa C901
         model, load_solutions=False
     )
 
-    # load the results only if the termination condition is not infeasible
+    # load the results only if a feasible solution has been found
     if len(results.solution) > 0:
         model.solutions.load_from(results)
 

--- a/flexmeasures/data/models/planning/linear_optimization.py
+++ b/flexmeasures/data/models/planning/linear_optimization.py
@@ -345,8 +345,8 @@ def device_scheduler(  # noqa C901
         model, load_solutions=False
     )
 
-    # load the results only if the termination conditions is optimal
-    if results.solver.termination_condition == TerminationCondition.optimal:
+    # load the results only if the termination conditions is not infeasible
+    if results.solver.termination_condition != TerminationCondition.infeasible:
         model.solutions.load_from(results)
 
     planned_costs = value(model.costs)

--- a/flexmeasures/data/models/planning/linear_optimization.py
+++ b/flexmeasures/data/models/planning/linear_optimization.py
@@ -345,7 +345,7 @@ def device_scheduler(  # noqa C901
         model, load_solutions=False
     )
 
-    # load the results only if the termination conditions is not infeasible
+    # load the results only if the termination condition is not infeasible
     if results.solver.termination_condition != TerminationCondition.infeasible:
         model.solutions.load_from(results)
 

--- a/flexmeasures/data/models/planning/linear_optimization.py
+++ b/flexmeasures/data/models/planning/linear_optimization.py
@@ -18,7 +18,7 @@ from pyomo.core import (
 )
 from pyomo.environ import UnknownSolver  # noqa F401
 from pyomo.environ import value
-from pyomo.opt import SolverFactory, SolverResults, TerminationCondition
+from pyomo.opt import SolverFactory, SolverResults
 
 from flexmeasures.data.models.planning.utils import initialize_series
 from flexmeasures.utils.calculations import apply_stock_changes_and_losses
@@ -346,7 +346,7 @@ def device_scheduler(  # noqa C901
     )
 
     # load the results only if the termination condition is not infeasible
-    if results.solver.termination_condition != TerminationCondition.infeasible:
+    if len(results.solution) > 0:
         model.solutions.load_from(results)
 
     planned_costs = value(model.costs)

--- a/flexmeasures/data/models/planning/linear_optimization.py
+++ b/flexmeasures/data/models/planning/linear_optimization.py
@@ -339,9 +339,16 @@ def device_scheduler(  # noqa C901
     model.costs = Objective(rule=cost_function, sense=minimize)
 
     # Solve
-    results = SolverFactory(current_app.config.get("FLEXMEASURES_LP_SOLVER")).solve(
-        model
-    )
+    solver_name = current_app.config.get("FLEXMEASURES_LP_SOLVER")
+    opt = SolverFactory(solver_name)
+
+    if "highs" in solver_name.lower():
+        try:
+            results = opt.solve(model)
+        except RuntimeError:
+            results = opt.solve(model, load_solutions=False)
+    else:
+        results = opt.solve(model)
 
     planned_costs = value(model.costs)
     planned_power_per_device = []

--- a/flexmeasures/data/models/planning/linear_optimization.py
+++ b/flexmeasures/data/models/planning/linear_optimization.py
@@ -18,7 +18,7 @@ from pyomo.core import (
 )
 from pyomo.environ import UnknownSolver  # noqa F401
 from pyomo.environ import value
-from pyomo.opt import SolverFactory, SolverResults
+from pyomo.opt import SolverFactory, SolverResults, TerminationCondition
 
 from flexmeasures.data.models.planning.utils import initialize_series
 from flexmeasures.utils.calculations import apply_stock_changes_and_losses
@@ -339,16 +339,15 @@ def device_scheduler(  # noqa C901
     model.costs = Objective(rule=cost_function, sense=minimize)
 
     # Solve
-    solver_name = current_app.config.get("FLEXMEASURES_LP_SOLVER")
-    opt = SolverFactory(solver_name)
 
-    if "highs" in solver_name.lower():
-        try:
-            results = opt.solve(model)
-        except RuntimeError:
-            results = opt.solve(model, load_solutions=False)
-    else:
-        results = opt.solve(model)
+    # load_solutions=False to avoid a RuntimeError exceptions in HiGHS when solving and infeasible problem.
+    results = SolverFactory(current_app.config.get("FLEXMEASURES_LP_SOLVER")).solve(
+        model, load_solutions=False
+    )
+
+    # load the results only if the termination conditions is optimal
+    if results.solver.termination_condition == TerminationCondition.optimal:
+        model.solutions.load_from(results)
 
     planned_costs = value(model.costs)
     planned_power_per_device = []

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -67,4 +67,3 @@ Flask-SQLAlchemy>=2.4.3,<3
 # flask should be after all the flask plugins, because setup might find they ARE flask
 # <2.3: https://github.com/Parallels/rq-dashboard/issues/417 and https://github.com/FlexMeasures/flexmeasures/issues/754 and flask-login 0.6.1 not compatible
 flask>=1.0, <=2.1.2
-werkzeug<=2.1

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -68,3 +68,4 @@ Flask-SQLAlchemy>=2.4.3,<3
 # <2.3: https://github.com/Parallels/rq-dashboard/issues/417 and https://github.com/FlexMeasures/flexmeasures/issues/754 and flask-login 0.6.1 not compatible
 flask>=1.0, <=2.1.2
 werkzeug<=2.1
+highspy

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -67,3 +67,4 @@ Flask-SQLAlchemy>=2.4.3,<3
 # flask should be after all the flask plugins, because setup might find they ARE flask
 # <2.3: https://github.com/Parallels/rq-dashboard/issues/417 and https://github.com/FlexMeasures/flexmeasures/issues/754 and flask-login 0.6.1 not compatible
 flask>=1.0, <=2.1.2
+werkzeug<=2.1

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -68,4 +68,3 @@ Flask-SQLAlchemy>=2.4.3,<3
 # <2.3: https://github.com/Parallels/rq-dashboard/issues/417 and https://github.com/FlexMeasures/flexmeasures/issues/754 and flask-login 0.6.1 not compatible
 flask>=1.0, <=2.1.2
 werkzeug<=2.1
-highspy

--- a/requirements/app.txt
+++ b/requirements/app.txt
@@ -109,6 +109,8 @@ fonttools==4.40.0
     # via matplotlib
 greenlet==2.0.2
     # via sqlalchemy
+highspy==1.5.3
+    # via -r requirements/app.in
 humanize==4.7.0
     # via -r requirements/app.in
 idna==3.4

--- a/requirements/app.txt
+++ b/requirements/app.txt
@@ -109,8 +109,6 @@ fonttools==4.40.0
     # via matplotlib
 greenlet==2.0.2
     # via sqlalchemy
-highspy==1.5.3
-    # via -r requirements/app.in
 humanize==4.7.0
     # via -r requirements/app.in
 idna==3.4


### PR DESCRIPTION
## Description

This PR adds the possibility to use the solver [Highs](https://highs.dev/) in FlexMeasures. To do so, you need to set the configuration variable `FLEXMEASURES_LP_SOLVER` to `appsi_highs`.

In addition, I've run a benchmark to compare Highs agains our current solver by default, `CBC`. The benchmark is running the following command 10 times:

```
 flexmeasures add schedule for-storage --sensor-id 7 --consumption-price-sensor 2 --inflexible-device-sensor 3 --start ${TOMORROW}T00:00+01:00 --duration ${DURATION} --soc-at-start 0% --roundtrip-efficiency 90%
```

The benchmark uses the data from the [Toy Tutorial Part II](https://flexmeasures.readthedocs.io/en/latest/tut/toy-example-expanded.html), repeating the pattern for the duration of the tests (12D).

#### Results

|solver|duration|time         |
|------|--------|-------------|
|cbc   |P12D    |2.795 ± 0.07 |
|cbc   |P3D     |0.269 ± 0.01 |
|cbc   |P6D     |0.797 ± 0.01 |
|highs |P12D    |**12.605 ± 0.11**|
|highs |P3D     |0.908 ± 0.01 |
|highs |P6D     |3.196 ± 0.03 |

#### Profile of computing a schedule with Highs (duration=12D)

![image](https://github.com/FlexMeasures/flexmeasures/assets/84775131/ef2a0873-990e-4ba2-afe8-ec1243b35c92)

#### Profile of computing a schedule with CBC (duration=12D)

![image](https://github.com/FlexMeasures/flexmeasures/assets/84775131/9de3e60b-7a85-4d77-ae55-293e18663a84)

#### Comment

Although the performance is worse in practice, Highs is being used in other projects (without Pyomo) providing interesting improvements:

- PyPSA: using linopy, in this [post](https://forum.openmod.org/t/open-source-highs-solver-performance-boost-for-energy-system-models/2922/15), they show Highs to be comparable to commercial solvers such as Gurobi.
- GridCal: using PuLP


Moreover, looking at the profile reports, we can see that Pyomo is consuming most of the time building the problem using  Highs as it's using a `LegacySolver`, which turns out to be pretty slow. The actual solving time is taking a small fraction of the total computation (10%).

## Further Improvements

Test with larger/more complex problems and wait for Pyomo to improve the creation of the model.

## Related Items

https://github.com/FlexMeasures/flexmeasures/discussions/614

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
