### PR TITLE
fix: parsing of soc-target timestamps in `fm add schedule for-storage`

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -26,7 +26,7 @@ Bugfixes
 * Use the `source` to filter beliefs in the `AggregatorReporter` and fix the case of having multiple sources [see `PR #819 <https://github.com/FlexMeasures/flexmeasures/pull/819>`_]
 * Disable HiGHS logs on the standard output when `LOGGING_LEVEL=INFO` [see `PR #824 <https://github.com/FlexMeasures/flexmeasures/pull/824>`_ and `PR #826 <https://github.com/FlexMeasures/flexmeasures/pull/826>`_]
 * Fix showing sensor data on the asset page of public assets, and searching for annotations on public assets [see `PR #830 <https://github.com/FlexMeasures/flexmeasures/pull/830>`_]
-
+* Make the command `flexmeasures add schedule for-storage` to pass the soc-target timestamp to the flex model as strings instead of `pd.Timestamp` [see `PR #834 <https://github.com/FlexMeasures/flexmeasures/pull/834>`_]
 
 v0.15.0 | August 9, 2023
 ============================

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -1163,14 +1163,16 @@ def add_schedule_for_storage(
     soc_at_start = convert_units(soc_at_start.magnitude, soc_at_start.units, "MWh", capacity=capacity_str)  # type: ignore
     soc_targets = []
     for soc_target_tuple in soc_target_strings:
-        soc_target_value_str, soc_target_datetime = soc_target_tuple
+        soc_target_value_str, soc_target_datetime_str = soc_target_tuple
         soc_target_value = convert_units(
             soc_target_value_str.magnitude,
             str(soc_target_value_str.units),
             "MWh",
             capacity=capacity_str,
         )
-        soc_targets.append(dict(value=soc_target_value, datetime=soc_target_datetime))
+        soc_targets.append(
+            dict(value=soc_target_value, datetime=soc_target_datetime_str)
+        )
 
     if soc_min is not None:
         soc_min = convert_units(soc_min.magnitude, str(soc_min.units), "MWh", capacity=capacity_str)  # type: ignore

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -1170,8 +1170,9 @@ def add_schedule_for_storage(
             "MWh",
             capacity=capacity_str,
         )
-        soc_target_datetime = pd.Timestamp(soc_target_dt_str)
+        soc_target_datetime = soc_target_dt_str
         soc_targets.append(dict(value=soc_target_value, datetime=soc_target_datetime))
+
     if soc_min is not None:
         soc_min = convert_units(soc_min.magnitude, str(soc_min.units), "MWh", capacity=capacity_str)  # type: ignore
     if soc_max is not None:

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -1163,14 +1163,13 @@ def add_schedule_for_storage(
     soc_at_start = convert_units(soc_at_start.magnitude, soc_at_start.units, "MWh", capacity=capacity_str)  # type: ignore
     soc_targets = []
     for soc_target_tuple in soc_target_strings:
-        soc_target_value_str, soc_target_dt_str = soc_target_tuple
+        soc_target_value_str, soc_target_datetime = soc_target_tuple
         soc_target_value = convert_units(
             soc_target_value_str.magnitude,
             str(soc_target_value_str.units),
             "MWh",
             capacity=capacity_str,
         )
-        soc_target_datetime = soc_target_dt_str
         soc_targets.append(dict(value=soc_target_value, datetime=soc_target_datetime))
 
     if soc_min is not None:

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -1066,7 +1066,7 @@ def create_schedule(ctx):
     ),
     multiple=True,
     required=False,
-    help="Target state of charge (e.g 100%, or 1) at some datetime. Follow up with a float value and a timezone-aware datetime in ISO 6081 format."
+    help="Target state of charge (e.g 100%, or 1) at some datetime. Follow up with a float value and a timezone-aware datetime in ISO 8601 format."
     " This argument can be given multiple times."
     " For example: --soc-target 100% 2022-02-23T13:40:52+00:00",
 )


### PR DESCRIPTION
## Description

I tried to add soc targets using the command `flexmeasures add schedule for-storage` but the timestamps couldn't get parsed:

```
  File "pandas/_libs/tslibs/timestamps.pyx", line 2251, in pandas._libs.tslibs.timestamps.Timestamp.replace
  File "pandas/_libs/tslibs/timestamps.pyx", line 2245, in pandas._libs.tslibs.timestamps.Timestamp.replace.validate
ValueError: value must be an integer, received <class 'str'> for year
```

The command was passing the datetime as a timestamp to the serialized `flex-model` while it should be a string.

## How to test

I've tested this running the toy tutorial followed by the command:

```
flexmeasures add schedule for-storage --sensor-id 2 --consumption-price-sensor 1 \
    --start ${TOMORROW}T07:00+01:00 --duration PT12H \
    --soc-at-start 50% --roundtrip-efficiency 90% \
    --soc-target 40% ${TOMORROW}T10:00+02:00
```

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
