### PR TITLE
give admin reader access to rq-scheduler

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -18,7 +18,7 @@ Bugfixes
 -----------
 
 * Show `Assets`, `Users`, `Tasks` and `Accounts` pages in the navigation bar for the `admin-reader` role [see `PR #900 <https://github.com/FlexMeasures/flexmeasures/pull/900>`_]
-* Give `admin-reader` role access to the RQ Scheduler dahsboard [see `PR #901 <https://github.com/FlexMeasures/flexmeasures/pull/901>`_]
+* Give `admin-reader` role access to the RQ Scheduler dashboard [see `PR #901 <https://github.com/FlexMeasures/flexmeasures/pull/901>`_]
 
 
 v0.17.1 | November 22, 2023

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -18,7 +18,7 @@ Bugfixes
 -----------
 
 * Show `Assets`, `Users`, `Tasks` and `Accounts` pages in the navigation bar for the `admin-reader` role [see `PR #900 <https://github.com/FlexMeasures/flexmeasures/pull/900>`_]
-
+* Give `admin-reader` role access to the RQ Scheduler dahsboard [see `PR #901 <https://github.com/FlexMeasures/flexmeasures/pull/901>`_]
 
 
 v0.17.1 | November 22, 2023

--- a/flexmeasures/ui/__init__.py
+++ b/flexmeasures/ui/__init__.py
@@ -99,7 +99,11 @@ def register_rq_dashboard(app):
     def basic_admin_auth():
         """Ensure basic admin authorization."""
 
-        if current_user.has_role(ADMIN_READER_ROLE) and request.method != "GET":
+        if (
+            current_user.has_role(ADMIN_READER_ROLE)
+            and (request.method != "GET")
+            and ("requeue" not in request.path)
+        ):
             raise Forbidden(
                 f"User with `{ADMIN_READER_ROLE}` role is only allowed to list/inspect tasks, queues and workers. Edition or deletion operations are forbidden."
             )


### PR DESCRIPTION
## Description

Before, the  `admin-reader` role wasn't included in the list of roles that could access the rq-dashboard. This PR adds the `admin-reader` to the list of allowed roles that can visualize the dasboard.

Note of the implementation: if the role is reader, we are not allowing to access endpoints or the blueprint that are not `GET`. Also, the endpoint `/requeue/<queue_name>` is blacklisted as it can be triggered using a `GET` method. You can find more on the endpoints https://github.com/Parallels/rq-dashboard/blob/master/rq_dashboard/web.py

Note: even as admin, the deletion doesn't work. Should be open an issue to tackle this in the future or rather not allow that on FlexMeasures?


## How to test

To test it, it is convenient to create a job to check if we can find it on the rq-scheduler and check that we can't delete it.

### Setup
```bash
flexmeasures add toy-account --kind battery

TOMORROW=$(date --date="next day" '+%Y-%m-%d')
echo "Hour,Price
${TOMORROW}T00:00:00,10
${TOMORROW}T01:00:00,11
${TOMORROW}T02:00:00,12
${TOMORROW}T03:00:00,15
${TOMORROW}T04:00:00,18
${TOMORROW}T05:00:00,17
${TOMORROW}T06:00:00,10.5
${TOMORROW}T07:00:00,9
${TOMORROW}T08:00:00,9.5
${TOMORROW}T09:00:00,9
${TOMORROW}T10:00:00,8.5
${TOMORROW}T11:00:00,10
${TOMORROW}T12:00:00,8
${TOMORROW}T13:00:00,5
${TOMORROW}T14:00:00,4
${TOMORROW}T15:00:00,4
${TOMORROW}T16:00:00,5.5
${TOMORROW}T17:00:00,8
${TOMORROW}T18:00:00,12
${TOMORROW}T19:00:00,13
${TOMORROW}T20:00:00,14
${TOMORROW}T21:00:00,12.5
${TOMORROW}T22:00:00,10
${TOMORROW}T23:00:00,7" > prices-tomorrow.csv

flexmeasures add beliefs --sensor-id 1 --source toy-user prices-tomorrow.csv --timezone Europe/Amsterdam
```

### Create job
```bash
flexmeasures add schedule for-storage --sensor-id 2 --consumption-price-sensor 1 \
    --start ${TOMORROW}T07:00+01:00 --duration PT12H \
    --soc-at-start 50% --roundtrip-efficiency 90% \
    --as-job
```

Here we can check that the job is on the queue.  

### Start worker
```bash
flexmeasures jobs run-worker --queue scheduling
```

Once is done, the job will be shown as finished.

## Further Improvements

- Allow admin users to delete/re-queue jobs

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
