### PR TITLE
Chore: update dependencies for #938

### DIFF
--- a/requirements/3.10/app.txt
+++ b/requirements/3.10/app.txt
@@ -4,33 +4,33 @@
 #
 #    pip-compile --output-file=requirements/3.10/app.txt requirements/app.in
 #
-alembic==1.12.0
+alembic==1.13.1
     # via flask-migrate
-altair==5.1.1
+altair==5.2.0
     # via -r requirements/app.in
-arrow==1.2.3
+arrow==1.3.0
     # via rq-dashboard
 async-timeout==4.0.3
     # via redis
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   jsonschema
     #   referencing
-babel==2.12.1
+babel==2.14.0
     # via py-moneyed
-bcrypt==4.0.1
+bcrypt==4.1.2
     # via -r requirements/app.in
-blinker==1.6.2
+blinker==1.7.0
     # via
     #   flask-mail
     #   flask-principal
     #   flask-security-too
     #   sentry-sdk
-certifi==2023.7.22
+certifi==2024.2.2
     # via
     #   requests
     #   sentry-sdk
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via
@@ -42,21 +42,21 @@ click-default-group==1.2.4
     # via -r requirements/app.in
 colour==0.1.5
     # via -r requirements/app.in
-contourpy==1.1.0
+contourpy==1.2.0
     # via matplotlib
 convertdate==2.4.0
     # via workalendar
-cycler==0.11.0
+cycler==0.12.1
     # via matplotlib
-dill==0.3.7
+dill==0.3.8
     # via openturns
-dnspython==2.4.2
+dnspython==2.5.0
     # via email-validator
-email-validator==2.0.0.post2
+email-validator==2.1.0.post1
     # via
     #   -r requirements/app.in
     #   flask-security-too
-filelock==3.12.3
+filelock==3.13.1
     # via tldextract
 flask==2.2.5
     # via
@@ -81,42 +81,42 @@ flask-cors==4.0.0
     # via -r requirements/app.in
 flask-json==0.4.0
     # via -r requirements/app.in
-flask-login==0.6.2
+flask-login==0.6.3
     # via
     #   -r requirements/app.in
     #   flask-security-too
 flask-mail==0.9.1
     # via -r requirements/app.in
-flask-marshmallow==0.15.0
+flask-marshmallow==1.2.0
     # via -r requirements/app.in
-flask-migrate==4.0.4
+flask-migrate==4.0.5
     # via -r requirements/app.in
 flask-principal==0.4.0
     # via flask-security-too
 flask-security-too==5.1.2
     # via -r requirements/app.in
-flask-sqlalchemy==3.0.5
+flask-sqlalchemy==3.1.1
     # via
     #   -r requirements/app.in
     #   flask-migrate
 flask-sslify==0.1.5
     # via -r requirements/app.in
-flask-wtf==1.1.1
+flask-wtf==1.2.1
     # via
     #   -r requirements/app.in
     #   flask-security-too
-fonttools==4.42.1
+fonttools==4.48.1
     # via matplotlib
-greenlet==2.0.2
+greenlet==3.0.3
     # via sqlalchemy
-humanize==4.8.0
+humanize==4.9.0
     # via -r requirements/app.in
-idna==3.4
+idna==3.6
     # via
     #   email-validator
     #   requests
     #   tldextract
-importlib-metadata==6.8.0
+importlib-metadata==7.0.1
     # via
     #   -r requirements/app.in
     #   timely-beliefs
@@ -124,7 +124,7 @@ inflect==6.0.2
     # via -r requirements/app.in
 inflection==0.5.1
     # via -r requirements/app.in
-iso8601==2.0.0
+iso8601==2.1.0
     # via -r requirements/app.in
 isodate==0.6.1
     # via
@@ -135,30 +135,31 @@ itsdangerous==2.1.2
     #   flask
     #   flask-security-too
     #   flask-wtf
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   altair
     #   flask
 joblib==1.3.2
     # via scikit-learn
-jsonschema==4.19.0
+jsonschema==4.21.1
     # via altair
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.12.1
     # via jsonschema
 kiwisolver==1.4.5
     # via matplotlib
-lunardate==0.2.0
+lunardate==0.2.2
     # via workalendar
-mako==1.2.4
+mako==1.3.2
     # via alembic
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
+    #   flask-security-too
     #   jinja2
     #   mako
     #   sentry-sdk
     #   werkzeug
     #   wtforms
-marshmallow==3.20.1
+marshmallow==3.20.2
     # via
     #   -r requirements/app.in
     #   flask-marshmallow
@@ -167,9 +168,9 @@ marshmallow==3.20.1
     #   webargs
 marshmallow-polyfield==5.11
     # via -r requirements/app.in
-marshmallow-sqlalchemy==0.29.0
+marshmallow-sqlalchemy==1.0.0
     # via -r requirements/app.in
-matplotlib==3.7.3
+matplotlib==3.8.2
     # via timetomodel
 numpy==1.24.4
     # via
@@ -187,19 +188,17 @@ numpy==1.24.4
     #   timely-beliefs
     #   timetomodel
     #   uniplot
-openturns==1.21
+openturns==1.22
     # via timely-beliefs
-packaging==23.1
+packaging==23.2
     # via
     #   altair
-    #   flask-marshmallow
     #   marshmallow
-    #   marshmallow-sqlalchemy
     #   matplotlib
     #   sktime
     #   statsmodels
     #   webargs
-pandas==2.0.3
+pandas==2.1.4
     # via
     #   -r requirements/app.in
     #   altair
@@ -209,13 +208,13 @@ pandas==2.0.3
     #   timetomodel
 passlib==1.7.4
     # via flask-security-too
-patsy==0.5.3
+patsy==0.5.6
     # via statsmodels
-pillow==10.0.1
+pillow==10.2.0
     # via
     #   -r requirements/app.in
     #   matplotlib
-pint==0.22
+pint==0.23
     # via -r requirements/app.in
 ply==3.11
     # via pyomo
@@ -223,15 +222,15 @@ properscoring==0.1
     # via timely-beliefs
 pscript==0.7.7
     # via -r requirements/app.in
-psutil==5.9.5
+psutil==5.9.8
     # via openturns
-psycopg2-binary==2.9.7
+psycopg2-binary==2.9.9
     # via
     #   -r requirements/app.in
     #   timely-beliefs
 py-moneyed==3.0
     # via -r requirements/app.in
-pydantic==1.10.12
+pydantic==1.10.14
     # via
     #   -r requirements/app.in
     #   inflect
@@ -239,7 +238,7 @@ pyluach==2.2.0
     # via workalendar
 pymeeus==0.5.12
     # via convertdate
-pyomo==6.6.2
+pyomo==6.7.0
     # via -r requirements/app.in
 pyparsing==3.1.1
     # via matplotlib
@@ -250,9 +249,9 @@ python-dateutil==2.8.2
     #   pandas
     #   timetomodel
     #   workalendar
-python-dotenv==1.0.0
+python-dotenv==1.0.1
     # via -r requirements/app.in
-pytz==2023.3.post1
+pytz==2024.1
     # via
     #   -r requirements/app.in
     #   pandas
@@ -268,7 +267,7 @@ redis==4.6.0
     #   rq-dashboard
 redis-sentinel-url==1.0.1
     # via rq-dashboard
-referencing==0.30.2
+referencing==0.33.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -276,9 +275,9 @@ requests==2.31.0
     # via
     #   requests-file
     #   tldextract
-requests-file==1.5.1
+requests-file==2.0.0
     # via tldextract
-rpds-py==0.10.2
+rpds-py==0.17.1
     # via
     #   jsonschema
     #   referencing
@@ -288,13 +287,13 @@ rq==1.15.1
     #   rq-dashboard
 rq-dashboard==0.6.7
     # via -r requirements/app.in
-scikit-base==0.5.1
+scikit-base==0.7.2
     # via sktime
-scikit-learn==1.3.0
+scikit-learn==1.4.0
     # via
     #   sktime
     #   timetomodel
-scipy==1.11.2
+scipy==1.12.0
     # via
     #   properscoring
     #   scikit-learn
@@ -302,17 +301,16 @@ scipy==1.11.2
     #   statsmodels
     #   timely-beliefs
     #   timetomodel
-sentry-sdk[flask]==1.30.0
+sentry-sdk[flask]==1.40.1
     # via -r requirements/app.in
 six==1.16.0
     # via
     #   isodate
     #   patsy
     #   python-dateutil
-    #   requests-file
-sktime==0.22.0
+sktime==0.26.0
     # via timely-beliefs
-sqlalchemy==2.0.0
+sqlalchemy==2.0.25
     # via
     #   -r requirements/app.in
     #   alembic
@@ -320,39 +318,41 @@ sqlalchemy==2.0.0
     #   marshmallow-sqlalchemy
     #   timely-beliefs
     #   timetomodel
-statsmodels==0.14.0
+statsmodels==0.14.1
     # via timetomodel
 tabulate==0.9.0
     # via -r requirements/app.in
 threadpoolctl==3.2.0
     # via scikit-learn
-timely-beliefs[forecast]==1.25.1
+timely-beliefs[forecast]==2.0.0
     # via -r requirements/app.in
 timetomodel==0.7.3
     # via -r requirements/app.in
-tldextract==3.5.0
+tldextract==5.1.1
     # via -r requirements/app.in
-toolz==0.12.0
+toolz==0.12.1
     # via altair
