### PR TITLE
fix: internationalize thousands separator to narrow non-breaking space

### DIFF
--- a/flexmeasures/ui/static/js/flexmeasures.js
+++ b/flexmeasures/ui/static/js/flexmeasures.js
@@ -375,7 +375,7 @@ function submit_sensor_type() {
 vega.expressionFunction('quantityWithUnitFormat', function(datum, params) {
     const formatDef = {
         "decimal": ".",
-        "thousands": ",",
+        "thousands": " ",
         "grouping": [3],
     };
     const locale = d3.formatLocale(formatDef);
@@ -384,7 +384,7 @@ vega.expressionFunction('quantityWithUnitFormat', function(datum, params) {
         return locale.format(params[0])(datum) + " " + convertCurrencyCodeToSymbol(params[1]);
     }
     else {
-        return d3.format(params[0])(datum) + " " + params[1];
+        return locale.format(params[0])(datum) + " " + params[1];
     }
 });
 


### PR DESCRIPTION
For instance, *20 000* instead of *20,000*, as suggested to me by @ardjonker.