### PR TITLE
feature: QuantityOrSensor fields for site capacities (flex-context)

### DIFF
--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -1,6 +1,6 @@
 from marshmallow import Schema, fields, validate
 
-from flexmeasures.data.schemas.sensors import SensorIdField
+from flexmeasures.data.schemas.sensors import QuantityOrSensor, SensorIdField
 from flexmeasures.data.schemas.units import QuantityField
 
 
@@ -15,17 +15,17 @@ class FlexContextSchema(Schema):
         data_key="site-power-capacity",
         validate=validate.Range(min=0),
     )
-    ems_production_capacity_in_mw = QuantityField(
+    ems_production_capacity_in_mw = QuantityOrSensor(
         "MW",
         required=False,
         data_key="site-production-capacity",
-        validate=validate.Range(min=0),
+        # validate=validate.Range(min=0),
     )
-    ems_consumption_capacity_in_mw = QuantityField(
+    ems_consumption_capacity_in_mw = QuantityOrSensor(
         "MW",
         required=False,
         data_key="site-consumption-capacity",
-        validate=validate.Range(min=0),
+        # validate=validate.Range(min=0),
     )
     consumption_price_sensor = SensorIdField(data_key="consumption-price-sensor")
     production_price_sensor = SensorIdField(data_key="production-price-sensor")


### PR DESCRIPTION
## Description

This PR updates the site-consumption-capacity and site-production-capacity fields in the flex-context to use the `QuantityOrSensor` schema.

## Look & Feel

Example flex-context with a dynamic consumption capacity recorded under sensor ID 8:

``` json
{
    "flex-context": {
        "site-power-capacity": "500 kVA",
        "site-consumption-capacity": {"sensor": 8},
        "site-production-capacity": "400 kW",
    }
}
```

## How to test

To do.

## Further Improvements

- [ ] Write test
- [ ] CLI support
- [ ] Support `site-power-capacity` as a sensor? It's not as dynamic as it is usually related to cable thickness, but moreover I propose to wait until sensor support for the `power-capacity` field is fixed.
- [ ] Update endpoint documentation (in `trigger_schedule` docstring)
- [ ] Update API documentation (in `scheduling.rst`)
- [ ] Create Issue to create tutorial for modelling dynamic network capacity contracts

## Related Items

Closes #925.

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
