### PR TITLE
fix(api): redirect url for fallback scheduler returns full url

### DIFF
--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -476,7 +476,10 @@ class SensorAPI(FlaskView):
                 return fallback_schedule_redirect(
                     message,
                     url_for(
-                        "SensorAPI:get_schedule", uuid=fallback_job_id, id=sensor.id
+                        "SensorAPI:get_schedule",
+                        uuid=fallback_job_id,
+                        id=sensor.id,
+                        _external=True,
                     ),
                 )
             else:

--- a/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
+++ b/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
@@ -443,7 +443,7 @@ def test_get_schedule_fallback(
         # check that the redirection location points to the fallback job
         assert (
             get_schedule_response.headers["location"]
-            == f"/api/v3_0/sensors/{charging_station.id}/schedules/{fallback_job_id}"
+            == f"http://localhost/api/v3_0/sensors/{charging_station.id}/schedules/{fallback_job_id}"
         )
 
         # run the fallback job


### PR DESCRIPTION
## Description

Redirect url returns full url instead of relative partial url.

## Look & Feel

before: "/api/v3_0/sensors/{charging_station.id}/schedules/{fallback_job_id}"
new: "http://localhost/api/v3_0/sensors/{charging_station.id}/schedules/{fallback_job_id}"

## How to test

Tests in `test_sensor_schedules.py`

## Further Improvements

Potential improvements to be done in the same PR or follow up Issues/Discussions/PRs.

## Related Items

Mention if this PR closes an Issue or Project.

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
