### PR TITLE
avoid redirecting when clicking over an input element

### DIFF
--- a/flexmeasures/ui/static/js/flexmeasures.js
+++ b/flexmeasures/ui/static/js/flexmeasures.js
@@ -75,8 +75,8 @@ function clickableTable(element, urlColumn) {
 
 
 function handleClick(event, url) {
-    // ignore clicks on <a href> or <button> elements
-    if (['a', 'button'].includes(event.target.tagName.toLowerCase())) {
+    // ignore clicks on <a href>, <button> or <input> elements
+    if (['a', 'button', 'input'].includes(event.target.tagName.toLowerCase())) {
         return
     } else if (event.ctrlKey) {
         window.open(url, "_blank");


### PR DESCRIPTION
## Description

https://github.com/FlexMeasures/flexmeasures/pull/923 introduced tables with rows that navigate on click and avoided the event in case of clicking a button or link elements. For an internal project, I need an `<input>` element in a row and avoid propagating the event. This PR adds this to the `handleClick` function.

## Related Items

https://github.com/FlexMeasures/flexmeasures/pull/923

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
