### PR TITLE
hotfix/convert capacity to MW

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -29,6 +29,11 @@ Infrastructure / Support
 Bugfixes
 -----------
 
+v0.18.3 | February xx, 2024
+============================
+
+* Convert unit of the power capacities to ``MW`` instead of that of the storage power sensor [see `PR #979 <https://github.com/FlexMeasures/flexmeasures/pull/979>`_]
+
 
 v0.18.2 | January xx, 2024
 ============================

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -27,7 +27,7 @@ from flexmeasures.data.schemas.scheduling.storage import StorageFlexModelSchema
 from flexmeasures.data.schemas.scheduling import FlexContextSchema
 from flexmeasures.utils.time_utils import get_max_planning_horizon
 from flexmeasures.utils.coding_utils import deprecated
-from flexmeasures.utils.unit_utils import ur, convert_units
+from flexmeasures.utils.unit_utils import ur
 
 
 def check_and_convert_power_capacity(
@@ -211,12 +211,12 @@ class MetaStorageScheduler(Scheduler):
             ) * get_continuous_series_sensor_or_quantity(
                 quantity_or_sensor=production_capacity,
                 actuator=sensor,
-                unit=sensor.unit,
+                unit="MW",
                 query_window=(start, end),
                 resolution=resolution,
                 beliefs_before=belief_time,
                 fallback_attribute="production_capacity",
-                max_value=convert_units(power_capacity_in_mw, "MW", sensor.unit),
+                max_value=power_capacity_in_mw,
             )
         if sensor.get_attribute("is_strictly_non_negative"):
             device_constraints[0]["derivative max"] = 0
@@ -226,12 +226,12 @@ class MetaStorageScheduler(Scheduler):
             ] = get_continuous_series_sensor_or_quantity(
                 quantity_or_sensor=consumption_capacity,
                 actuator=sensor,
-                unit=sensor.unit,
+                unit="MW",
                 query_window=(start, end),
                 resolution=resolution,
                 beliefs_before=belief_time,
                 fallback_attribute="consumption_capacity",
-                max_value=convert_units(power_capacity_in_mw, "MW", sensor.unit),
+                max_value=power_capacity_in_mw,
             )
 
         soc_gain = self.flex_model.get("soc_gain", [])


### PR DESCRIPTION
## Description

The power limits were converted to the units of the power storage sensor. Luckily, as the current `StorageScheduler` doesn't support non-MW units, this issue hasn't pop up yet.

## Further Improvements

- Add a test with a storage sensor with units other than `MW`. A unit test cannot be added for now because we don't support scheduling power sensors with units 

## Related Items

- This issue was introduced in PR https://github.com/FlexMeasures/flexmeasures/pull/897
- Change is isolated from https://github.com/FlexMeasures/flexmeasures/pull/968

> [!IMPORTANT]  
> This PR needs to be backported to version **0.18.X**
---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
