### PR TITLE
serialize sensor only when there's data

### DIFF
--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -440,9 +440,11 @@ class GenericAsset(db.Model, AuthModelMixin):
                     append=True,
                 )
             df = df.reset_index()
-            if len(df) > 0:
-                df["source"] = df["source"].apply(lambda x: x.to_dict())
+            df["source"] = df["source"].apply(lambda x: x.to_dict())
+
+            if "sensor" in df.columns:
                 df["sensor"] = df["sensor"].apply(lambda x: x.to_dict())
+
             return df.to_json(orient="records")
         return bdf_dict
 

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -439,12 +439,10 @@ class GenericAsset(db.Model, AuthModelMixin):
                     else ["belief_time", "source"],
                     append=True,
                 )
+                df["sensor"] = {}  # ensure the same columns as a non-empty frame
             df = df.reset_index()
             df["source"] = df["source"].apply(lambda x: x.to_dict())
-
-            if "sensor" in df.columns:
-                df["sensor"] = df["sensor"].apply(lambda x: x.to_dict())
-
+            df["sensor"] = df["sensor"].apply(lambda x: x.to_dict())
             return df.to_json(orient="records")
         return bdf_dict
 

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -440,8 +440,9 @@ class GenericAsset(db.Model, AuthModelMixin):
                     append=True,
                 )
             df = df.reset_index()
-            df["source"] = df["source"].apply(lambda x: x.to_dict())
-            df["sensor"] = df["sensor"].apply(lambda x: x.to_dict())
+            if len(df) > 0:
+                df["source"] = df["source"].apply(lambda x: x.to_dict())
+                df["sensor"] = df["sensor"].apply(lambda x: x.to_dict())
             return df.to_json(orient="records")
         return bdf_dict
 


### PR DESCRIPTION
## Description

Visualizing an asset page with sensors holding no data I encountered the following error:

```
  File "/home/victor/Work/Seita/flexmeasures/flexmeasures/data/models/generic_assets.py", line 444, in search_beliefs
    df["sensor"] = df["sensor"].apply(lambda x: x.to_dict())
                   ~~^^^^^^^^^^
  File "/home/victor/Work/Seita/flexmeasures/venv/lib/python3.11/site-packages/pandas/core/frame.py", line 3761, in __getitem__
    indexer = self.columns.get_loc(key)
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/victor/Work/Seita/flexmeasures/venv/lib/python3.11/site-packages/pandas/core/indexes/base.py", line 3655, in get_loc
    raise KeyError(key) from err
KeyError: 'sensor'

```

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
