### PR TITLE
feature(UI): navigate sibling assets/sensors

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -12,6 +12,7 @@ v0.19.0 | February xx, 2024
 New features
 -------------   
 
+* Expand the UI's breadcrumb functionality with the ability to navigate directly to sibling assets and sensors using their child-parent relationship [see `PR #977 <https://github.com/FlexMeasures/flexmeasures/pull/977>`_]
 * Enable the use of QuantityOrSensor fields for the ``flexmeasures add schedule for-storage`` CLI command [see `PR #966 <https://github.com/FlexMeasures/flexmeasures/pull/966>`_]
 * Support for defining the storage efficiency as a sensor or quantity for the ``StorageScheduler`` [see `PR #965 <https://github.com/FlexMeasures/flexmeasures/pull/965>`_]
 * Support a less verbose way of setting the same :abbr:`SoC (state of charge)` constraint for a given time window [see `PR #899 <https://github.com/FlexMeasures/flexmeasures/pull/899>`_]

--- a/flexmeasures/ui/static/css/flexmeasures.css
+++ b/flexmeasures/ui/static/css/flexmeasures.css
@@ -240,6 +240,7 @@ p.error {
 
 .dropdown-menu {
     border: none !important;
+    z-index: 2000;
 }
 
 .navbar-default .navbar-nav>li>a:focus,

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -10,11 +10,16 @@
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb">
     {% for breadcrumb in breadcrumb_info["ancestors"] %}
-      <li class="breadcrumb-item{% if loop.last %} active{% endif %}" {% if loop.last %}aria-current="page"{% endif %}>
+      <li class="breadcrumb-item{% if loop.last %} dropdown active{% endif %}" {% if loop.last %}aria-current="page"{% endif %}>
         {% if breadcrumb["url"] is not none and not loop.last %}
           <a href="{{ breadcrumb['url'] }}">{{ breadcrumb['name'] }}</a>
         {% else %}
-          {{ breadcrumb['name'] }}
+          <a class="dropdown-toggle" data-toggle="dropdown" href="#">{{ breadcrumb['name'] }}<span class="caret"></span></a>
+          <ul class="dropdown-menu">
+            {% for sibling in breadcrumb_info["siblings"] %}
+              <li><a href="{{ sibling['url'] }}">{{ sibling["name"] }}</a></li>
+            {% endfor %}
+          </ul>
         {% endif %}
       </li>
     {% endfor %}

--- a/flexmeasures/ui/templates/views/sensors.html
+++ b/flexmeasures/ui/templates/views/sensors.html
@@ -10,11 +10,16 @@
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb">
     {% for breadcrumb in breadcrumb_info["ancestors"] %}
-      <li class="breadcrumb-item{% if loop.last %} active{% endif %}" {% if loop.last %}aria-current="page"{% endif %}>
+      <li class="breadcrumb-item{% if loop.last %} dropdown active{% endif %}" {% if loop.last %}aria-current="page"{% endif %}>
         {% if breadcrumb["url"] is not none and not loop.last %}
           <a href="{{ breadcrumb['url'] }}">{{ breadcrumb['name'] }}</a>
         {% else %}
-          {{ breadcrumb['name'] }}
+          <a class="dropdown-toggle" data-toggle="dropdown" href="#">{{ breadcrumb['name'] }}<span class="caret"></span></a>
+          <ul class="dropdown-menu">
+            {% for sibling in breadcrumb_info["siblings"] %}
+              <li><a href="{{ sibling['url'] }}">{{ sibling["name"] }}</a></li>
+            {% endfor %}
+          </ul>
         {% endif %}
       </li>
     {% endfor %}

--- a/flexmeasures/ui/utils/breadcrumb_utils.py
+++ b/flexmeasures/ui/utils/breadcrumb_utils.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
 from flexmeasures import Sensor, Asset, Account
+from flexmeasures.utils.flexmeasures_inflection import human_sorted
 from flask import url_for
 
 
 def get_breadcrumb_info(entity: Sensor | Asset | Account | None) -> dict:
     return {
         "ancestors": get_ancestry(entity),
+        "siblings": get_siblings(entity),
     }
 
 
 def get_ancestry(entity: Sensor | Asset | Account | None) -> list[dict]:
-
     # Public account
     if entity is None:
         return [{"url": None, "name": "PUBLIC", "type": "Account"}]
@@ -55,3 +56,31 @@ def get_ancestry(entity: Sensor | Asset | Account | None) -> list[dict]:
             return get_ancestry(entity.parent_asset) + current_entity_info
 
     return []
+
+
+def get_siblings(entity: Sensor | Asset | Account | None) -> list[dict]:
+    siblings = []
+    if isinstance(entity, Sensor):
+        siblings = [
+            {
+                "url": url_for("SensorUI:get", id=sensor.id),
+                "name": sensor.name,
+                "type": "Sensor",
+            }
+            for sensor in entity.generic_asset.sensors
+        ]
+    if isinstance(entity, Asset):
+        if entity.parent_asset is not None:
+            sibling_assets = entity.parent_asset.child_assets
+        else:
+            sibling_assets = entity.owner.generic_assets
+        siblings = [
+            {
+                "url": url_for("AssetCrudUI:get", id=asset.id),
+                "name": asset.name,
+                "type": "Asset",
+            }
+            for asset in sibling_assets
+        ]
+    siblings = human_sorted(siblings, attr="name")
+    return siblings

--- a/flexmeasures/utils/flexmeasures_inflection.py
+++ b/flexmeasures/utils/flexmeasures_inflection.py
@@ -1,7 +1,9 @@
 """ FlexMeasures way of handling inflection """
 
 from __future__ import annotations
+
 import re
+from typing import Any
 
 import inflect
 import inflection
@@ -61,3 +63,51 @@ def titleize(word):
 
 def join_words_into_a_list(words: list[str]) -> str:
     return p.join(words, final_sep="")
+
+
+def atoi(text):
+    """Utility method for the `natural_keys` method."""
+    return int(text) if text.isdigit() else text
+
+
+def natural_keys(text: str):
+    """Support for human sorting.
+
+    `alist.sort(key=natural_keys)` sorts in human order.
+
+    https://stackoverflow.com/a/5967539/13775459
+    """
+    return [atoi(c) for c in re.split(r"(\d+)", text)]
+
+
+def human_sorted(alist: list, attr: Any | None = None, reverse: bool = False):
+    """Human sort a list (for example, a list of strings or dictionaries).
+
+    :param alist:   List to be sorted.
+    :param attr:    Optionally, pass a dictionary key or attribute name to sort by
+    :param reverse: If True, sorts descending.
+
+    Example:
+    >>> alist = ["PV 10", "CP1", "PV 2", "PV 1", "CP 2"]
+    >>> sorted(alist)
+    ['CP 2', 'CP1', 'PV 1', 'PV 10', 'PV 2']
+    >>> human_sorted(alist)
+    ['CP1', 'CP 2', 'PV 1', 'PV 2', 'PV 10']
+    """
+    if attr is None:
+        # List of strings, to be sorted
+        sorted_list = sorted(alist, key=lambda k: natural_keys(str(k)), reverse=reverse)
+    else:
+        try:
+            # List of dictionaries, to be sorted by key
+            sorted_list = sorted(
+                alist, key=lambda k: natural_keys(k[attr]), reverse=reverse
+            )
+        except TypeError:
+            # List of objects, to be sorted by attribute
+            sorted_list = sorted(
+                alist,
+                key=lambda k: natural_keys(str(getattr(k, attr))),
+                reverse=reverse,
+            )
+    return sorted_list


### PR DESCRIPTION
## Description

This PR let's you navigate sibling assets or sibling sensors in the breadcrumb.

## Look & Feel

![image](https://github.com/FlexMeasures/flexmeasures/assets/30658763/b41c0d61-b150-4e26-89c2-0fc46bce91ed)

## How to test

Load an asset page or sensor page, preferably one that actually has siblings.

## Further Improvements

One idea is to support sibling navigation on any of the ancestors. However, the UX would then need a little rethinking, as the dropdown currently opens on click, and clicking an ancestor already takes you to that ancestor's page. I don't think it's really needed.
