### PR TITLE
Shortened CLI option names and updated corresponding tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,12 +50,12 @@ jobs:
         run: docker cp prices-tomorrow.csv fm-container:/app/prices-tomorrow.csv
       - name: Add beliefs
         run: docker exec --env-file .env fm-container flexmeasures
-          add beliefs --sensor-id 1 --source toy-user prices-tomorrow.csv --timezone Europe/Amsterdam
+          add beliefs --sensor 1 --source toy-user prices-tomorrow.csv --timezone Europe/Amsterdam
       - name: Export TOMORROW
         run: echo "TOMORROW=$(date --date="next day" '+%Y-%m-%d')"
           >> $GITHUB_ENV
       - name: Add schedule
         run: docker exec --env-file .env fm-container flexmeasures
-          add schedule for-storage --sensor-id 2 --consumption-price-sensor 1 
+          add schedule for-storage --sensor 2 --consumption-price-sensor 1 
           --start ${TOMORROW}T07:00+01:00 --duration PT12H 
           --soc-at-start 50% --roundtrip-efficiency 90%

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -16,7 +16,7 @@ Infrastructure / Support
 ----------------------
 
 * Deprecate use of flask's ``FLASK_ENV`` variable and replace it with ``FLEXMEASURES_ENV`` [see `PR #907 <https://github.com/FlexMeasures/flexmeasures/pull/907>`_]
-* Deprecate ``--account-id``, ``--asset-id``, ``--asset-type-id``, ``--sensor-id``, ``--source-id`` and ``--user-id`` cli options. Instead use ``--account``, ``--asset``, ``--asset-type``, ``--sensor``, ``--source`` and ``--user`` options, respectively [see `PR #907 <https://github.com/FlexMeasures/flexmeasures/pull/946>`_]
+* Deprecate ``--account-id``, ``--asset-id``, ``--asset-type-id``, ``--sensor-id``, ``--source-id`` and ``--user-id`` cli options. Instead use ``--account``, ``--asset``, ``--asset-type``, ``--sensor``, ``--source`` and ``--user`` options, respectively [see `PR #946 <https://github.com/FlexMeasures/flexmeasures/pull/946>`_]
 
 
 Bugfixes

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -16,7 +16,7 @@ Infrastructure / Support
 ----------------------
 
 * Deprecate use of flask's ``FLASK_ENV`` variable and replace it with ``FLEXMEASURES_ENV`` [see `PR #907 <https://github.com/FlexMeasures/flexmeasures/pull/907>`_]
-* Deprecate ``--account-id``, ``--asset-id``, ``--asset-type-id``, ``--sensor-id``, ``--source-id`` and ``--user-id`` cli options. Instead use ``--account``, ``--asset``, ``--asset-type``, ``--sensor``, ``--source`` and ``--user`` options, respectively [see `PR #946 <https://github.com/FlexMeasures/flexmeasures/pull/946>`_]
+* Streamline CLI option naming by favoring ``--<entity>`` over ``--<entity>-id`` [see `PR #946 <https://github.com/FlexMeasures/flexmeasures/pull/946>`_]
 
 
 Bugfixes

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -16,6 +16,8 @@ Infrastructure / Support
 ----------------------
 
 * Deprecate use of flask's ``FLASK_ENV`` variable and replace it with ``FLEXMEASURES_ENV`` [see `PR #907 <https://github.com/FlexMeasures/flexmeasures/pull/907>`_]
+* Deprecate ``--account-id``, ``--asset-id``, ``--asset-type-id``, ``--sensor-id``, ``--source-id`` and ``--user-id`` cli options. Instead use ``--account``, ``--asset``, ``--asset-type``, ``--sensor``, ``--source`` and ``--user`` options, respectively [see `PR #907 <https://github.com/FlexMeasures/flexmeasures/pull/946>`_]
+
 
 Bugfixes
 -----------

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -7,7 +7,14 @@ FlexMeasures CLI Changelog
 since v0.19.0 | February xx, 2024
 =======================================
 
