### PR TITLE
Breadcrumb for the asset page

### DIFF
--- a/documentation/api/change_log.rst
+++ b/documentation/api/change_log.rst
@@ -5,6 +5,11 @@ API change log
 
 .. note:: The FlexMeasures API follows its own versioning scheme. This is also reflected in the URL (e.g. `/api/v3_0`), allowing developers to upgrade at their own pace.
 
+v3.0-14 | 2023-12-07
+""""""""""""""""""""
+
+- Fix API version listing (GET /api/v3_0) for hosts running on Python 3.8.
+
 v3.0-13 | 2023-10-31
 """"""""""""""""""""
 

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -17,16 +17,16 @@ Infrastructure / Support
 Bugfixes
 -----------
 
-* Show `Assets`, `Users`, `Tasks` and `Accounts` pages in the navigation bar for the `admin-reader` role [see `PR #900 <https://github.com/FlexMeasures/flexmeasures/pull/900>`_]
 * Give `admin-reader` role access to the RQ Scheduler dashboard [see `PR #901 <https://github.com/FlexMeasures/flexmeasures/pull/901>`_]
 
 
-v0.17.1 | November 22, 2023
+v0.17.1 | December 7, 2023
 ============================
 
 Bugfixes
 -----------
 
+* Show `Assets`, `Users`, `Tasks` and `Accounts` pages in the navigation bar for the `admin-reader` role [see `PR #900 <https://github.com/FlexMeasures/flexmeasures/pull/900>`_]
 * Reduce worker logs when datetime exceeds the end of the schedule [see `PR #918 <https://github.com/FlexMeasures/flexmeasures/pull/918>`_]
 * Fix infeasible problem due to incorrect estimation of the big-M value [see `PR #905 <https://github.com/FlexMeasures/flexmeasures/pull/905>`_]
 * Fix API version listing (GET /api/v3_0) for hosts running on Python 3.8 [see `PR #917 <https://github.com/FlexMeasures/flexmeasures/pull/917>`_]

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -10,6 +10,7 @@ New features
 -------------
 
 * Better navigation experience through listings (sensors / assets / users / accounts) in the :abbr:`UI (user interface)`, by heading to the selected entity upon a click (or CTRL + click) anywhere within a row [see `PR #923 <https://github.com/FlexMeasures/flexmeasures/pull/923>`_]
+* Introduce a breadcrumb to navigate through assets and sensor pages using its child-parent relationship [see `PR #930 <https://github.com/FlexMeasures/flexmeasures/pull/930>`_]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,7 +13,6 @@ New features
 
 * Better navigation experience through listings (sensors / assets / users / accounts) in the :abbr:`UI (user interface)`, by heading to the selected entity upon a click (or CTRL + click) anywhere within a row [see `PR #923 <https://github.com/FlexMeasures/flexmeasures/pull/923>`_]
 * Introduce a breadcrumb to navigate through assets and sensor pages using its child-parent relationship [see `PR #930 <https://github.com/FlexMeasures/flexmeasures/pull/930>`_]
-* New flexmeasures configuration setting `FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY` for upgrading insecure `http` requests to secured requests `https` [see `PR #920 <https://github.com/FlexMeasures/flexmeasures/pull/920>`_]
 * Define device-level power constraints as sensors to create schedules with changing power limits. [see `PR #897 <https://github.com/FlexMeasures/flexmeasures/pull/897>`_]
 * Allow to provide external storage usage or gain components using the ``soc-usage`` and ``soc-gain`` fields of the `flex-model` [see `PR #906 <https://github.com/FlexMeasures/flexmeasures/pull/906>`_]
 

--- a/documentation/concepts/device_scheduler.rst
+++ b/documentation/concepts/device_scheduler.rst
@@ -74,7 +74,7 @@ The cost function quantifies the total cost of upwards and downwards deviations 
 .. math:: 
     :name: cost_function
 
-    \min [\sum_{c,j} \Delta _{up}(c,j) \cdot Price_{up}(c,j) +  \Delta_{down}(c,j) \cdot Price_{down}(c,j)]
+    \min [\sum_{c,j} \Delta_{up}(c,j) \cdot Price_{up}(c,j) +  \Delta_{down}(c,j) \cdot Price_{down}(c,j)]
 
 
 State dynamics