-typing-extensions==4.7.1
+types-python-dateutil==2.8.19.20240106
+    # via arrow
+typing-extensions==4.9.0
     # via
     #   alembic
     #   altair
-    #   filelock
     #   pint
     #   py-moneyed
     #   pydantic
-tzdata==2023.3
+    #   sqlalchemy
+tzdata==2023.4
     # via pandas
-uniplot==0.10.2
+uniplot==0.11.0
     # via -r requirements/app.in
-urllib3==2.0.4
+urllib3==2.2.0
     # via
     #   requests
     #   sentry-sdk
-vl-convert-python==0.13.1
+vl-convert-python==1.2.3
     # via -r requirements/app.in
-webargs==8.3.0
+webargs==8.4.0
     # via -r requirements/app.in
 werkzeug==2.2.3
     # via
@@ -361,13 +361,13 @@ werkzeug==2.2.3
     #   flask-login
 workalendar==17.0.0
     # via -r requirements/app.in
-wtforms==3.0.1
+wtforms==3.1.2
     # via
     #   flask-security-too
     #   flask-wtf
 xlrd==2.0.1
     # via -r requirements/app.in
-zipp==3.16.2
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/3.10/dev.txt
+++ b/requirements/3.10/dev.txt
@@ -13,9 +13,9 @@ click==8.1.7
     #   -c requirements/3.10/app.txt
     #   -c requirements/3.10/test.txt
     #   black
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
-filelock==3.12.3
+filelock==3.13.1
     # via
     #   -c requirements/3.10/app.txt
     #   virtualenv
@@ -23,11 +23,11 @@ flake8==4.0.1
     # via -r requirements/dev.in
 flake8-blind-except==0.2.1
     # via -r requirements/dev.in
-identify==2.5.28
+identify==2.5.33
     # via pre-commit
 mccabe==0.6.1
     # via flake8
-mypy==1.5.1
+mypy==1.8.0
     # via -r requirements/dev.in
 mypy-extensions==1.0.0
     # via
@@ -35,32 +35,32 @@ mypy-extensions==1.0.0
     #   mypy
 nodeenv==1.8.0
     # via pre-commit
-packaging==23.1
+packaging==23.2
     # via
     #   -c requirements/3.10/app.txt
     #   -c requirements/3.10/test.txt
     #   setuptools-scm
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-platformdirs==3.10.0
+platformdirs==4.2.0
     # via
     #   black
     #   virtualenv
-pre-commit==3.4.0
+pre-commit==3.6.0
     # via -r requirements/dev.in
 pycodestyle==2.8.0
     # via flake8
 pyflakes==2.4.0
     # via flake8
-pyinstrument==4.5.3
+pyinstrument==4.6.2
     # via -r requirements/dev.in
-pytest-runner==6.0.0
+pytest-runner==6.0.1
     # via -r requirements/dev.in
 pyyaml==6.0.1
     # via
     #   -c requirements/3.10/app.txt
     #   pre-commit
-setuptools-scm==7.1.0
+setuptools-scm==8.0.4
     # via -r requirements/dev.in
 tomli==2.0.1
     # via
@@ -68,13 +68,12 @@ tomli==2.0.1
     #   black
     #   mypy
     #   setuptools-scm
-typing-extensions==4.7.1
+typing-extensions==4.9.0
     # via
     #   -c requirements/3.10/app.txt
-    #   filelock
     #   mypy
     #   setuptools-scm
-virtualenv==20.24.5
+virtualenv==20.25.0
     # via pre-commit
 watchdog==3.0.0
     # via -r requirements/dev.in

--- a/requirements/3.10/docs.txt
+++ b/requirements/3.10/docs.txt
@@ -4,44 +4,44 @@
 #
 #    pip-compile --constraint=requirements/3.10/app.txt --output-file=requirements/3.10/docs.txt requirements/docs.in
 #
-alabaster==0.7.13
+alabaster==0.7.16
     # via sphinx
-babel==2.12.1
+babel==2.14.0
     # via
     #   -c requirements/3.10/app.txt
     #   sphinx
-certifi==2023.7.22
+certifi==2024.2.2
     # via
     #   -c requirements/3.10/app.txt
     #   requests
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via
     #   -c requirements/3.10/app.txt
     #   requests
-docutils==0.18.1
+docutils==0.20.1
     # via
     #   sphinx
     #   sphinx-rtd-theme
     #   sphinx-tabs
-idna==3.4
+idna==3.6
     # via
     #   -c requirements/3.10/app.txt
     #   requests
 imagesize==1.4.1
     # via sphinx
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   -c requirements/3.10/app.txt
     #   sphinx
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   -c requirements/3.10/app.txt
     #   jinja2
-packaging==23.1
+packaging==23.2
     # via
     #   -c requirements/3.10/app.txt
     #   sphinx
-pygments==2.16.1
+pygments==2.17.2
     # via
     #   sphinx
     #   sphinx-tabs
@@ -55,33 +55,28 @@ six==1.16.0
     #   sphinxcontrib-httpdomain
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==7.2.5
+sphinx==7.2.6
     # via
     #   -r requirements/docs.in
     #   sphinx-copybutton
     #   sphinx-fontawesome
     #   sphinx-rtd-theme
     #   sphinx-tabs
-    #   sphinxcontrib-applehelp
-    #   sphinxcontrib-devhelp
-    #   sphinxcontrib-htmlhelp
     #   sphinxcontrib-httpdomain
     #   sphinxcontrib-jquery
-    #   sphinxcontrib-qthelp
-    #   sphinxcontrib-serializinghtml
 sphinx-copybutton==0.5.2
     # via -r requirements/docs.in
 sphinx-fontawesome==0.0.6
     # via -r requirements/docs.in
-sphinx-rtd-theme==1.3.0
+sphinx-rtd-theme==2.0.0
     # via -r requirements/docs.in
-sphinx-tabs==3.4.1
+sphinx-tabs==3.4.5
     # via -r requirements/docs.in
-sphinxcontrib-applehelp==1.0.7
+sphinxcontrib-applehelp==1.0.8
     # via sphinx
-sphinxcontrib-devhelp==1.0.5
+sphinxcontrib-devhelp==1.0.6
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.4
+sphinxcontrib-htmlhelp==2.0.5
     # via sphinx
 sphinxcontrib-httpdomain==1.8.1
     # via -r requirements/docs.in
@@ -89,11 +84,11 @@ sphinxcontrib-jquery==4.1
     # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.6
+sphinxcontrib-qthelp==1.0.7
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.9
+sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
-urllib3==2.0.4
+urllib3==2.2.0
     # via
     #   -c requirements/3.10/app.txt
     #   requests

--- a/requirements/3.10/test.txt
+++ b/requirements/3.10/test.txt
@@ -8,11 +8,11 @@ async-timeout==4.0.3
     # via
     #   -c requirements/3.10/app.txt
     #   redis
-certifi==2023.7.22
+certifi==2024.2.2
     # via
     #   -c requirements/3.10/app.txt
     #   requests
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via
     #   -c requirements/3.10/app.txt
     #   requests
@@ -20,13 +20,11 @@ click==8.1.7
     # via
     #   -c requirements/3.10/app.txt
     #   flask
-coverage[toml]==7.3.1
-    # via
-    #   coverage
-    #   pytest-cov
-exceptiongroup==1.1.3
+coverage[toml]==7.4.1
+    # via pytest-cov
+exceptiongroup==1.2.0
     # via pytest
-fakeredis==2.18.1
+fakeredis==2.21.0
     # via -r requirements/test.in
 flask==2.2.5
     # via
@@ -34,7 +32,7 @@ flask==2.2.5
     #   pytest-flask
 highspy==1.5.3
     # via -r requirements/test.in
-idna==3.4
+idna==3.6
     # via
     #   -c requirements/3.10/app.txt
     #   requests
@@ -44,25 +42,25 @@ itsdangerous==2.1.2
     # via
     #   -c requirements/3.10/app.txt
     #   flask
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   -c requirements/3.10/app.txt
     #   flask
 lupa==2.0
     # via -r requirements/test.in
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   -c requirements/3.10/app.txt
     #   jinja2
     #   werkzeug
-packaging==23.1
+packaging==23.2
     # via
     #   -c requirements/3.10/app.txt
     #   pytest
     #   pytest-sugar
-pluggy==1.3.0
+pluggy==1.4.0
     # via pytest
-pytest==7.4.2
+pytest==8.0.0
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -70,9 +68,9 @@ pytest==7.4.2
     #   pytest-sugar
 pytest-cov==4.1.0
     # via -r requirements/test.in
-pytest-flask==1.2.0
+pytest-flask==1.3.0
     # via -r requirements/test.in
-pytest-sugar==0.9.7
+pytest-sugar==1.0.0
     # via -r requirements/test.in
 redis==4.6.0
     # via
@@ -91,13 +89,13 @@ six==1.16.0
     #   requests-mock
 sortedcontainers==2.4.0
     # via fakeredis
-termcolor==2.3.0
+termcolor==2.4.0
     # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage
     #   pytest
-urllib3==2.0.4
+urllib3==2.2.0
     # via
     #   -c requirements/3.10/app.txt
     #   requests

--- a/requirements/3.11/app.txt
+++ b/requirements/3.11/app.txt
@@ -4,31 +4,31 @@
 #
 #    pip-compile --output-file=requirements/3.11/app.txt requirements/app.in
 #