-* Deprecate ``--account-id``, ``--asset-id``, ``--asset-type-id``, ``--sensor-id``, ``--source-id`` and ``--user-id`` cli options. Instead use ``--account``, ``--asset``, ``--asset-type``, ``--sensor``, ``--source`` and ``--user`` options, respectively.
+* Streamline CLI option naming by favoring ``--<entity>`` over ``--<entity>-id``. This affects the following options:
+
+    * ``--account-id`` -> ``--account``
+    * ``--asset-id`` -> ``--asset``
+    * ``--asset-type-id`` -> ``--asset-type``
+    * ``--sensor-id`` -> ``--sensor``
+    * ``--source-id`` -> ``--source``
+    * ``--user-id`` -> ``--user`
 
 
 since v0.17.0 | November 8, 2023

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -4,6 +4,12 @@
 FlexMeasures CLI Changelog
 **********************
 
+since v0.19.0 | February xx, 2024
+=======================================
+
+* Deprecate ``--account-id``, ``--asset-id``, ``--asset-type-id``, ``--sensor-id``, ``--source-id`` and ``--user-id`` cli options. Instead use ``--account``, ``--asset``, ``--asset-type``, ``--sensor``, ``--source`` and ``--user`` options, respectively.
+
+
 since v0.17.0 | November 8, 2023
 =======================================
 

--- a/documentation/dev/docker-compose.rst
+++ b/documentation/dev/docker-compose.rst
@@ -96,7 +96,7 @@ Next, we put a scheduling job in the worker's queue. This only works because we 
 
 .. code-block:: bash
 
-    $ flexmeasures add schedule for-storage --sensor-id 2 --consumption-price-sensor 1 \
+    $ flexmeasures add schedule for-storage --sensor 2 --consumption-price-sensor 1 \
         --start ${TOMORROW}T07:00+01:00 --duration PT12H --soc-at-start 50% \
         --roundtrip-efficiency 90% --as-job
 
@@ -113,7 +113,7 @@ We'll not go into the server container this time, but simply send a command:
 .. code-block:: bash
 
     $ TOMORROW=$(date --date="next day" '+%Y-%m-%d')
-    $ docker exec -it flexmeasures-server-1 bash -c "flexmeasures show beliefs --sensor-id 2 --start ${TOMORROW}T07:00:00+01:00 --duration PT12H"
+    $ docker exec -it flexmeasures-server-1 bash -c "flexmeasures show beliefs --sensor 2 --start ${TOMORROW}T07:00:00+01:00 --duration PT12H"
 
 The charging/discharging schedule should be there:
 

--- a/documentation/dev/introduction.rst
+++ b/documentation/dev/introduction.rst
@@ -132,10 +132,10 @@ Otherwise, you need to add some other user first. Here is how we add an admin:
 
 .. code-block:: bash
     
-    $ flexmeasures add account --name MyCompany   
-    $ flexmeasures add user --username admin --account-id 1 --email admin@mycompany.io --roles admin
+    $ flexmeasures add account --name MyCompany
+    $ flexmeasures add user --username admin --account 1 --email admin@mycompany.io --roles admin
 
-(The account-id you need in the 2nd command is printed by the 1st)
+(The `account` you need in the 2nd command is printed by the 1st)
 
 
 .. note::

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -40,11 +40,11 @@ A tiny, but complete example: Let's install FlexMeasures from scratch. Then, usi
     $ export SQLALCHEMY_DATABASE_URI="postgresql://postgres:docker@127.0.0.1:5433/flexmeasures-db" && export SECRET_KEY=notsecret 
     $ flexmeasures db upgrade  # create tables
     $ flexmeasures add toy-account --kind battery  # setup account incl. a user, battery (ID 1) and market (ID 2)
-    $ flexmeasures add beliefs --sensor-id 2 --source toy-user prices-tomorrow.csv --timezone utc  # load prices, also possible per API
-    $ flexmeasures add schedule for-storage --sensor-id 1 --consumption-price-sensor 2 \
+    $ flexmeasures add beliefs --sensor 2 --source toy-user prices-tomorrow.csv --timezone utc  # load prices, also possible per API
+    $ flexmeasures add schedule for-storage --sensor 1 --consumption-price-sensor 2 \
         --start ${TOMORROW}T07:00+01:00 --duration PT12H \
         --soc-at-start 50% --roundtrip-efficiency 90%  # this is also possible per API
-    $ flexmeasures show beliefs --sensor-id 1 --start ${TOMORROW}T07:00:00+01:00 --duration PT12H  # also visible per UI, of course
+    $ flexmeasures show beliefs --sensor 1 --start ${TOMORROW}T07:00:00+01:00 --duration PT12H  # also visible per UI, of course
 
 We discuss this in more depth at :ref:`tut_toy_schedule`.
 

--- a/documentation/tut/forecasting_scheduling.rst
+++ b/documentation/tut/forecasting_scheduling.rst
@@ -75,7 +75,7 @@ Here we request 6-hour forecasts to be made for two sensors, for a period of two
 
 .. code-block:: bash
 
-    $ flexmeasures add forecasts --sensor-id 2 --sensor-id 3 \
+    $ flexmeasures add forecasts --sensor 2 --sensor 3 \
         --from-date 2015-02-01 --to-date 2015-08-31 \
         --horizon 6 --as-job
 
@@ -131,7 +131,7 @@ A second way to add scheduling jobs is via the CLI, so this is available for peo
 
 .. code-block:: bash
 
-    $ flexmeasures add schedule for-storage --sensor-id 1 --consumption-price-sensor 2 \
+    $ flexmeasures add schedule for-storage --sensor 1 --consumption-price-sensor 2 \
         --start 2022-07-05T07:00+01:00 --duration PT12H \
         --soc-at-start 50% --roundtrip-efficiency 90% --as-job
 

--- a/documentation/tut/installation.rst
+++ b/documentation/tut/installation.rst
@@ -163,9 +163,9 @@ Usually, we are here because we want to measure something with respect to our as
 
 .. code-block:: bash
 
-   $ flexmeasures add sensor --name power --unit MW --event-resolution 5 --timezone Europe/Amsterdam --asset-id 1 --attributes '{"capacity_in_mw": 7}'
+   $ flexmeasures add sensor --name power --unit MW --event-resolution 5 --timezone Europe/Amsterdam --asset 1 --attributes '{"capacity_in_mw": 7}'
 
-The asset ID I got from the last CLI command, or I could consult ``flexmeasures show account --account-id <my-account-id>``.
+The asset ID I got from the last CLI command, or I could consult ``flexmeasures show account --account <my-account-id>``.
 
 .. note: The event resolution is given in minutes. Capacity is something unique to power sensors, so it is added as an attribute.
 
@@ -179,7 +179,7 @@ First, you can load in data from a file (CSV or Excel) via the ``flexmeasures`` 
 
 .. code-block:: bash
    
-   $ flexmeasures add beliefs --file my-data.csv --skiprows 2 --delimiter ";" --source OurLegacyDatabase --sensor-id 1
+   $ flexmeasures add beliefs --file my-data.csv --skiprows 2 --delimiter ";" --source OurLegacyDatabase --sensor 1
 
 This assumes you have a file `my-data.csv` with measurements, which was exported from some legacy database, and that the data is about our sensor with ID 1. This command has many options, so do use its ``--help`` function.
 

--- a/documentation/tut/toy-example-expanded.rst
+++ b/documentation/tut/toy-example-expanded.rst
@@ -60,7 +60,7 @@ Setting the data source type to "forecaster" helps FlexMeasures to visually dist
 
     $ flexmeasures add source --name "toy-forecaster" --type forecaster
     Added source <Data source 4 (toy-forecaster)>
-    $ flexmeasures add beliefs --sensor-id 3 --source 4 solar-tomorrow.csv --timezone Europe/Amsterdam
+    $ flexmeasures add beliefs --sensor 3 --source 4 solar-tomorrow.csv --timezone Europe/Amsterdam
     Successfully created beliefs
 
 The one-hour CSV data is automatically resampled to the 15-minute resolution of the sensor that is recording solar production. We can see solar production in the `FlexMeasures UI <http://localhost:5000/sensors/3/>`_ :
@@ -79,7 +79,7 @@ Now, we'll reschedule the battery while taking into account the solar production
 
 .. code-block:: bash
 
-    $ flexmeasures add schedule for-storage --sensor-id 2 --consumption-price-sensor 1 \
+    $ flexmeasures add schedule for-storage --sensor 2 --consumption-price-sensor 1 \
         --inflexible-device-sensor 3 \
         --start ${TOMORROW}T07:00+02:00 --duration PT12H \
         --soc-at-start 50% --roundtrip-efficiency 90%

--- a/documentation/tut/toy-example-from-scratch.rst
+++ b/documentation/tut/toy-example-from-scratch.rst
@@ -24,7 +24,7 @@ To keep it short, we'll only ask for a 12-hour window starting at 7am. Finally, 
 
 .. code-block:: bash
 
-    $ flexmeasures add schedule for-storage --sensor-id 2 --consumption-price-sensor 1 \
+    $ flexmeasures add schedule for-storage --sensor 2 --consumption-price-sensor 1 \
         --start ${TOMORROW}T07:00+01:00 --duration PT12H \
         --soc-at-start 50% --roundtrip-efficiency 90%
     New schedule is stored.
@@ -33,7 +33,7 @@ Great. Let's see what we made:
 
 .. code-block:: bash
 
-    $ flexmeasures show beliefs --sensor-id 2 --start ${TOMORROW}T07:00:00+01:00 --duration PT12H
+    $ flexmeasures show beliefs --sensor 2 --start ${TOMORROW}T07:00:00+01:00 --duration PT12H
     Beliefs for Sensor 'discharging' (ID 2).
     Data spans 12 hours and starts at 2022-03-04 07:00:00+01:00.
     The time resolution (x-axis) is 15 minutes.

--- a/documentation/tut/toy-example-process.rst
+++ b/documentation/tut/toy-example-process.rst
@@ -61,7 +61,7 @@ Now we are ready to schedule a process. Let's start with the INFLEXIBLE policy, 
 
 .. code-block:: bash
 
-    flexmeasures add schedule for-process --sensor-id 4 --consumption-price-sensor 1\
+    flexmeasures add schedule for-process --sensor 4 --consumption-price-sensor 1\
       --start ${TOMORROW}T00:00:00+02:00 --duration PT24H --process-duration PT4H \
       --process-power 0.2MW --process-type INFLEXIBLE \ 
       --forbid "{\"start\" : \"${TOMORROW}T15:00:00+02:00\", \"duration\" : \"PT1H\"}"
