### PR TITLE
fix(sensor): removes resolution from fetch one response to only retur…

### DIFF
--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -531,7 +531,6 @@ class SensorAPI(FlaskView):
         :status 422: UNPROCESSABLE_ENTITY
         """
 
-        sensor.resolution = sensor.event_resolution
         return sensor_schema.dump(sensor), 200
 
     @route("", methods=["POST"])


### PR DESCRIPTION
## Description

In PR #767 the fetch one sensor incorrectly returned `resolution` in the API response. This field would have the same value as `event_resolution`. The fetch one sensor endpoint now only returns the `event_resolution`

## Look & Feel

Before:
            {
                "name": "some gas sensor",
                "unit": "m³/h",
                "entity_address": "ea1.2023-08.localhost:fm1.1",
                "event_resolution": "PT10M",
                "resolution": "PT10M",
                "generic_asset_id": 4,
                "timezone": "UTC",
            }
After:

            {
                "name": "some gas sensor",
                "unit": "m³/h",
                "entity_address": "ea1.2023-08.localhost:fm1.1",
                "event_resolution": "PT10M",
                "generic_asset_id": 4,
                "timezone": "UTC",
            }


- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
