### PR TITLE
fix(logs):reduce log messages from schedule

### DIFF
--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -2,6 +2,9 @@ from datetime import datetime, timedelta
 import pytest
 import pytz
 
+
+import logging
+
 import numpy as np
 import pandas as pd
 from pandas.tseries.frequencies import to_offset
@@ -13,6 +16,7 @@ from flexmeasures.data.models.planning.storage import (
     StorageScheduler,
     add_storage_constraints,
     validate_storage_constraints,
+    build_device_soc_values,
 )
 from flexmeasures.data.models.planning.linear_optimization import device_scheduler
 from flexmeasures.data.models.planning.tests.utils import check_constraints
@@ -1255,3 +1259,30 @@ def test_capacity(
 
     assert all(ems_constraints["derivative min"] == expected_site_production_capacity)
     assert all(ems_constraints["derivative max"] == expected_site_consumption_capacity)
+
+
+def test_build_device_soc_values(caplog):
+    caplog.set_level(logging.WARNING)
+    soc_values = [
+        {"datetime": datetime(2023, 5, 20, tzinfo=pytz.utc), "value": 1.0},
+        {"datetime": datetime(2023, 5, 23, tzinfo=pytz.utc), "value": 1.0},
+        {"datetime": datetime(2023, 5, 21, tzinfo=pytz.utc), "value": 1.0},
+    ]
+    soc_at_start = 3.0
+    start_of_schedule = datetime(2023, 5, 18, tzinfo=pytz.utc)
+    end_of_schedule = datetime(2023, 5, 19, tzinfo=pytz.utc)
+    resolution = timedelta(minutes=5)
+
+    with caplog.at_level(logging.WARNING):
+        device_values = build_device_soc_values(
+            soc_values=soc_values,
+            soc_at_start=soc_at_start,
+            start_of_schedule=start_of_schedule,
+            end_of_schedule=end_of_schedule,
+            resolution=resolution,
+        )
+    print(device_values)
+    assert (
+        "Disregarding 3 target datetimes from 2023-05-20 00:00:00+00:00 until 2023-05-23 00:00:00+00:00, because they exceeds 2023-05-19 00:00:00+00:00"
+        in caplog.text
+    )


### PR DESCRIPTION
## Description

reduce the amount of logs when targets for a requested schedule exceed the datetime limit for the scheduler. 

## Look & Feel

The first and last datetime that are ignored are now listed in one logging message

## How to test

Steps to test it or name of the tests functions.
`test_build_device_soc_values` in `flexmeasures/data/models/planning/tests/test_solver.py`

## Further Improvements

Potential improvements to be done in the same PR or follow up Issues/Discussions/PRs.

## Related Items

Closes #910 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
