### PR TITLE
Add Redis Credentials to Docker Compose for Web Server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,8 @@ services:
       SQLALCHEMY_DATABASE_URI: "postgresql://fm-dev-db-user:fm-dev-db-pass@dev-db:5432/fm-dev-db"
       SECRET_KEY: notsecret
       FLASK_ENV: development
+      FLEXMEASURES_REDIS_URL: queue-db
+      FLEXMEASURES_REDIS_PASSWORD: fm-redis-pass
       LOGGING_LEVEL: INFO 
     volumes:
       # a place for config and plugin code - the mount point is for running the FlexMeasures CLI, the 2nd for gunicorn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - 5000:5000
     depends_on:
       - dev-db
-      - test-db  # use -e SQLALCHEMY_TEST_DATABASE_URI=... to exec
+      - test-db  # use -e SQLALCHEMY_TEST_DATABASE_URI=... to exec pytest
       - queue-db
     restart: on-failure
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,8 @@ services:
       - 5000:5000
     depends_on:
       - dev-db
-      - test-db  # use -e SQLALCHEMY_TEST_DATABASE_URI=... to exec pytest
+      - test-db  # use -e SQLALCHEMY_TEST_DATABASE_URI=... to exec
+      - queue-db
     restart: on-failure
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000/api/v3_0/health/ready"]

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -28,6 +28,7 @@ Bugfixes
 -----------
 
 * Allow showing beliefs (plot and file export) via the CLI for sensors with non-unique names [see `PR #947 <https://github.com/FlexMeasures/flexmeasures/pull/947>`_]
+* Added Redis credentials to the Docker Compose configuration for the web server to ensure proper interaction with the Redis queue [see `PR #945 <https://github.com/FlexMeasures/flexmeasures/pull/945>`_]
 
 
 v0.18.0 | December 23, 2023


### PR DESCRIPTION
Added Redis credentials to the Docker Compose configuration for the web server to ensure proper interaction with the Redis queue.

Tested the updated configuration to confirm seamless integration between the web server and Redis.