### PR TITLE
fix: getSourceMasking safe for pages other than sensor view

### DIFF
--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -265,13 +265,16 @@
     }
 
     function checkSourceMasking(data) {
+        var sourceWarn = document.getElementById("sourcewarn");
+        if (sourceWarn == null)
+            return
         var uniqueSourceIds = getUniqueValues(data, 'source.id');
         if (chartType == 'daily_heatmap' && uniqueSourceIds.length > 1) {
-            document.getElementById('sourcewarn').style.display = 'block';
-            document.getElementById('sourcewarn').innerHTML = 'Please note that only data from the most prevalent source is shown.';
+            sourceWarn.style.display = 'block';
+            sourceWarn.innerHTML = 'Please note that only data from the most prevalent source is shown.';
         }
         else {
-            document.getElementById('sourcewarn').style.display = 'none';
+            sourceWarn.style.display = 'none';
         }
     }
 


### PR DESCRIPTION

## Description

The asset page had an error after selecting a date range. The new JS function `getSourceMasking` threw an error when no #sourcewarn element is present (which only is present on the sensor page).

## Look & Feel, How to test

Loading new date ranges on the asset page works again.

