### PR TITLE
Implement Content Security Policy (CSP) Upgrade for Enhanced Web Application Security

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -19,6 +19,7 @@ Bugfixes
 
 * Show `Assets`, `Users`, `Tasks` and `Accounts` pages in the navigation bar for the `admin-reader` role [see `PR #900 <https://github.com/FlexMeasures/flexmeasures/pull/900>`_]
 * Give `admin-reader` role access to the RQ Scheduler dashboard [see `PR #901 <https://github.com/FlexMeasures/flexmeasures/pull/901>`_]
+* New flexmeasures configuration setting `FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY` for upgrading insecure `http` requests to secured requests `https` [see `PR #920 <https://github.com/FlexMeasures/flexmeasures/pull/920>`_]
 
 
 v0.17.1 | November 22, 2023

--- a/documentation/configuration.rst
+++ b/documentation/configuration.rst
@@ -104,7 +104,7 @@ FLEXMEASURES_PROFILE_REQUESTS
 
 If True, the processing time of requests are profiled.
 
-The overall time used by requests are logged to the console. In addiition, if `pyinstrument` is installed, then a profiling report is made (of time being spent in different function calls) for all Flask API endpoints.
+The overall time used by requests are logged to the console. In addition, if `pyinstrument` is installed, then a profiling report is made (of time being spent in different function calls) for all Flask API endpoints.
 
 The profiling results are stored in the ``profile_reports`` folder in the instance directory.
 

--- a/documentation/configuration.rst
+++ b/documentation/configuration.rst
@@ -647,3 +647,10 @@ FLEXMEASURES_API_SUNSET_LINK
 Allow to override the default sunset link for your clients.
 
 Default: ``None`` (defaults are set internally for each sunset API version, e.g. ``"https://flexmeasures.readthedocs.io/en/v0.13.0/api/v2_0.html"`` for v2.0)
+
+FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When ``FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY`` is set to ``true``, insecure ``http`` connections are automatically upgraded to secure ``https``.
+
+Default: ``False``

--- a/documentation/configuration.rst
+++ b/documentation/configuration.rst
@@ -235,12 +235,6 @@ FLEXMEASURES_JS_VERSIONS
 
 Default: ``{"vega": "5.22.1", "vegaembed": "6.20.8", "vegalite": "5.2.0"}``
 
-FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-When ``FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY`` is set to ``True``, the ``<meta>`` tag with the ``Content-Security-Policy`` directive, specifically ``upgrade-insecure-requests``, is included in the HTML head. This directive instructs the browser to upgrade insecure requests from ``http`` to ``https``, promoting a more secure browsing experience.
-
-Default: ``False``
 
 Timing
 ------
@@ -390,7 +384,9 @@ You can use this setting to overwrite that URI and point the tests to an (empty)
 Security
 --------
 
-This is only a selection of the most important settings.
+Settings to ensure secure handling of credentials and data.
+
+For Flask-Security and Flask-Cors (setting names start with "SECURITY" or "CORS"), this is only a selection of the most important settings.
 See `the Flask-Security Docs <https://flask-security-too.readthedocs.io/en/stable/configuration.html>`_ as well as the `Flask-CORS docs <https://flask-cors.readthedocs.io/en/latest/configuration.html>`_ for all possibilities.
 
 SECRET_KEY (**)
@@ -458,6 +454,13 @@ Allows users to make authenticated requests. If true, injects the Access-Control
 
 Default: ``True``
 
+
+FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When ``FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY`` is set to ``True``, the ``<meta>`` tag with the ``Content-Security-Policy`` directive, specifically ``upgrade-insecure-requests``, is included in the HTML head. This directive instructs the browser to upgrade insecure requests from ``http`` to ``https``. One example of a use case for this is if you have a load balancer in front of FlexMeasures, which is secured with a certificate and only accepts https.
+
+Default: ``False``
 
 
 .. _mail-config:

--- a/documentation/configuration.rst
+++ b/documentation/configuration.rst
@@ -235,6 +235,12 @@ FLEXMEASURES_JS_VERSIONS
 
 Default: ``{"vega": "5.22.1", "vegaembed": "6.20.8", "vegalite": "5.2.0"}``
 
+FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When ``FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY`` is set to ``true``, insecure ``http`` connections are automatically upgraded to secure ``https``.
+
+Default: ``False``
 
 Timing
 ------
@@ -647,10 +653,3 @@ FLEXMEASURES_API_SUNSET_LINK
 Allow to override the default sunset link for your clients.
 
 Default: ``None`` (defaults are set internally for each sunset API version, e.g. ``"https://flexmeasures.readthedocs.io/en/v0.13.0/api/v2_0.html"`` for v2.0)
-
-FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-When ``FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY`` is set to ``true``, insecure ``http`` connections are automatically upgraded to secure ``https``.
-
-Default: ``False``

--- a/documentation/configuration.rst
+++ b/documentation/configuration.rst
@@ -238,7 +238,7 @@ Default: ``{"vega": "5.22.1", "vegaembed": "6.20.8", "vegalite": "5.2.0"}``
 FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When ``FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY`` is set to ``true``, insecure ``http`` connections are automatically upgraded to secure ``https``.
