### PR TITLE
fix: unreachable code on the endpoint to get a schedule

### DIFF
--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -464,7 +464,7 @@ class SensorAPI(FlaskView):
                     "or its exception handler is not storing the exception as job meta data."
                 ),
             )
-            message = f"Scheduling job failed with {type(e).__name__}: {e}"
+            message = f"Scheduling job failed with {type(e).__name__}: {e}. {scheduler_info_msg}"
 
             fallback_job_id = job.meta.get("fallback_job_id")
 
@@ -480,9 +480,6 @@ class SensorAPI(FlaskView):
             else:
                 return unknown_schedule(message)
 
-            return unknown_schedule(
-                f"Scheduling job failed with {type(e).__name__}: {e}. {scheduler_info_msg}",
-            )
         elif job.is_started:
             return unknown_schedule(f"Scheduling job in progress. {scheduler_info_msg}")
         elif job.is_queued:

--- a/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
+++ b/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
@@ -435,7 +435,7 @@ def test_get_schedule_fallback(
         )  # Status code for redirect ("See other")
         assert (
             get_schedule_response.json["message"]
-            == "Scheduling job failed with InfeasibleProblemException: "
+            == "Scheduling job failed with InfeasibleProblemException: . StorageScheduler was used."
         )
         assert get_schedule_response.json["status"] == "UNKNOWN_SCHEDULE"
         assert get_schedule_response.json["result"] == "Rejected"

--- a/flexmeasures/data/models/planning/__init__.py
+++ b/flexmeasures/data/models/planning/__init__.py
@@ -80,7 +80,7 @@ class Scheduler:
         self.flex_context = flex_context
 
         if self.info is None:
-            self.info = dict(scheduler="")
+            self.info = dict(scheduler=self.__class__.__name__)
 
     def compute_schedule(self) -> Optional[pd.Series]:
         """

--- a/flexmeasures/data/services/scheduling.py
+++ b/flexmeasures/data/services/scheduling.py
@@ -267,6 +267,11 @@ def make_schedule(
     if flex_config_has_been_deserialized:
         scheduler.config_deserialized = True
 
+    # we get the default scheduler info in case it fails in the compute step
+    if rq_job:
+        click.echo("Job %s made schedule." % rq_job.id)
+        rq_job.meta["scheduler_info"] = scheduler.info
+
     consumption_schedule = scheduler.compute()
 
     if rq_job:


### PR DESCRIPTION
## Description

The `scheduler_info` wasn't returned when the fallback scehdule was activated. Moreover, I've added a default info (the class name) to the scheduler class.


## Related Items

Closes #882 

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
