### PR TITLE
fix: stop making app.reports a property 

### DIFF
--- a/flexmeasures/app.py
+++ b/flexmeasures/app.py
@@ -133,7 +133,7 @@ def create(  # noqa C901
     )  # use copy to avoid mutating app.reporters
     app.data_generators["scheduler"] = schedulers
 
-    # deprecation of app.reporters
+    # deprecated: app.reporters and app.schedulers
     app.reporters = reporters
     app.schedulers = schedulers
 
@@ -143,7 +143,7 @@ def create(  # noqa C901
         )
         return app.data_generators["reporter"]
 
-    setattr(app, "reporters", property(get_reporters))
+    setattr(app, "reporters", get_reporters())
 
     # add auth policy
 

--- a/flexmeasures/utils/plugin_utils.py
+++ b/flexmeasures/utils/plugin_utils.py
@@ -16,7 +16,7 @@ from flask import Flask, Blueprint
 from flexmeasures.utils.coding_utils import get_classes_module
 
 
-def register_plugins(app: Flask):
+def register_plugins(app: Flask):  # noqa: C901
     """
     Register FlexMeasures plugins as Blueprints.
     This is configured by the config setting FLEXMEASURES_PLUGINS.
@@ -113,13 +113,14 @@ def register_plugins(app: Flask):
         plugin_reporters = get_classes_module(module.__name__, Reporter)
         plugin_schedulers = get_classes_module(module.__name__, Scheduler)
 
-        # for legacy, we keep reporters and schedulers
-        app.reporters.update(plugin_reporters)
-        app.schedulers.update(plugin_schedulers)
-
         # add DataGenerators
-        app.data_generators["scheduler"].update(plugin_schedulers)
-        app.data_generators["reporter"].update(plugin_reporters)
+        # for legacy, we still maintain app.reporters and app.schedulers
+        if plugin_reporters:
+            app.data_generators["reporter"].update(plugin_reporters)
+            app.reporters.update(plugin_reporters)
+        if plugin_schedulers:
+            app.data_generators["scheduler"].update(plugin_schedulers)
+            app.schedulers.update(plugin_schedulers)
 
         app.config["LOADED_PLUGINS"][plugin_name] = plugin_version
     app.logger.info(f"Loaded plugins: {app.config['LOADED_PLUGINS']}")


### PR DESCRIPTION
## Description

When FLEXMEASURES_PLUGINS is set, app.reports.update fails otherwise.

## Look & Feel

FlexMeasures starts without an error.

## How to test

1. Set a plugin in FLEXMEASURES_PLUGINS
2. flexmeasures run --no-reload

## Further Improvements

I feel the legacy treatment of app.reporters and app.schedulers in app.py is not completely round. Do they need to be treated equally? Why not? I also don't believe anybody made a plugin with custom reporters just yet, so let's not overdo it with supporting that. A warning is enough.
In this case, code that deals with legacy treatment broke something, so there is always a price.