### PR TITLE
fix: allow showing beliefs for sensors with non-unique names

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -3,6 +3,16 @@
 FlexMeasures Changelog
 **********************
 
+
+v0.18.1 | January XX, 2024
+============================
+
+Bugfixes
+-----------
+
+* Allow showing beliefs (plot and file export) via the CLI for sensors with non-unique names [see `PR #947 <https://github.com/FlexMeasures/flexmeasures/pull/947>`_]
+
+
 v0.18.0 | December 23, 2023
 ============================
 

--- a/flexmeasures/cli/data_show.py
+++ b/flexmeasures/cli/data_show.py
@@ -29,7 +29,7 @@ from flexmeasures.data.schemas.sources import DataSourceIdField
 from flexmeasures.data.schemas.times import AwareDateTimeField, DurationField
 from flexmeasures.data.services.time_series import simplify_index
 from flexmeasures.utils.time_utils import determine_minimum_resampling_resolution
-from flexmeasures.cli.utils import MsgStyle
+from flexmeasures.cli.utils import MsgStyle, validate_unique
 from flexmeasures.utils.coding_utils import delete_key_recursive
 
 
@@ -377,7 +377,6 @@ def chart(
         assets = []
 
     for entity in sensors + assets:
-
         entity_type = "sensor"
 
         if isinstance(entity, GenericAsset):
@@ -441,6 +440,7 @@ def chart(
     "sensors",
     required=True,
     multiple=True,
+    callback=validate_unique,
     type=SensorIdField(),
     help="ID of sensor(s). This argument can be given multiple times.",
 )

--- a/flexmeasures/cli/utils.py
+++ b/flexmeasures/cli/utils.py
@@ -125,3 +125,12 @@ def get_timerange_from_flag(
         )  # get first day of previous year
 
     return start, end
+
+
+def validate_unique(ctx, param, value):
+    """Callback function to ensure multiple values are unique."""
+    if value is not None:
+        # Check if all values are unique
+        if len(value) != len(set(value)):
+            raise click.BadParameter("Values must be unique.")
+    return value

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -632,7 +632,7 @@ class TimedBelief(db.Model, tb.TimedBeliefDBMixin):
         :param one_deterministic_belief_per_event: only return a single value per event (no probabilistic distribution and only 1 source)
         :param one_deterministic_belief_per_event_per_source: only return a single value per event per source (no probabilistic distribution)
         :param resolution: Optional timedelta or pandas freqstr used to resample the results **
-        :param sum_multiple: if True, sum over multiple sensors; otherwise, return a dictionary with sensor names as key, each holding a BeliefsDataFrame as its value
+        :param sum_multiple: if True, sum over multiple sensors; otherwise, return a dictionary with sensors as key, each holding a BeliefsDataFrame as its value
 
         *  If user_source_ids is specified, the "user" source type is automatically included (and not excluded).
            Somewhat redundant, though still allowed, is to set both source_types and exclude_source_types.
@@ -722,7 +722,7 @@ class TimedBelief(db.Model, tb.TimedBeliefDBMixin):
                 # Workaround (2nd half) for https://github.com/FlexMeasures/flexmeasures/issues/484
                 bdf = bdf[bdf.event_starts >= event_starts_after]
                 bdf = bdf[bdf.event_ends <= event_ends_before]
-            bdf_dict[bdf.sensor.name] = bdf
+            bdf_dict[bdf.sensor] = bdf
 
         if sum_multiple:
             return aggregate_values(bdf_dict)

--- a/flexmeasures/data/tests/test_queries.py
+++ b/flexmeasures/data/tests/test_queries.py
@@ -45,7 +45,7 @@ def test_collect_power(db, app, query_start, query_end, num_values, setup_test_d
     data = TimedBelief.query.filter(TimedBelief.sensor_id == wind_device_1.id).all()
     print(data)
     bdf: tb.BeliefsDataFrame = TimedBelief.search(
-        wind_device_1.name,
+        wind_device_1,
         event_starts_after=query_start,
         event_ends_before=query_end,
     )


### PR DESCRIPTION
## Description

- Internally, sensor objects rather than sensor names are now used as keys in a dict that holds data for multiple sensors.
- IDs are automatically shown (together with a warning) in case of sensors with non-unique names.
- It is no longer possible to accidentally pass the same sensor ID multiple times when calling `flexmeasures show beliefs`.
- In `flexmeasures show beliefs`, IDs can be toggled to always show in legend labels and column headers using the new flag `--include-ids`.

## How to test

Trigger an error by passing ID 2 twice:

```
flexmeasures show beliefs --sensor-id 1 --sensor-id 2 --sensor-id 2 --timezone Europe/Amsterdam --start 2022-11-01T00:00+01 --duration P1D --to-file temp.csv
```

Include IDs in the plot's legend labels and the file's column headers, only in case of non-unique sensor names:

```
flexmeasures show beliefs --sensor-id 1 --sensor-id 2 --sensor-id 3 --timezone Europe/Amsterdam --start 2022-11-01T00:00+01 --duration P1D --to-file temp.csv
```

Always include IDs in labels and headers:

```
flexmeasures show beliefs --sensor-id 1 --sensor-id 2 --sensor-id 3 --timezone Europe/Amsterdam --start 2022-11-01T00:00+01 --duration P1D --to-file temp.csv --include-ids
```


## Related Items

Closes #867.

> This has the potential to break other things, though, so we should be careful in deprecating the use of sensor names as dict keys (consider e.g. that adding another option to search_beliefs to toggle the new behaviour is safer than modifying existing function arguments or return values).

I checked the use of sensor names as dict keys, and found it only to be used by legacy FM code that has already been removed (analytics page, for example). Only 1 FM plugin that I know off is relying on this feature, for which I'll make a separate PR.

- [ ] Create plugin issue