-alembic==1.12.0
+alembic==1.13.1
     # via flask-migrate
-altair==5.1.1
+altair==5.2.0
     # via -r requirements/app.in
-arrow==1.2.3
+arrow==1.3.0
     # via rq-dashboard
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   jsonschema
     #   referencing
-babel==2.12.1
+babel==2.14.0
     # via py-moneyed
-bcrypt==4.0.1
+bcrypt==4.1.2
     # via -r requirements/app.in
-blinker==1.6.2
+blinker==1.7.0
     # via
     #   flask-mail
     #   flask-principal
     #   flask-security-too
     #   sentry-sdk
-certifi==2023.7.22
+certifi==2024.2.2
     # via
     #   requests
     #   sentry-sdk
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via
@@ -40,21 +40,21 @@ click-default-group==1.2.4
     # via -r requirements/app.in
 colour==0.1.5
     # via -r requirements/app.in
-contourpy==1.1.0
+contourpy==1.2.0
     # via matplotlib
 convertdate==2.4.0
     # via workalendar
-cycler==0.11.0
+cycler==0.12.1
     # via matplotlib
-dill==0.3.7
+dill==0.3.8
     # via openturns
-dnspython==2.4.2
+dnspython==2.5.0
     # via email-validator
-email-validator==2.0.0.post2
+email-validator==2.1.0.post1
     # via
     #   -r requirements/app.in
     #   flask-security-too
-filelock==3.12.3
+filelock==3.13.1
     # via tldextract
 flask==2.2.5
     # via
@@ -79,42 +79,42 @@ flask-cors==4.0.0
     # via -r requirements/app.in
 flask-json==0.4.0
     # via -r requirements/app.in
-flask-login==0.6.2
+flask-login==0.6.3
     # via
     #   -r requirements/app.in
     #   flask-security-too
 flask-mail==0.9.1
     # via -r requirements/app.in
-flask-marshmallow==0.15.0
+flask-marshmallow==1.2.0
     # via -r requirements/app.in
-flask-migrate==4.0.4
+flask-migrate==4.0.5
     # via -r requirements/app.in
 flask-principal==0.4.0
     # via flask-security-too
 flask-security-too==5.1.2
     # via -r requirements/app.in
-flask-sqlalchemy==3.0.5
+flask-sqlalchemy==3.1.1
     # via
     #   -r requirements/app.in
     #   flask-migrate
 flask-sslify==0.1.5
     # via -r requirements/app.in
-flask-wtf==1.1.1
+flask-wtf==1.2.1
     # via
     #   -r requirements/app.in
     #   flask-security-too
-fonttools==4.42.1
+fonttools==4.48.1
     # via matplotlib
-greenlet==2.0.2
+greenlet==3.0.3
     # via sqlalchemy
-humanize==4.8.0
+humanize==4.9.0
     # via -r requirements/app.in
-idna==3.4
+idna==3.6
     # via
     #   email-validator
     #   requests
     #   tldextract
-importlib-metadata==6.8.0
+importlib-metadata==7.0.1
     # via
     #   -r requirements/app.in
     #   timely-beliefs
@@ -122,7 +122,7 @@ inflect==6.0.2
     # via -r requirements/app.in
 inflection==0.5.1
     # via -r requirements/app.in
-iso8601==2.0.0
+iso8601==2.1.0
     # via -r requirements/app.in
 isodate==0.6.1
     # via
@@ -133,30 +133,31 @@ itsdangerous==2.1.2
     #   flask
     #   flask-security-too
     #   flask-wtf
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   altair
     #   flask
 joblib==1.3.2
     # via scikit-learn
-jsonschema==4.19.0
+jsonschema==4.21.1
     # via altair
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.12.1
     # via jsonschema
 kiwisolver==1.4.5
     # via matplotlib
-lunardate==0.2.0
+lunardate==0.2.2
     # via workalendar
-mako==1.2.4
+mako==1.3.2
     # via alembic
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
+    #   flask-security-too
     #   jinja2
     #   mako
     #   sentry-sdk
     #   werkzeug
     #   wtforms
-marshmallow==3.20.1
+marshmallow==3.20.2
     # via
     #   -r requirements/app.in
     #   flask-marshmallow
@@ -165,9 +166,9 @@ marshmallow==3.20.1
     #   webargs
 marshmallow-polyfield==5.11
     # via -r requirements/app.in
-marshmallow-sqlalchemy==0.29.0
+marshmallow-sqlalchemy==1.0.0
     # via -r requirements/app.in
-matplotlib==3.7.3
+matplotlib==3.8.2
     # via timetomodel
 numpy==1.24.4
     # via
@@ -185,19 +186,17 @@ numpy==1.24.4
     #   timely-beliefs
     #   timetomodel
     #   uniplot
-openturns==1.21
+openturns==1.22
     # via timely-beliefs
-packaging==23.1
+packaging==23.2
     # via
     #   altair
-    #   flask-marshmallow
     #   marshmallow
-    #   marshmallow-sqlalchemy
     #   matplotlib
     #   sktime
     #   statsmodels
     #   webargs
-pandas==2.0.3
+pandas==2.1.4
     # via
     #   -r requirements/app.in
     #   altair
@@ -207,13 +206,13 @@ pandas==2.0.3
     #   timetomodel
 passlib==1.7.4
     # via flask-security-too
-patsy==0.5.3
+patsy==0.5.6
     # via statsmodels
-pillow==10.0.1
+pillow==10.2.0
     # via
     #   -r requirements/app.in
     #   matplotlib
-pint==0.22
+pint==0.23
     # via -r requirements/app.in
 ply==3.11
     # via pyomo
@@ -221,15 +220,15 @@ properscoring==0.1
     # via timely-beliefs
 pscript==0.7.7
     # via -r requirements/app.in
-psutil==5.9.5
+psutil==5.9.8
     # via openturns
-psycopg2-binary==2.9.7
+psycopg2-binary==2.9.9
     # via
     #   -r requirements/app.in
     #   timely-beliefs
 py-moneyed==3.0
     # via -r requirements/app.in
-pydantic==1.10.12
+pydantic==1.10.14
     # via
     #   -r requirements/app.in
     #   inflect
@@ -237,7 +236,7 @@ pyluach==2.2.0
     # via workalendar
 pymeeus==0.5.12
     # via convertdate
-pyomo==6.6.2
+pyomo==6.7.0
     # via -r requirements/app.in
 pyparsing==3.1.1
     # via matplotlib
@@ -248,9 +247,9 @@ python-dateutil==2.8.2
     #   pandas
     #   timetomodel
     #   workalendar
-python-dotenv==1.0.0
+python-dotenv==1.0.1
     # via -r requirements/app.in
-pytz==2023.3.post1
+pytz==2024.1
     # via
     #   -r requirements/app.in
     #   pandas
@@ -266,7 +265,7 @@ redis==4.6.0
     #   rq-dashboard
 redis-sentinel-url==1.0.1
     # via rq-dashboard
-referencing==0.30.2
+referencing==0.33.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -274,9 +273,9 @@ requests==2.31.0
     # via
     #   requests-file
     #   tldextract
-requests-file==1.5.1
+requests-file==2.0.0
     # via tldextract
-rpds-py==0.10.2
+rpds-py==0.17.1
     # via
     #   jsonschema
     #   referencing
@@ -286,13 +285,13 @@ rq==1.15.1
     #   rq-dashboard
 rq-dashboard==0.6.7
     # via -r requirements/app.in
-scikit-base==0.5.1
+scikit-base==0.7.2
     # via sktime
-scikit-learn==1.3.0
+scikit-learn==1.4.0
     # via
     #   sktime
     #   timetomodel
-scipy==1.11.2
+scipy==1.12.0
     # via
     #   properscoring
     #   scikit-learn
@@ -300,17 +299,16 @@ scipy==1.11.2
     #   statsmodels
     #   timely-beliefs
     #   timetomodel
-sentry-sdk[flask]==1.30.0
+sentry-sdk[flask]==1.40.1
     # via -r requirements/app.in
 six==1.16.0
     # via
     #   isodate
     #   patsy
     #   python-dateutil
-    #   requests-file
-sktime==0.22.0
+sktime==0.26.0
     # via timely-beliefs
-sqlalchemy==1.4.49
+sqlalchemy==2.0.25
     # via
     #   -r requirements/app.in
     #   alembic
@@ -318,37 +316,40 @@ sqlalchemy==1.4.49
     #   marshmallow-sqlalchemy
     #   timely-beliefs
     #   timetomodel
-statsmodels==0.14.0
+statsmodels==0.14.1
     # via timetomodel
 tabulate==0.9.0
     # via -r requirements/app.in
 threadpoolctl==3.2.0
     # via scikit-learn
-timely-beliefs[forecast]==1.25.1
+timely-beliefs[forecast]==2.0.0
     # via -r requirements/app.in
 timetomodel==0.7.3
     # via -r requirements/app.in
-tldextract==3.5.0
+tldextract==5.1.1
     # via -r requirements/app.in
-toolz==0.12.0
+toolz==0.12.1
     # via altair
-typing-extensions==4.7.1
+types-python-dateutil==2.8.19.20240106
+    # via arrow
+typing-extensions==4.9.0
     # via
     #   alembic
     #   pint
     #   py-moneyed
     #   pydantic
-tzdata==2023.3
+    #   sqlalchemy
+tzdata==2023.4
     # via pandas
