### PR TITLE
infra/specify postgres version to match when dumping and restoring

### DIFF
--- a/flexmeasures/cli/db_ops.py
+++ b/flexmeasures/cli/db_ops.py
@@ -161,7 +161,7 @@ def pg_cluster_arg_from_version(pg_version: str | None) -> str:
     More info (e.g. on the format) at https://manpages.ubuntu.com/manpages/trusty/man1/pg_wrapper.1.html
     """
     if pg_version:
-        return f"--version {pg_version}"
+        return f"--cluster {pg_version}/main"
     return ""
 
 

--- a/flexmeasures/cli/db_ops.py
+++ b/flexmeasures/cli/db_ops.py
@@ -161,7 +161,7 @@ def pg_cluster_arg_from_version(pg_version: str | None) -> str:
     More info (e.g. on the format) at https://manpages.ubuntu.com/manpages/trusty/man1/pg_wrapper.1.html
     """
     if pg_version:
-        return f"--cluster {pg_version}/main"
+        return f"--version {pg_version}"
     return ""
 
 

--- a/flexmeasures/cli/db_ops.py
+++ b/flexmeasures/cli/db_ops.py
@@ -1,4 +1,5 @@
 """CLI commands for saving, resetting, etc of the database"""
+from __future__ import annotations
 
 from datetime import datetime
 import subprocess


### PR DESCRIPTION
## Description

When dumping or restoring a database, FlexMeasures devs and hosters would have a problem, when the target database has a different version than the default local database. One needs to install the version of the target database locally, but `pg_dump` and `pg_restore` might still choose the default local version by default and then report a version mismatch as error. 

## Look & Feel

This PR adds a new CLI option `--pg-version` to the two commands `flexmeasures db-ops dump` and `flexmeasures db-ops restore`. 

## How to test

Dump the simulation database to file (it has PG 15, you might have PG 14 locally as default - which you can test with `pg_dump --version`.

Restore that dump to your local test database (set the db connection string in your ~/.flexmeasures.cfg first). I'm not sure this would run into the version mismatch, but you can see if restoring still works.