### PR TITLE
feature: show beliefs from a given source type only

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,6 +13,7 @@ New features
 -------------   
 
 * Enable the use of QuantityOrSensor fields for the ``flexmeasures add schedule for-storage`` CLI command [see `PR #966 <https://github.com/FlexMeasures/flexmeasures/pull/966>`_]
+* CLI support for showing/savings time series data for a given type of source only, with the new ``--source-type`` option of ``flexmeasures show beliefs``, which let's you filter out schedules, forecasts, or data POSTed by users (through the API), which each have a different source type [see `PR #976 <https://github.com/FlexMeasures/flexmeasures/pull/976>`_]
 * Support for defining the storage efficiency as a sensor or quantity for the ``StorageScheduler`` [see `PR #965 <https://github.com/FlexMeasures/flexmeasures/pull/965>`_]
 * Support a less verbose way of setting the same :abbr:`SoC (state of charge)` constraint for a given time window [see `PR #899 <https://github.com/FlexMeasures/flexmeasures/pull/899>`_]
 

--- a/flexmeasures/cli/data_show.py
+++ b/flexmeasures/cli/data_show.py
@@ -482,6 +482,13 @@ def chart(
     help="Source of the beliefs (an existing source id).",
 )
 @click.option(
+    "--source-type",
+    "source_types",
+    required=False,
+    type=str,
+    help="Only show beliefs from this type of source, for example, 'user', 'forecaster' or 'scheduler'.",
+)
+@click.option(
     "--resolution",
     "resolution",
     type=DurationField(),
@@ -519,6 +526,7 @@ def plot_beliefs(
     belief_time_before: datetime | None,
     source: DataSource | None,
     filepath: str | None,
+    source_types: list[str] = None,
     include_ids: bool = False,
 ):
     """
@@ -537,6 +545,7 @@ def plot_beliefs(
         event_ends_before=start + duration,
         beliefs_before=belief_time_before,
         source=source,
+        source_types=source_types,
         one_deterministic_belief_per_event=True,
         resolution=resolution,
         sum_multiple=False,


### PR DESCRIPTION
## Description

This PR let's you show beliefs (and save them to file) **for a given type of source**, which let's you filter out schedules, forecasts, or data POSTed by users through the API, each of which have a different source type.

## Look & Feel

```
flexmeasures show beliefs --source-type user --start "2023-01-01T00:00+01" --duration "P1Y" --resolution "PT1H" --sensor-id 1 --sensor-id 2 --sensor-id 3 --to-file V2G-Liberty-2023.csv
```
