### PR TITLE
Parallelize sensor search

### DIFF
--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -389,22 +389,24 @@ class GenericAsset(db.Model, AuthModelMixin):
         :param as_json: return beliefs in JSON format (e.g. for use in charts) rather than as BeliefsDataFrame
         :returns: dictionary of BeliefsDataFrames or JSON string (if as_json is True)
         """
-        bdf_dict = {}
+        from flexmeasures.data.models.time_series import TimedBelief
+
         if sensors is None:
             sensors = self.sensors
-        for sensor in sensors:
-            bdf_dict[sensor] = sensor.search_beliefs(
-                event_starts_after=event_starts_after,
-                event_ends_before=event_ends_before,
-                beliefs_after=beliefs_after,
-                beliefs_before=beliefs_before,
-                horizons_at_least=horizons_at_least,
-                horizons_at_most=horizons_at_most,
-                source=source,
-                most_recent_beliefs_only=most_recent_beliefs_only,
-                most_recent_events_only=most_recent_events_only,
-                one_deterministic_belief_per_event_per_source=True,
-            )
+        bdf_dict = TimedBelief.search(
+            sensors=sensors,
+            event_starts_after=event_starts_after,
+            event_ends_before=event_ends_before,
+            beliefs_after=beliefs_after,
+            beliefs_before=beliefs_before,
+            horizons_at_least=horizons_at_least,
+            horizons_at_most=horizons_at_most,
+            source=source,
+            most_recent_beliefs_only=most_recent_beliefs_only,
+            most_recent_events_only=most_recent_events_only,
+            one_deterministic_belief_per_event_per_source=True,
+            sum_multiple=False,
+        )
         if as_json:
             from flexmeasures.data.services.time_series import simplify_index
 

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional, Tuple, List, Union
 import json
-import multiprocessing
 
 from flask import current_app
 from flask_security import current_user
@@ -390,24 +389,22 @@ class GenericAsset(db.Model, AuthModelMixin):
         :param as_json: return beliefs in JSON format (e.g. for use in charts) rather than as BeliefsDataFrame
         :returns: dictionary of BeliefsDataFrames or JSON string (if as_json is True)
         """
+        bdf_dict = {}
         if sensors is None:
             sensors = self.sensors
-        search_kwargs = dict(
-            event_starts_after=event_starts_after,
-            event_ends_before=event_ends_before,
-            beliefs_after=beliefs_after,
-            beliefs_before=beliefs_before,
-            horizons_at_least=horizons_at_least,
-            horizons_at_most=horizons_at_most,
-            source=source,
-            most_recent_beliefs_only=most_recent_beliefs_only,
-            most_recent_events_only=most_recent_events_only,
-            one_deterministic_belief_per_event_per_source=True,
-        )
-        n = 4
-        with multiprocessing.Pool(processes=n) as pool:
-            results = pool.starmap(search_wrapper, [(s, search_kwargs) for s in sensors])
-        bdf_dict = dict(results)
+        for sensor in sensors:
+            bdf_dict[sensor] = sensor.search_beliefs(
+                event_starts_after=event_starts_after,
+                event_ends_before=event_ends_before,
+                beliefs_after=beliefs_after,
+                beliefs_before=beliefs_before,
+                horizons_at_least=horizons_at_least,
+                horizons_at_most=horizons_at_most,
+                source=source,
+                most_recent_beliefs_only=most_recent_beliefs_only,
+                most_recent_events_only=most_recent_events_only,
+                one_deterministic_belief_per_event_per_source=True,
+            )
         if as_json:
             from flexmeasures.data.services.time_series import simplify_index
 
@@ -649,17 +646,3 @@ def get_center_location_of_assets(user: Optional[User]) -> Tuple[float, float]:
     ):
         return 52.366, 4.904  # Amsterdam, NL
     return locations[0].latitude, locations[0].longitude
-
-
-def search_wrapper(
-    s,
-    search_kwargs,
-):
-    # db_uri = current_app.config.get("SQLALCHEMY_DATABASE_URI")
-    # engine = create_engine(db_uri)
-    # Session = sessionmaker(bind=engine)
-    # session = Session()
-    # search_kwargs["session"] = session
-
-    bdf = s.search_beliefs(**search_kwargs)
-    return bdf.sensor, bdf


### PR DESCRIPTION
Tech spike to increase chart loading speed through parallelization. I'm using `n=4` parallel processes here, but that could become a config setting.

@Ahmad-Wahid could you do a speed benchmark on this branch (compared to main) for me? Some manual tests of mine (locally) suggested an asset chart with 4 sensors and 1 week of data loads about twice as fast. I'm interested to see whether you can reproduce that result on a cloud server, and how the speed-up factor would change with a larger time frame and with more sensors.