-uniplot==0.10.2
+uniplot==0.11.0
     # via -r requirements/app.in
-urllib3==2.0.4
+urllib3==2.2.0
     # via
     #   requests
     #   sentry-sdk
-vl-convert-python==0.13.1
+vl-convert-python==1.2.3
     # via -r requirements/app.in
-webargs==8.3.0
+webargs==8.4.0
     # via -r requirements/app.in
 werkzeug==2.2.3
     # via
@@ -357,13 +358,13 @@ werkzeug==2.2.3
     #   flask-login
 workalendar==17.0.0
     # via -r requirements/app.in
-wtforms==3.0.1
+wtforms==3.1.2
     # via
     #   flask-security-too
     #   flask-wtf
 xlrd==2.0.1
     # via -r requirements/app.in
-zipp==3.16.2
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/3.11/dev.txt
+++ b/requirements/3.11/dev.txt
@@ -13,9 +13,9 @@ click==8.1.7
     #   -c requirements/3.11/app.txt
     #   -c requirements/3.11/test.txt
     #   black
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
-filelock==3.12.3
+filelock==3.13.1
     # via
     #   -c requirements/3.11/app.txt
     #   virtualenv
@@ -23,11 +23,11 @@ flake8==4.0.1
     # via -r requirements/dev.in
 flake8-blind-except==0.2.1
     # via -r requirements/dev.in
-identify==2.5.28
+identify==2.5.33
     # via pre-commit
 mccabe==0.6.1
     # via flake8
-mypy==1.5.1
+mypy==1.8.0
     # via -r requirements/dev.in
 mypy-extensions==1.0.0
     # via
@@ -35,39 +35,39 @@ mypy-extensions==1.0.0
     #   mypy
 nodeenv==1.8.0
     # via pre-commit
-packaging==23.1
+packaging==23.2
     # via
     #   -c requirements/3.11/app.txt
     #   -c requirements/3.11/test.txt
     #   setuptools-scm
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-platformdirs==3.10.0
+platformdirs==4.2.0
     # via
     #   black
     #   virtualenv
-pre-commit==3.4.0
+pre-commit==3.6.0
     # via -r requirements/dev.in
 pycodestyle==2.8.0
     # via flake8
 pyflakes==2.4.0
     # via flake8
-pyinstrument==4.5.3
+pyinstrument==4.6.2
     # via -r requirements/dev.in
-pytest-runner==6.0.0
+pytest-runner==6.0.1
     # via -r requirements/dev.in
 pyyaml==6.0.1
     # via
     #   -c requirements/3.11/app.txt
     #   pre-commit
-setuptools-scm==7.1.0
+setuptools-scm==8.0.4
     # via -r requirements/dev.in
-typing-extensions==4.7.1
+typing-extensions==4.9.0
     # via
     #   -c requirements/3.11/app.txt
     #   mypy
     #   setuptools-scm
-virtualenv==20.24.5
+virtualenv==20.25.0
     # via pre-commit
 watchdog==3.0.0
     # via -r requirements/dev.in

--- a/requirements/3.11/docs.txt
+++ b/requirements/3.11/docs.txt
@@ -4,44 +4,44 @@
 #
 #    pip-compile --constraint=requirements/3.11/app.txt --output-file=requirements/3.11/docs.txt requirements/docs.in
 #
-alabaster==0.7.13
+alabaster==0.7.16
     # via sphinx
-babel==2.12.1
+babel==2.14.0
     # via
     #   -c requirements/3.11/app.txt
     #   sphinx
-certifi==2023.7.22
+certifi==2024.2.2
     # via
     #   -c requirements/3.11/app.txt
     #   requests
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via
     #   -c requirements/3.11/app.txt
     #   requests
-docutils==0.18.1
+docutils==0.20.1
     # via
     #   sphinx
     #   sphinx-rtd-theme
     #   sphinx-tabs
-idna==3.4
+idna==3.6
     # via
     #   -c requirements/3.11/app.txt
     #   requests
 imagesize==1.4.1
     # via sphinx
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   -c requirements/3.11/app.txt
     #   sphinx
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   -c requirements/3.11/app.txt
     #   jinja2
-packaging==23.1
+packaging==23.2
     # via
     #   -c requirements/3.11/app.txt
     #   sphinx
-pygments==2.16.1
+pygments==2.17.2
     # via
     #   sphinx
     #   sphinx-tabs
@@ -55,33 +55,28 @@ six==1.16.0
     #   sphinxcontrib-httpdomain
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==7.2.5
+sphinx==7.2.6
     # via
     #   -r requirements/docs.in
     #   sphinx-copybutton
     #   sphinx-fontawesome
     #   sphinx-rtd-theme
     #   sphinx-tabs
-    #   sphinxcontrib-applehelp
-    #   sphinxcontrib-devhelp
-    #   sphinxcontrib-htmlhelp
     #   sphinxcontrib-httpdomain
     #   sphinxcontrib-jquery
-    #   sphinxcontrib-qthelp
-    #   sphinxcontrib-serializinghtml
 sphinx-copybutton==0.5.2
     # via -r requirements/docs.in
 sphinx-fontawesome==0.0.6
     # via -r requirements/docs.in
-sphinx-rtd-theme==1.3.0
+sphinx-rtd-theme==2.0.0
     # via -r requirements/docs.in
-sphinx-tabs==3.4.1
+sphinx-tabs==3.4.5
     # via -r requirements/docs.in
-sphinxcontrib-applehelp==1.0.7
+sphinxcontrib-applehelp==1.0.8
     # via sphinx
-sphinxcontrib-devhelp==1.0.5
+sphinxcontrib-devhelp==1.0.6
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.4
+sphinxcontrib-htmlhelp==2.0.5
     # via sphinx
 sphinxcontrib-httpdomain==1.8.1
     # via -r requirements/docs.in
@@ -89,11 +84,11 @@ sphinxcontrib-jquery==4.1
     # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.6
+sphinxcontrib-qthelp==1.0.7
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.9
+sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
-urllib3==2.0.4
+urllib3==2.2.0
     # via
     #   -c requirements/3.11/app.txt
     #   requests

--- a/requirements/3.11/test.txt
+++ b/requirements/3.11/test.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile --constraint=requirements/3.11/app.txt --output-file=requirements/3.11/test.txt requirements/test.in
 #
-certifi==2023.7.22
+certifi==2024.2.2
     # via
     #   -c requirements/3.11/app.txt
     #   requests
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via
     #   -c requirements/3.11/app.txt
     #   requests
@@ -16,9 +16,9 @@ click==8.1.7
     # via
     #   -c requirements/3.11/app.txt
     #   flask
-coverage[toml]==7.3.1
+coverage[toml]==7.4.1
     # via pytest-cov
-fakeredis==2.18.1
+fakeredis==2.21.0
     # via -r requirements/test.in
 flask==2.2.5
     # via
@@ -26,7 +26,7 @@ flask==2.2.5
     #   pytest-flask
 highspy==1.5.3
     # via -r requirements/test.in
-idna==3.4
+idna==3.6
     # via
     #   -c requirements/3.11/app.txt
     #   requests
@@ -36,25 +36,25 @@ itsdangerous==2.1.2
     # via
     #   -c requirements/3.11/app.txt
     #   flask
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   -c requirements/3.11/app.txt
     #   flask
 lupa==2.0
     # via -r requirements/test.in
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   -c requirements/3.11/app.txt
     #   jinja2
     #   werkzeug
-packaging==23.1
+packaging==23.2
     # via
     #   -c requirements/3.11/app.txt
     #   pytest
     #   pytest-sugar
-pluggy==1.3.0
+pluggy==1.4.0
     # via pytest
-pytest==7.4.2
+pytest==8.0.0
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -62,9 +62,9 @@ pytest==7.4.2
     #   pytest-sugar
 pytest-cov==4.1.0
     # via -r requirements/test.in
-pytest-flask==1.2.0
+pytest-flask==1.3.0
     # via -r requirements/test.in
-pytest-sugar==0.9.7
+pytest-sugar==1.0.0
     # via -r requirements/test.in
 redis==4.6.0
     # via
@@ -83,9 +83,9 @@ six==1.16.0
     #   requests-mock
 sortedcontainers==2.4.0
     # via fakeredis
-termcolor==2.3.0
+termcolor==2.4.0
     # via pytest-sugar
-urllib3==2.0.4
+urllib3==2.2.0
     # via
     #   -c requirements/3.11/app.txt
     #   requests

--- a/requirements/3.8/app.txt
+++ b/requirements/3.8/app.txt
@@ -4,35 +4,35 @@
 #
 #    pip-compile --output-file=requirements/3.8/app.txt requirements/app.in
 #
-alembic==1.12.0
+alembic==1.13.1
     # via flask-migrate
-altair==5.1.1
+altair==5.2.0
     # via -r requirements/app.in
-arrow==1.2.3
+arrow==1.3.0
     # via rq-dashboard
 async-timeout==4.0.3
     # via redis
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   jsonschema
     #   referencing
-babel==2.12.1
+babel==2.14.0
     # via py-moneyed
 backports-zoneinfo==0.2.1
     # via workalendar
-bcrypt==4.0.1
+bcrypt==4.1.2
     # via -r requirements/app.in
-blinker==1.6.2
+blinker==1.7.0
     # via
     #   flask-mail
     #   flask-principal
     #   flask-security-too
     #   sentry-sdk
