### PR TITLE
fix unresolved reference

### DIFF
--- a/documentation/tut/toy-example-from-scratch.rst
+++ b/documentation/tut/toy-example-from-scratch.rst
@@ -9,12 +9,7 @@ Okay, let's get started!
 
 .. note:: You can copy the commands by hovering on the top right corner of code examples. You'll copy only the commands, not the output!
 
-Setup
-------
-
 .. note:: If you haven't run through :ref:`tut_install_load_data` yet, do that first. There, we added power prices for a 24h window.
-
-For this tutorial, we'll setup a battery asset and a (dis)charging sensor (ID 2) where the schedule will be stored into.
 
 
 

--- a/documentation/tut/toy-example-setup.rst
+++ b/documentation/tut/toy-example-setup.rst
@@ -1,4 +1,4 @@
-.. _tut_install_load_data
+.. _tut_install_load_data:
 
 Toy example: Introduction and setup
 ===================================


### PR DESCRIPTION
## Description

Fix unresolved reference in the docs: "If you haven’t run through tut_install_load_data yet, ..."

https://flexmeasures.readthedocs.io/en/latest/tut/toy-example-from-scratch.html

## Related Items

https://github.com/FlexMeasures/flexmeasures/pull/777

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
