### PR TITLE
feature: weekly heatmap

### DIFF
--- a/flexmeasures/ui/templates/views/sensors.html
+++ b/flexmeasures/ui/templates/views/sensors.html
@@ -25,6 +25,7 @@
                               <ul class="dropdown-menu center-aligned" aria-labelledby="chartTypeDropdown">
                                   <li><a class="dropdown-item" href="#" data-chart-type="bar_chart">Bar chart</a></li>
                                   <li><a class="dropdown-item" href="#" data-chart-type="daily_heatmap">Daily heatmap</a></li>
+                                  <li><a class="dropdown-item" href="#" data-chart-type="weekly_heatmap">Weekly heatmap</a></li>
                               </ul>
                           </div>
                       </div>


### PR DESCRIPTION
## Description

New sensor chart type: weekly heatmap.

## Look & Feel

![sensor-1](https://github.com/FlexMeasures/flexmeasures/assets/30658763/f5ff2899-20df-4b7a-b791-85afc3c59186)

DST transitions behave similar as in the daily heatmap.

## How to test

Select the new chart type on any sensor page (just below the date selector).

## Further Improvements

- Avoiding repetitive years on the y-axis labels may be possible, but it's not a must.
- Note that setting Monday to be the first day of the week in these charts is not so easy. (I personally like having the week start on Sunday.)
