### PR TITLE
Transfer ownership of asset and its children to a different account.

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -10,6 +10,9 @@ v0.20.0 | April XX, 2024
 New features
 -------------   
 
+* Add command ``flexmeasures edit transfer-ownership`` to transfer the ownership of an asset and its children [see `PR #983 <https://github.com/FlexMeasures/flexmeasures/pull/983>`_]
+
+
 Infrastructure / Support
 ----------------------
 

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -10,7 +10,7 @@ v0.20.0 | April XX, 2024
 New features
 -------------   
 
-* Add command ``flexmeasures edit transfer-ownership`` to transfer the ownership of an asset and its children [see `PR #983 <https://github.com/FlexMeasures/flexmeasures/pull/983>`_]
+* Add command ``flexmeasures edit transfer-ownership`` to transfer the ownership of an asset and its children from one account to another[see `PR #983 <https://github.com/FlexMeasures/flexmeasures/pull/983>`_]
 
 
 Infrastructure / Support

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -4,6 +4,11 @@
 FlexMeasures CLI Changelog
 **********************
 
+since v.0.20.0 | March XX, 2024
+=================================
+
+* Add command ``flexmeasures edit transfer-ownership`` to transfer the ownership of an asset and its children.
+
 since v0.19.0 | February 18, 2024
 =======================================
 

--- a/documentation/cli/commands.rst
+++ b/documentation/cli/commands.rst
@@ -68,6 +68,8 @@ of which some are referred to in this documentation.
 ``flexmeasures edit attribute``                   Edit (or add) an asset attribute or sensor attribute.
 ``flexmeasures edit resample-data``               | Assign a new event resolution to an existing sensor
                                                   | and resample its data accordingly.
+``flexmeasures edit transfer-ownership``          | Transfer the ownership of an asset and its children to
+                                                  | a different account.
 ================================================= =======================================
 
 

--- a/flexmeasures/cli/data_edit.py
+++ b/flexmeasures/cli/data_edit.py
@@ -256,13 +256,13 @@ def resample_sensor_data(
     help="Change the ownership of this asset and its children. Follow up with the asset's ID.",
 )
 @click.option(
-    "--account",
-    "account",
+    "--new-owner",
+    "new_owner",
     type=AccountIdField(),
     required=True,
     help="New owner of the asset and its children.",
 )
-def transfer_ownership(asset: Asset, account: Account):
+def transfer_ownership(asset: Asset, new_owner: Account):
     """
     Transfer the ownership of and asset and its children to an account.
     """
@@ -272,9 +272,9 @@ def transfer_ownership(asset: Asset, account: Account):
         for child in asset.child_assets:
             transfer_ownership_recursive(child, account)
 
-    transfer_ownership_recursive(asset, account)
+    transfer_ownership_recursive(asset, new_owner)
     click.secho(
-        f"Success! Asset `{asset}` ownership was transfered to account `{account}`.",
+        f"Success! Asset `{asset}` ownership was transfered to account `{new_owner}`.",
         **MsgStyle.SUCCESS,
     )
 

--- a/flexmeasures/cli/tests/conftest.py
+++ b/flexmeasures/cli/tests/conftest.py
@@ -3,6 +3,7 @@ import pytest
 from datetime import datetime, timedelta
 from pytz import utc
 
+from flexmeasures import Account
 from flexmeasures.data.models.data_sources import DataSource
 from flexmeasures.data.models.generic_assets import GenericAsset, GenericAssetType
 from flexmeasures.data.models.time_series import Sensor, TimedBelief
