### PR TITLE
fix: stop using upgrade-insecure-requests header

### DIFF
--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -11,9 +11,6 @@
     </title>
     {% endblock head %}
     <meta charset="windows-1252">
-    {% if flask_env != 'development' and flask_env != 'testing' %}
-      <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
-    {% endif %}
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="/favicon.ico" type="image/x-icon" />
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />


### PR DESCRIPTION
## Description

We had introduced the [upgrade-insecure-requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/upgrade-insecure-requests) header before (#716), but it seems to cause problems on most cloud infrastructures. Reportedly, it helped to deploy on GCE which might have problems with mixed active content.

This PR reverses using it.

If mixed active content is a problem on some platforms, we need a different solution. Jut this header is an incomplete solution.

## How to test

Deploy on production setting (e.g. in AWS) and browse to dashboard. No errors / timeouts should appear.