-certifi==2023.7.22
+certifi==2024.2.2
     # via
     #   requests
     #   sentry-sdk
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via
@@ -44,21 +44,21 @@ click-default-group==1.2.4
     # via -r requirements/app.in
 colour==0.1.5
     # via -r requirements/app.in
-contourpy==1.1.0
+contourpy==1.1.1
     # via matplotlib
 convertdate==2.4.0
     # via workalendar
-cycler==0.11.0
+cycler==0.12.1
     # via matplotlib
-dill==0.3.7
+dill==0.3.8
     # via openturns
-dnspython==2.4.2
+dnspython==2.5.0
     # via email-validator
-email-validator==2.0.0.post2
+email-validator==2.1.0.post1
     # via
     #   -r requirements/app.in
     #   flask-security-too
-filelock==3.12.3
+filelock==3.13.1
     # via tldextract
 flask==2.2.5
     # via
@@ -83,50 +83,51 @@ flask-cors==4.0.0
     # via -r requirements/app.in
 flask-json==0.4.0
     # via -r requirements/app.in
-flask-login==0.6.2
+flask-login==0.6.3
     # via
     #   -r requirements/app.in
     #   flask-security-too
 flask-mail==0.9.1
     # via -r requirements/app.in
-flask-marshmallow==0.15.0
+flask-marshmallow==1.2.0
     # via -r requirements/app.in
-flask-migrate==4.0.4
+flask-migrate==4.0.5
     # via -r requirements/app.in
 flask-principal==0.4.0
     # via flask-security-too
 flask-security-too==5.1.2
     # via -r requirements/app.in
-flask-sqlalchemy==3.0.5
+flask-sqlalchemy==3.1.1
     # via
     #   -r requirements/app.in
     #   flask-migrate
 flask-sslify==0.1.5
     # via -r requirements/app.in
-flask-wtf==1.1.1
+flask-wtf==1.2.1
     # via
     #   -r requirements/app.in
     #   flask-security-too
-fonttools==4.42.1
+fonttools==4.48.1
     # via matplotlib
-greenlet==2.0.2
+greenlet==3.0.3
     # via sqlalchemy
-humanize==4.8.0
+humanize==4.9.0
     # via -r requirements/app.in
-idna==3.4
+idna==3.6
     # via
     #   email-validator
     #   requests
     #   tldextract
-importlib-metadata==6.8.0
+importlib-metadata==7.0.1
     # via
     #   -r requirements/app.in
     #   alembic
     #   flask
     #   timely-beliefs
-importlib-resources==6.0.1
+importlib-resources==6.1.1
     # via
     #   alembic
+    #   flask-security-too
     #   jsonschema
     #   jsonschema-specifications
     #   matplotlib
@@ -134,7 +135,7 @@ inflect==6.0.2
     # via -r requirements/app.in
 inflection==0.5.1
     # via -r requirements/app.in
-iso8601==2.0.0
+iso8601==2.1.0
     # via -r requirements/app.in
 isodate==0.6.1
     # via
@@ -145,30 +146,31 @@ itsdangerous==2.1.2
     #   flask
     #   flask-security-too
     #   flask-wtf
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   altair
     #   flask
 joblib==1.3.2
     # via scikit-learn
-jsonschema==4.19.0
+jsonschema==4.21.1
     # via altair
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.12.1
     # via jsonschema
 kiwisolver==1.4.5
     # via matplotlib
-lunardate==0.2.0
+lunardate==0.2.2
     # via workalendar
-mako==1.2.4
+mako==1.3.2
     # via alembic
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
+    #   flask-security-too
     #   jinja2
     #   mako
     #   sentry-sdk
     #   werkzeug
     #   wtforms
-marshmallow==3.20.1
+marshmallow==3.20.2
     # via
     #   -r requirements/app.in
     #   flask-marshmallow
@@ -177,9 +179,9 @@ marshmallow==3.20.1
     #   webargs
 marshmallow-polyfield==5.11
     # via -r requirements/app.in
-marshmallow-sqlalchemy==0.29.0
+marshmallow-sqlalchemy==1.0.0
     # via -r requirements/app.in
-matplotlib==3.7.3
+matplotlib==3.7.4
     # via timetomodel
 numpy==1.24.4
     # via
@@ -197,14 +199,12 @@ numpy==1.24.4
     #   timely-beliefs
     #   timetomodel
     #   uniplot
-openturns==1.21
+openturns==1.22
     # via timely-beliefs
-packaging==23.1
+packaging==23.2
     # via
     #   altair
-    #   flask-marshmallow
     #   marshmallow
-    #   marshmallow-sqlalchemy
     #   matplotlib
     #   sktime
     #   statsmodels
@@ -219,9 +219,9 @@ pandas==2.0.3
     #   timetomodel
 passlib==1.7.4
     # via flask-security-too
-patsy==0.5.3
+patsy==0.5.6
     # via statsmodels
-pillow==10.0.1
+pillow==10.2.0
     # via
     #   -r requirements/app.in
     #   matplotlib
@@ -235,15 +235,15 @@ properscoring==0.1
     # via timely-beliefs
 pscript==0.7.7
     # via -r requirements/app.in
-psutil==5.9.5
+psutil==5.9.8
     # via openturns
-psycopg2-binary==2.9.7
+psycopg2-binary==2.9.9
     # via
     #   -r requirements/app.in
     #   timely-beliefs
 py-moneyed==3.0
     # via -r requirements/app.in
-pydantic==1.10.12
+pydantic==1.10.14
     # via
     #   -r requirements/app.in
     #   inflect
@@ -251,7 +251,7 @@ pyluach==2.2.0
     # via workalendar
 pymeeus==0.5.12
     # via convertdate
-pyomo==6.6.2
+pyomo==6.7.0
     # via -r requirements/app.in
 pyparsing==3.1.1
     # via matplotlib
@@ -262,9 +262,9 @@ python-dateutil==2.8.2
     #   pandas
     #   timetomodel
     #   workalendar
-python-dotenv==1.0.0
+python-dotenv==1.0.1
     # via -r requirements/app.in
-pytz==2023.3.post1
+pytz==2024.1
     # via
     #   -r requirements/app.in
     #   babel
@@ -281,7 +281,7 @@ redis==4.6.0
     #   rq-dashboard
 redis-sentinel-url==1.0.1
     # via rq-dashboard
-referencing==0.30.2
+referencing==0.33.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -289,9 +289,9 @@ requests==2.31.0
     # via
     #   requests-file
     #   tldextract
-requests-file==1.5.1
+requests-file==2.0.0
     # via tldextract
-rpds-py==0.10.2
+rpds-py==0.17.1
     # via
     #   jsonschema
     #   referencing
@@ -301,9 +301,9 @@ rq==1.15.1
     #   rq-dashboard
 rq-dashboard==0.6.7
     # via -r requirements/app.in
-scikit-base==0.5.1
+scikit-base==0.7.2
     # via sktime
-scikit-learn==1.3.0
+scikit-learn==1.3.2
     # via
     #   sktime
     #   timetomodel
@@ -315,17 +315,16 @@ scipy==1.10.1
     #   statsmodels
     #   timely-beliefs
     #   timetomodel
-sentry-sdk[flask]==1.30.0
+sentry-sdk[flask]==1.40.1
     # via -r requirements/app.in
 six==1.16.0
     # via
     #   isodate
     #   patsy
     #   python-dateutil
-    #   requests-file
-sktime==0.22.0
+sktime==0.26.0
     # via timely-beliefs
-sqlalchemy==1.4.49
+sqlalchemy==2.0.25
     # via
     #   -r requirements/app.in
     #   alembic
@@ -333,38 +332,40 @@ sqlalchemy==1.4.49
     #   marshmallow-sqlalchemy
     #   timely-beliefs
     #   timetomodel
-statsmodels==0.14.0
+statsmodels==0.14.1
     # via timetomodel
 tabulate==0.9.0
     # via -r requirements/app.in
 threadpoolctl==3.2.0
     # via scikit-learn
-timely-beliefs[forecast]==1.25.1
+timely-beliefs[forecast]==2.0.0
     # via -r requirements/app.in
 timetomodel==0.7.3
     # via -r requirements/app.in
-tldextract==3.5.0
+tldextract==5.1.1
     # via -r requirements/app.in
-toolz==0.12.0
+toolz==0.12.1
     # via altair
-typing-extensions==4.7.1
+types-python-dateutil==2.8.19.20240106
+    # via arrow
+typing-extensions==4.9.0
     # via
     #   alembic
     #   altair
-    #   filelock
     #   py-moneyed
     #   pydantic
-tzdata==2023.3
+    #   sqlalchemy
+tzdata==2023.4
     # via pandas
-uniplot==0.10.2
+uniplot==0.11.0
     # via -r requirements/app.in
-urllib3==2.0.4
+urllib3==2.2.0
     # via
     #   requests
     #   sentry-sdk
-vl-convert-python==0.13.1
+vl-convert-python==1.2.3
     # via -r requirements/app.in
-webargs==8.3.0
+webargs==8.4.0
     # via -r requirements/app.in
 werkzeug==2.2.3
     # via
@@ -373,13 +374,13 @@ werkzeug==2.2.3
     #   flask-login
 workalendar==17.0.0
     # via -r requirements/app.in
-wtforms==3.0.1
+wtforms==3.1.2
     # via
     #   flask-security-too
     #   flask-wtf
 xlrd==2.0.1
     # via -r requirements/app.in
