### PR TITLE
feature(UI): Tables with rows that navigate on click

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -9,6 +9,8 @@ v0.18.0 | December XX, 2023
 New features
 -------------
 
+* Better navigation experience through listings (sensors / assets / users / accounts) in the :abbr:`UI (user interface)`, by heading to the selected entity upon a click (or CTRL + click) anywhere within a row [see `PR #923 <https://github.com/FlexMeasures/flexmeasures/pull/923>`_]
+
 Infrastructure / Support
 ----------------------
 

--- a/flexmeasures/ui/static/css/flexmeasures.css
+++ b/flexmeasures/ui/static/css/flexmeasures.css
@@ -556,6 +556,8 @@ i:not(.supersize):before, i:not(.supersize):after {
 /* icon on the left (use left-icon class) */
 :not(.map-icon) > i.left-icon {
     left: 40px;
+    /* Prevent user agent stylesheets from treating this tag as an italics tag */
+    font-style: normal;
 }
 :not(.map-icon) > i.left-icon:after, :not(.map-icon) > i.left-icon:before {
     position: absolute;
@@ -817,6 +819,13 @@ i.icon-wind:hover:before {
 
 
 /* --- Tables ---- */
+
+/* Clickable list items */
+
+table.dataTable.nav-on-click tbody tr:hover {
+    background-color: var(--nav-current-hover-background-color) !important;
+    cursor: pointer;
+}
 
 /* scrolling */
 .floatThead-wrapper table {

--- a/flexmeasures/ui/static/js/flexmeasures.js
+++ b/flexmeasures/ui/static/js/flexmeasures.js
@@ -104,11 +104,6 @@ function ready() {
         }
     );
 
-    // Tables with the nav-on-click class
-
-    navTables = document.getElementsByClassName('nav-on-click');
-    Array.prototype.forEach.call(navTables, function(t) {clickableTable(t, 'URL')});
-
     // Table pagination
 
     $.extend(true, $.fn.dataTable.defaults, {
@@ -144,6 +139,11 @@ function ready() {
     // set default page lengths
     $('.paginate-5').dataTable().api().page.len(5).draw();
     $('.paginate-10').dataTable().api().page.len(10).draw();
+
+    // Tables with the nav-on-click class
+
+    navTables = document.getElementsByClassName('nav-on-click');
+    Array.prototype.forEach.call(navTables, function(t) {clickableTable(t, 'URL')});
 
 
     // Sliders

--- a/flexmeasures/ui/static/js/flexmeasures.js
+++ b/flexmeasures/ui/static/js/flexmeasures.js
@@ -42,6 +42,30 @@ function defaultImage(action) {
 }
 
 
+function clickableTable(element, urlColumn) {
+    var table = $(element).DataTable();
+    var tbody = element.getElementsByTagName('tbody')[0];
+    $(tbody).on('click', 'tr', function (event) {
+        var columnIndex = table.column(':contains(' + urlColumn + ')').index();
+        var data = table.row(this).data();
+        var url = data[columnIndex]
+        handleClick(event, url);
+    });
+}
+
+
+function handleClick(event, url) {
+    // ignore clicks on <a href> elements
+    if (event.target.tagName.toLowerCase() === 'a') {
+        return
+    } else if (event.ctrlKey) {
+        window.open(url, "_blank");
+    } else {
+        window.open(url, "_self");
+    }
+}
+
+
 function ready() {
 
     console.log("ready...");
@@ -61,6 +85,10 @@ function ready() {
         }
     );
 
+    // Tables with the nav-on-click class
+
+    navTables = document.getElementsByClassName('nav-on-click');
+    Array.prototype.forEach.call(navTables, function(t) {clickableTable(t, 'URL')});
 
     // Table pagination
 

--- a/flexmeasures/ui/static/js/flexmeasures.js
+++ b/flexmeasures/ui/static/js/flexmeasures.js
@@ -74,8 +74,8 @@ function clickableTable(element, urlColumn) {
 
 
 function handleClick(event, url) {
-    // ignore clicks on <a href> elements
-    if (event.target.tagName.toLowerCase() === 'a') {
+    // ignore clicks on <a href> or <button> elements
+    if (['a', 'button'].includes(event.target.tagName.toLowerCase())) {
         return
     } else if (event.ctrlKey) {
         window.open(url, "_blank");

--- a/flexmeasures/ui/static/js/flexmeasures.js
+++ b/flexmeasures/ui/static/js/flexmeasures.js
@@ -43,6 +43,7 @@ function defaultImage(action) {
 
 
 function clickableTable(element, urlColumn) {
+    // This will keep actions like text selection or dragging functional
     var table = $(element).DataTable();
     var tbody = element.getElementsByTagName('tbody')[0];
     var startX, startY;

--- a/flexmeasures/ui/static/js/flexmeasures.js
+++ b/flexmeasures/ui/static/js/flexmeasures.js
@@ -45,12 +45,31 @@ function defaultImage(action) {
 function clickableTable(element, urlColumn) {
     var table = $(element).DataTable();
     var tbody = element.getElementsByTagName('tbody')[0];
-    $(tbody).on('click', 'tr', function (event) {
-        var columnIndex = table.column(':contains(' + urlColumn + ')').index();
-        var data = table.row(this).data();
-        var url = data[columnIndex]
-        handleClick(event, url);
-    });
+    var startX, startY;
+    var radiusLimit = 0;  // how much the mouse is allowed to move during clicking
+
+    $(tbody).on({
+        mousedown: function (event) {
+            startX = event.pageX;
+            startY = event.pageY;
+        },
+        mouseup: function (event) {
+            var endX = event.pageX;
+            var endY = event.pageY;
+
+            var deltaX = endX - startX;
+            var deltaY = endY - startY;
+
+            var euclidean = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+
+            if (euclidean <= radiusLimit) {
+                var columnIndex = table.column(':contains(' + urlColumn + ')').index();
+                var data = table.row(this).data();
+                var url = data[columnIndex];
+                handleClick(event, url);
+            }
+        }
+    }, 'tr');
 }
 
 

--- a/flexmeasures/ui/templates/crud/account.html
+++ b/flexmeasures/ui/templates/crud/account.html
@@ -53,7 +53,7 @@
                         </label>
                     </div>
                 </form>
-                <table class="table table-striped table-responsive paginate">
+                <table class="table table-striped table-responsive paginate nav-on-click" title="View/edit this user">
                     <thead>
                         <tr>
                             <th>Username</th>
@@ -63,14 +63,14 @@
                             <th>Last Login</th>
                             <th>Last Seen</th>
                             <th>Active</th>
+                            <th class="hidden">URL</th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for user in users %}
                         <tr>
                             <td>
-                                <a href="/users/{{ user.id }}" title="View/edit this user">{{ user.username
-                                    }}</a>
+                                {{ user.username }}
                             </td>
                             <td>
                                 <a href="mailto:{{ user.email }}" title="Mail this user">{{ user.email }}</a>
@@ -91,7 +91,9 @@
                             <td>
                                 {{ user.active }}
                             </td>
-
+                            <td class="hidden">
+                                /users/{{ user.id }}
+                            </td>
                         </tr>
                         {% endfor %}
                     </tbody>
@@ -100,10 +102,10 @@
             <div class="card">
                 <h3>Assets</h3>
 
-                <table class="table table-striped table-responsive paginate">
+                <table class="table table-striped table-responsive paginate nav-on-click" title="View this asset">
                     <thead>
                         <tr>
-                            <th>Name</th>
+                            <th><i class="left-icon">Name</i></th>
                             <th>Location</th>
                             <th>Asset ID</th>
                             <th>Account</th>
@@ -118,14 +120,14 @@
                                 </form>
                                 {% endif %}
                             </th>
+                            <th class="hidden">URL</th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for asset in assets %}
                         <tr>
                             <td>
-                                <i class="{{ asset.generic_asset_type.name | asset_icon }} left-icon"><a
-                                        href="/assets/{{ asset.id }}" alt="View this asset">{{ asset.name }}</a></i>
+                                <i class="{{ asset.generic_asset_type.name | asset_icon }} left-icon">{{ asset.name }}</i>
                             </td>
                             <td>
                                 {% if asset.latitude and asset.longitude %}
@@ -148,7 +150,9 @@
                             </td>
                             <td class="text-right">
                             </td>
-
+                            <td class="hidden">
+                                /assets/{{ asset.id }}
+                            </td>
                         </tr>
                         {% endfor %}
                     </tbody>

--- a/flexmeasures/ui/templates/crud/accounts.html
+++ b/flexmeasures/ui/templates/crud/accounts.html
@@ -8,7 +8,7 @@ divs %}
             <div class="card">
             <h3>All Accounts
             </h3>
-            <table class="table table-striped table-responsive paginate">
+            <table class="table table-striped table-responsive paginate nav-on-click" title="View this account">
                 <thead>
                     <tr>
                         <th>Account</th>
@@ -16,14 +16,14 @@ divs %}
                         <th>Assets</th>
                         <th>Users</th>
                         <th>Roles</th>
-
+                        <th class="hidden">URL</th>
                     </tr>
                 </thead>
                 <tbody>
                     {% for account in accounts %}
                     <tr>
                         <td>
-                            <a href="/accounts/{{ account.id }}" title="View this account">{{ account.name }}</a>
+                            {{ account.name }}
                         </td>
                         <td>
                             {{ account.id }}
@@ -36,6 +36,9 @@ divs %}
                         </td>
                         <td>
                             {{ account.account_roles | map(attribute='name') | join(", ") }}
+                        </td>
+                        <td class="hidden">
+                            /accounts/{{ account.id }}
                         </td>
                     </tr>
                     {% endfor %}

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -125,14 +125,14 @@
             <div id="sensorchart" class="card" style="width: 100%;"></div>
             <div class="sensors-asset card">
                 <h3>All sensors for {{ asset.name }}</h3>
-                <table class="table table-striped table-responsive paginate">
+                <table class="table table-striped table-responsive paginate nav-on-click" title="View data">
                     <thead>
                         <tr>
                             <th>Name</th>
                             <th class="text-right">Unit</th>
                             <th class="text-right">Resolution</th>
                             <th class="text-right no-sort">Entity address</th>
-                            <th class="text-right no-sort">Data</th>
+                            <th class="hidden">URL</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -150,8 +150,8 @@
                             <td class="text-right">
                                 {{ sensor.entity_address }}
                             </td>
-                            <td class="text-right">
-                                <a href="/sensors/{{ sensor.id }}">View plot</a>
+                            <td class="hidden">
+                                /sensors/{{ sensor.id }}
                             </td>
                         </tr>
                         {% endfor %}

--- a/flexmeasures/ui/templates/crud/assets.html
+++ b/flexmeasures/ui/templates/crud/assets.html
@@ -73,7 +73,7 @@
             </div>
         </div>
     </div>
+</div>
+{% block paginate_tables_script %} {{ super() }} {% endblock %}
 
-    {% block paginate_tables_script %} {{ super() }} {% endblock %}
-
-    {% endblock%}
+{% endblock %}

--- a/flexmeasures/ui/templates/crud/assets.html
+++ b/flexmeasures/ui/templates/crud/assets.html
@@ -27,24 +27,22 @@
                     for account {{ account.name }}
                     {% endif %}
                 </h3>
-                <table class="table table-striped table-responsive paginate">
+                <table class="table table-striped table-responsive paginate nav-on-click" title="View this asset">
                     <thead>
                         <tr>
-                            <th>Name</th>
+                            <th><i class="left-icon">Name</i></th>
                             <th class="no-sort">Location</th>
                             <th>Asset id</th>
                             <th>Account</th>
                             <th class="no-sort">Sensors</th>
-
-                            </th>
+                            <th class="hidden">URL</th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for asset in assets: %}
                         <tr>
                             <td>
-                                <i class="{{ asset.generic_asset_type.name | asset_icon }} left-icon"><a
-                                        href="/assets/{{ asset.id }}" alt="View this asset">{{ asset.name }}</a></i>
+                                <i class="{{ asset.generic_asset_type.name | asset_icon }} left-icon">{{ asset.name }}</i>
                             </td>
                             <td>
                                 {% if asset.latitude and asset.longitude %}
@@ -57,13 +55,16 @@
                             </td>
                             <td>
                                 {% if asset.owner %}
-                                <a href="/accounts/{{ asset.owner.id }}">{{ asset.owner.name }}</a> 
+                                <a href="/accounts/{{ asset.owner.id }}" title="View this account">{{ asset.owner.name }}</a>
                                 {% else %}
                                 PUBLIC
                                 {% endif %}
                             </td>
                             <td>
                                 {{ asset.sensors | length }}
+                            </td>
+                            <td class="hidden">
+                                /assets/{{ asset.id }}
                             </td>
                         </tr>
                         {% endfor %}

--- a/flexmeasures/ui/templates/crud/users.html
+++ b/flexmeasures/ui/templates/crud/users.html
@@ -20,7 +20,7 @@
                             </label>
                     </div>
                 </form>
-                <table class="table table-striped table-responsive paginate">
+                <table class="table table-striped table-responsive paginate nav-on-click" title="View/edit this user">
                     <thead>
                         <tr>
                             <th>Username</th>
@@ -31,13 +31,14 @@
                             <th>Last Login</th>
                             <th>Last Seen</th>
                             <th>Active</th>
+                            <th class="hidden">URL</th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for user in users %}
                         <tr>
                             <td>
-                                <a href="/users/{{ user.id }}" title="View/edit this user">{{ user.username }}</a>
+                                {{ user.username }}
                             </td>
                             <td>
                                 <a href="mailto:{{ user.email }}" title="Mail this user">{{ user.email }}</a>
@@ -61,7 +62,9 @@
                             <td>
                                 {{ user.active }}
                             </td>
-
+                            <td class="hidden">
+                                /users/{{ user.id }}
+                            </td>
                         </tr>
                         {% endfor %}
                     </tbody>

--- a/flexmeasures/ui/templates/crud/users.html
+++ b/flexmeasures/ui/templates/crud/users.html
@@ -75,6 +75,6 @@
     </div>
 </div>
 
-    {% block paginate_tables_script %} {{ super() }} {% endblock %}
+{% block paginate_tables_script %} {{ super() }} {% endblock %}
 
 {% endblock%}


### PR DESCRIPTION
## Description

- Tables with rows that navigate on click.
- Hover effect: background and tooltip.
- Rows may still contain `<a href>` elements that navigate elsewhere.
- Handles CTRL+click.
- Tested for touchscreen actions.
- Best for last: the `Name` header is finally aligned with the asset names rather than with their icons.

## Look & Feel

![Peek 2023-12-11 22-56](https://github.com/FlexMeasures/flexmeasures/assets/30658763/e029bcaf-4495-49d2-8f30-9711c3013fca)

## How to test

Just navigate your local UI. If you find out that this requires a hard refresh in the browser (to reload `flexmeasures.js`), please let me know.

Use `ngrok http 5000` to test on a different (touchscreen) device.
