### PR TITLE
fix: 'str' object has no attribute 'removesuffix' in Python 3.8

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -16,6 +16,8 @@ Infrastructure / Support
 Bugfixes
 -----------
 
+* Added custom `removesuffix` function to support Python 3.8; consider transitioning to `str.removesuffix` after dropping support for Python 3.8. [see `PR #1001 <https://github.com/FlexMeasures/flexmeasures/pull/950>`_]
+
 
 v0.18.0 | December 23, 2023
 ============================

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -20,8 +20,6 @@ Infrastructure / Support
 Bugfixes
 -----------
 
-* Added custom `removesuffix` function to support Python 3.8; consider transitioning to `str.removesuffix` after dropping support for Python 3.8. [see `PR #1001 <https://github.com/FlexMeasures/flexmeasures/pull/950>`_]
-
 
 v0.18.1 | January XX, 2024
 ============================
@@ -31,6 +29,7 @@ Bugfixes
 
 * Allow showing beliefs (plot and file export) via the CLI for sensors with non-unique names [see `PR #947 <https://github.com/FlexMeasures/flexmeasures/pull/947>`_]
 * Added Redis credentials to the Docker Compose configuration for the web server to ensure proper interaction with the Redis queue [see `PR #945 <https://github.com/FlexMeasures/flexmeasures/pull/945>`_]
+* Fix API version listing (GET /api/v3_0) for hosts running on Python 3.8 [see `PR #917 <https://github.com/FlexMeasures/flexmeasures/pull/917>`_ and `PR #950 <https://github.com/FlexMeasures/flexmeasures/pull/950>`_]
 
 
 v0.18.0 | December 23, 2023
@@ -74,7 +73,7 @@ Bugfixes
 * Show `Assets`, `Users`, `Tasks` and `Accounts` pages in the navigation bar for the `admin-reader` role [see `PR #900 <https://github.com/FlexMeasures/flexmeasures/pull/900>`_]
 * Reduce worker logs when datetime exceeds the end of the schedule [see `PR #918 <https://github.com/FlexMeasures/flexmeasures/pull/918>`_]
 * Fix infeasible problem due to incorrect estimation of the big-M value [see `PR #905 <https://github.com/FlexMeasures/flexmeasures/pull/905>`_]
-* Fix API version listing (GET /api/v3_0) for hosts running on Python 3.8 [see `PR #917 <https://github.com/FlexMeasures/flexmeasures/pull/917>`_]
+* [Incomplete fix; full fix in v0.18.1] Fix API version listing (GET /api/v3_0) for hosts running on Python 3.8 [see `PR #917 <https://github.com/FlexMeasures/flexmeasures/pull/917>`_]
 
 
 v0.17.0 | November 8, 2023

--- a/flexmeasures/api/v3_0/public.py
+++ b/flexmeasures/api/v3_0/public.py
@@ -33,7 +33,7 @@ class ServicesAPI(FlaskView):
                 )
                 stripped_url = removeprefix(url, self.route_base)
                 full_url = (
-                    request.url_root.removesuffix("/") + url
+                    removesuffix(request.url_root, "/") + url
                     if url.startswith("/")
                     else request.url_root + url
                 )
@@ -85,5 +85,17 @@ def removeprefix(text: str, prefix: str) -> str:
     """
     if text.startswith(prefix):
         return text[len(prefix) :]
+    else:
+        return text
+
+
+def removesuffix(text: str, suffix: str) -> str:
+    """Remove a suffix from a text.
+
+    todo: use text.removesuffix(suffix) instead of this method, after dropping support for Python 3.8
+        See https://docs.python.org/3.9/library/stdtypes.html#str.removesuffix
+    """
+    if text.endswith(suffix):
+        return text[: -len(suffix)]
     else:
         return text


### PR DESCRIPTION
Introduced a custom `removesuffix` function for removing a suffix from the URL, catering to Python 3.8 users since `text.removesuffix` is not a built-in feature in Python 3.8. Consider deprecating this function after discontinuing support for Python 3.8.