### PR TITLE
Cache-busting to automatically fix table navigation for 0.18 UI changes

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -21,6 +21,12 @@ Bugfixes
 -----------
 
 
+v0.18.2 | January xx, 2024
+============================
+
+* Automatically update table navigation in the UI without requiring users to hard refresh their browser [see `PR #961 <https://github.com/FlexMeasures/flexmeasures/pull/961>`_]
+
+
 v0.18.1 | January 15, 2024
 ============================
 

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -33,7 +33,7 @@
     <link href="https://cdn.jsdelivr.net/npm/ion-rangeslider@2.3.1/css/ion.rangeSlider.css"
         rel="stylesheet" />
     <!-- Custom CSS -->
-    <link href="{{ url_for('flexmeasures_ui.static', filename='css/flexmeasures.css') }}" rel="stylesheet" />
+    <link href="{{ url_for('flexmeasures_ui.static', filename='css/flexmeasures.css') }}?v={{ flexmeasures_version }}" rel="stylesheet" />
     {% if active_page == "tasks" %}
     <link href="{{ url_for('rq_dashboard.static', filename='css/main.css') }}" rel="stylesheet">
     <link href="{{ url_for('flexmeasures_ui.static', filename='css/external/rq-dashboard-bootstrap.min.css') }}" rel="stylesheet" />

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -660,7 +660,7 @@
 
     <!-- Custom scripts -->
     <script src="{{ url_for('flexmeasures_ui.static', filename='js/swiped-events.min.js') }}"></script>
-    <script src="{{ url_for('flexmeasures_ui.static', filename='js/flexmeasures.js') }}"></script>
+    <script src="{{ url_for('flexmeasures_ui.static', filename='js/flexmeasures.js') }}?v={{ flexmeasures_version }}"></script>
 
     {% endblock scripts %}
 


### PR DESCRIPTION
## Description

Cache-busting to ensure the UI reloads internal CSS and JS with every new FlexMeasures release.

- Cache-bust `flexmeasures.css`
- Cache-bust `flexmeasures.js`

## Look & Feel

The 0.18.0 release introduced changes in table navigation that renders the assets page, users and accounts pages unnavigable, unless these caches are busted.

Without this PR, the UI user needs to hit a hard refresh on any of our UI pages, which reloads the styling and scripting as imported in our `base.html`.

## Follow-up

I intend to backport this to 0.18.x.