### PR TITLE
show child assets in the asset page

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -12,6 +12,7 @@ v0.19.0 | February xx, 2024
 New features
 -------------
 
+* List child assets on the asset page [see `PR #967 <https://github.com/FlexMeasures/flexmeasures/pull/967>`_]
 * Support a less verbose way of setting the same :abbr:`SoC (state of charge)` constraint for a given time window [see `PR #899 <https://github.com/FlexMeasures/flexmeasures/pull/899>`_]
 
 Infrastructure / Support

--- a/flexmeasures/api/v3_0/tests/test_assets_api.py
+++ b/flexmeasures/api/v3_0/tests/test_assets_api.py
@@ -103,6 +103,23 @@ def test_get_assets(
         assert turbine["account_id"] == setup_accounts["Supplier"].id
 
 
+@pytest.mark.parametrize("requesting_user", ["test_admin_user@seita.nl"], indirect=True)
+def test_get_asset_with_children(client, add_asset_with_children, requesting_user):
+    """
+    Get asset `parent` with children `child_1` and `child_2`.
+    We expect the response to be the serialized asset including its
+    child assets in the field `child_assets`.
+    """
+
+    parent = add_asset_with_children["parent"]
+    get_assets_response = client.get(
+        url_for("AssetAPI:fetch_one", id=parent.id),
+    )
+    print("Server responded with:\n%s" % get_assets_response.json)
+    assert get_assets_response.status_code == 200
+    assert len(get_assets_response.json["child_assets"]) == 2
+
+
 @pytest.mark.parametrize("requesting_user", [None], indirect=True)
 def test_get_public_assets_noauth(
     client, setup_api_test_data, setup_accounts, requesting_user

--- a/flexmeasures/data/schemas/generic_assets.py
+++ b/flexmeasures/data/schemas/generic_assets.py
@@ -43,6 +43,7 @@ class GenericAssetSchema(ma.SQLAlchemySchema):
     generic_asset_type_id = fields.Integer(required=True)
     attributes = JSON(required=False)
     parent_asset_id = fields.Int(required=False, allow_none=True)
+    child_assets = ma.Nested("GenericAssetSchema", many=True, dumb_only=True)
 
     class Meta:
         model = GenericAsset

--- a/flexmeasures/ui/crud/assets.py
+++ b/flexmeasures/ui/crud/assets.py
@@ -280,6 +280,7 @@ class AssetCrudUI(FlaskView):
             mapboxAccessToken=current_app.config.get("MAPBOX_ACCESS_TOKEN", ""),
             user_can_create_assets=user_can_create_assets(),
             user_can_delete_asset=user_can_delete(asset),
+            children=GenericAsset.query.get(asset.id).child_assets,
         )
 
     @login_required

--- a/flexmeasures/ui/static/css/flexmeasures.css
+++ b/flexmeasures/ui/static/css/flexmeasures.css
@@ -1515,12 +1515,13 @@ body .dataTables_wrapper .dataTables_paginate .paginate_button.current:hover {
 
 
 /* ---- Sensors on asset page ---- */
+/* [id^=DataTables_Table] [id$=filter] matches all the ids starting with DataTables_Table and ending with filter */
 
-.sensors-asset #DataTables_Table_0_wrapper {
+.sensors-asset .dataTables_wrapper {
     margin-top: 30px;
 }
 
-.sensors-asset #DataTables_Table_0_filter input {
+.sensors-asset .dataTables_filter input {
     border: var(--light-gray) 1px solid;
     padding: 10px;
     outline: none;
@@ -1531,7 +1532,7 @@ body .dataTables_wrapper .dataTables_paginate .paginate_button.current:hover {
     -o-transition: .4s;
 }
 
-.sensors-asset #DataTables_Table_0_filter input:focus {
+.sensors-asset .dataTables_filter input:focus {
     box-shadow: 0 0 10px rgba(0,0,0,.1);
     border-color: var(--secondary-color);
 }

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -174,6 +174,54 @@
                     </tbody>
                 </table>
             </div>
+                
+            <div class="card">
+                <h3>All child assets for {{ asset.name }}</h3>
+
+                <table class="table table-striped table-responsive paginate nav-on-click" title="View this asset">
+                    <thead>
+                        <tr>
+                            <th><i class="left-icon">Name</i></th>
+                            <th>Location</th>
+                            <th>Asset ID</th>
+                            <th>Account</th>
+                            <th>Sensors</th>
+                            <th class="hidden">URL</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for child in children %}
+                        <tr>
+                            <td>
+                                <i class="{{ child.generic_asset_type.name | asset_icon }} left-icon">{{ child.name }}</i>
+                            </td>
+                            <td>
+                                {% if child.latitude and child.longitude %}
+                                LAT: {{ "{:,.4f}".format( child.latitude ) }} LONG:
+                                {{ "{:,.4f}".format( child.longitude ) }}
+                                {% endif %}
+                            </td>
+                            <td>
+                                {{ child.id }}
+                            </td>
+                            <td>
+                                {% if child.owner %}
+                                {{ child.owner.name }}
+                                {% else %}
+                                PUBLIC
+                                {% endif %}
+                            </td>
+                            <td>
+                                {{ child.sensors | length }}
+                            </td>
+                            <td class="hidden">
+                                /assets/{{ child.id }}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
         </div>
         <div class="col-sm-2">
             <div class="replay-container">

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -190,7 +190,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for child in children %}
+                        {% for child in asset.child_assets %}
                         <tr>
                             <td>
                                 <i class="{{ child.generic_asset_type.name | asset_icon }} left-icon">{{ child.name }}</i>

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -175,9 +175,9 @@
                 </table>
             </div>
                 
-            <div class="card">
+            <div class="sensors-asset card">
                 <h3>All child assets for {{ asset.name }}</h3>
-
+                
                 <table class="table table-striped table-responsive paginate nav-on-click" title="View this asset">
                     <thead>
                         <tr>


### PR DESCRIPTION
## Description

This PR introduces a new section to the asset page to list all the child assets of a given asset.

## Look & Feel

![image](https://github.com/FlexMeasures/flexmeasures/assets/84775131/d2dcf9e0-f44e-4291-8b30-f9c8f9809517)

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
