### PR TITLE
Feature/currency symbols

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,6 +13,7 @@ Infrastructure / Support
 ----------------------
 
 * New documentation section on constructing a flex model for :abbr:`V2G (vehicle-to-grid)` [see `PR #885 <https://github.com/FlexMeasures/flexmeasures/pull/885>`_]
+* Allow charts in plugins to show currency codes (such as EUR) as currency symbols (€) [see `PR #922 <https://github.com/FlexMeasures/flexmeasures/pull/922>`_]
 
 Bugfixes
 -----------

--- a/flexmeasures/ui/static/js/flexmeasures.js
+++ b/flexmeasures/ui/static/js/flexmeasures.js
@@ -331,6 +331,7 @@ vega.expressionFunction('quantityWithUnitFormat', function(datum, params) {
         "grouping": [3],
     };
     const locale = d3.formatLocale(formatDef);
+    //  The third element on param allows choosing to show the currency symbol (true) or the currency name (false)
     if (params.length > 2 && params[2] === true){
         return locale.format(params[0])(datum) + " " + convertCurrencyCodeToSymbol(params[1]);
     }
@@ -380,13 +381,27 @@ vega.expressionFunction('timezoneFormat', function(date, params) {
  * This relies on the currencyToSymbolMap imported from currency-symbol-map/map.js
  */
 const convertCurrencyCodeToSymbol = (unit) => {
-    return replace_multiple(unit, currencySymbolMap);
+    return replaceMultiple(unit, currencySymbolMap);
 };
 
-/*
- * Replace substrings according to some mapping
+/**
+ * Replaces multiple substrings in a given string based on a provided mapping object.
+ *
+ * @param {string} str - The input string in which replacements will be performed.
+ * @param {Object} mapObj - An object where keys are substrings to be replaced, and values are their corresponding replacements.
+ * @returns {string} - A new string with the specified substitutions applied.
+ *
+ * @example
+ * // Replace currency codes with symbols in the given string
+ * const inputString = "The price is 50 EUR/MWh, and 30 AUD/MWh.";
+ * const currencyMapping = { EUR: '€', AUD: '$' };
+ * const result = replace_multiple(inputString, currencyMapping);
+ * // The result will be "The price is 50 €/MWh, and 30 $/MWh."
  */
-function replace_multiple(str, mapObj){
-    let regex = new RegExp(Object.keys(mapObj).join("|"),"gi");
+function replaceMultiple(str, mapObj){
+    // Create a regular expression pattern using the keys of the mapObj joined with "|" (OR) to match any of the substrings.
+    let regex = new RegExp(Object.keys(mapObj).join("|"),"g");
+    // Use the regular expression to replace matched substrings with their corresponding values from the mapObj.
+    // The "g" flag makes the replacement global (replaces all occurrences), and it is case-sensitive by default.
     return str.replace(regex, matched => mapObj[matched]);
 }

--- a/flexmeasures/ui/static/js/flexmeasures.js
+++ b/flexmeasures/ui/static/js/flexmeasures.js
@@ -319,6 +319,10 @@ function submit_sensor_type() {
  *         'format': [<d3-format>, <sensor unit>, <optional preference to show currency symbol instead of currency code>],
  *         'formatType': 'quantityWithUnitFormat'
  *     }
+ * The use of currency symbols, such as the euro sign (€), should be reserved for use in graphics.
+ * See, for example, https://publications.europa.eu/code/en/en-370303.htm
+ * The rationale behind this is that they are often ambiguous.
+ * For example, both the Australian dollar (AUD) and the United States dollar (USD) map to the dollar sign ($).
  */
 vega.expressionFunction('quantityWithUnitFormat', function(datum, params) {
     const formatDef = {

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -649,6 +649,10 @@
     <script src="https://cdn.jsdelivr.net/npm/vega@{{ js_versions.vega }}"></script>
     <script src="https://cdn.jsdelivr.net/npm/vega-lite@{{ js_versions.vegalite }}"></script>
     <script src="https://cdn.jsdelivr.net/npm/vega-embed@{{ js_versions.vegaembed }}"></script>
+    {# Workaround for loading a NodeJS module without NodeJS #}
+    <script>var module = { exports: {} };</script>
+    <script src="https://cdn.jsdelivr.net/npm/currency-symbol-map@{{ js_versions.currencysymbolmap }}/map.js"></script>
+    <script>const currencySymbolMap = module.exports;</script>
     {% endif %}
 
     <!-- Custom scripts -->

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -125,6 +125,7 @@ class Config(object):
         vega="5.22.1",
         vegaembed="6.21.0",
         vegalite="5.5.0",  # "5.6.0" has a problematic bar chart: see our sensor page and https://github.com/vega/vega-lite/issues/8496
+        currencysymbolmap="5.1.0",
         # todo: expand with other js versions used in FlexMeasures
     )
 


### PR DESCRIPTION
## Description

This PR is meant for plugins to be able to show currency symbols instead of currency codes in charts.

## Look & Feel

In JS syntax, use `quantityWithUnitFormat(datum['value'], ',.0f', 'EUR/yr', true)` to obtain the value in €/yr.

## How to test

No FM core code is using this new feature, but you can test it by editing [this line in `beliefs_charts.py`](https://github.com/FlexMeasures/flexmeasures/blob/8824476a4f56edd162ec621f319e36986008ab99/flexmeasures/data/models/charts/belief_charts.py#L27) to `format=[".3~r", unit, True],` and visiting the sensor page of a sensor with a unit that includes any currency code. The tooltip should show the effect.

## Further Improvements

The workaround I used for importing a NodeJS module isn't beautiful, but I just wanted to import the currency-symbol-map without getting into a discussion about whether or not to use NodeJS.
