### PR TITLE
hotfix/Use the right event resolution for the efficiency in the CLI test

### DIFF
--- a/flexmeasures/cli/tests/conftest.py
+++ b/flexmeasures/cli/tests/conftest.py
@@ -187,12 +187,12 @@ def storage_schedule_sensors(
     storage_efficiency = Sensor(
         "storage_efficiency",
         generic_asset=data_storage,
-        event_resolution=timedelta(hours=1),
+        event_resolution=timedelta(minutes=15),
         unit="%",
     )
     db.session.add(storage_efficiency)
 
-    for h in range(24):
+    for h in range(24 * 4):
         beliefs.append(
             TimedBelief(
                 event_start=start + timedelta(hours=h),


### PR DESCRIPTION
PR https://github.com/FlexMeasures/flexmeasures/pull/965 introduced the the storage efficiency field as a `QuantityOrSensor` type and later an end-to-end test for the command `flexmeasures add schedule for-storage` was introduced. At the time of implementing the test, the PR #965 was still ongoing and we decided to raise in case of getting an efficiency in a resolution different to that of the power sensor. 

This PR fixes the test to use a 15min resolution sensor for the storage efficiency to match that of the power sensor.

> [!IMPORTANT]  
> There's no need to backport as this is feature was introduced in the current release cycle (v0.19.0)

 

## Related Items

https://github.com/FlexMeasures/flexmeasures/pull/965


---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
