### PR TITLE
fix: 'str' object has no attribute 'removeprefix' in Python 3.8

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -28,7 +28,7 @@ Bugfixes
 -----------
 
 * Fix infeasible problem due to incorrect estimation of the big-M value [see `PR #905 <https://github.com/FlexMeasures/flexmeasures/pull/905>`_]
-
+* Fix API version listing (GET /api/v3_0) for hosts running on Python 3.8 [see `PR #917 <https://github.com/FlexMeasures/flexmeasures/pull/917>`_]
 
 
 v0.17.0 | November 8, 2023

--- a/flexmeasures/api/v3_0/public.py
+++ b/flexmeasures/api/v3_0/public.py
@@ -31,7 +31,7 @@ class ServicesAPI(FlaskView):
                 methods: str = "/".join(
                     [m for m in rule.methods if m not in ("OPTIONS", "HEAD")]
                 )
-                stripped_url = url.removeprefix(self.route_base)
+                stripped_url = removeprefix(url, self.route_base)
                 full_url = (
                     request.url_root.removesuffix("/") + url
                     if url.startswith("/")
@@ -75,3 +75,15 @@ def quickref_directive(content):
             break
 
     return description
+
+
+def removeprefix(text: str, prefix: str) -> str:
+    """Remove a prefix from a text.
+
+    todo: use text.removeprefix(prefix) instead of this method, after dropping support for Python 3.8
+          See https://docs.python.org/3.9/library/stdtypes.html#str.removeprefix
+    """
+    if text.startswith(prefix):
+        return text[len(prefix) :]
+    else:
+        return text


### PR DESCRIPTION
## Description

Visiting `some-flexmeasures-host-using-python3.8.com/api/v3_0` would return:
```
{"message":"'str' object has no attribute 'removeprefix'","status":500}
```

This happened because I used [a string method](https://docs.python.org/3.9/library/stdtypes.html#str.removeprefix) that was only introduced in Python 3.9.