### PR TITLE
fix: Fix pytest suite allowing it to complete on Python 3.8

### DIFF
--- a/flexmeasures/api/tests/conftest.py
+++ b/flexmeasures/api/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 import pytz
 

--- a/flexmeasures/api/v3_0/tests/conftest.py
+++ b/flexmeasures/api/v3_0/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import timedelta
 
 import pandas as pd


### PR DESCRIPTION
## Description

This PR adds the 2 missing `__future__ import annotations` statements in the pytest files. This allows `pytest` to run on `Python 3.8` 

---

- [ ] I agree to contribute to the project under Apache 2 License. 
- [ ] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
