### PR TITLE
Fix: public sensors to show

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -10,7 +10,7 @@ Bugfixes
 -----------
 
 * Disable HiGHS logs on the standard output when `LOGGING_LEVEL=INFO` [see `PR #824 <https://github.com/FlexMeasures/flexmeasures/pull/824>`_]
-* Fix showing sensor data on the asset page of public assets [see `PR #830 <https://github.com/FlexMeasures/flexmeasures/pull/830>`_]
+* Fix showing sensor data on the asset page of public assets, and searching for annotations on public assets [see `PR #830 <https://github.com/FlexMeasures/flexmeasures/pull/830>`_]
 
 
 v0.15.0 | August 9, 2023

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -10,6 +10,7 @@ Bugfixes
 -----------
 
 * Disable HiGHS logs on the standard output when `LOGGING_LEVEL=INFO` [see `PR #824 <https://github.com/FlexMeasures/flexmeasures/pull/824>`_]
+* Fix showing sensor data on the asset page of public assets [see `PR #830 <https://github.com/FlexMeasures/flexmeasures/pull/830>`_]
 
 
 v0.15.0 | August 9, 2023

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -459,7 +459,7 @@ class GenericAsset(db.Model, AuthModelMixin):
 
         # Only allow showing sensors from assets owned by the user's organization,
         # except in play mode, where any sensor may be shown
-        accounts = [self.owner]
+        accounts = [self.owner] if self.owner else None
         if current_app.config.get("FLEXMEASURES_MODE") == "play":
             from flexmeasures.data.models.user import Account
 

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -215,6 +215,8 @@ class GenericAsset(db.Model, AuthModelMixin):
     ) -> Union[List[Annotation], pd.DataFrame]:
         """Return annotations assigned to this asset, and optionally, also those assigned to the asset's account.
 
+        The returned annotations do not include any annotations on public accounts.
+
         :param annotations_after: only return annotations that end after this datetime (exclusive)
         :param annotations_before: only return annotations that start before this datetime (exclusive)
         """
@@ -226,7 +228,7 @@ class GenericAsset(db.Model, AuthModelMixin):
             sources=parsed_sources,
             annotation_type=annotation_type,
         ).all()
-        if include_account_annotations:
+        if include_account_annotations and self.owner is not None:
             annotations += self.owner.search_annotations(
                 annotations_after=annotations_after,
                 annotations_before=annotations_before,

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -461,7 +461,7 @@ class GenericAsset(db.Model, AuthModelMixin):
 
         # Only allow showing sensors from assets owned by the user's organization,
         # except in play mode, where any sensor may be shown
-        accounts = [self.owner] if self.owner else None
+        accounts = [self.owner] if self.owner is not None else None
         if current_app.config.get("FLEXMEASURES_MODE") == "play":
             from flexmeasures.data.models.user import Account
 


### PR DESCRIPTION
## Description

Public asset pages with sensors to show no longer loaded the chart. This PR fixes that. The bug had been introduced in #740.