@@ -72,7 +72,7 @@ Following the INFLEXIBLE policy, we'll schedule the same 4h block using a BREAKA
 
 .. code-block:: bash
 
-    flexmeasures add schedule for-process --sensor-id 5 --consumption-price-sensor 1\
+    flexmeasures add schedule for-process --sensor 5 --consumption-price-sensor 1\
       --start ${TOMORROW}T00:00:00+02:00 --duration PT24H --process-duration PT4H \
       --process-power 0.2MW --process-type BREAKABLE \ 
       --forbid "{\"start\" : \"${TOMORROW}T15:00:00+02:00\", \"duration\" : \"PT1H\"}"
@@ -83,7 +83,7 @@ Finally, we'll schedule the process using the SHIFTABLE policy.
 
 .. code-block:: bash
 
-    flexmeasures add schedule for-process --sensor-id 6 --consumption-price-sensor 1\
+    flexmeasures add schedule for-process --sensor 6 --consumption-price-sensor 1\
       --start ${TOMORROW}T00:00:00+02:00 --duration PT24H --process-duration PT4H \
       --process-power 0.2MW --process-type SHIFTABLE \ 
       --forbid "{\"start\" : \"${TOMORROW}T15:00:00+02:00\", \"duration\" : \"PT1H\"}"

--- a/documentation/tut/toy-example-reporter.rst
+++ b/documentation/tut/toy-example-reporter.rst
@@ -44,7 +44,7 @@ Run the command below to show the values for the `grid connection capacity`:
 .. code-block:: bash
 
     $ TOMORROW=$(date --date="next day" '+%Y-%m-%d')
-    $ flexmeasures show beliefs --sensor-id 7 --start ${TOMORROW}T00:00:00+02:00 --duration PT24H --resolution PT1H
+    $ flexmeasures show beliefs --sensor 7 --start ${TOMORROW}T00:00:00+02:00 --duration PT24H --resolution PT1H
       
       Beliefs for Sensor 'grid connection capacity' (ID 7).
         Data spans a day and starts at 2023-08-14 00:00:00+02:00.

--- a/documentation/tut/toy-example-setup.rst
+++ b/documentation/tut/toy-example-setup.rst
@@ -20,7 +20,7 @@ Below are the ``flexmeasures`` CLI commands we'll run, and which we'll explain s
     # setup an account with a user and an energy market (ID 1)
     $ flexmeasures add toy-account
     # load prices to optimise the schedule against
-    $ flexmeasures add beliefs --sensor-id 1 --source toy-user prices-tomorrow.csv --timezone Europe/Amsterdam
+    $ flexmeasures add beliefs --sensor 1 --source toy-user prices-tomorrow.csv --timezone Europe/Amsterdam
 
 
 Okay, let's get started!
@@ -255,7 +255,7 @@ This is time series data, in FlexMeasures we call *"beliefs"*. Beliefs can also 
 
 .. code-block:: bash
 
-    $ flexmeasures add beliefs --sensor-id 1 --source toy-user prices-tomorrow.csv --timezone Europe/Amsterdam
+    $ flexmeasures add beliefs --sensor 1 --source toy-user prices-tomorrow.csv --timezone Europe/Amsterdam
     Successfully created beliefs
 
 In FlexMeasures, all beliefs have a data source. Here, we use the username of the user we created earlier. We could also pass a user ID, or the name of a new data source we want to use for CLI scripts.
@@ -266,7 +266,7 @@ Let's look at the price data we just loaded:
 
 .. code-block:: bash
 
