### PR TITLE
fix: instruct client browser to reload JS

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -26,6 +26,7 @@ Infrastructure / Support
 * Test all supported Python versions in our CI pipeline (GitHub Actions) [see `PR #847 <https://github.com/FlexMeasures/flexmeasures/pull/847>`_]
 * Have our CI pipeline (GitHub Actions) build the Docker image and make a schedule [see `PR #800 <https://github.com/FlexMeasures/flexmeasures/pull/800>`_]
 * Updated documentation on the consequences of setting the `FLEXMEASURES_MODE` config setting [see `PR #857 <https://github.com/FlexMeasures/flexmeasures/pull/857>`_]
+* Implement cache-busting to avoid the need for users to hard refresh the browser when new JavaScript functionality is added to the :abbr:`UI (user interface)` in a new FlexMeasures version [see `PR #860 <https://github.com/FlexMeasures/flexmeasures/pull/860>`_]
 
 
 v0.15.1 | August 28, 2023

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -193,9 +193,10 @@
     <!-- Render Charts -->
     <script type="module" type="text/javascript">
 
-    import { getUniqueValues, convertToCSV } from "{{ url_for('flexmeasures_ui.static', filename='js/data-utils.js') }}";
-    import { subtract, thisMonth, lastNMonths, countDSTTransitions, getOffsetBetweenTimezonesForDate } from "{{ url_for('flexmeasures_ui.static', filename='js/daterange-utils.js') }}";
-    import { partition, updateBeliefs, beliefTimedelta, setAbortableTimeout} from "{{ url_for('flexmeasures_ui.static', filename='js/replay-utils.js') }}";
+    // Import local js (the FM version is used for cache-busting, causing the browser to fetch the updated version from the server)
+    import { getUniqueValues, convertToCSV } from "{{ url_for('flexmeasures_ui.static', filename='js/data-utils.js') }}?v={{ flexmeasures_version }}";
+    import { subtract, thisMonth, lastNMonths, countDSTTransitions, getOffsetBetweenTimezonesForDate } from "{{ url_for('flexmeasures_ui.static', filename='js/daterange-utils.js') }}?v={{ flexmeasures_version }}";
+    import { partition, updateBeliefs, beliefTimedelta, setAbortableTimeout} from "{{ url_for('flexmeasures_ui.static', filename='js/replay-utils.js') }}?v={{ flexmeasures_version }}";
 
     let vegaView;
     let previousResult;


### PR DESCRIPTION
## Description

Implement cache-busting to avoid the need to hard refresh the browser.

## Look & Feel

Without this, the asset/sensor page will not load when a new function needs to be loaded from a local JS file. I ran into this when the `convertToCSV` function was introduced as part of the `js/data-utils.js` file. The browser caches these files, so we need to tell the browser to reload it. A common technique for this is cache-busting. In this PR I'm using the FlexMeasures version, so each new release (incl. local dev versions) leads to reloading the (locally imported) JS files.