+When ``FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY`` is set to ``True``, the ``<meta>`` tag with the ``Content-Security-Policy`` directive, specifically ``upgrade-insecure-requests``, is included in the HTML head. This directive instructs the browser to upgrade insecure requests from ``http`` to ``https``, promoting a more secure browsing experience.
 
 Default: ``False``
 

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -11,6 +11,9 @@
     </title>
     {% endblock head %}
     <meta charset="windows-1252">
+    {% if FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY == true %}
+      <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+    {% endif %}
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="/favicon.ico" type="image/x-icon" />
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -11,7 +11,7 @@
     </title>
     {% endblock head %}
     <meta charset="windows-1252">
-    {% if FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY == true %}
+    {% if FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY %}
       <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
     {% endif %}
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/flexmeasures/ui/utils/view_utils.py
+++ b/flexmeasures/ui/utils/view_utils.py
@@ -19,7 +19,9 @@ from flexmeasures.ui.utils.chart_defaults import chart_options
 def render_flexmeasures_template(html_filename: str, **variables):
     """Render template and add all expected template variables, plus the ones given as **variables."""
     variables["flask_env"] = current_app.env
-    variables["FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY"] = current_app.config.get("FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY")
+    variables["FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY"] = current_app.config.get(
+        "FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY"
+    )
     variables["documentation_exists"] = False
     if os.path.exists(
         "%s/static/documentation/html/index.html" % flexmeasures_ui.root_path

--- a/flexmeasures/ui/utils/view_utils.py
+++ b/flexmeasures/ui/utils/view_utils.py
@@ -19,6 +19,7 @@ from flexmeasures.ui.utils.chart_defaults import chart_options
 def render_flexmeasures_template(html_filename: str, **variables):
     """Render template and add all expected template variables, plus the ones given as **variables."""
     variables["flask_env"] = current_app.env
+    variables["FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY"] = current_app.config.get("FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY")
     variables["documentation_exists"] = False
     if os.path.exists(
         "%s/static/documentation/html/index.html" % flexmeasures_ui.root_path

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -135,9 +135,8 @@ class Config(object):
     FLEXMEASURES_API_SUNSET_DATE: str | None = None  # e.g. 2023-05-01
     FLEXMEASURES_API_SUNSET_LINK: str | None = None  # e.g. https://flexmeasures.readthedocs.io/en/latest/api/introduction.html#deprecation-and-sunset
 
-    FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY: bool = (
-        False  # if True, the content could be accessed via HTTPS.
-    )
+    # if True, the content could be accessed via HTTPS.
+    FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY: bool = False
 
 
 #  names of settings which cannot be None

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -135,6 +135,7 @@ class Config(object):
     FLEXMEASURES_API_SUNSET_DATE: str | None = None  # e.g. 2023-05-01
     FLEXMEASURES_API_SUNSET_LINK: str | None = None  # e.g. https://flexmeasures.readthedocs.io/en/latest/api/introduction.html#deprecation-and-sunset
 
+    FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY: bool = False    # if True, the content could be accessed via HTTPS.
 
 #  names of settings which cannot be None
 #  SECRET_KEY is also required but utils.app_utils.set_secret_key takes care of this better.

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -135,7 +135,10 @@ class Config(object):
     FLEXMEASURES_API_SUNSET_DATE: str | None = None  # e.g. 2023-05-01
     FLEXMEASURES_API_SUNSET_LINK: str | None = None  # e.g. https://flexmeasures.readthedocs.io/en/latest/api/introduction.html#deprecation-and-sunset
 
-    FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY: bool = False    # if True, the content could be accessed via HTTPS.
+    FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY: bool = (
+        False  # if True, the content could be accessed via HTTPS.
+    )
+
 
 #  names of settings which cannot be None
 #  SECRET_KEY is also required but utils.app_utils.set_secret_key takes care of this better.

--- a/requirements/3.10/app.txt
+++ b/requirements/3.10/app.txt
@@ -327,7 +327,9 @@ tabulate==0.9.0
 threadpoolctl==3.2.0
     # via scikit-learn
 timely-beliefs[forecast]==1.22.0
-    # via -r requirements/app.in
+    # via
+    #   -r requirements/app.in
+    #   timely-beliefs
 timetomodel==0.7.3
     # via -r requirements/app.in
 tldextract==3.5.0

--- a/requirements/3.10/test.txt
+++ b/requirements/3.10/test.txt
@@ -21,7 +21,9 @@ click==8.1.7
     #   -c requirements/3.10/app.txt
     #   flask
 coverage[toml]==7.3.1
-    # via pytest-cov
+    # via
+    #   coverage
+    #   pytest-cov
 exceptiongroup==1.1.3
     # via pytest
 fakeredis==2.18.1


### PR DESCRIPTION
Introduced a new configuration setting, `FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY`, allowing secure UI loading via HTTPS when set to `True` (default is `False` for local developments). This enhancement includes the implementation of a Content Security Policy (CSP) upgrade, automatically securing `http` connections to `https`. The documentation has been updated to provide detailed information on this security measure.