@@ -209,3 +210,46 @@ def storage_schedule_sensors(
     db.session.commit()
 
     yield power_capacity.id, storage_efficiency.id
+
+
+@pytest.fixture(scope="module")
+def add_asset_with_children(db, setup_roles_users):
+    test_supplier_user = setup_roles_users["Test Supplier User"]
+    parent_type = GenericAssetType(
+        name="parent",
+    )
+    child_type = GenericAssetType(name="child")
+
+    db.session.add_all([parent_type, child_type])
+
+    parent = GenericAsset(
+        name="parent",
+        generic_asset_type=parent_type,
+        account_id=test_supplier_user,
+    )
+    db.session.add(parent)
+    db.session.flush()  # assign parent asset id
+
+    assets = [
+        GenericAsset(
+            name=f"child_{i}",
+            generic_asset_type=child_type,
+            parent_asset_id=parent.id,
+            account_id=test_supplier_user,
+        )
+        for i in range(1, 3)
+    ]
+
+    db.session.add_all(assets)
+    db.session.flush()  # assign children asset ids
+
+    assets.append(parent)
+
+    return {a.name: a for a in assets}
+
+
+@pytest.fixture(scope="module")
+def add_alternative_account(app, db):
+    alternative_account = Account(name="Alternative Account")
+    db.session.add(alternative_account)
+    return alternative_account

--- a/flexmeasures/cli/tests/conftest.py
+++ b/flexmeasures/cli/tests/conftest.py
@@ -3,7 +3,7 @@ import pytest
 from datetime import datetime, timedelta
 from pytz import utc
 
-from flexmeasures import Account, User
+from flexmeasures import Account
 from flexmeasures.data.models.data_sources import DataSource
 from flexmeasures.data.models.generic_assets import GenericAsset, GenericAssetType
 from flexmeasures.data.models.time_series import Sensor, TimedBelief
@@ -213,9 +213,8 @@ def storage_schedule_sensors(
 
 
 @pytest.fixture(scope="module")
-def add_asset_with_children(db, setup_roles_users):
-    test_supplier_user = setup_roles_users["Test Supplier User"]
-    account_id = db.session.get(User, test_supplier_user).account_id
+def add_asset_with_children(db, setup_accounts):
+    account_id = setup_accounts["Supplier"].id
     parent_type = GenericAssetType(
         name="parent",
     )

--- a/flexmeasures/cli/tests/conftest.py
+++ b/flexmeasures/cli/tests/conftest.py
@@ -3,7 +3,7 @@ import pytest
 from datetime import datetime, timedelta
 from pytz import utc
 
-from flexmeasures import Account
+from flexmeasures import Account, User
 from flexmeasures.data.models.data_sources import DataSource
 from flexmeasures.data.models.generic_assets import GenericAsset, GenericAssetType
 from flexmeasures.data.models.time_series import Sensor, TimedBelief
@@ -215,6 +215,7 @@ def storage_schedule_sensors(
 @pytest.fixture(scope="module")
 def add_asset_with_children(db, setup_roles_users):
     test_supplier_user = setup_roles_users["Test Supplier User"]
+    account_id = db.session.get(User, test_supplier_user).account_id
     parent_type = GenericAssetType(
         name="parent",
     )
@@ -225,7 +226,7 @@ def add_asset_with_children(db, setup_roles_users):
     parent = GenericAsset(
         name="parent",
         generic_asset_type=parent_type,
-        account_id=test_supplier_user,
+        account_id=account_id,
     )
     db.session.add(parent)
     db.session.flush()  # assign parent asset id
@@ -235,7 +236,7 @@ def add_asset_with_children(db, setup_roles_users):
             name=f"child_{i}",
             generic_asset_type=child_type,
             parent_asset_id=parent.id,
-            account_id=test_supplier_user,
+            account_id=account_id,
         )
         for i in range(1, 3)
     ]

--- a/flexmeasures/cli/tests/test_data_edit.py
+++ b/flexmeasures/cli/tests/test_data_edit.py
@@ -117,7 +117,7 @@ def test_cli_help(app):
         assert "Usage" in result.output
 
 
-def test_trasfer_ownership(app, db, add_asset_with_children, add_alternative_account):
+def test_transfer_ownership(app, db, add_asset_with_children, add_alternative_account):
     """
     Test that the parent and its children change their ownership from the old account
     to the new one.
@@ -135,7 +135,7 @@ def test_trasfer_ownership(app, db, add_asset_with_children, add_alternative_acc
 
     cli_input_params = {
         "asset": parent.id,
-        "account": new_account.id,
+        "new_owner": new_account.id,
     }
 
     cli_input = to_flags(cli_input_params)

--- a/flexmeasures/cli/tests/test_data_edit.py
+++ b/flexmeasures/cli/tests/test_data_edit.py
@@ -115,3 +115,37 @@ def test_cli_help(app):
         result = runner.invoke(cmd, ["--help"])
         assert result.exit_code == 0
         assert "Usage" in result.output
+
+
+def test_trasfer_ownership(app, db, add_asset_with_children, add_alternative_account):
+    """
+    Test that the parent and its children change their ownership from the old account
+    to the new one.
+    """
+
+    from flexmeasures.cli.data_edit import transfer_ownership
+
+    parent = add_asset_with_children["parent"]
+    old_account = parent.owner
+    new_account = add_alternative_account
+
+    # assert that the children belong to the same account as the parent
+    for child in parent.child_assets:
+        assert child.owner == old_account
+
+    cli_input_params = {
+        "asset": parent.id,
+        "account": new_account.id,
+    }
+
+    cli_input = to_flags(cli_input_params)
+
+    runner = app.test_cli_runner()
+    result = runner.invoke(transfer_ownership, cli_input)
+
+    assert result.exit_code == 0  # run command without errors
+
+    # assert that the parent and its children now belong to the new account
+    assert parent.owner == new_account
+    for child in parent.child_assets:
+        assert child.owner == new_account


### PR DESCRIPTION
## Description

This PR introduces a new command to transfer the ownership of an asset and its children to a different account.

## Look & Feel

```
flexmeasures edit transfer-ownership --asset 1 --account 2
```

## How to test

Currently, we are not running the CLI test on the GH pipe, please, consider run pytest locally.

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