@@ -191,5 +191,5 @@ Power coupling constraints
 .. math:: 
     :name: ems_flow_commitment_equalities
 
-    \sum_d P^{ems}(d,j) = \sum_c Commitment(c,j) + \Delta {up}(c,j) + \Delta {down}(c,j)
+    \sum_d P^{ems}(d,j) = \sum_c Commitment(c,j) + \Delta_{up}(c,j) + \Delta_{down}(c,j)
 

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -369,6 +369,13 @@ def add_asset_type(**args):
     type=int,
     help="Asset type to assign to this asset",
 )
+@click.option(
+    "--parent-asset",
+    "parent_asset_id",
+    required=False,
+    type=int,
+    help="Parent of this asset. The entity needs to exists on the database.",
+)
 def add_asset(**args):
     """Add an asset."""
     check_errors(GenericAssetSchema().validate(args))

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -67,6 +67,7 @@ from flexmeasures.data.schemas.units import QuantityField
 from flexmeasures.data.schemas.generic_assets import (
     GenericAssetSchema,
     GenericAssetTypeSchema,
+    GenericAssetIdField,
 )
 from flexmeasures.data.models.generic_assets import GenericAsset, GenericAssetType
 from flexmeasures.data.models.user import User
@@ -371,9 +372,9 @@ def add_asset_type(**args):
 )
 @click.option(
     "--parent-asset",
-    "parent_asset_id",
+    "parent_asset",
     required=False,
-    type=int,
+    type=GenericAssetIdField(),
     help="Parent of this asset. The entity needs to exists on the database.",
 )
 def add_asset(**args):

--- a/flexmeasures/ui/crud/assets.py
+++ b/flexmeasures/ui/crud/assets.py
@@ -191,8 +191,11 @@ class AssetCrudUI(FlaskView):
 
     route_base = "/assets"
 
-    def get_asset_parent_and_account(self, asset: GenericAsset):
+    def get_breadcrumb_info(self, asset: GenericAsset):
         account_id = asset.account_id
+        account = Account.query.get(account_id)
+        if account is None:
+            account_id = None
         account_name = (
             Account.query.get(account_id).name if account_id is not None else None
         )
@@ -277,12 +280,9 @@ class AssetCrudUI(FlaskView):
         asset = process_internal_api_response(asset_dict, int(id), make_obj=True)
         asset_form.process(data=process_internal_api_response(asset_dict))
 
-        (
-            account_id,
-            parent_asset,
-            account_url,
-            account_name,
-        ) = self.get_asset_parent_and_account(asset)
+        account_id, account_name, parent_asset, account_url = self.get_breadcrumb_info(
+            asset
+        )
 
         return render_flexmeasures_template(
             "crud/asset.html",
@@ -372,10 +372,10 @@ class AssetCrudUI(FlaskView):
                 )
                 (
                     account_id,
+                    account_name,
                     parent_asset,
                     account_url,
-                    account_name,
-                ) = self.get_asset_parent_and_account(asset)
+                ) = self.get_breadcrumb_info(asset)
 
                 return render_flexmeasures_template(
                     "crud/asset.html",
@@ -411,12 +411,9 @@ class AssetCrudUI(FlaskView):
                 )
                 asset = GenericAsset.query.get(id)
 