-zipp==3.16.2
+zipp==3.17.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/3.8/dev.txt
+++ b/requirements/3.8/dev.txt
@@ -13,9 +13,9 @@ click==8.1.7
     #   -c requirements/3.8/app.txt
     #   -c requirements/3.8/test.txt
     #   black
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
-filelock==3.12.3
+filelock==3.13.1
     # via
     #   -c requirements/3.8/app.txt
     #   virtualenv
@@ -23,11 +23,11 @@ flake8==4.0.1
     # via -r requirements/dev.in
 flake8-blind-except==0.2.1
     # via -r requirements/dev.in
-identify==2.5.28
+identify==2.5.33
     # via pre-commit
 mccabe==0.6.1
     # via flake8
-mypy==1.5.1
+mypy==1.8.0
     # via -r requirements/dev.in
 mypy-extensions==1.0.0
     # via
@@ -35,32 +35,32 @@ mypy-extensions==1.0.0
     #   mypy
 nodeenv==1.8.0
     # via pre-commit
-packaging==23.1
+packaging==23.2
     # via
     #   -c requirements/3.8/app.txt
     #   -c requirements/3.8/test.txt
     #   setuptools-scm
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-platformdirs==3.10.0
+platformdirs==4.2.0
     # via
     #   black
     #   virtualenv
-pre-commit==3.4.0
+pre-commit==3.5.0
     # via -r requirements/dev.in
 pycodestyle==2.8.0
     # via flake8
 pyflakes==2.4.0
     # via flake8
-pyinstrument==4.5.3
+pyinstrument==4.6.2
     # via -r requirements/dev.in
-pytest-runner==6.0.0
+pytest-runner==6.0.1
     # via -r requirements/dev.in
 pyyaml==6.0.1
     # via
     #   -c requirements/3.8/app.txt
     #   pre-commit
-setuptools-scm==7.1.0
+setuptools-scm==8.0.4
     # via -r requirements/dev.in
 tomli==2.0.1
     # via
@@ -68,14 +68,13 @@ tomli==2.0.1
     #   black
     #   mypy
     #   setuptools-scm
-typing-extensions==4.7.1
+typing-extensions==4.9.0
     # via
     #   -c requirements/3.8/app.txt
     #   black
-    #   filelock
     #   mypy
     #   setuptools-scm
-virtualenv==20.24.5
+virtualenv==20.25.0
     # via pre-commit
 watchdog==3.0.0
     # via -r requirements/dev.in

--- a/requirements/3.8/docs.txt
+++ b/requirements/3.8/docs.txt
@@ -6,50 +6,50 @@
 #
 alabaster==0.7.13
     # via sphinx
-babel==2.12.1
+babel==2.14.0
     # via
     #   -c requirements/3.8/app.txt
     #   sphinx
-certifi==2023.7.22
+certifi==2024.2.2
     # via
     #   -c requirements/3.8/app.txt
     #   requests
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via
     #   -c requirements/3.8/app.txt
     #   requests
-docutils==0.18.1
+docutils==0.20.1
     # via
     #   sphinx
     #   sphinx-rtd-theme
     #   sphinx-tabs
-idna==3.4
+idna==3.6
     # via
     #   -c requirements/3.8/app.txt
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.8.0
+importlib-metadata==7.0.1
     # via
     #   -c requirements/3.8/app.txt
     #   sphinx
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   -c requirements/3.8/app.txt
     #   sphinx
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   -c requirements/3.8/app.txt
     #   jinja2
-packaging==23.1
+packaging==23.2
     # via
     #   -c requirements/3.8/app.txt
     #   sphinx
-pygments==2.16.1
+pygments==2.17.2
     # via
     #   sphinx
     #   sphinx-tabs
-pytz==2023.3.post1
+pytz==2024.1
     # via
     #   -c requirements/3.8/app.txt
     #   babel
@@ -76,9 +76,9 @@ sphinx-copybutton==0.5.2
     # via -r requirements/docs.in
 sphinx-fontawesome==0.0.6
     # via -r requirements/docs.in
-sphinx-rtd-theme==1.3.0
+sphinx-rtd-theme==2.0.0
     # via -r requirements/docs.in
-sphinx-tabs==3.4.1
+sphinx-tabs==3.4.5
     # via -r requirements/docs.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -96,11 +96,11 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-urllib3==2.0.4
+urllib3==2.2.0
     # via
     #   -c requirements/3.8/app.txt
     #   requests
-zipp==3.16.2
+zipp==3.17.0
     # via
     #   -c requirements/3.8/app.txt
     #   importlib-metadata

--- a/requirements/3.8/test.txt
+++ b/requirements/3.8/test.txt
@@ -8,11 +8,11 @@ async-timeout==4.0.3
     # via
     #   -c requirements/3.8/app.txt
     #   redis
-certifi==2023.7.22
+certifi==2024.2.2
     # via
     #   -c requirements/3.8/app.txt
     #   requests
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via
     #   -c requirements/3.8/app.txt
     #   requests
@@ -20,11 +20,11 @@ click==8.1.7
     # via
     #   -c requirements/3.8/app.txt
     #   flask
-coverage[toml]==7.3.1
+coverage[toml]==7.4.1
     # via pytest-cov
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via pytest
-fakeredis==2.18.1
+fakeredis==2.21.0
     # via -r requirements/test.in
 flask==2.2.5
     # via
@@ -32,11 +32,11 @@ flask==2.2.5
     #   pytest-flask
 highspy==1.5.3
     # via -r requirements/test.in
-idna==3.4
+idna==3.6
     # via
     #   -c requirements/3.8/app.txt
     #   requests
-importlib-metadata==6.8.0
+importlib-metadata==7.0.1
     # via
     #   -c requirements/3.8/app.txt
     #   flask
@@ -46,25 +46,25 @@ itsdangerous==2.1.2
     # via
     #   -c requirements/3.8/app.txt
     #   flask
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   -c requirements/3.8/app.txt
     #   flask
 lupa==2.0
     # via -r requirements/test.in
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   -c requirements/3.8/app.txt
     #   jinja2
     #   werkzeug
-packaging==23.1
+packaging==23.2
     # via
     #   -c requirements/3.8/app.txt
     #   pytest
     #   pytest-sugar
-pluggy==1.3.0
+pluggy==1.4.0
     # via pytest
-pytest==7.4.2
+pytest==8.0.0
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -72,9 +72,9 @@ pytest==7.4.2
     #   pytest-sugar
 pytest-cov==4.1.0
     # via -r requirements/test.in
-pytest-flask==1.2.0
+pytest-flask==1.3.0
     # via -r requirements/test.in
-pytest-sugar==0.9.7
+pytest-sugar==1.0.0
     # via -r requirements/test.in
 redis==4.6.0
     # via
@@ -93,13 +93,13 @@ six==1.16.0
     #   requests-mock
 sortedcontainers==2.4.0
     # via fakeredis
-termcolor==2.3.0
+termcolor==2.4.0
     # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage
     #   pytest
-urllib3==2.0.4
+urllib3==2.2.0
     # via
     #   -c requirements/3.8/app.txt
     #   requests
@@ -108,7 +108,7 @@ werkzeug==2.2.3
     #   -c requirements/3.8/app.txt
     #   flask
     #   pytest-flask
-zipp==3.16.2
+zipp==3.17.0
     # via
     #   -c requirements/3.8/app.txt
     #   importlib-metadata

--- a/requirements/3.9/app.txt
+++ b/requirements/3.9/app.txt
@@ -4,33 +4,33 @@
 #
 #    pip-compile --output-file=requirements/3.9/app.txt requirements/app.in
 #
-alembic==1.12.0
+alembic==1.13.1
     # via flask-migrate
-altair==5.1.1
+altair==5.2.0
     # via -r requirements/app.in
-arrow==1.2.3
+arrow==1.3.0
     # via rq-dashboard
 async-timeout==4.0.3
     # via redis
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   jsonschema
     #   referencing
-babel==2.12.1
+babel==2.14.0
     # via py-moneyed
-bcrypt==4.0.1
+bcrypt==4.1.2
     # via -r requirements/app.in
-blinker==1.6.2
+blinker==1.7.0
     # via
     #   flask-mail
     #   flask-principal
     #   flask-security-too
     #   sentry-sdk
-certifi==2023.7.22
+certifi==2024.2.2
     # via
     #   requests
     #   sentry-sdk
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via
@@ -42,21 +42,21 @@ click-default-group==1.2.4
     # via -r requirements/app.in
 colour==0.1.5
     # via -r requirements/app.in
-contourpy==1.1.0
+contourpy==1.2.0
     # via matplotlib
 convertdate==2.4.0
     # via workalendar
-cycler==0.11.0
+cycler==0.12.1
     # via matplotlib
-dill==0.3.7
+dill==0.3.8
     # via openturns
-dnspython==2.4.2
+dnspython==2.5.0
     # via email-validator
-email-validator==2.0.0.post2
+email-validator==2.1.0.post1
     # via
     #   -r requirements/app.in
     #   flask-security-too
-filelock==3.12.3
+filelock==3.13.1
     # via tldextract
 flask==2.2.5
     # via
@@ -81,53 +81,55 @@ flask-cors==4.0.0
     # via -r requirements/app.in
 flask-json==0.4.0
     # via -r requirements/app.in
