### PR TITLE
fix: apply soc-unit when deserializing soc-minima and soc-maxima

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -41,6 +41,15 @@ Infrastructure / Support
 * Implement cache-busting to avoid the need for users to hard refresh the browser when new JavaScript functionality is added to the :abbr:`UI (user interface)` in a new FlexMeasures version [see `PR #860 <https://github.com/FlexMeasures/flexmeasures/pull/860>`_]
 
 
+v0.15.2 | October 2, 2023
+============================
+
+Bugfixes
+-----------
+
+* Fix infeasible problem due to incorrect parsing of soc units of the ``soc-minima`` and ``soc-maxima`` fields within the ``flex-model`` field [see `PR #864 <https://github.com/FlexMeasures/flexmeasures/pull/864>`_]
+
+
 v0.15.1 | August 28, 2023
 ============================
 
@@ -52,6 +61,7 @@ Bugfixes
 * Disable HiGHS logs on the standard output when `LOGGING_LEVEL=INFO` [see `PR #824 <https://github.com/FlexMeasures/flexmeasures/pull/824>`_ and `PR #826 <https://github.com/FlexMeasures/flexmeasures/pull/826>`_]
 * Fix showing sensor data on the asset page of public assets, and searching for annotations on public assets [see `PR #830 <https://github.com/FlexMeasures/flexmeasures/pull/830>`_]
 * Make the command `flexmeasures add schedule for-storage` to pass the soc-target timestamp to the flex model as strings instead of `pd.Timestamp` [see `PR #834 <https://github.com/FlexMeasures/flexmeasures/pull/834>`_]
+
 
 v0.15.0 | August 9, 2023
 ============================
@@ -96,6 +106,16 @@ Infrastructure / Support
 * Add support for installing FlexMeasures under Python 3.11 [see `PR #771 <https://www.github.com/FlexMeasures/flexmeasures/pull/771>`_]
 * Start keeping sets of pinned requirements per supported Python version. Also fixes recent Docker build problem. [see `PR #776 <https://www.github.com/FlexMeasures/flexmeasures/pull/776>`_]
 * Removed obsolete code dealing with deprecated data models (e.g. assets, markets and weather sensors), and sunset the fm0 scheme for entity addresses [see `PR #695 <https://www.github.com/FlexMeasures/flexmeasures/pull/695>`_ and `project 11 <https://www.github.com/FlexMeasures/flexmeasures/projects/11>`_]
+
+
+v0.14.3 | October 2, 2023
+============================
+
+Bugfixes
+-----------
+
+* Fix infeasible problem due to incorrect parsing of soc units of the ``soc-minima`` and ``soc-maxima`` fields within the ``flex-model`` field [see `PR #864 <https://github.com/FlexMeasures/flexmeasures/pull/864>`_]
+
 
 v0.14.2 | July 25, 2023
 ============================

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -3,6 +3,16 @@
 FlexMeasures Changelog
 **********************
 
+
+v0.16.1 | October 2, 2023
+============================
+
+Bugfixes
+-----------
+
+* Fix infeasible problem due to incorrect parsing of soc units of the ``soc-minima`` and ``soc-maxima`` fields within the ``flex-model`` field [see `PR #864 <https://github.com/FlexMeasures/flexmeasures/pull/864>`_]
+
+
 v0.16.0 | September 27, 2023
 ============================
 

--- a/flexmeasures/api/v3_0/tests/utils.py
+++ b/flexmeasures/api/v3_0/tests/utils.py
@@ -90,4 +90,11 @@ def message_for_trigger_schedule(
         message["flex-model"]["soc-targets"] = [
             {"value": target_value, "datetime": target_datetime}
         ]
+        # Also create some minima and maxima constraints to test correct deserialization using the soc-unit
+        message["flex-model"]["soc-minima"] = [
+            {"value": target_value - 1, "datetime": target_datetime}
+        ]
+        message["flex-model"]["soc-maxima"] = [
+            {"value": target_value + 1, "datetime": target_datetime}
+        ]
     return message

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -136,6 +136,12 @@ class StorageFlexModelSchema(Schema):
             if data.get("soc_targets"):
                 for target in data["soc_targets"]:
                     target["value"] /= 1000.0
+            if data.get("soc_minima"):
+                for minimum in data["soc_minima"]:
+                    minimum["value"] /= 1000.0
+            if data.get("soc_maxima"):
+                for maximum in data["soc_maxima"]:
+                    maximum["value"] /= 1000.0
             data["soc_unit"] = "MWh"
 
         # Convert efficiencies to dimensionless (to the (0,1] range)


### PR DESCRIPTION
## Description

The `soc-minima` and `soc-maxima` fields of the `flex-model` field were not deserialized to the correct soc unit, resulting in failing schedules for valid flex models.

## Further Improvements

Switching to using pint `Quantity` objects in code may possibly have made this easier to debug.
