### PR TITLE
rename `source` to `sources` and fetch only one value per event

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -9,7 +9,7 @@ v0.16.0 | September XX, 2023
 New features
 -------------
 
-* Introduce new reporter to compute profit/loss due to electricity flows: `ProfitOrLossReporter` [see `PR #808 <https://github.com/FlexMeasures/flexmeasures/pull/808>`_]
+* Introduce new reporter to compute profit/loss due to electricity flows: `ProfitOrLossReporter` [see `PR #808 <https://github.com/FlexMeasures/flexmeasures/pull/808>`_ and `PR #844 <https://github.com/FlexMeasures/flexmeasures/pull/844>`_]
 * Charts visible in the UI can be exported to PNG or SVG formats in a more automated fashion, using the new CLI command flexmeasures show chart [see `PR #833 <https://github.com/FlexMeasures/flexmeasures/pull/833>`_]
 
 Infrastructure / Support

--- a/flexmeasures/data/models/reporting/profit.py
+++ b/flexmeasures/data/models/reporting/profit.py
@@ -72,7 +72,8 @@ class ProfitOrLossReporter(Reporter):
         loss_is_positive: bool = self._config.get("loss_is_positive", False)
 
         input_sensor: Sensor = input[0]["sensor"]  # power or energy sensor
-        input_source: Sensor = input[0].get("source", None)
+        input_source: Sensor = input[0].get("sources", None)
+
         timezone = input_sensor.timezone
 
         if belief_time is None:
@@ -85,6 +86,8 @@ class ProfitOrLossReporter(Reporter):
                 event_ends_before=end,
                 beliefs_before=belief_time,
                 resolution=input_sensor.event_resolution,
+                most_recent_beliefs_only=True,
+                one_deterministic_belief_per_event=True,
             )
         )
         production_price = production_price.tz_convert(timezone)
@@ -94,6 +97,8 @@ class ProfitOrLossReporter(Reporter):
                 event_ends_before=end,
                 beliefs_before=belief_time,
                 resolution=input_sensor.event_resolution,
+                most_recent_beliefs_only=True,
+                one_deterministic_belief_per_event=True,
             )
         )
         consumption_price = consumption_price.tz_convert(timezone)
@@ -105,6 +110,8 @@ class ProfitOrLossReporter(Reporter):
                 event_ends_before=end,
                 beliefs_before=belief_time,
                 source=input_source,
+                most_recent_beliefs_only=True,
+                one_deterministic_belief_per_event=True,
             )
         )
 


### PR DESCRIPTION
## Description

This PR renames `source` to `sources` given that `source` is deprecated. In addition, it fixes the issue of having multiple values per event in the price (e.g. different sources).

## Related Items

#808

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