-flask-login==0.6.2
+flask-login==0.6.3
     # via
     #   -r requirements/app.in
     #   flask-security-too
 flask-mail==0.9.1
     # via -r requirements/app.in
-flask-marshmallow==0.15.0
+flask-marshmallow==1.2.0
     # via -r requirements/app.in
-flask-migrate==4.0.4
+flask-migrate==4.0.5
     # via -r requirements/app.in
 flask-principal==0.4.0
     # via flask-security-too
 flask-security-too==5.1.2
     # via -r requirements/app.in
-flask-sqlalchemy==3.0.5
+flask-sqlalchemy==3.1.1
     # via
     #   -r requirements/app.in
     #   flask-migrate
 flask-sslify==0.1.5
     # via -r requirements/app.in
-flask-wtf==1.1.1
+flask-wtf==1.2.1
     # via
     #   -r requirements/app.in
     #   flask-security-too
-fonttools==4.42.1
+fonttools==4.48.1
     # via matplotlib
-greenlet==2.0.2
+greenlet==3.0.3
     # via sqlalchemy
-humanize==4.8.0
+humanize==4.9.0
     # via -r requirements/app.in
-idna==3.4
+idna==3.6
     # via
     #   email-validator
     #   requests
     #   tldextract
-importlib-metadata==6.8.0
+importlib-metadata==7.0.1
     # via
     #   -r requirements/app.in
     #   flask
     #   timely-beliefs
-importlib-resources==6.0.1
-    # via matplotlib
+importlib-resources==6.1.1
+    # via
+    #   flask-security-too
+    #   matplotlib
 inflect==6.0.2
     # via -r requirements/app.in
 inflection==0.5.1
     # via -r requirements/app.in
-iso8601==2.0.0
+iso8601==2.1.0
     # via -r requirements/app.in
 isodate==0.6.1
     # via
@@ -138,30 +140,31 @@ itsdangerous==2.1.2
     #   flask
     #   flask-security-too
     #   flask-wtf
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   altair
     #   flask
 joblib==1.3.2
     # via scikit-learn
-jsonschema==4.19.0
+jsonschema==4.21.1
     # via altair
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.12.1
     # via jsonschema
 kiwisolver==1.4.5
     # via matplotlib
-lunardate==0.2.0
+lunardate==0.2.2
     # via workalendar
-mako==1.2.4
+mako==1.3.2
     # via alembic
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
+    #   flask-security-too
     #   jinja2
     #   mako
     #   sentry-sdk
     #   werkzeug
     #   wtforms
-marshmallow==3.20.1
+marshmallow==3.20.2
     # via
     #   -r requirements/app.in
     #   flask-marshmallow
@@ -170,9 +173,9 @@ marshmallow==3.20.1
     #   webargs
 marshmallow-polyfield==5.11
     # via -r requirements/app.in
-marshmallow-sqlalchemy==0.29.0
+marshmallow-sqlalchemy==1.0.0
     # via -r requirements/app.in
-matplotlib==3.7.3
+matplotlib==3.8.2
     # via timetomodel
 numpy==1.24.4
     # via
@@ -190,19 +193,17 @@ numpy==1.24.4
     #   timely-beliefs
     #   timetomodel
     #   uniplot
-openturns==1.21
+openturns==1.22
     # via timely-beliefs
-packaging==23.1
+packaging==23.2
     # via
     #   altair
-    #   flask-marshmallow
     #   marshmallow
-    #   marshmallow-sqlalchemy
     #   matplotlib
     #   sktime
     #   statsmodels
     #   webargs
-pandas==2.0.3
+pandas==2.1.4
     # via
     #   -r requirements/app.in
     #   altair
@@ -212,13 +213,13 @@ pandas==2.0.3
     #   timetomodel
 passlib==1.7.4
     # via flask-security-too
-patsy==0.5.3
+patsy==0.5.6
     # via statsmodels
-pillow==10.0.1
+pillow==10.2.0
     # via
     #   -r requirements/app.in
     #   matplotlib
-pint==0.22
+pint==0.23
     # via -r requirements/app.in
 ply==3.11
     # via pyomo
@@ -226,15 +227,15 @@ properscoring==0.1
     # via timely-beliefs
 pscript==0.7.7
     # via -r requirements/app.in
-psutil==5.9.5
+psutil==5.9.8
     # via openturns
-psycopg2-binary==2.9.7
+psycopg2-binary==2.9.9
     # via
     #   -r requirements/app.in
     #   timely-beliefs
 py-moneyed==3.0
     # via -r requirements/app.in
-pydantic==1.10.12
+pydantic==1.10.14
     # via
     #   -r requirements/app.in
     #   inflect
@@ -242,7 +243,7 @@ pyluach==2.2.0
     # via workalendar
 pymeeus==0.5.12
     # via convertdate
-pyomo==6.6.2
+pyomo==6.7.0
     # via -r requirements/app.in
 pyparsing==3.1.1
     # via matplotlib
@@ -253,9 +254,9 @@ python-dateutil==2.8.2
     #   pandas
     #   timetomodel
     #   workalendar
-python-dotenv==1.0.0
+python-dotenv==1.0.1
     # via -r requirements/app.in
-pytz==2023.3.post1
+pytz==2024.1
     # via
     #   -r requirements/app.in
     #   pandas
@@ -271,7 +272,7 @@ redis==4.6.0
     #   rq-dashboard
 redis-sentinel-url==1.0.1
     # via rq-dashboard
-referencing==0.30.2
+referencing==0.33.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -279,9 +280,9 @@ requests==2.31.0
     # via
     #   requests-file
     #   tldextract
-requests-file==1.5.1
+requests-file==2.0.0
     # via tldextract
-rpds-py==0.10.2
+rpds-py==0.17.1
     # via
     #   jsonschema
     #   referencing
@@ -291,13 +292,13 @@ rq==1.15.1
     #   rq-dashboard
 rq-dashboard==0.6.7
     # via -r requirements/app.in
-scikit-base==0.5.1
+scikit-base==0.7.2
     # via sktime
-scikit-learn==1.3.0
+scikit-learn==1.4.0
     # via
     #   sktime
     #   timetomodel
-scipy==1.11.2
+scipy==1.12.0
     # via
     #   properscoring
     #   scikit-learn
@@ -305,15 +306,14 @@ scipy==1.11.2
     #   statsmodels
     #   timely-beliefs
     #   timetomodel
-sentry-sdk[flask]==1.30.0
+sentry-sdk[flask]==1.40.1
     # via -r requirements/app.in
 six==1.16.0
     # via
     #   isodate
     #   patsy
     #   python-dateutil
-    #   requests-file
-sktime==0.22.0
+sktime==0.26.0
     # via timely-beliefs
 sqlalchemy==2.0.25
     # via
@@ -323,42 +323,41 @@ sqlalchemy==2.0.25
     #   marshmallow-sqlalchemy
     #   timely-beliefs
     #   timetomodel
-statsmodels==0.14.0
+statsmodels==0.14.1
     # via timetomodel
 tabulate==0.9.0
     # via -r requirements/app.in
 threadpoolctl==3.2.0
     # via scikit-learn
-timely-beliefs[forecast]==1.25.1
-    # via
-    #   -r requirements/app.in
-    #   timely-beliefs
+timely-beliefs[forecast]==2.0.0
+    # via -r requirements/app.in
 timetomodel==0.7.3
     # via -r requirements/app.in
-tldextract==3.5.0
+tldextract==5.1.1
     # via -r requirements/app.in
-toolz==0.12.0
+toolz==0.12.1
     # via altair
-typing-extensions==4.7.1
+types-python-dateutil==2.8.19.20240106
+    # via arrow
+typing-extensions==4.9.0
     # via
     #   alembic
     #   altair
-    #   filelock
     #   pint
     #   py-moneyed
     #   pydantic
     #   sqlalchemy
-tzdata==2023.3
+tzdata==2023.4
     # via pandas
-uniplot==0.10.2
+uniplot==0.11.0
     # via -r requirements/app.in
-urllib3==2.0.4
+urllib3==2.2.0
     # via
     #   requests
     #   sentry-sdk
-vl-convert-python==0.13.1
+vl-convert-python==1.2.3
     # via -r requirements/app.in
-webargs==8.3.0
+webargs==8.4.0
     # via -r requirements/app.in
 werkzeug==2.2.3
     # via
@@ -367,13 +366,13 @@ werkzeug==2.2.3
     #   flask-login
 workalendar==17.0.0
     # via -r requirements/app.in
-wtforms==3.0.1
+wtforms==3.1.2
     # via
     #   flask-security-too
     #   flask-wtf
 xlrd==2.0.1
     # via -r requirements/app.in
-zipp==3.16.2
+zipp==3.17.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/3.9/dev.txt
+++ b/requirements/3.9/dev.txt
@@ -13,9 +13,9 @@ click==8.1.7
     #   -c requirements/3.9/app.txt
     #   -c requirements/3.9/test.txt
     #   black
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
-filelock==3.12.3
+filelock==3.13.1
     # via
     #   -c requirements/3.9/app.txt
     #   virtualenv
@@ -23,11 +23,11 @@ flake8==4.0.1
     # via -r requirements/dev.in
 flake8-blind-except==0.2.1
     # via -r requirements/dev.in
-identify==2.5.28
+identify==2.5.33
     # via pre-commit
 mccabe==0.6.1
     # via flake8
-mypy==1.5.1
+mypy==1.8.0
     # via -r requirements/dev.in
 mypy-extensions==1.0.0
     # via
