### PR TITLE
fix: rq queue name in menu

### DIFF
--- a/flexmeasures/app.py
+++ b/flexmeasures/app.py
@@ -185,7 +185,7 @@ def create(  # noqa C901
     # Global template variables for both our own templates and external templates
     @app.context_processor
     def set_global_template_variables():
-        return {'queue_names': app.queues.keys()}
+        return {"queue_names": app.queues.keys()}
 
     # Profile endpoints (if needed, e.g. during development)
 

--- a/flexmeasures/app.py
+++ b/flexmeasures/app.py
@@ -182,6 +182,11 @@ def create(  # noqa C901
 
     register_ui_at(app)
 
+    # Global template variables for both our own templates and external templates
+    @app.context_processor
+    def set_global_template_variables():
+        return {'queue_names': app.queues.keys()}
+
     # Profile endpoints (if needed, e.g. during development)
 
     @app.before_request

--- a/flexmeasures/ui/__init__.py
+++ b/flexmeasures/ui/__init__.py
@@ -97,13 +97,13 @@ def register_rq_dashboard(app):
         """Ensure basic admin authorization."""
         return
 
-    # Logged in users can view queues on the demo server, but only admins can view them on other servers
+    # Logged-in users can view queues on the demo server, but only admins can view them on other servers
     if app.config.get("FLEXMEASURES_MODE", "") == "demo":
         rq_dashboard.blueprint.before_request(basic_auth)
     else:
         rq_dashboard.blueprint.before_request(basic_admin_auth)
 
-    # Todo: rq dashboard has no way of passing FlexMeasures template variables, so how to conditionally disable menu items?
+    # To set template variables, use set_global_template_variables in app.py
     app.register_blueprint(rq_dashboard.blueprint, url_prefix="/tasks")
 
 

--- a/flexmeasures/ui/static/css/flexmeasures.css
+++ b/flexmeasures/ui/static/css/flexmeasures.css
@@ -1833,3 +1833,9 @@ div.heading-group {
 #exportToCSVAction {
   cursor: pointer;
 }
+
+/* override rq-dashboard ellipsis styling to unhide important parts of the job kwargs */
+.ellipsify {
+  overflow: visible !important;
+  white-space: normal !important;
+}

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -84,10 +84,10 @@
                             Tasks
                             <span class="caret"></span></a>
                         <ul class="dropdown-menu">
-                            {% for queue in queues %}
+                            {% for queue in queue_names %}
                                 <li {% if current_user.has_role('anonymous') %}class="disabled" {% endif %}><a
                                     {% if not current_user.has_role('anonymous') %}href="/tasks/0/view/jobs/{{ queue }}/started/10/1"
-                                    {% endif %}>{{ queue | string | capitalize }}</a></li>
+                                    {% endif %}>{{ queue | capitalize }}</a></li>
                             {% endfor %}
                             <li {% if current_user.has_role('anonymous') %}class="disabled" {% endif %}><a
                                     {% if not current_user.has_role('anonymous') %}href="/tasks/"

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -87,7 +87,7 @@
                             {% for queue in queues %}
                                 <li {% if current_user.has_role('anonymous') %}class="disabled" {% endif %}><a
                                     {% if not current_user.has_role('anonymous') %}href="/tasks/0/view/jobs/{{ queue }}/started/10/1"
-                                    {% endif %}>{{ queue | capitalize }}</a></li>
+                                    {% endif %}>{{ queue | string | capitalize }}</a></li>
                             {% endfor %}
                             <li {% if current_user.has_role('anonymous') %}class="disabled" {% endif %}><a
                                     {% if not current_user.has_role('anonymous') %}href="/tasks/"

--- a/flexmeasures/ui/utils/view_utils.py
+++ b/flexmeasures/ui/utils/view_utils.py
@@ -25,8 +25,6 @@ def render_flexmeasures_template(html_filename: str, **variables):
     ):
         variables["documentation_exists"] = True
 
-    variables["queues"] = current_app.queues.keys()
-
     variables["event_starts_after"] = session.get("event_starts_after")
     variables["event_ends_before"] = session.get("event_ends_before")
     variables["chart_type"] = session.get("chart_type", "bar_chart")


### PR DESCRIPTION
## Description

- The `queues` variable in rq-dasboard is full of `Queue` objects rather than `str` objects. Each needs to be cast to a string before we can capitalize.
- This fixes an unreleased bug, so I'm not making a changelog entry for it.

## Look & Feel / How to test

Without this PR, the tasks page simply crashes.

## Further Improvements

We are missing a UI test for the tasks page. I spent two hours on it, but failed to write a decent test. I simply can't get rid of the `<h1>Connection Error</h1>` response. The interplay between flask, fakeredis, rq and rq-dashboard is tricky.