-        (
-            account_id,
-            parent_asset,
-            account_url,
-            account_name,
-        ) = self.get_asset_parent_and_account(asset)
+        account_id, account_name, parent_asset, account_url = self.get_breadcrumb_info(
+            asset
+        )
 
         return render_flexmeasures_template(
             "crud/asset.html",

--- a/flexmeasures/ui/crud/assets.py
+++ b/flexmeasures/ui/crud/assets.py
@@ -263,9 +263,24 @@ class AssetCrudUI(FlaskView):
         asset = process_internal_api_response(asset_dict, int(id), make_obj=True)
         asset_form.process(data=process_internal_api_response(asset_dict))
 
+        account_id = asset.account_id
+        account_name = (
+            Account.query.get(account_id).name if account_id is not None else None
+        )
+        account_url = (
+            url_for("AccountCrudUI:get", account_id=account_id)
+            if account_id is not None
+            else None
+        )
+        parent_asset = GenericAsset.query.get(asset.id).parent_asset
+
         return render_flexmeasures_template(
             "crud/asset.html",
             asset=asset,
+            account_id=account_id,
+            parent_asset=parent_asset,
+            account_url=account_url,
+            account_name=account_name,
             asset_form=asset_form,
             msg="",
             mapboxAccessToken=current_app.config.get("MAPBOX_ACCESS_TOKEN", ""),

--- a/flexmeasures/ui/crud/assets.py
+++ b/flexmeasures/ui/crud/assets.py
@@ -203,7 +203,7 @@ class AssetCrudUI(FlaskView):
         )
         parent_asset = GenericAsset.query.get(asset.id).parent_asset
 
-        return account_id, account_name, parent_asset, account_url, account_name
+        return account_id, account_name, parent_asset, account_url
 
     @login_required
     def index(self, msg=""):
@@ -288,9 +288,9 @@ class AssetCrudUI(FlaskView):
             "crud/asset.html",
             asset=asset,
             account_id=account_id,
-            parent_asset=parent_asset,
-            account_url=account_url,
             account_name=account_name,
+            account_url=account_url,
+            parent_asset=parent_asset,
             asset_form=asset_form,
             msg="",
             mapboxAccessToken=current_app.config.get("MAPBOX_ACCESS_TOKEN", ""),

--- a/flexmeasures/ui/crud/assets.py
+++ b/flexmeasures/ui/crud/assets.py
@@ -191,6 +191,20 @@ class AssetCrudUI(FlaskView):
 
     route_base = "/assets"
 
+    def get_asset_parent_and_account(self, asset: GenericAsset):
+        account_id = asset.account_id
+        account_name = (
+            Account.query.get(account_id).name if account_id is not None else None
+        )
+        account_url = (
+            url_for("AccountCrudUI:get", account_id=account_id)
+            if account_id is not None
+            else None
+        )
+        parent_asset = GenericAsset.query.get(asset.id).parent_asset
+
+        return account_id, account_name, parent_asset, account_url, account_name
+
     @login_required
     def index(self, msg=""):
         """GET from /assets
@@ -263,16 +277,12 @@ class AssetCrudUI(FlaskView):
         asset = process_internal_api_response(asset_dict, int(id), make_obj=True)
         asset_form.process(data=process_internal_api_response(asset_dict))
 
-        account_id = asset.account_id
-        account_name = (
-            Account.query.get(account_id).name if account_id is not None else None
-        )
-        account_url = (
-            url_for("AccountCrudUI:get", account_id=account_id)
-            if account_id is not None
-            else None
-        )
-        parent_asset = GenericAsset.query.get(asset.id).parent_asset
+        (
+            account_id,
+            parent_asset,
+            account_url,
+            account_name,
+        ) = self.get_asset_parent_and_account(asset)
 
         return render_flexmeasures_template(
             "crud/asset.html",
@@ -360,10 +370,21 @@ class AssetCrudUI(FlaskView):
                 asset = process_internal_api_response(
                     asset_info, int(id), make_obj=True
                 )
+                (
+                    account_id,
+                    parent_asset,
+                    account_url,
+                    account_name,
+                ) = self.get_asset_parent_and_account(asset)
+
                 return render_flexmeasures_template(
                     "crud/asset.html",
                     asset_form=asset_form,
                     asset=asset,
+                    account_id=account_id,
+                    parent_asset=parent_asset,
+                    account_url=account_url,
+                    account_name=account_name,
                     msg="Cannot edit asset.",
                     mapboxAccessToken=current_app.config.get("MAPBOX_ACCESS_TOKEN", ""),
                     user_can_create_assets=user_can_create_assets(),
@@ -390,9 +411,20 @@ class AssetCrudUI(FlaskView):
                 )
                 asset = GenericAsset.query.get(id)
 
+        (
+            account_id,
+            parent_asset,
+            account_url,
+            account_name,
+        ) = self.get_asset_parent_and_account(asset)
+
         return render_flexmeasures_template(
             "crud/asset.html",
             asset=asset,
+            account_id=account_id,
+            parent_asset=parent_asset,
+            account_url=account_url,
+            account_name=account_name,
             asset_form=asset_form,
             msg=msg,
             mapboxAccessToken=current_app.config.get("MAPBOX_ACCESS_TOKEN", ""),

--- a/flexmeasures/ui/crud/assets.py
+++ b/flexmeasures/ui/crud/assets.py
@@ -152,7 +152,7 @@ def process_internal_api_response(
                 Sensor.generic_asset_id == asset_data["id"]
             ).all()
             expunge_asset()
-        if asset_data.get("parent_asset_id") is not None:
+        if asset_data.get("parent_asset_id", None) is not None:
             asset.parent_asset = GenericAsset.query.filter(
                 GenericAsset.id == asset_data["parent_asset_id"]
             ).one_or_none()

--- a/flexmeasures/ui/static/css/flexmeasures.css
+++ b/flexmeasures/ui/static/css/flexmeasures.css
@@ -1848,3 +1848,19 @@ div.heading-group {
   overflow: visible !important;
   white-space: normal !important;
 }
+
+/* Breadcrumb */
+.breadcrumb {
+  margin: 0px;
+  background: var(--light-gray);
+}
+.breadcrumb a {
+  color: var(--primary-color);
+}
+.breadcrumb a:hover {
+  color: var(--primary-hover-color);
+}
+.breadcrumb-item + .breadcrumb-item::before {
+  content: " > ";
+  color: var(--primary-color);
+}

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -9,7 +9,7 @@
 {% block divs %}
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb">
-    {% for breadcrumb in breadcrumb_info["breadcrumb"] %}
+    {% for breadcrumb in breadcrumb_info["ancestors"] %}
       <li class="breadcrumb-item{% if loop.last %} active{% endif %}" {% if loop.last %}aria-current="page"{% endif %}>
         {% if breadcrumb["url"] is not none and not loop.last %}
           <a href="{{ breadcrumb['url'] }}">{{ breadcrumb['name'] }}</a>

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -4,7 +4,26 @@
 
 {% block title %} {{asset.name}} {% endblock %}
 
+
+
 {% block divs %}
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item">
+        {% if account_name is not none %}
+            <a href="{{account_url}}">{{ account_name }}</a>
+        {% else %}
+        PUBLIC
+        {% endif %}
+    </li>
+    <li class="breadcrumb-item">
+        {% if parent_asset is not none %}
+        <a href="{{ url_for('AssetCrudUI:get', id=parent_asset.id) }}">{{parent_asset.name}} ({{ parent_asset.generic_asset_type.name }})</a>
+        {% endif %}
+    </li>
+    <li class="breadcrumb-item active" aria-current="page">{{ asset.name }} ({{ asset.generic_asset_type.name }})</li>
+  </ol>
+</nav>
 
 <div class="container-fluid">
     <div class="row">

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -9,15 +9,18 @@
 {% block divs %}
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb">
-      {% for breadcrumb in breadcrumb_info["breadcrumb"] %}
-      <li class="breadcrumb-item">
-        {% if breadcrumb["url"] is not none %}
-        <a href="{{ breadcrumb['url'] }}"> {{ breadcrumb['name'] }}</a>
+    {% for breadcrumb in breadcrumb_info["breadcrumb"] %}
+      <li class="breadcrumb-item{% if loop.last %} active{% endif %}" {% if loop.last %}aria-current="page"{% endif %}>
+        {% if breadcrumb["url"] is not none and not loop.last %}
+          <a href="{{ breadcrumb['url'] }}">{{ breadcrumb['name'] }}</a>
+        {% else %}
+          {{ breadcrumb['name'] }}
         {% endif %}
-         </li>
-      {% endfor %}
+      </li>
+    {% endfor %}
   </ol>
 </nav>
+
 
 <div class="container-fluid">
     <div class="row">

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -9,19 +9,13 @@
 {% block divs %}
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb">
-    <li class="breadcrumb-item">
-        {% if account_name is not none %}
-            <a href="{{account_url}}">{{ account_name }}</a>
-        {% else %}
-        PUBLIC
+      {% for breadcrumb in breadcrumb_info["breadcrumb"] %}
+      <li class="breadcrumb-item">
+        {% if breadcrumb["url"] is not none %}
+        <a href="{{ breadcrumb['url'] }}"> {{ breadcrumb['name'] }}</a>
         {% endif %}
-    </li>
-    <li class="breadcrumb-item">
-        {% if parent_asset is not none %}
-        <a href="{{ url_for('AssetCrudUI:get', id=parent_asset.id) }}">{{parent_asset.name}} ({{ parent_asset.generic_asset_type.name }})</a>
-        {% endif %}
-    </li>
-    <li class="breadcrumb-item active" aria-current="page">{{ asset.name }} ({{ asset.generic_asset_type.name }})</li>
+         </li>
+      {% endfor %}
   </ol>
 </nav>
 

--- a/flexmeasures/ui/templates/views/sensors.html
+++ b/flexmeasures/ui/templates/views/sensors.html
@@ -9,7 +9,7 @@
 {% block divs %}
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb">
-    {% for breadcrumb in breadcrumb_info["breadcrumb"] %}
+    {% for breadcrumb in breadcrumb_info["ancestors"] %}
       <li class="breadcrumb-item{% if loop.last %} active{% endif %}" {% if loop.last %}aria-current="page"{% endif %}>
         {% if breadcrumb["url"] is not none and not loop.last %}
           <a href="{{ breadcrumb['url'] }}">{{ breadcrumb['name'] }}</a>

--- a/flexmeasures/ui/templates/views/sensors.html
+++ b/flexmeasures/ui/templates/views/sensors.html
@@ -9,13 +9,15 @@
 {% block divs %}
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb">
-      {% for breadcrumb in breadcrumb_info["breadcrumb"] %}
-      <li class="breadcrumb-item">
-        {% if breadcrumb["url"] is not none %}
-        <a href="{{ breadcrumb['url'] }}"> {{ breadcrumb['name'] }}</a>
+    {% for breadcrumb in breadcrumb_info["breadcrumb"] %}
+      <li class="breadcrumb-item{% if loop.last %} active{% endif %}" {% if loop.last %}aria-current="page"{% endif %}>
+        {% if breadcrumb["url"] is not none and not loop.last %}
+          <a href="{{ breadcrumb['url'] }}">{{ breadcrumb['name'] }}</a>
+        {% else %}
+          {{ breadcrumb['name'] }}
         {% endif %}
-         </li>
-      {% endfor %}
+      </li>
+    {% endfor %}
   </ol>
 </nav>
       <div class="sensor-data charts text-center">

--- a/flexmeasures/ui/templates/views/sensors.html
+++ b/flexmeasures/ui/templates/views/sensors.html
@@ -4,8 +4,20 @@
 
 {% block title %} Sensor data {% endblock %}
 
-{% block divs %}
 
+
+{% block divs %}
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+      {% for breadcrumb in breadcrumb_info["breadcrumb"] %}
+      <li class="breadcrumb-item">
+        {% if breadcrumb["url"] is not none %}
+        <a href="{{ breadcrumb['url'] }}"> {{ breadcrumb['name'] }}</a>
+        {% endif %}
+         </li>
+      {% endfor %}
+  </ol>
+</nav>
       <div class="sensor-data charts text-center">
           <div class="row">
               <div class="alert alert-info" id="tzwarn" style="display:none;"></div>

--- a/flexmeasures/ui/tests/test_utils.py
+++ b/flexmeasures/ui/tests/test_utils.py
@@ -1,0 +1,49 @@
+from flexmeasures import Asset, AssetType, Account, Sensor
+from flexmeasures.ui.utils.breadcrumb_utils import get_ancestry
+
+
+def test_get_ancestry(app, db):
+    account = Account(name="Test Account")
+    asset_type = AssetType(name="TestAssetType")
+
+    parent_asset = Asset(name="Parent", generic_asset_type=asset_type, owner=account)
+    assets = [parent_asset]
+    for i in range(4):
+        child_asset = Asset(
+            name=f"Child {i}",
+            generic_asset_type=asset_type,
+            owner=account,
+            parent_asset=parent_asset,
+        )
+        assets.append(child_asset)
+        parent_asset = child_asset
+
+    sensor = Sensor(name="Test Sensor", generic_asset=child_asset)
+
+    db.session.add_all([account, asset_type, sensor] + assets)
+    db.session.commit()
+
+    # ancestry of a public account
+    assert get_ancestry(None) == [{"url": None, "name": "PUBLIC", "type": "Account"}]
+
+    # ancestry of an account
+    account_id = account.id
+    assert get_ancestry(account) == [
+        {"url": f"/accounts/{account_id}", "name": "Test Account", "type": "Account"}
+    ]
+
+    # ancestry of a parentless asset
+    assert get_ancestry(assets[0]) == [
+        {"url": f"/accounts/{account_id}", "name": "Test Account", "type": "Account"},
+        {"url": f"/assets/{assets[0].id}/", "name": "Parent", "type": "Asset"},
+    ]
+
+    # check that the number of elements of the ancestry of each assets corresponds to 2 + levels
+    for i, asset in enumerate(assets):
+        assert len(get_ancestry(asset)) == i + 2
+
+    # ancestry of the sensor
+    sensor_ancestry = get_ancestry(sensor)
+    assert sensor_ancestry[-1]["type"] == "Sensor"
+    assert sensor_ancestry[0]["type"] == "Account"
+    assert all(b["type"] == "Asset" for b in sensor_ancestry[1:-1])

--- a/flexmeasures/ui/utils/breadcrumb_utils.py
+++ b/flexmeasures/ui/utils/breadcrumb_utils.py
@@ -6,7 +6,7 @@ from flask import url_for
 
 def get_breadcrumb_info(entity: Sensor | Asset | Account | None) -> dict:
     return {
-        "breadcrumb": get_ancestry(entity),
+        "ancestors": get_ancestry(entity),
     }
 
 

--- a/flexmeasures/ui/utils/breadcrumb_utils.py
+++ b/flexmeasures/ui/utils/breadcrumb_utils.py
@@ -10,7 +10,7 @@ def get_breadcrumb_info(entity: Sensor | Asset | Account | None) -> dict:
     }
 
 
-def get_ancestry(entity: Sensor | Asset | Account | None) -> list:
+def get_ancestry(entity: Sensor | Asset | Account | None) -> list[dict]:
 
     # Public account
     if entity is None:

--- a/flexmeasures/ui/utils/breadcrumb_utils.py
+++ b/flexmeasures/ui/utils/breadcrumb_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from flexmeasures import Sensor, Asset, Account
 from flask import url_for
 

--- a/flexmeasures/ui/utils/breadcrumb_utils.py
+++ b/flexmeasures/ui/utils/breadcrumb_utils.py
@@ -1,0 +1,55 @@
+from flexmeasures import Sensor, Asset, Account
+from flask import url_for
+
+
+def get_breadcrumb_info(entity: Sensor | Asset | Account | None) -> dict:
+    return {
+        "breadcrumb": get_ancestry(entity),
+    }
+
+
+def get_ancestry(entity: Sensor | Asset | Account | None) -> list:
+
+    # Public account
+    if entity is None:
+        return [{"url": None, "name": "PUBLIC", "type": "Account"}]
+
+    # account
+    if isinstance(entity, Account):
+        return [
+            {
+                "url": url_for("AccountCrudUI:get", account_id=entity.id),
+                "name": entity.name,
+                "type": "Account",
+            }
+        ]
+
+    # sensor
+    if isinstance(entity, Sensor):
+        current_entity_info = [
+            {
+                "url": url_for("SensorUI:get", id=entity.id),
+                "name": entity.name,
+                "type": "Sensor",
+            }
+        ]
+
+        return get_ancestry(entity.generic_asset) + current_entity_info
+
+    # asset
+    if isinstance(entity, Asset):
+        current_entity_info = [
+            {
+                "url": url_for("AssetCrudUI:get", id=entity.id),
+                "name": entity.name,
+                "type": "Asset",
+            }
+        ]
+
+        # asset without parent
+        if entity.parent_asset is None:
+            return get_ancestry(entity.owner) + current_entity_info
+        else:  # asset with parent
+            return get_ancestry(entity.parent_asset) + current_entity_info
+
+    return []

--- a/flexmeasures/ui/utils/view_utils.py
+++ b/flexmeasures/ui/utils/view_utils.py
@@ -10,6 +10,7 @@ from flask_security.core import current_user
 
 from flexmeasures import __version__ as flexmeasures_version
 from flexmeasures.auth.policy import user_has_admin_access
+from flexmeasures.ui.utils.breadcrumb_utils import get_breadcrumb_info
 from flexmeasures.utils import time_utils
 from flexmeasures.ui import flexmeasures_ui
 from flexmeasures.data.models.user import User, Account
@@ -78,6 +79,9 @@ def render_flexmeasures_template(html_filename: str, **variables):
 
     variables["menu_logo"] = current_app.config.get("FLEXMEASURES_MENU_LOGO_PATH")
     variables["extra_css"] = current_app.config.get("FLEXMEASURES_EXTRA_CSS_PATH")
+
+    if "asset" in variables:
+        variables["breadcrumb_info"] = (get_breadcrumb_info(asset),)
 
     return render_template(html_filename, **variables)
 

--- a/flexmeasures/ui/utils/view_utils.py
+++ b/flexmeasures/ui/utils/view_utils.py
@@ -81,7 +81,7 @@ def render_flexmeasures_template(html_filename: str, **variables):
     variables["extra_css"] = current_app.config.get("FLEXMEASURES_EXTRA_CSS_PATH")
 
     if "asset" in variables:
-        variables["breadcrumb_info"] = (get_breadcrumb_info(asset),)
+        variables["breadcrumb_info"] = get_breadcrumb_info(asset)
 
     return render_template(html_filename, **variables)
 

--- a/flexmeasures/ui/views/sensors.py
+++ b/flexmeasures/ui/views/sensors.py
@@ -9,8 +9,10 @@ from webargs.flaskparser import use_kwargs
 
 from flexmeasures.data.schemas.times import AwareDateTimeField
 from flexmeasures.api.dev.sensors import SensorAPI
+from flexmeasures import Sensor
 from flexmeasures.ui.utils.view_utils import render_flexmeasures_template
 from flexmeasures.ui.utils.chart_defaults import chart_options
+from flexmeasures.ui.utils.breadcrumb_utils import get_breadcrumb_info
 
 
 class SensorUI(FlaskView):
@@ -70,4 +72,5 @@ class SensorUI(FlaskView):
             "views/sensors.html",
             sensor_id=id,
             msg="",
+            breadcrumb_info=get_breadcrumb_info(Sensor.query.get(id)),
         )


### PR DESCRIPTION
## Description

So far, we have introduced the child-parent relationship which allows to define a hierarchy of Assets. This is very nice as to model complex relationships but currently we are unable to navigate the Asset tree through the UI. 

Some time ago @GustaafL proposed to have a breadcrumb as a way to move around in FlexMeasures. This PR introduces a little breadcrumb that lets you go back to the parent asset page (if an asset has a parent) and the account page of current asset.


## Look & Feel

![image](https://github.com/FlexMeasures/flexmeasures/assets/84775131/81f18235-eb92-46d9-962a-db407e3525f1)


## How to test

- Create a test account

```
flexmeasures add account --name TestAccount
```

- Create a test asset type
```
flexmeasures add asset-type --name TestAssetType
```

- Create a parent asset
```
flexmeasures add asset  --name Parent --account-id <account-id> --asset-type-id <asset-type-id>

```

```
flexmeasures add asset  --name Child --account-id <account-id> --asset-type-id <asset-type-id>  --parent-asset <parent-asset-id>
```


## Further Improvements

- Extend the breadcrumb to the sensor page


---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
