### PR TITLE
Feature/datetime unit conversions with dayfirst and timezone

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -3,7 +3,7 @@
 FlexMeasures Changelog
 **********************
 
-v0.15.1 | August XX, 2023
+v0.16.0 | September XX, 2023
 ============================
 
 New features
@@ -11,6 +11,9 @@ New features
 
 * Introduce new reporter to compute profit/loss due to electricity flows: `ProfitOrLossReporter` [see `PR #808 <https://github.com/FlexMeasures/flexmeasures/pull/808>`_]
 
+
+v0.15.1 | August XX, 2023
+============================
 
 Bugfixes
 -----------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -11,6 +11,11 @@ New features
 
 * Introduce new reporter to compute profit/loss due to electricity flows: `ProfitOrLossReporter` [see `PR #808 <https://github.com/FlexMeasures/flexmeasures/pull/808>`_]
 
+Infrastructure / Support
+----------------------
+
+* Allow additional datetime conversions to quantitative time units, specifically, from timezone-naive and/or dayfirst datetimes, which can be useful when importing data [see `PR #831 <https://github.com/FlexMeasures/flexmeasures/pull/831>`_]
+
 
 v0.15.1 | August XX, 2023
 ============================

--- a/flexmeasures/utils/unit_utils.py
+++ b/flexmeasures/utils/unit_utils.py
@@ -240,9 +240,12 @@ def _convert_time_units(
         # unit abbreviations passed to pd.Timedelta need a number (so, for example, h becomes 1h)
         to_unit = f"1{to_unit}"
     if from_unit == "datetime":
-        return (
-            pd.to_datetime(data, utc=True) - pd.Timestamp("1970-01-01", tz="utc")
-        ) // pd.Timedelta(to_unit)
+        dt_data = pd.to_datetime(data)
+        # localize timezone naive data to the sensor's timezone, if available
+        if dt_data.dt.tz is None:
+            timezone = data.sensor.timezone if hasattr(data, "sensor") else "utc"
+            dt_data = dt_data.dt.tz_localize(timezone)
+        return (dt_data - pd.Timestamp("1970-01-01", tz="utc")) // pd.Timedelta(to_unit)
     else:
         return data / pd.Timedelta(to_unit)
 


### PR DESCRIPTION
## Description

This PR is about some special cases of unit conversion, used primarily when importing data from file: event values that themselves represent durations or timestamps that need to be converted to quantitative values. Two features:
1. The first feature deals with naive datetimes, that need to be localized to the timezone of the sensor.
2. The second feature deals with datetimes that are in a dayfirst format.

## Look & Feel

```
import pandas as pd
from flexmeasures.utils.unit_utils import convert_units

data = pd.Series(["01-01-1970", "02-01-1970", "03-01-1970"])
converted_data = convert_units(data, from_unit="dayfirst datetime", to_unit="s")
expected_data = pd.Series([0, 60 * 60 * 24, 60 * 60 * 48])
pd.testing.assert_series_equal(converted_data, expected_data)  # should be True
```

For the issue of localizing to a timezone issue, simply pass a `BeliefsSeries` instance (or give the Series instance a `sensor` atrribute, which itself should have a `timezone` attribute).

## How to test

Additional test cases for unit conversion are added in this PR.

## Further Improvements

I'm just listing ideas here, but none of these require an immediate follow-up.

The `infer_datetime_format` of `pd.to_datetime` isn't smart enough for our purposes. For example:

```
>>> pd.to_datetime(pd.Series(["01-01-2023 00:00", "01-01-2023 12:00", "02-01-2023 00:00", "02-01-2023 12:00", "03-01-2023 00:00", "03-01-2023 12:00",]), infer_datetime_format=True)
0   2023-01-01 00:00:00
1   2023-01-01 12:00:00
2   2023-02-01 00:00:00
3   2023-02-01 12:00:00
4   2023-03-01 00:00:00
5   2023-03-01 12:00:00
dtype: datetime64[ns]
```
This time series can be interpreted in both dayfirst and monthfirst format, but only the dayfirst leads to a steady frequency, whereas the monthfirst is chosen by `pd.to_datetime`.

It would be quite nice if the `dayfirst` parameter passed to `pd.to_datetime` could be derived automatically, also for the case of a `from_unit="datetime"`. This should be possible under the assumption that all of the input data is formatted in the same way, but even then only possible if a date of >12 is present within the data. This is what `infer_datetime_format` already does well. As a fallback, the one leading to a steady frequency should be preferred (at least in the context of FlexMeasures). And if that still leads to a tie, I would pick the one that leads to a chronological order. And if that ties, I'd raise (which for the use case of importing data, means the user could be asked to either update the input data, or use the "dayfirst datetime", which we could keep supporting).


---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
