### PR TITLE
add parent_asset_id to GenericAssetSchema and turn the type to int

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -30,6 +30,8 @@ Bugfixes
 * Allow showing beliefs (plot and file export) via the CLI for sensors with non-unique names [see `PR #947 <https://github.com/FlexMeasures/flexmeasures/pull/947>`_]
 * Added Redis credentials to the Docker Compose configuration for the web server to ensure proper interaction with the Redis queue [see `PR #945 <https://github.com/FlexMeasures/flexmeasures/pull/945>`_]
 * Fix API version listing (GET /api/v3_0) for hosts running on Python 3.8 [see `PR #917 <https://github.com/FlexMeasures/flexmeasures/pull/917>`_ and `PR #950 <https://github.com/FlexMeasures/flexmeasures/pull/950>`_]
+* Fix the validation of the option ``--parent-asset`` of command ``flexmeasures add asset`` [see `PR #959 <https://github.com/FlexMeasures/flexmeasures/pull/959>`_]
+
 
 
 v0.18.0 | December 23, 2023

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -4,10 +4,17 @@
 FlexMeasures CLI Changelog
 **********************
 
+since v0.18.1 | January XX, 2023
+=======================================
+
+* Fix the validation of the option ``--parent-asset`` of command ``flexmeasures add asset``.
+
+
 since v0.17.0 | November 8, 2023
 =======================================
 
 * Add ``--consultancy`` option to ``flexmeasures add account`` to create a consultancy relationship with another account.
+
 
 since v0.16.0 | September 29, 2023
 =======================================

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -67,7 +67,6 @@ from flexmeasures.data.schemas.units import QuantityField
 from flexmeasures.data.schemas.generic_assets import (
     GenericAssetSchema,
     GenericAssetTypeSchema,
-    GenericAssetIdField,
 )
 from flexmeasures.data.models.generic_assets import GenericAsset, GenericAssetType
 from flexmeasures.data.models.user import User
@@ -372,9 +371,9 @@ def add_asset_type(**args):
 )
 @click.option(
     "--parent-asset",
-    "parent_asset",
+    "parent_asset_id",
     required=False,
-    type=GenericAssetIdField(),
+    type=int,
     help="Parent of this asset. The entity needs to exists on the database.",
 )
 def add_asset(**args):

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -330,10 +330,10 @@ def add_sensor(**args):
     type=str,
     help="Description (useful to explain acronyms, for example).",
 )
-def add_asset_type(**args):
+def add_asset_type(**kargs):
     """Add an asset type."""
-    check_errors(GenericAssetTypeSchema().validate(args))
-    generic_asset_type = GenericAssetType(**args)
+    check_errors(GenericAssetTypeSchema().validate(kargs))
+    generic_asset_type = GenericAssetType(**kargs)
     db.session.add(generic_asset_type)
     db.session.commit()
     click.secho(

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -330,10 +330,10 @@ def add_sensor(**args):
     type=str,
     help="Description (useful to explain acronyms, for example).",
 )
-def add_asset_type(**kargs):
+def add_asset_type(**kwargs):
     """Add an asset type."""
-    check_errors(GenericAssetTypeSchema().validate(kargs))
-    generic_asset_type = GenericAssetType(**kargs)
+    check_errors(GenericAssetTypeSchema().validate(kwargs))
+    generic_asset_type = GenericAssetType(**kwargs)
     db.session.add(generic_asset_type)
     db.session.commit()
     click.secho(

--- a/flexmeasures/data/schemas/generic_assets.py
+++ b/flexmeasures/data/schemas/generic_assets.py
@@ -71,6 +71,14 @@ class GenericAssetSchema(ma.SQLAlchemySchema):
                 f"GenericAssetType with id {generic_asset_type_id} doesn't exist."
             )
 
+    @validates("parent_asset_id")
+    def validate_parent_asset(self, parent_asset_id: int):
+        parent_asset = GenericAsset.query.get(parent_asset_id)
+        if not parent_asset:
+            raise ValidationError(
+                f"Parent GenericAsset with id {parent_asset_id} doesn't exist."
+            )
+
     @validates("account_id")
     def validate_account(self, account_id: int | None):
         if account_id is None and (

--- a/flexmeasures/data/schemas/generic_assets.py
+++ b/flexmeasures/data/schemas/generic_assets.py
@@ -72,12 +72,13 @@ class GenericAssetSchema(ma.SQLAlchemySchema):
             )
 
     @validates("parent_asset_id")
-    def validate_parent_asset(self, parent_asset_id: int):
-        parent_asset = GenericAsset.query.get(parent_asset_id)
-        if not parent_asset:
-            raise ValidationError(
-                f"Parent GenericAsset with id {parent_asset_id} doesn't exist."
-            )
+    def validate_parent_asset(self, parent_asset_id: int | None):
+        if parent_asset_id is not None:
+            parent_asset = GenericAsset.query.get(parent_asset_id)
+            if not parent_asset:
+                raise ValidationError(
+                    f"Parent GenericAsset with id {parent_asset_id} doesn't exist."
+                )
 
     @validates("account_id")
     def validate_account(self, account_id: int | None):


### PR DESCRIPTION
At some point, I mixed up the `AssetIDField` way of validating the CLI inputs of the command `fm add asset` with the validation using a Schema.

This PR fixes that issue by changing the field type to int and moving the validation to the schema.

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