-    $ flexmeasures show beliefs --sensor-id 1 --start ${TOMORROW}T00:00:00+01:00 --duration PT24H
+    $ flexmeasures show beliefs --sensor 1 --start ${TOMORROW}T00:00:00+01:00 --duration PT24H
     
     Beliefs for Sensor 'day-ahead prices' (ID 1).
     Data spans a day and starts at 2022-03-03 00:00:00+01:00.

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -373,6 +373,7 @@ def add_asset_type(**kwargs):
 @click.option(
     "--account",
     "--account-id",
+    "account_id",
     type=int,
     required=False,
     cls=DeprecatedOption,

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -194,8 +194,8 @@ def new_account(name: str, roles: str, consultancy_account: Account | None):
 @click.option("--username", required=True)
 @click.option("--email", required=True)
 @click.option(
-    "--account-id",
     "--account",
+    "--account-id",
     "account_id",
     type=int,
     required=True,
@@ -274,8 +274,8 @@ def new_user(
     help="Timezone as string, e.g. 'UTC' or 'Europe/Amsterdam'",
 )
 @click.option(
-    "--asset-id",
     "--asset",
+    "--asset-id",
     "generic_asset_id",
     required=True,
     type=int,
@@ -371,8 +371,8 @@ def add_asset_type(**kwargs):
     help="Longitude of the asset's location",
 )
 @click.option(
-    "--account-id",
     "--account",
+    "--account-id",
     type=int,
     required=False,
     cls=DeprecatedOption,
@@ -381,8 +381,8 @@ def add_asset_type(**kwargs):
     help="Add asset to this account. Follow up with the account's ID. If not set, the asset will become public (which makes it accessible to all users).",
 )
 @click.option(
-    "--asset-type-id",
     "--asset-type",
+    "--asset-type-id",
     "generic_asset_type_id",
     required=True,
     type=int,
@@ -742,8 +742,8 @@ def add_beliefs(
     help="Annotation ends at this datetime. Follow up with a timezone-aware datetime in ISO 6801 format. Defaults to one (nominal) day after the start of the annotation.",
 )
 @click.option(
-    "--account-id",
     "--account",
+    "--account-id",
     "account_ids",
     type=click.INT,
     multiple=True,
@@ -753,8 +753,8 @@ def add_beliefs(
     help="Add annotation to this organisation account. Follow up with the account's ID. This argument can be given multiple times.",
 )
 @click.option(
-    "--asset-id",
     "--asset",
+    "--asset-id",
     "generic_asset_ids",
     type=int,
     multiple=True,
@@ -764,8 +764,8 @@ def add_beliefs(
     help="Add annotation to this asset. Follow up with the asset's ID. This argument can be given multiple times.",
 )
 @click.option(
-    "--sensor-id",
     "--sensor",
+    "--sensor-id",
     "sensor_ids",
     type=int,
     multiple=True,
@@ -775,8 +775,8 @@ def add_beliefs(
     help="Add annotation to this sensor. Follow up with the sensor's ID. This argument can be given multiple times.",
 )
 @click.option(
-    "--user-id",
     "--user",
+    "--user-id",
     "user_id",
     type=int,
     required=True,
@@ -858,8 +858,8 @@ def add_annotation(
     help="The ISO 3166-1 country/region or ISO 3166-2 sub-region for which to look up holidays (such as US, BR and DE). This argument can be given multiple times.",
 )
 @click.option(
-    "--asset-id",
     "--asset",
+    "--asset-id",
     "generic_asset_ids",
     type=click.INT,
     multiple=True,
@@ -869,8 +869,8 @@ def add_annotation(
     help="Add annotations to this asset. Follow up with the asset's ID. This argument can be given multiple times.",
 )
 @click.option(
-    "--account-id",
     "--account",
+    "--account-id",
     "account_ids",
     type=click.INT,
     multiple=True,
@@ -937,8 +937,8 @@ def add_holidays(
 @fm_add_data.command("forecasts", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option(
-    "--sensor-id",
     "--sensor",
+    "--sensor-id",
     "sensor_ids",
     multiple=True,
     required=True,
@@ -1069,8 +1069,8 @@ def create_schedule(ctx):
 @create_schedule.command("for-storage", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option(
-    "--sensor-id",
     "--sensor",
+    "--sensor-id",
     "power_sensor",
     type=SensorIdField(),
     required=True,
@@ -1293,8 +1293,8 @@ def add_schedule_for_storage(
 @create_schedule.command("for-process", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option(
-    "--sensor-id",
     "--sensor",
+    "--sensor-id",
     "power_sensor",
     type=SensorIdField(),
     required=True,

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -190,7 +190,8 @@ def new_account(name: str, roles: str, consultancy_account: Account | None):
 @click.option("--username", required=True)
 @click.option("--email", required=True)
 @click.option(
-    "--account-id",
+    "--account",
+    "account_id",
     type=int,
     required=True,
     help="Add user to this account. Follow up with the account's ID.",
@@ -265,7 +266,7 @@ def new_user(
     help="Timezone as string, e.g. 'UTC' or 'Europe/Amsterdam'",
 )
 @click.option(
-    "--asset-id",
+    "--asset",
     "generic_asset_id",
     required=True,
     type=int,
@@ -358,13 +359,13 @@ def add_asset_type(**args):
     help="Longitude of the asset's location",
 )
 @click.option(
-    "--account-id",
+    "--account",
     type=int,
     required=False,
     help="Add asset to this account. Follow up with the account's ID. If not set, the asset will become public (which makes it accessible to all users).",
 )
 @click.option(
-    "--asset-type-id",
+    "--asset-type",
     "generic_asset_type_id",
     required=True,
     type=int,
@@ -443,7 +444,7 @@ def add_source(name: str, model: str, version: str, source_type: str):
 @with_appcontext
 @click.argument("file", type=click.Path(exists=True))
 @click.option(
-    "--sensor-id",
+    "--sensor",
     "sensor",
     required=True,
     type=SensorIdField(),
@@ -721,28 +722,29 @@ def add_beliefs(
     help="Annotation ends at this datetime. Follow up with a timezone-aware datetime in ISO 6801 format. Defaults to one (nominal) day after the start of the annotation.",
 )
 @click.option(
-    "--account-id",
+    "--account",
     "account_ids",
     type=click.INT,
     multiple=True,
     help="Add annotation to this organisation account. Follow up with the account's ID. This argument can be given multiple times.",
 )
 @click.option(
-    "--asset-id",
+    "--asset",
     "generic_asset_ids",
     type=int,
     multiple=True,
     help="Add annotation to this asset. Follow up with the asset's ID. This argument can be given multiple times.",
 )
 @click.option(
-    "--sensor-id",
+    "--sensor",
     "sensor_ids",
     type=int,
     multiple=True,
     help="Add annotation to this sensor. Follow up with the sensor's ID. This argument can be given multiple times.",
 )
 @click.option(
-    "--user-id",
+    "--user",
+    "user_id",
     type=int,
     required=True,
     help="Attribute annotation to this user. Follow up with the user's ID.",
@@ -820,14 +822,14 @@ def add_annotation(
     help="The ISO 3166-1 country/region or ISO 3166-2 sub-region for which to look up holidays (such as US, BR and DE). This argument can be given multiple times.",
 )
 @click.option(
-    "--asset-id",
+    "--asset",
     "generic_asset_ids",
     type=click.INT,
     multiple=True,
     help="Add annotations to this asset. Follow up with the asset's ID. This argument can be given multiple times.",
 )
 @click.option(
-    "--account-id",
+    "--account",
     "account_ids",
     type=click.INT,
     multiple=True,
@@ -891,7 +893,7 @@ def add_holidays(
 @fm_add_data.command("forecasts")
 @with_appcontext
 @click.option(
-    "--sensor-id",
+    "--sensor",
     "sensor_ids",
     multiple=True,
     required=True,
@@ -1019,7 +1021,7 @@ def create_schedule(ctx):
 @create_schedule.command("for-storage")
 @with_appcontext
 @click.option(
-    "--sensor-id",
+    "--sensor",
     "power_sensor",
     type=SensorIdField(),
     required=True,
@@ -1040,7 +1042,7 @@ def create_schedule(ctx):
     help="Optimize production against this sensor. Defaults to the consumption price sensor. The sensor typically records an electricity price (e.g. in EUR/kWh), but this field can also be used to optimize against some emission intensity factor (e.g. in kg CO₂ eq./kWh). Follow up with the sensor's ID.",
 )
 @click.option(
-    "--optimization-context-id",
+    "--optimization-context",
     "optimization_context_sensor",
     type=SensorIdField(),
     required=False,
@@ -1239,7 +1241,7 @@ def add_schedule_for_storage(
 @create_schedule.command("for-process")
 @with_appcontext
 @click.option(
-    "--sensor-id",
+    "--sensor",
     "power_sensor",
     type=SensorIdField(),
     required=True,

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -372,7 +372,8 @@ def add_asset_type(**args):
     help="Longitude of the asset's location",
 )
 @click.option(
-    "--account-id" "--account",
+    "--account-id",
+    "--account",
     type=int,
     required=False,
     cls=DeprecatedOption,
@@ -869,7 +870,8 @@ def add_annotation(
     help="Add annotations to this asset. Follow up with the asset's ID. This argument can be given multiple times.",
 )
 @click.option(
-    "--account-id" "--account",
+    "--account-id",
+    "--account",
     "account_ids",
     type=click.INT,
     multiple=True,

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -754,7 +754,7 @@ def add_beliefs(
     help="Add annotation to this organisation account. Follow up with the account's ID. This argument can be given multiple times.",
 )
 @click.option(
-    "--asset-it",
+    "--asset-id",
     "--asset",
     "generic_asset_ids",
     type=int,

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -461,14 +461,18 @@ def add_source(name: str, model: str, version: str, source_type: str):
     click.secho(f"Added source {source.__repr__()}", **MsgStyle.SUCCESS)
 
 
-@fm_add_data.command("beliefs")
+@fm_add_data.command("beliefs", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.argument("file", type=click.Path(exists=True))
 @click.option(
     "--sensor",
+    "--sensor-id",
     "sensor",
     required=True,
     type=SensorIdField(),
+    cls=DeprecatedOption,
+    deprecated=["--sensor-id"],
+    preferred="--sensor",
     help="Record the beliefs under this sensor. Follow up with the sensor's ID. ",
 )
 @click.option(

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -27,7 +27,12 @@ import timely_beliefs as tb
 import timely_beliefs.utils as tb_utils
 from workalendar.registry import registry as workalendar_registry
 
-from flexmeasures.cli.utils import DeprecatedDefaultGroup, MsgStyle
+from flexmeasures.cli.utils import (
+    DeprecatedDefaultGroup,
+    MsgStyle,
+    DeprecatedOption,
+    DeprecatedOptionsCommand,
+)
 from flexmeasures.data import db
 from flexmeasures.data.scripts.data_gen import (
     add_transmission_zone_asset,
@@ -185,15 +190,19 @@ def new_account(name: str, roles: str, consultancy_account: Account | None):
     )
 
 
-@fm_add_data.command("user")
+@fm_add_data.command("user", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option("--username", required=True)
 @click.option("--email", required=True)
 @click.option(
+    "--account-id",
     "--account",
     "account_id",
     type=int,
     required=True,
+    cls=DeprecatedOption,
+    deprecated=["--account-id"],
+    preferred="--account",
     help="Add user to this account. Follow up with the account's ID.",
 )
 @click.option("--roles", help="e.g. anonymous,Prosumer,CPO")
@@ -250,7 +259,7 @@ def new_user(
     click.secho(f"Successfully created user {created_user}", **MsgStyle.SUCCESS)
 
 
-@fm_add_data.command("sensor")
+@fm_add_data.command("sensor", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option("--name", required=True)
 @click.option("--unit", required=True, help="e.g. °C, m/s, kW/m²")
@@ -266,10 +275,14 @@ def new_user(
     help="Timezone as string, e.g. 'UTC' or 'Europe/Amsterdam'",
 )
 @click.option(
+    "--asset-id",
     "--asset",
     "generic_asset_id",
     required=True,
     type=int,
+    cls=DeprecatedOption,
+    deprecated=["--asset-id"],
+    preferred="--asset",
     help="Generic asset to assign this sensor to",
 )
 @click.option(
@@ -345,7 +358,7 @@ def add_asset_type(**args):
     click.secho("You can now assign assets to it.", **MsgStyle.SUCCESS)
 
 
-@fm_add_data.command("asset")
+@fm_add_data.command("asset", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option("--name", required=True)
 @click.option(
@@ -359,16 +372,23 @@ def add_asset_type(**args):
     help="Longitude of the asset's location",
 )
 @click.option(
-    "--account",
+    "--account-id" "--account",
     type=int,
     required=False,
+    cls=DeprecatedOption,
+    deprecated=["--account-id"],
+    preferred="--account",
     help="Add asset to this account. Follow up with the account's ID. If not set, the asset will become public (which makes it accessible to all users).",
 )
 @click.option(
+    "--asset-type-id",
     "--asset-type",
     "generic_asset_type_id",
     required=True,
     type=int,
+    cls=DeprecatedOption,
+    deprecated=["--asset-type-id"],
+    preferred="--asset-type",
     help="Asset type to assign to this asset",
 )
 @click.option(
@@ -702,7 +722,7 @@ def add_beliefs(
             )
 
 
-@fm_add_data.command("annotation")
+@fm_add_data.command("annotation", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option(
     "--content",
@@ -722,31 +742,47 @@ def add_beliefs(
     help="Annotation ends at this datetime. Follow up with a timezone-aware datetime in ISO 6801 format. Defaults to one (nominal) day after the start of the annotation.",
 )
 @click.option(
+    "--account-id",
     "--account",
     "account_ids",
     type=click.INT,
     multiple=True,
+    cls=DeprecatedOption,
+    deprecated=["--account-id"],
+    preferred="--account",
     help="Add annotation to this organisation account. Follow up with the account's ID. This argument can be given multiple times.",
 )
 @click.option(
+    "--asset-it",
     "--asset",
     "generic_asset_ids",
     type=int,
     multiple=True,
+    cls=DeprecatedOption,
+    deprecated=["--asset-id"],
+    preferred="--asset",
     help="Add annotation to this asset. Follow up with the asset's ID. This argument can be given multiple times.",
 )
 @click.option(
+    "--sensor-id",
     "--sensor",
     "sensor_ids",
     type=int,
     multiple=True,
+    cls=DeprecatedOption,
+    deprecated=["--sensor-id"],
+    preferred="--sensor",
     help="Add annotation to this sensor. Follow up with the sensor's ID. This argument can be given multiple times.",
 )
 @click.option(
+    "--user-id",
     "--user",
     "user_id",
     type=int,
     required=True,
+    cls=DeprecatedOption,
+    deprecated=["--user-id"],
+    preferred="--user",
     help="Attribute annotation to this user. Follow up with the user's ID.",
 )
 def add_annotation(
@@ -807,7 +843,7 @@ def add_annotation(
     click.secho("Successfully added annotation.", **MsgStyle.SUCCESS)
 
 
-@fm_add_data.command("holidays")
+@fm_add_data.command("holidays", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option(
     "--year",
@@ -822,17 +858,24 @@ def add_annotation(
     help="The ISO 3166-1 country/region or ISO 3166-2 sub-region for which to look up holidays (such as US, BR and DE). This argument can be given multiple times.",
 )
 @click.option(
+    "--asset-id",
     "--asset",
     "generic_asset_ids",
     type=click.INT,
     multiple=True,
+    cls=DeprecatedOption,
+    deprecated=["--asset-id"],
+    preferred="--asset",
     help="Add annotations to this asset. Follow up with the asset's ID. This argument can be given multiple times.",
 )
 @click.option(
-    "--account",
+    "--account-id" "--account",
     "account_ids",
     type=click.INT,
     multiple=True,
+    cls=DeprecatedOption,
+    deprecated=["--account-id"],
+    preferred="--account",
     help="Add annotations to this account. Follow up with the account's ID. This argument can be given multiple times.",
 )
 def add_holidays(
@@ -890,13 +933,17 @@ def add_holidays(
     )
 
 
-@fm_add_data.command("forecasts")
+@fm_add_data.command("forecasts", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option(
+    "--sensor-id",
     "--sensor",
     "sensor_ids",
     multiple=True,
     required=True,
+    cls=DeprecatedOption,
+    deprecated=["--sensor-id"],
+    preferred="--sensor",
     help="Create forecasts for this sensor. Follow up with the sensor's ID. This argument can be given multiple times.",
 )
 @click.option(
@@ -1018,13 +1065,17 @@ def create_schedule(ctx):
     pass
 
 
-@create_schedule.command("for-storage")
+@create_schedule.command("for-storage", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option(
+    "--sensor-id",
     "--sensor",
     "power_sensor",
     type=SensorIdField(),
     required=True,
+    cls=DeprecatedOption,
+    deprecated=["--sensor-id"],
+    preferred="--sensor",
     help="Create schedule for this sensor. Should be a power sensor. Follow up with the sensor's ID.",
 )
 @click.option(
@@ -1042,7 +1093,7 @@ def create_schedule(ctx):
     help="Optimize production against this sensor. Defaults to the consumption price sensor. The sensor typically records an electricity price (e.g. in EUR/kWh), but this field can also be used to optimize against some emission intensity factor (e.g. in kg CO₂ eq./kWh). Follow up with the sensor's ID.",
 )
 @click.option(
-    "--optimization-context",
+    "--optimization-context-id",
     "optimization_context_sensor",
     type=SensorIdField(),
     required=False,
@@ -1238,13 +1289,17 @@ def add_schedule_for_storage(
             click.secho("New schedule is stored.", **MsgStyle.SUCCESS)
 
 
-@create_schedule.command("for-process")
+@create_schedule.command("for-process", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option(
+    "--sensor-id",
     "--sensor",
     "power_sensor",
     type=SensorIdField(),
     required=True,
+    cls=DeprecatedOption,
+    deprecated=["--sensor-id"],
+    preferred="--sensor",
     help="Create schedule for this sensor. Should be a power sensor. Follow up with the sensor's ID.",
 )
 @click.option(

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -992,7 +992,7 @@ def create_forecasts(
 
     For example:
 
-        --from-date 2015-02-02 --to-date 2015-02-04 --horizon 6 --sensor-id 12 --sensor-id 14
+        --from-date 2015-02-02 --to-date 2015-02-04 --horizon 6 --sensor 12 --sensor 14
 
         This will create forecast values from 0am on May 2nd to 0am on May 5th,
         based on a 6-hour horizon, for sensors 12 and 14.

--- a/flexmeasures/cli/data_delete.py
+++ b/flexmeasures/cli/data_delete.py
@@ -163,7 +163,8 @@ def delete_structure(force):
 @fm_delete_data.command("measurements")
 @with_appcontext
 @click.option(
-    "--sensor-id",
+    "--sensor",
+    "sensor_id",
     type=int,
     help="Delete (time series) data for a single sensor only. Follow up with the sensor's ID.",
 )
@@ -188,7 +189,8 @@ def delete_measurements(
     "--force/--no-force", default=False, help="Skip warning about consequences."
 )
 @click.option(
-    "--sensor-id",
+    "--sensor",
+    "sensor_id",
     type=int,
     help="Delete (time series) data for a single sensor only. Follow up with the sensor's ID. ",
 )
@@ -288,7 +290,8 @@ def delete_unchanged_beliefs(
 @fm_delete_data.command("nan-beliefs")
 @with_appcontext
 @click.option(
-    "--sensor-id",
+    "--sensor",
+    "sensor_id",
     type=int,
     help="Delete NaN time series data for a single sensor only. Follow up with the sensor's ID.",
 )

--- a/flexmeasures/cli/data_delete.py
+++ b/flexmeasures/cli/data_delete.py
@@ -163,8 +163,8 @@ def delete_structure(force):
 @fm_delete_data.command("measurements", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option(
-    "--sensor-id",
     "--sensor",
+    "--sensor-id",
     "sensor_id",
     type=int,
     cls=DeprecatedOption,
@@ -193,8 +193,8 @@ def delete_measurements(
     "--force/--no-force", default=False, help="Skip warning about consequences."
 )
 @click.option(
-    "--sensor-id",
     "--sensor",
+    "--sensor-id",
     "sensor_id",
     type=int,
     cls=DeprecatedOption,
@@ -217,8 +217,9 @@ def delete_prognoses(
 @fm_delete_data.command("unchanged-beliefs", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option(
+    "--sensor",
     "--sensor-id",
-    "--sensor" "sensor_id",
+    "sensor_id",
     type=int,
     cls=DeprecatedOption,
     deprecated=["--sensor-id"],
@@ -302,8 +303,8 @@ def delete_unchanged_beliefs(
 @fm_delete_data.command("nan-beliefs", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option(
-    "--sensor-id",
     "--sensor",
+    "--sensor-id",
     "sensor_id",
     type=int,
     cls=DeprecatedOption,

--- a/flexmeasures/cli/data_delete.py
+++ b/flexmeasures/cli/data_delete.py
@@ -19,7 +19,7 @@ from flexmeasures.data.models.time_series import Sensor, TimedBelief
 from flexmeasures.data.schemas.generic_assets import GenericAssetIdField
 from flexmeasures.data.schemas.sensors import SensorIdField
 from flexmeasures.data.services.users import find_user_by_email, delete_user
-from flexmeasures.cli.utils import MsgStyle
+from flexmeasures.cli.utils import MsgStyle, DeprecatedOption, DeprecatedOptionsCommand
 
 
 @click.group("delete")
@@ -160,12 +160,16 @@ def delete_structure(force):
     depopulate_structure(db)
 
 
-@fm_delete_data.command("measurements")
+@fm_delete_data.command("measurements", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option(
+    "--sensor-id",
     "--sensor",
     "sensor_id",
     type=int,
+    cls=DeprecatedOption,
+    deprecated=["--sensor-id"],
+    preferred="--sensor",
     help="Delete (time series) data for a single sensor only. Follow up with the sensor's ID.",
 )
 @click.option(
@@ -183,15 +187,19 @@ def delete_measurements(
     depopulate_measurements(db, sensor_id)
 
 
-@fm_delete_data.command("prognoses")
+@fm_delete_data.command("prognoses", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option(
     "--force/--no-force", default=False, help="Skip warning about consequences."
 )
 @click.option(
+    "--sensor-id",
     "--sensor",
     "sensor_id",
     type=int,
+    cls=DeprecatedOption,
+    deprecated=["--sensor-id"],
+    preferred="--sensor",
     help="Delete (time series) data for a single sensor only. Follow up with the sensor's ID. ",
 )
 def delete_prognoses(
@@ -206,11 +214,15 @@ def delete_prognoses(
     depopulate_prognoses(db, sensor_id)
 
 
-@fm_delete_data.command("unchanged-beliefs")
+@fm_delete_data.command("unchanged-beliefs", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option(
     "--sensor-id",
+    "--sensor" "sensor_id",
     type=int,
+    cls=DeprecatedOption,
+    deprecated=["--sensor-id"],
+    preferred="--sensor",
     help="Delete unchanged (time series) data for a single sensor only. Follow up with the sensor's ID. ",
 )
 @click.option(
@@ -287,12 +299,16 @@ def delete_unchanged_beliefs(
     click.secho(f"Done! {num_beliefs_after} beliefs left", **MsgStyle.SUCCESS)
 
 
-@fm_delete_data.command("nan-beliefs")
+@fm_delete_data.command("nan-beliefs", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option(
+    "--sensor-id",
     "--sensor",
     "sensor_id",
     type=int,
+    cls=DeprecatedOption,
+    deprecated=["--sensor-id"],
+    preferred="--sensor",
     help="Delete NaN time series data for a single sensor only. Follow up with the sensor's ID.",
 )
 def delete_nan_beliefs(sensor_id: int | None = None):

--- a/flexmeasures/cli/data_edit.py
+++ b/flexmeasures/cli/data_edit.py
@@ -20,7 +20,7 @@ from flexmeasures.data.schemas.sensors import SensorIdField
 from flexmeasures.data.models.generic_assets import GenericAsset
 from flexmeasures.data.models.time_series import TimedBelief
 from flexmeasures.data.utils import save_to_db
-from flexmeasures.cli.utils import MsgStyle
+from flexmeasures.cli.utils import MsgStyle, DeprecatedOption, DeprecatedOptionsCommand
 
 
 @click.group("edit")
@@ -28,22 +28,30 @@ def fm_edit_data():
     """FlexMeasures: Edit data."""
 
 
-@fm_edit_data.command("attribute")
+@fm_edit_data.command("attribute", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option(
+    "--asset-id",
     "--asset",
     "assets",
     required=False,
     multiple=True,
     type=GenericAssetIdField(),
+    cls=DeprecatedOption,
+    deprecated=["--asset-id"],
+    preferred="--asset",
     help="Add/edit attribute to this asset. Follow up with the asset's ID.",
 )
 @click.option(
+    "--sensor-id",
     "--sensor",
     "sensors",
     required=False,
     multiple=True,
     type=SensorIdField(),
+    cls=DeprecatedOption,
+    deprecated=["--sensor-id"],
+    preferred="--sensor",
     help="Add/edit attribute to this sensor. Follow up with the sensor's ID.",
 )
 @click.option(
@@ -144,13 +152,17 @@ def edit_attribute(
     click.secho("Successfully edited/added attribute.", **MsgStyle.SUCCESS)
 
 
-@fm_edit_data.command("resample-data")
+@fm_edit_data.command("resample-data", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option(
+    "--sensor-id",
     "--sensor",
     "sensor_ids",
     multiple=True,
     required=True,
+    cls=DeprecatedOption,
+    deprecated=["--sensor-id"],
+    preferred="--sensor",
     help="Resample data for this sensor. Follow up with the sensor's ID. This argument can be given multiple times.",
 )
 @click.option(

--- a/flexmeasures/cli/data_edit.py
+++ b/flexmeasures/cli/data_edit.py
@@ -31,8 +31,8 @@ def fm_edit_data():
 @fm_edit_data.command("attribute", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option(
-    "--asset-id",
     "--asset",
+    "--asset-id",
     "assets",
     required=False,
     multiple=True,
@@ -43,8 +43,8 @@ def fm_edit_data():
     help="Add/edit attribute to this asset. Follow up with the asset's ID.",
 )
 @click.option(
-    "--sensor-id",
     "--sensor",
+    "--sensor-id",
     "sensors",
     required=False,
     multiple=True,
@@ -155,8 +155,8 @@ def edit_attribute(
 @fm_edit_data.command("resample-data", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option(
-    "--sensor-id",
     "--sensor",
+    "--sensor-id",
     "sensor_ids",
     multiple=True,
     required=True,

--- a/flexmeasures/cli/data_edit.py
+++ b/flexmeasures/cli/data_edit.py
@@ -31,7 +31,7 @@ def fm_edit_data():
 @fm_edit_data.command("attribute")
 @with_appcontext
 @click.option(
-    "--asset-id",
+    "--asset",
     "assets",
     required=False,
     multiple=True,
@@ -39,7 +39,7 @@ def fm_edit_data():
     help="Add/edit attribute to this asset. Follow up with the asset's ID.",
 )
 @click.option(
-    "--sensor-id",
+    "--sensor",
     "sensors",
     required=False,
     multiple=True,
@@ -147,7 +147,7 @@ def edit_attribute(
 @fm_edit_data.command("resample-data")
 @with_appcontext
 @click.option(
-    "--sensor-id",
+    "--sensor",
     "sensor_ids",
     multiple=True,
     required=True,

--- a/flexmeasures/cli/data_show.py
+++ b/flexmeasures/cli/data_show.py
@@ -437,7 +437,7 @@ def chart(
 @fm_show_data.command("beliefs")
 @with_appcontext
 @click.option(
-    "--sensor-id",
+    "--sensor",
     "sensors",
     required=True,
     multiple=True,
@@ -466,7 +466,7 @@ def chart(
     help="Time at which beliefs had been known. Follow up with a timezone-aware datetime in ISO 6801 format.",
 )
 @click.option(
-    "--source-id",
+    "--source",
     "source",
     required=False,
     type=DataSourceIdField(),

--- a/flexmeasures/cli/data_show.py
+++ b/flexmeasures/cli/data_show.py
@@ -31,6 +31,7 @@ from flexmeasures.data.services.time_series import simplify_index
 from flexmeasures.utils.time_utils import determine_minimum_resampling_resolution
 from flexmeasures.cli.utils import MsgStyle
 from flexmeasures.utils.coding_utils import delete_key_recursive
+from flexmeasures.cli.utils import DeprecatedOptionsCommand, DeprecatedOption
 
 
 @click.group("show")
@@ -434,14 +435,18 @@ def chart(
         )
 
 
-@fm_show_data.command("beliefs")
+@fm_show_data.command("beliefs", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option(
+    "--sensor-id",
     "--sensor",
     "sensors",
     required=True,
     multiple=True,
     type=SensorIdField(),
+    cls=DeprecatedOption,
+    preferred="--sensor",
+    deprecated=["--sensor-id"],
     help="ID of sensor(s). This argument can be given multiple times.",
 )
 @click.option(
@@ -466,10 +471,14 @@ def chart(
     help="Time at which beliefs had been known. Follow up with a timezone-aware datetime in ISO 6801 format.",
 )
 @click.option(
+    "--source-id",
     "--source",
     "source",
     required=False,
     type=DataSourceIdField(),
+    cls=DeprecatedOption,
+    preferred="--source",
+    deprecated=["--source-id"],
     help="Source of the beliefs (an existing source id).",
 )
 @click.option(

--- a/flexmeasures/cli/data_show.py
+++ b/flexmeasures/cli/data_show.py
@@ -437,8 +437,8 @@ def chart(
 @fm_show_data.command("beliefs", cls=DeprecatedOptionsCommand)
 @with_appcontext
 @click.option(
-    "--sensor-id",
     "--sensor",
+    "--sensor-id",
     "sensors",
     required=True,
     multiple=True,
@@ -471,8 +471,8 @@ def chart(
     help="Time at which beliefs had been known. Follow up with a timezone-aware datetime in ISO 6801 format.",
 )
 @click.option(
-    "--source-id",
     "--source",
+    "--source-id",
     "source",
     required=False,
     type=DataSourceIdField(),

--- a/flexmeasures/cli/tests/test_data_add.py
+++ b/flexmeasures/cli/tests/test_data_add.py
@@ -25,8 +25,8 @@ def test_add_annotation(app, db, setup_roles_users):
     cli_input = {
         "content": "Company founding day",
         "at": "2016-05-11T00:00+02:00",
-        "account-id": 1,
-        "user-id": 1,
+        "account": 1,
+        "user": 1,
     }
     runner = app.test_cli_runner()
     result = runner.invoke(add_annotation, to_flags(cli_input))
@@ -42,13 +42,13 @@ def test_add_annotation(app, db, setup_roles_users):
         )
         .join(AccountAnnotationRelationship)
         .filter(
-            AccountAnnotationRelationship.account_id == cli_input["account-id"],
+            AccountAnnotationRelationship.account_id == cli_input["account"],
             AccountAnnotationRelationship.annotation_id == Annotation.id,
         )
         .join(DataSource)
         .filter(
             DataSource.id == Annotation.source_id,
-            DataSource.user_id == cli_input["user-id"],
+            DataSource.user_id == cli_input["user"],
         )
         .one_or_none()
     )
@@ -61,7 +61,7 @@ def test_add_holidays(app, db, setup_roles_users):
     cli_input = {
         "year": 2020,
         "country": "NL",
-        "account-id": 1,
+        "account": 1,
     }
     runner = app.test_cli_runner()
     result = runner.invoke(add_holidays, to_flags(cli_input))
@@ -73,7 +73,7 @@ def test_add_holidays(app, db, setup_roles_users):
     assert (
         Annotation.query.join(AccountAnnotationRelationship)
         .filter(
-            AccountAnnotationRelationship.account_id == cli_input["account-id"],
+            AccountAnnotationRelationship.account_id == cli_input["account"],
             AccountAnnotationRelationship.annotation_id == Annotation.id,
         )
         .join(DataSource)
@@ -358,7 +358,7 @@ def test_add_process(
     process_power_sensor_id = process_power_sensor
 
     cli_input_params = {
-        "sensor-id": process_power_sensor_id,
+        "sensor": process_power_sensor_id,
         "start": "2015-01-02T00:00:00+01:00",
         "duration": "PT24H",
         "process-duration": "PT4H",
@@ -402,7 +402,7 @@ def test_add_sensor(app, db, setup_dummy_asset, event_resolution, name, success)
         "name": name,
         "event-resolution": event_resolution,
         "unit": "kWh",
-        "asset-id": asset,
+        "asset": asset,
         "timezone": "UTC",
     }
     runner = app.test_cli_runner()

--- a/flexmeasures/cli/tests/test_data_edit.py
+++ b/flexmeasures/cli/tests/test_data_edit.py
@@ -17,7 +17,7 @@ def test_add_one_sensor_attribute(app, db, setup_markets):
     n_attributes_before = len(sensor.attributes)
 
     cli_input = {
-        "sensor-id": sensor.id,
+        "sensor": sensor.id,
         "attribute": "some new attribute",
         "float": 3,
     }
@@ -73,7 +73,7 @@ def test_resample_sensor_data(
     )
 
     cli_input = {
-        "sensor-id": sensor.id,
+        "sensor": sensor.id,
         "event-resolution": sensor.event_resolution.seconds / 60 / 2,
     }
     runner = app.test_cli_runner()

--- a/flexmeasures/cli/tests/test_data_show.py
+++ b/flexmeasures/cli/tests/test_data_show.py
@@ -99,7 +99,7 @@ def test_plot_beliefs(app, fresh_db, setup_beliefs_fresh_db):
     result = runner.invoke(
         plot_beliefs,
         [
-            "--sensor-id",
+            "--sensor",
             sensor.id,
             "--start",
             "2021-03-28T16:00+01",

--- a/flexmeasures/cli/utils.py
+++ b/flexmeasures/cli/utils.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Any
 from datetime import datetime, timedelta
 
-
+import warnings
 import click
 import pytz
 from click_default_group import DefaultGroup
@@ -26,6 +26,66 @@ class MsgStyle(object):
     SUCCESS: dict[str, Any] = {"fg": "green"}
     WARN: dict[str, Any] = {"fg": "yellow"}
     ERROR: dict[str, Any] = {"fg": "red"}
+
+
+class DeprecatedOption(click.Option):
+    """A custom option that can be used to mark an option as deprecated."""
+
+    def __init__(self, *args, **kwargs):
+        self.deprecated = kwargs.pop("deprecated", ())
+        self.preferred = kwargs.pop("preferred", args[0][-1])
+        super(DeprecatedOption, self).__init__(*args, **kwargs)
+
+
+class DeprecatedOptionsCommand(click.Command):
+    """A custom command that can be used to mark options as deprecated."""
+
+    def make_parser(self, ctx):
+        """Hook 'make_parser' and during processing check the name
+        used to invoke the option to see if it is preferred"""
+
+        parser = super(DeprecatedOptionsCommand, self).make_parser(ctx)
+
+        # get the parser options
+        options = set(parser._short_opt.values())
+        options |= set(parser._long_opt.values())
+
+        for option in options:
+            if not isinstance(option.obj, DeprecatedOption):
+                continue
+
+            def make_process(an_option):
+                """Construct a closure to the parser option processor"""
+
+                orig_process = an_option.process
+                deprecated = getattr(an_option.obj, "deprecated", None)
+                preferred = getattr(an_option.obj, "preferred", None)
+                msg = "Expected `deprecated` value for `{}`"
+                assert deprecated is not None, msg.format(an_option.obj.name)
+
+                def process(value, state):
+                    """The function above us on the stack used 'opt' to
+                    pick option from a dict, see if it is deprecated"""
+
+                    # reach up the stack and get 'opt'
+                    import inspect
+
+                    frame = inspect.currentframe()
+                    try:
+                        opt = frame.f_back.f_locals.get("opt")
+                    finally:
+                        del frame
+
+                    if opt in deprecated:
+                        msg = "Option '{}' will be replaced by '{}'."
+                        warnings.warn(msg.format(opt, preferred), FutureWarning)
+                    return orig_process(value, state)
+
+                return process
+
+            option.process = make_process(option)
+
+        return parser
 
 
 class DeprecatedDefaultGroup(DefaultGroup):

--- a/flexmeasures/cli/utils.py
+++ b/flexmeasures/cli/utils.py
@@ -48,7 +48,7 @@ class DeprecatedOptionsCommand(click.Command):
     References
     ----------------
 
-    Adopted from  https://stackoverflow.com/a/50402799/13775459
+    Adapted from  https://stackoverflow.com/a/50402799/13775459
     """
 
     def make_parser(self, ctx):

--- a/flexmeasures/cli/utils.py
+++ b/flexmeasures/cli/utils.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from typing import Any
 from datetime import datetime, timedelta
 
-import warnings
 import click
 import pytz
 from click_default_group import DefaultGroup
@@ -29,7 +28,13 @@ class MsgStyle(object):
 
 
 class DeprecatedOption(click.Option):
-    """A custom option that can be used to mark an option as deprecated."""
+    """A custom option that can be used to mark an option as deprecated.
+
+    References
+    ----------------
+
+    Copied from  https://stackoverflow.com/a/50402799/13775459
+    """
 
     def __init__(self, *args, **kwargs):
         self.deprecated = kwargs.pop("deprecated", ())
@@ -38,7 +43,13 @@ class DeprecatedOption(click.Option):
 
 
 class DeprecatedOptionsCommand(click.Command):
-    """A custom command that can be used to mark options as deprecated."""
+    """A custom command that can be used to mark options as deprecated.
+
+    References
+    ----------------
+
+    Adopted from  https://stackoverflow.com/a/50402799/13775459
+    """
 
     def make_parser(self, ctx):
         """Hook 'make_parser' and during processing check the name
@@ -77,8 +88,10 @@ class DeprecatedOptionsCommand(click.Command):
                         del frame
 
                     if opt in deprecated:
-                        msg = "Option '{}' will be replaced by '{}'."
-                        warnings.warn(msg.format(opt, preferred), FutureWarning)
+                        click.secho(
+                            f"Option '{opt}' will be replaced by '{preferred}'.",
+                            **MsgStyle.WARN,
+                        )
                     return orig_process(value, state)
 
                 return process


### PR DESCRIPTION
Within this pull request, I've reduced the length of the CLI option names and modified the associated tests accordingly. For instance, `--sensor-id` has been changed to `--sensor`, `--account-id` is now `--account`, and `--user-id` has been updated to `--user`, etc.