@@ -35,32 +35,32 @@ mypy-extensions==1.0.0
     #   mypy
 nodeenv==1.8.0
     # via pre-commit
-packaging==23.1
+packaging==23.2
     # via
     #   -c requirements/3.9/app.txt
     #   -c requirements/3.9/test.txt
     #   setuptools-scm
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-platformdirs==3.10.0
+platformdirs==4.2.0
     # via
     #   black
     #   virtualenv
-pre-commit==3.4.0
+pre-commit==3.6.0
     # via -r requirements/dev.in
 pycodestyle==2.8.0
     # via flake8
 pyflakes==2.4.0
     # via flake8
-pyinstrument==4.5.3
+pyinstrument==4.6.2
     # via -r requirements/dev.in
-pytest-runner==6.0.0
+pytest-runner==6.0.1
     # via -r requirements/dev.in
 pyyaml==6.0.1
     # via
     #   -c requirements/3.9/app.txt
     #   pre-commit
-setuptools-scm==7.1.0
+setuptools-scm==8.0.4
     # via -r requirements/dev.in
 tomli==2.0.1
     # via
@@ -68,14 +68,13 @@ tomli==2.0.1
     #   black
     #   mypy
     #   setuptools-scm
-typing-extensions==4.7.1
+typing-extensions==4.9.0
     # via
     #   -c requirements/3.9/app.txt
     #   black
-    #   filelock
     #   mypy
     #   setuptools-scm
-virtualenv==20.24.5
+virtualenv==20.25.0
     # via pre-commit
 watchdog==3.0.0
     # via -r requirements/dev.in

--- a/requirements/3.9/docs.txt
+++ b/requirements/3.9/docs.txt
@@ -4,48 +4,48 @@
 #
 #    pip-compile --constraint=requirements/3.9/app.txt --output-file=requirements/3.9/docs.txt requirements/docs.in
 #
-alabaster==0.7.13
+alabaster==0.7.16
     # via sphinx
-babel==2.12.1
+babel==2.14.0
     # via
     #   -c requirements/3.9/app.txt
     #   sphinx
-certifi==2023.7.22
+certifi==2024.2.2
     # via
     #   -c requirements/3.9/app.txt
     #   requests
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via
     #   -c requirements/3.9/app.txt
     #   requests
-docutils==0.18.1
+docutils==0.20.1
     # via
     #   sphinx
     #   sphinx-rtd-theme
     #   sphinx-tabs
-idna==3.4
+idna==3.6
     # via
     #   -c requirements/3.9/app.txt
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.8.0
+importlib-metadata==7.0.1
     # via
     #   -c requirements/3.9/app.txt
     #   sphinx
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   -c requirements/3.9/app.txt
     #   sphinx
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   -c requirements/3.9/app.txt
     #   jinja2
-packaging==23.1
+packaging==23.2
     # via
     #   -c requirements/3.9/app.txt
     #   sphinx
-pygments==2.16.1
+pygments==2.17.2
     # via
     #   sphinx
     #   sphinx-tabs
@@ -59,33 +59,28 @@ six==1.16.0
     #   sphinxcontrib-httpdomain
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==7.2.5
+sphinx==7.2.6
     # via
     #   -r requirements/docs.in
     #   sphinx-copybutton
     #   sphinx-fontawesome
     #   sphinx-rtd-theme
     #   sphinx-tabs
-    #   sphinxcontrib-applehelp
-    #   sphinxcontrib-devhelp
-    #   sphinxcontrib-htmlhelp
     #   sphinxcontrib-httpdomain
     #   sphinxcontrib-jquery
-    #   sphinxcontrib-qthelp
-    #   sphinxcontrib-serializinghtml
 sphinx-copybutton==0.5.2
     # via -r requirements/docs.in
 sphinx-fontawesome==0.0.6
     # via -r requirements/docs.in
-sphinx-rtd-theme==1.3.0
+sphinx-rtd-theme==2.0.0
     # via -r requirements/docs.in
-sphinx-tabs==3.4.1
+sphinx-tabs==3.4.5
     # via -r requirements/docs.in
-sphinxcontrib-applehelp==1.0.7
+sphinxcontrib-applehelp==1.0.8
     # via sphinx
-sphinxcontrib-devhelp==1.0.5
+sphinxcontrib-devhelp==1.0.6
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.4
+sphinxcontrib-htmlhelp==2.0.5
     # via sphinx
 sphinxcontrib-httpdomain==1.8.1
     # via -r requirements/docs.in
@@ -93,15 +88,15 @@ sphinxcontrib-jquery==4.1
     # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.6
+sphinxcontrib-qthelp==1.0.7
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.9
+sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
-urllib3==2.0.4
+urllib3==2.2.0
     # via
     #   -c requirements/3.9/app.txt
     #   requests
-zipp==3.16.2
+zipp==3.17.0
     # via
     #   -c requirements/3.9/app.txt
     #   importlib-metadata

--- a/requirements/3.9/test.txt
+++ b/requirements/3.9/test.txt
@@ -8,11 +8,11 @@ async-timeout==4.0.3
     # via
     #   -c requirements/3.9/app.txt
     #   redis
-certifi==2023.7.22
+certifi==2024.2.2
     # via
     #   -c requirements/3.9/app.txt
     #   requests
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via
     #   -c requirements/3.9/app.txt
     #   requests
@@ -20,13 +20,11 @@ click==8.1.7
     # via
     #   -c requirements/3.9/app.txt
     #   flask
-coverage[toml]==7.3.1
-    # via
-    #   coverage
-    #   pytest-cov
-exceptiongroup==1.1.3
+coverage[toml]==7.4.1
+    # via pytest-cov
+exceptiongroup==1.2.0
     # via pytest
-fakeredis==2.18.1
+fakeredis==2.21.0
     # via -r requirements/test.in
 flask==2.2.5
     # via
@@ -34,11 +32,11 @@ flask==2.2.5
     #   pytest-flask
 highspy==1.5.3
     # via -r requirements/test.in
-idna==3.4
+idna==3.6
     # via
     #   -c requirements/3.9/app.txt
     #   requests
-importlib-metadata==6.8.0
+importlib-metadata==7.0.1
     # via
     #   -c requirements/3.9/app.txt
     #   flask
@@ -48,25 +46,25 @@ itsdangerous==2.1.2
     # via
     #   -c requirements/3.9/app.txt
     #   flask
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   -c requirements/3.9/app.txt
     #   flask
 lupa==2.0
     # via -r requirements/test.in
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   -c requirements/3.9/app.txt
     #   jinja2
     #   werkzeug
-packaging==23.1
+packaging==23.2
     # via
     #   -c requirements/3.9/app.txt
     #   pytest
     #   pytest-sugar
-pluggy==1.3.0
+pluggy==1.4.0
     # via pytest
-pytest==7.4.2
+pytest==8.0.0
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -74,9 +72,9 @@ pytest==7.4.2
     #   pytest-sugar
 pytest-cov==4.1.0
     # via -r requirements/test.in
-pytest-flask==1.2.0
+pytest-flask==1.3.0
     # via -r requirements/test.in
-pytest-sugar==0.9.7
+pytest-sugar==1.0.0
     # via -r requirements/test.in
 redis==4.6.0
     # via
@@ -95,13 +93,13 @@ six==1.16.0
     #   requests-mock
 sortedcontainers==2.4.0
     # via fakeredis
-termcolor==2.3.0
+termcolor==2.4.0
     # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage
     #   pytest
-urllib3==2.0.4
+urllib3==2.2.0
     # via
     #   -c requirements/3.9/app.txt
     #   requests
@@ -110,7 +108,7 @@ werkzeug==2.2.3
     #   -c requirements/3.9/app.txt
     #   flask
     #   pytest-flask
-zipp==3.16.2
+zipp==3.17.0
     # via
     #   -c requirements/3.9/app.txt
     #   importlib-metadata

--- a/requirements/Readme.md
+++ b/requirements/Readme.md
@@ -18,4 +18,4 @@ Here, we describe the requirements. We give the name of a requirement or even a 
 
 These files are not to be edited by hand. They are created by `pip-compile` (or `make freeze-deps`).
 
-Each requirement is pinned to a specific version in these files. The great benefit is reproducability across environemnts (local dev as well as staging or production).
+Each requirement is pinned to a specific version in these files. The great benefit is reproducibility across environments (local dev as well as staging or production).

--- a/requirements/Readme.md
+++ b/requirements/Readme.md
@@ -19,3 +19,5 @@ Here, we describe the requirements. We give the name of a requirement or even a 
 These files are not to be edited by hand. They are created by `pip-compile` (or `make freeze-deps`).
 
 Each requirement is pinned to a specific version in these files. The great benefit is reproducibility across environments (local dev as well as staging or production).
+
+To update the .txt files for all supported Python versions, see `ci/update-packages.sh`.


### PR DESCRIPTION
## Description

> We can run the script @Nischay-Pro  wrote to update the dependencies for all supported versions.

_Originally posted by @nhoening in https://github.com/FlexMeasures/flexmeasures/issues/938#issuecomment-1930752289_

While looking up the script, I became confused about the state of our tooling for this. I could run `make upgrade-deps`, but also `. ci/update-packages.sh`.
- Why do we still have both options?
- And doesn't either amount to updating/upgrading(?) all dependencies, rather than just what would be required for SQLAlchemy==2?
