### PR TITLE
revert (refactoring): avoid duplicating large docstring

### DIFF
--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -238,7 +238,7 @@ class StorageScheduler(Scheduler):
             commitment_upwards_deviation_price,
         ) = self._prepare(skip_validation=skip_validation)
 
-        ems_schedule, expected_costs, scheduler_results = device_scheduler(
+        ems_schedule, expected_costs, scheduler_results, _ = device_scheduler(
             device_constraints,
             ems_constraints,
             commitment_quantities,

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -13,7 +13,7 @@ from flexmeasures.data.models.planning.storage import (
     add_storage_constraints,
     validate_storage_constraints,
 )
-from flexmeasures.data.models.planning.linear_optimization import run_device_scheduler
+from flexmeasures.data.models.planning.linear_optimization import device_scheduler
 from flexmeasures.data.models.planning.tests.utils import check_constraints
 from flexmeasures.data.models.planning.utils import initialize_series, initialize_df
 from flexmeasures.utils.calculations import (
@@ -211,7 +211,7 @@ def run_test_charge_discharge_sign(
         commitment_upwards_deviation_price,
     ) = scheduler._prepare(skip_validation=True)
 
-    model, results = run_device_scheduler(
+    _, _, results, model = device_scheduler(
         device_constraints,
         ems_constraints,
         commitment_quantities,


### PR DESCRIPTION
This PR is my suggestion to revert the refactoring part of aa328391dd4d0eb1ce7cbe71c0e37628d7b35c60.

It prepends the pyomo model to the return tuple of the device_scheduler, which prevents duplicating a large docstring at the cost of introducing a breaking change in the function signature of the `device_scheduler` (but no external code uses that function to the best of my knowledge).
