### PR TITLE
fix: do not use async_mode in profiler, as we might run several

### DIFF
--- a/flexmeasures/app.py
+++ b/flexmeasures/app.py
@@ -188,7 +188,7 @@ def create(  # noqa C901
             try:
                 import pyinstrument  # noqa F401
 
-                g.profiler = pyinstrument.Profiler()
+                g.profiler = pyinstrument.Profiler(async_mode="disabled")
                 g.profiler.start()
             except ImportError:
                 pass


### PR DESCRIPTION
## Description

Closes #799 - We got error reports about multiple profilers running (maybe as several requests were profiled at the same time). Turning [the async feature](https://pyinstrument.readthedocs.io/en/latest/reference.html#pyinstrument.Profiler.async_mode) off should fix it.

## Look & Feel

The error should not happen anymore.

## How to test

This was difficult to reproduce in the first place (but we got two reports).

Turning FLEXMEASURES_PROFILE_REQUESTS to `True` (or using `FLASK_ENV="development"` in `.env`), hitting the server with multiple requests ...

## Further Improvements

Maybe profiling all requests is a bad idea and we should stick to one request at a time.

Then we can turn this mode back on, and profile async code properly.
