### PR TITLE
Switch off HiGHS logs for `LOGGING_LEVEL=INFO`

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -3,6 +3,15 @@
 FlexMeasures Changelog
 **********************
 
+v0.15.1 | August XX, 2023
+============================
+
+Bugfixes
+-----------
+
+* Disable HiGHS logs on the standard output when `LOGGING_LEVEL=INFO` [see `PR #824 <https://github.com/FlexMeasures/flexmeasures/pull/824>`_]
+
+
 v0.15.0 | August 9, 2023
 ============================
 

--- a/flexmeasures/data/models/planning/linear_optimization.py
+++ b/flexmeasures/data/models/planning/linear_optimization.py
@@ -364,11 +364,18 @@ def device_scheduler(  # noqa C901
     model.costs = Objective(rule=cost_function, sense=minimize)
 
     # Solve
+    solver_name = current_app.config.get("FLEXMEASURES_LP_SOLVER")
+
+    solver = SolverFactory(solver_name)
+
+    # disable logs for the HiGHS solver in case that LOGGING_LEVEL is INFO
+    if current_app.config["LOGGING_LEVEL"] == "INFO" and solver_name.lower().contains(
+        "highs"
+    ):
+        solver.options["output_flag"] = "false"
 
     # load_solutions=False to avoid a RuntimeError exception in appsi solvers when solving an infeasible problem.
-    results = SolverFactory(current_app.config.get("FLEXMEASURES_LP_SOLVER")).solve(
-        model, load_solutions=False
-    )
+    results = solver.solve(model, load_solutions=False)
 
     # load the results only if a feasible solution has been found
     if len(results.solution) > 0:


### PR DESCRIPTION
## Description

This PR allows toggling the display of the the logs of the HiGHS solver using the `LOGGING_LEVEL` env variable. The logs will show up for `WARNING`  and `DEBUG` levels.


## Related Items

Closes https://github.com/FlexMeasures/flexmeasures/issues/821

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
