### PR TITLE
use storage efficiency quantity or sensor

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -12,6 +12,7 @@ v0.19.0 | February xx, 2024
 New features
 -------------
 
+* Support for using storage efficiency data from a sensor in storage scheduler [see `PR #965 <https://github.com/FlexMeasures/flexmeasures/pull/965>`_]
 * Support a less verbose way of setting the same :abbr:`SoC (state of charge)` constraint for a given time window [see `PR #899 <https://github.com/FlexMeasures/flexmeasures/pull/899>`_]
 
 Infrastructure / Support

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -12,7 +12,7 @@ v0.19.0 | February xx, 2024
 New features
 -------------
 
-* Support for using storage efficiency data from a sensor in storage scheduler [see `PR #965 <https://github.com/FlexMeasures/flexmeasures/pull/965>`_]
+* Support for defining the storage efficiency as a sensor or quantity for the ``StorageScheduler`` [see `PR #965 <https://github.com/FlexMeasures/flexmeasures/pull/965>`_]
 * Support a less verbose way of setting the same :abbr:`SoC (state of charge)` constraint for a given time window [see `PR #899 <https://github.com/FlexMeasures/flexmeasures/pull/899>`_]
 
 Infrastructure / Support

--- a/flexmeasures/data/models/planning/tests/conftest.py
+++ b/flexmeasures/data/models/planning/tests/conftest.py
@@ -313,13 +313,19 @@ def add_stock_delta(db, add_battery_assets, setup_sources) -> dict[str, Sensor]:
 @pytest.fixture(scope="module")
 def add_storage_efficiency(db, add_battery_assets, setup_sources) -> dict[str, Sensor]:
     """
-    Different usage forecast sensors are defined:
-        - "delta fails": the usage forecast exceeds the maximum power.
-        - "delta": the usage forecast can be fulfilled just right. This coincides with the schedule resolution.
-        - "delta hourly": the event resolution is changed to test that the schedule is still feasible.
-                          This has a greater resolution.
-        - "delta 5min": the event resolution is reduced even more. This sensor has a resolution smaller than that used
-                        for the scheduler.
+    Fixture to add storage efficiency sensors and their beliefs to the database.
+
+    This fixture creates several storage efficiency sensors with different characteristics
+    and attaches them to a test battery asset.
+
+    The sensor specifications include:
+    - "storage efficiency 90%" with 15-minute resolution and 90% efficiency.
+    - "storage efficiency 110%" with 15-minute resolution and 110% efficiency.
+    - "storage efficiency negative" with 15-minute resolution and -90% efficiency.
+    - "storage efficiency hourly" with 1-hour resolution and 90% efficiency.
+
+    The function creates a day's worth of test data for each sensor starting from
+    January 1, 2015.
     """
 
     battery = add_battery_assets["Test battery"]

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -1698,9 +1698,10 @@ def test_battery_efficiency_quantity(
         ("storage efficiency 90%", 0.9),  # regular value
         ("storage efficiency 110%", 1),  # clip values that exceed 100%
         ("storage efficiency negative", 0),  # clip negative values
-        ("storage efficiency hourly", 0.9)  # this one should fail.
+        ("storage efficiency hourly", 0.974003)  # this one fails.
         # We should resample making sure that the efficiencies are equivalent.
         # For example, 90% defined in 1h is equivalent to 97% in a 15min period (0.97^4≈0.9).
+        # Plans to support resampling efficiencies can be found here https://github.com/FlexMeasures/flexmeasures/issues/720
     ],
 )
 def test_battery_storage_efficiency_sensor(

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -1635,3 +1635,94 @@ def test_battery_stock_delta_quantity(add_battery_assets, gain, usage, expected_
         assert all(scheduler_info[5][0]["stock delta"] == expected_delta)
     else:
         assert all(scheduler_info[5][0]["stock delta"].isna())
+
+
+@pytest.mark.parametrize(
+    "efficiency,expected_efficiency",
+    [
+        ("100%", 1),
+        (
+            "110%",
+            1,
+        ),  # value exceeding the upper bound (100%). It clips the values above 100%.
+        (
+            "90%",
+            0.9,
+        ),  # percentage unit to dimensionless units within the [0,1] interval
+        (0.9, 0.9),  # numeric values are interpreted as dimensionless
+        (
+            None,
+            None,
+        ),  # if the `storage-efficiency` is not defined, the constraint dataframe
+        # uses NaN.
+    ],
+)
+def test_battery_efficiency_quantity(
+    add_battery_assets, efficiency, expected_efficiency
+):
+    _, battery = get_sensors_from_db(add_battery_assets)
+    tz = pytz.timezone("Europe/Amsterdam")
+    start = tz.localize(datetime(2015, 1, 1))
+    end = tz.localize(datetime(2015, 1, 2))
+    resolution = timedelta(minutes=15)
+    flex_model = {
+        "soc-max": 2,
+        "soc-min": 0,
+        "roundtrip-efficiency": 1,
+    }
+
+    if efficiency is not None:
+        flex_model["storage-efficiency"] = efficiency
+
+    scheduler: Scheduler = StorageScheduler(
+        battery, start, end, resolution, flex_model=flex_model
+    )
+    scheduler_info = scheduler._prepare()
+
+    if efficiency is not None:
+        assert all(scheduler_info[5][0]["efficiency"] == expected_efficiency)
+    else:
+        assert all(scheduler_info[5][0]["efficiency"].isna())
+
+
+@pytest.mark.parametrize(
+    "efficiency_sensor_name, expected_efficiency",
+    [
+        ("storage efficiency 90%", 0.9),  # regular value
+        ("storage efficiency 110%", 1),  # clip values that exceed 100%
+        ("storage efficiency negative", 0),  # clip negative values
+        ("storage efficiency hourly", 0.9)  # this one should fail.
+        # We should resample making sure that the efficiencies are equivalent.
+        # For example, 90% defined in 1h is equivalent to 97% in a 15min period (0.97^4≈0.9).
+    ],
+)
+def test_battery_storage_efficiency_sensor(
+    add_battery_assets,
+    add_storage_efficiency,
+    efficiency_sensor_name,
+    expected_efficiency,
+):
+    _, battery = get_sensors_from_db(add_battery_assets)
+    tz = pytz.timezone("Europe/Amsterdam")
+    start = tz.localize(datetime(2015, 1, 1))
+    end = tz.localize(datetime(2015, 1, 2))
+    resolution = timedelta(minutes=15)
+    storage_efficiency_sensor_obj = add_storage_efficiency[efficiency_sensor_name]
+
+    scheduler: Scheduler = StorageScheduler(
+        battery,
+        start,
+        end,
+        resolution,
+        flex_model={
+            "soc-max": 2,
+            "soc-min": 0,
+            "roundtrip-efficiency": 1,
+            "storage-efficiency": {"sensor": storage_efficiency_sensor_obj.id},
+            "production-capacity": "0kW",
+            "soc-at-start": 0,
+        },
+    )
+
+    scheduler_info = scheduler._prepare()
+    assert all(scheduler_info[5][0]["efficiency"] == expected_efficiency)

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -1660,6 +1660,13 @@ def test_battery_stock_delta_quantity(add_battery_assets, gain, usage, expected_
 def test_battery_efficiency_quantity(
     add_battery_assets, efficiency, expected_efficiency
 ):
+    """
+    Test to ensure correct handling of storage efficiency quantities in the StorageScheduler.
+
+    The test covers the handling of percentage values, dimensionless numeric values, and the
+    case where the efficiency is not defined.
+    """
+
     _, battery = get_sensors_from_db(add_battery_assets)
     tz = pytz.timezone("Europe/Amsterdam")
     start = tz.localize(datetime(2015, 1, 1))
@@ -1702,6 +1709,12 @@ def test_battery_storage_efficiency_sensor(
     efficiency_sensor_name,
     expected_efficiency,
 ):
+    """
+    Test the handling of different storage efficiency sensors in the StorageScheduler.
+
+    It checks if the scheduler correctly handles regular values, values exceeding 100%, negative values,
+    and values with different resolutions compared to the scheduling resolution.
+    """
     _, battery = get_sensors_from_db(add_battery_assets)
     tz = pytz.timezone("Europe/Amsterdam")
     start = tz.localize(datetime(2015, 1, 1))

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -1698,7 +1698,7 @@ def test_battery_efficiency_quantity(
         ("storage efficiency 90%", 0.9),  # regular value
         ("storage efficiency 110%", 1),  # clip values that exceed 100%
         ("storage efficiency negative", 0),  # clip negative values
-        ("storage efficiency hourly", 0.974003)  # this one fails.
+        # ("storage efficiency hourly", 0.974003)  # this one fails.
         # We should resample making sure that the efficiencies are equivalent.
         # For example, 90% defined in 1h is equivalent to 97% in a 15min period (0.97^4≈0.9).
         # Plans to support resampling efficiencies can be found here https://github.com/FlexMeasures/flexmeasures/issues/720

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -1698,7 +1698,13 @@ def test_battery_efficiency_quantity(
         ("storage efficiency 90%", 0.9),  # regular value
         ("storage efficiency 110%", 1),  # clip values that exceed 100%
         ("storage efficiency negative", 0),  # clip negative values
-        # ("storage efficiency hourly", 0.974003)  # this one fails.
+        pytest.param(
+            "storage efficiency hourly",
+            0.974003,
+            marks=pytest.mark.xfail(
+                reason="resampling storage efficiency is not supported"
+            ),
+        ),  # this one fails.
         # We should resample making sure that the efficiencies are equivalent.
         # For example, 90% defined in 1h is equivalent to 97% in a 15min period (0.97^4≈0.9).
         # Plans to support resampling efficiencies can be found here https://github.com/FlexMeasures/flexmeasures/issues/720

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -190,7 +190,9 @@ class StorageFlexModelSchema(Schema):
         data_key="roundtrip-efficiency", required=False
     )
 
-    storage_efficiency = EfficiencyField(data_key="storage-efficiency")
+    storage_efficiency = QuantityOrSensor(
+        "%", default_src_unit="dimensionless", data_key="storage-efficiency"
+    )
     prefer_charging_sooner = fields.Bool(data_key="prefer-charging-sooner")
 
     soc_gain = fields.List(QuantityOrSensor("MW"), data_key="soc-gain", required=False)
@@ -275,10 +277,10 @@ class StorageFlexModelSchema(Schema):
                     maximum["value"] /= 1000.0
             data["soc_unit"] = "MWh"
 
-        # Convert efficiencies to dimensionless (to the (0,1] range)
-        efficiency_fields = ("storage_efficiency", "roundtrip_efficiency")
-        for field in efficiency_fields:
-            if data.get(field) is not None:
-                data[field] = data[field].to(ur.Quantity("dimensionless")).magnitude
+        # Convert efficiency to dimensionless (to the (0,1] range)
+        if data.get("roundtrip_efficiency") is not None:
+            data["roundtrip_efficiency"] = (
+                data["roundtrip_efficiency"].to(ur.Quantity("dimensionless")).magnitude
+            )
 
         return data

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -237,6 +237,16 @@ class StorageFlexModelSchema(Schema):
                 f"Target datetime exceeds {max_server_datetime}. Maximum scheduling horizon is {max_server_horizon}."
             )
 
+    @validates("storage_efficiency")
+    def validate_storage_efficiency_resolution(self, unit: Sensor | ur.Quantity):
+        if (
+            isinstance(unit, Sensor)
+            and unit.event_resolution != self.sensor.event_resolution
+        ):
+            raise ValidationError(
+                "Event resolution of the storage efficiency and the power sensor don't match. Resampling the storage efficiency is not supported."
+            )
+
     @validates_schema
     def check_redundant_efficiencies(self, data: dict, **kwargs):
         """

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -97,6 +97,11 @@ class QuantityOrSensor(MarshmallowClickMixin, fields.Field):
     def __init__(
         self, to_unit: str, default_src_unit: str | None = None, *args, **kwargs
     ):
+        """
+        :param to_unit: unit in which the sensor or quantity should be convertible to
+        :param default_src_unit: what unit to use in case of getting a numeric value
+        """
+
         super().__init__(*args, **kwargs)
         self.to_unit = ur.Quantity(to_unit)
         self.default_src_unit = default_src_unit

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -94,9 +94,12 @@ class SensorIdField(MarshmallowClickMixin, fields.Int):
 
 
 class QuantityOrSensor(MarshmallowClickMixin, fields.Field):
-    def __init__(self, to_unit: str, *args, **kwargs):
+    def __init__(
+        self, to_unit: str, default_src_unit: str | None = None, *args, **kwargs
+    ):
         super().__init__(*args, **kwargs)
         self.to_unit = ur.Quantity(to_unit)
+        self.default_src_unit = default_src_unit
 
     @with_appcontext_if_needed()
     def _deserialize(
@@ -132,6 +135,12 @@ class QuantityOrSensor(MarshmallowClickMixin, fields.Field):
                     f"Cannot convert value `{value}` to '{self.to_unit}'"
                 ) from e
         else:
+
+            if self.default_src_unit is not None:
+                return self._deserialize(
+                    f"{value} {self.default_src_unit}", attr, obj, **kwargs
+                )
+
             raise FMValidationError(
                 f"Unsupported value type. `{type(value)}` was provided but only dict and str are supported."
             )


### PR DESCRIPTION
## Description

This PR allows the user to use the storage efficiency from a sensor.

There is a detail to be discussed. In case of a fix value, we assume that the timeframe of the efficiency corresponds to the resolution of the sensor. In case of the sensor, this PR assumes a similar thing. 

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
