### PR TITLE
fix: `highs` string is in `solve_name`

### DIFF
--- a/flexmeasures/data/models/planning/linear_optimization.py
+++ b/flexmeasures/data/models/planning/linear_optimization.py
@@ -369,8 +369,8 @@ def device_scheduler(  # noqa C901
     solver = SolverFactory(solver_name)
 
     # disable logs for the HiGHS solver in case that LOGGING_LEVEL is INFO
-    if current_app.config["LOGGING_LEVEL"] == "INFO" and solver_name.lower().contains(
-        "highs"
+    if current_app.config["LOGGING_LEVEL"] == "INFO" and (
+        "highs" in solver_name.lower()
     ):
         solver.options["output_flag"] = "false"
 


### PR DESCRIPTION
## Description

This PR fixes a bug in the code to check if the solver `HiGHS` is being used.

## Related Items

https://github.com/FlexMeasures/flexmeasures/pull/824

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
