### PR TITLE
add support for python 3.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ install-flexmeasures:
 	pip install -e .
 
 install-pip-tools:
-	pip3 install -q "pip-tools>=6.4"
+	pip3 install -q "pip-tools>=7.0"
 
 install-docs-dependencies:
 	pip install -r requirements/docs.txt

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -17,7 +17,7 @@ psycopg2-binary
 bcrypt
 pytz
 # limit the numpy version to make it compatible with numba==0.56.4, which timely-beliefs >=1.18 depends on (library sktime).
-numpy<1.24
+numpy<1.26
 isodate
 click
 click-default-group


### PR DESCRIPTION
## Description

This PR updates the Makefile to add support for Python 3.11. Currently, pip-tools < 7.0 is not supported on Python 3.11+.

Configuring a minimum requirement to install pip-tools >= 7.0 provides allows the setup to support 3.11.

## Related Items

Partially related to #748

---

- [ ] I agree to contribute to the project under Apache 2 License. 
- [ ] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
