### PR TITLE
Replace click.echo by click.secho

### DIFF
--- a/flexmeasures/cli/db_ops.py
+++ b/flexmeasures/cli/db_ops.py
@@ -105,8 +105,8 @@ def dump():
         click.secho(f"db dump successful: saved to {dump_filename}", **MsgStyle.SUCCESS)
 
     except Exception as e:
-        click.echo(f"Exception happened during dump: {e}", **MsgStyle.ERROR)
-        click.echo("db dump unsuccessful", **MsgStyle.ERROR)
+        click.secho(f"Exception happened during dump: {e}", **MsgStyle.ERROR)
+        click.secho("db dump unsuccessful", **MsgStyle.ERROR)
 
 
 @fm_db_ops.command()


### PR DESCRIPTION
When there's a failure during getting db dump, the error message should printed. But the it fails because `click.echo()` gets `fg` argument which should be passed to `click.secho()`.

``` python
    try:
        subprocess.check_output(command_for_dumping, shell=True)
        click.secho(f"db dump successful: saved to {dump_filename}", **MsgStyle.SUCCESS)

    except Exception as e:
        click.echo(f"Exception happened during dump: {e}", **MsgStyle.ERROR)
        click.echo("db dump unsuccessful", **MsgStyle.ERROR)
```