### PR TITLE
add headroom charts to tutorial part II

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -17,7 +17,7 @@ Infrastructure / Support
 ----------------------
 
 * Allow additional datetime conversions to quantitative time units, specifically, from timezone-naive and/or dayfirst datetimes, which can be useful when importing data [see `PR #831 <https://github.com/FlexMeasures/flexmeasures/pull/831>`_]
-* Add a new tutorial to explain the use of the `AggregatorReporter` to compute the headroom and the `ProfitOrLossReporter` to compute the cost of running a process [see `PR #825 <https://github.com/FlexMeasures/flexmeasures/pull/825>`_]
+* Add a new tutorial to explain the use of the `AggregatorReporter` to compute the headroom and the `ProfitOrLossReporter` to compute the cost of running a process [see `PR #825 <https://github.com/FlexMeasures/flexmeasures/pull/825>`_ and `PR #856 <https://github.com/FlexMeasures/flexmeasures/pull/856>`_]
 * Script to update dependencies across supported Python versions [see `PR #843 <https://github.com/FlexMeasures/flexmeasures/pull/843>`_]
 * Test all supported Python versions in our CI pipeline (GitHub Actions) [see `PR #847 <https://github.com/FlexMeasures/flexmeasures/pull/847>`_]
 * Have our CI pipeline (GitHub Actions) build the Docker image and make a schedule [see `PR #800 <https://github.com/FlexMeasures/flexmeasures/pull/800>`_]

--- a/documentation/tut/toy-example-expanded.rst
+++ b/documentation/tut/toy-example-expanded.rst
@@ -103,6 +103,29 @@ First, during the sunny hours of the day, when solar power is being send to the 
 
 Second, charging of the battery is also changed a bit (around 10am), as less can be discharged later.
 
+Moreover, we can use reporters to compute the capacity headroom (see :ref:`tut_toy_schedule_process` for more details). The image below shows that the scheduler is respecting the capacity limits.
+
+.. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/sensor-data-headroom-pv.png
+    :align: center
+|
+
+In the case of the scheduler that we run in the previous tutorial, the PV is not taken into consideration and the discharge power exceeds the headroom:
+
+.. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/sensor-data-headroom-pv.png
+    :align: center
+|
+
 We hope this part of the tutorial shows how to incorporate a limited grid connection rather easily with FlexMeasures. There are more ways to model such settings, but this is a straightforward one.
 
 This tutorial showed a quick way to add an inflexible load (like solar power) and a grid connection. In :ref:`tut_toy_schedule_process`, we'll turn to something different: the optimal timing of processes with fixed energy work and duration.
+
+
+
+
+
+
+
+
+.. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/sensor-data-headroom-nopv.png
+    :align: center
+|

--- a/documentation/tut/toy-example-expanded.rst
+++ b/documentation/tut/toy-example-expanded.rst
@@ -109,9 +109,9 @@ Moreover, we can use reporters to compute the capacity headroom (see :ref:`tut_t
     :align: center
 |
 
-In the case of the scheduler that we run in the previous tutorial, the PV is not taken into consideration and the discharge power exceeds the headroom:
+In the case of the scheduler that we ran in the previous tutorial, which did not yet consider the PV, the discharge power would have exceeded the headroom:
 
-.. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/sensor-data-headroom-pv.png
+.. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/sensor-data-headroom-nopv.png
     :align: center
 |
 
@@ -120,14 +120,3 @@ In the case of the scheduler that we run in the previous tutorial, the PV is not
 We hope this part of the tutorial shows how to incorporate a limited grid connection rather easily with FlexMeasures. There are more ways to model such settings, but this is a straightforward one.
 
 This tutorial showed a quick way to add an inflexible load (like solar power) and a grid connection. In :ref:`tut_toy_schedule_process`, we'll turn to something different: the optimal timing of processes with fixed energy work and duration.
-
-
-
-
-
-
-
-
-.. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/sensor-data-headroom-nopv.png
-    :align: center
-|

--- a/documentation/tut/toy-example-expanded.rst
+++ b/documentation/tut/toy-example-expanded.rst
@@ -115,7 +115,7 @@ In the case of the scheduler that we ran in the previous tutorial, which did not
     :align: center
 |
 
-.. note:: You can add arbitrary sensors to a chart using the attribute ``sensors_to_show``. See :ref: `view_asset-data` for more.
+.. note:: You can add arbitrary sensors to a chart using the attribute ``sensors_to_show``. See :ref:`view_asset-data` for more.
 
 We hope this part of the tutorial shows how to incorporate a limited grid connection rather easily with FlexMeasures. There are more ways to model such settings, but this is a straightforward one.
 

--- a/documentation/tut/toy-example-expanded.rst
+++ b/documentation/tut/toy-example-expanded.rst
@@ -115,6 +115,8 @@ In the case of the scheduler that we run in the previous tutorial, the PV is not
     :align: center
 |
 
+.. note:: You can add arbitrary sensors to a chart using the attribute ``sensors_to_show``. See :ref: `view_asset-data` for more.
+
 We hope this part of the tutorial shows how to incorporate a limited grid connection rather easily with FlexMeasures. There are more ways to model such settings, but this is a straightforward one.
 
 This tutorial showed a quick way to add an inflexible load (like solar power) and a grid connection. In :ref:`tut_toy_schedule_process`, we'll turn to something different: the optimal timing of processes with fixed energy work and duration.

--- a/documentation/tut/toy-example-reporter.rst
+++ b/documentation/tut/toy-example-reporter.rst
@@ -148,8 +148,9 @@ we are going to create share the same `config`. The `config` defines the price s
 that it will return costs as positive values and revenue as negative values.
 
 Still, we need to define the parameters. The three reports share the same structure for the parameters with the following fields:
-* `input`: sensor that stores the power/energy flow. The number of sensors is limited to 1.
-* `output`: sensor to store the report. We can provide sensors with different resolutions to store the same results at different time scales.
+
+    - `input`: sensor that stores the power/energy flow. The number of sensors is limited to 1.
+    - `output`: sensor to store the report. We can provide sensors with different resolutions to store the same results at different time scales.
 
 .. note::
     It's possible to define the `config` and `parameters` in JSON or YAML formats.
@@ -241,6 +242,7 @@ Check the results `here <http://localhost:5000/sensor/11/>`_. The image should b
 .. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/sensor-data-shiftable.png
     :align: center
 |
+
 
 Now, we can compare the results of the reports to the ones we computed manually in :ref:`this table <table-process>`). Keep in mind that the
 report is showing the profit of each 15min period and adding them all shows that it matches with our previous results.


### PR DESCRIPTION
## Description

This PR adds a couple of images to show that the schedulers are taking inflexible assets into account in tut. part II.

## Related Items

Closes https://github.com/FlexMeasures/flexmeasures/issues/584
Requires https://github.com/FlexMeasures/screenshots/pull/6

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
