### PR TITLE
Feature/ support passing the site power capacity as a sensor

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -52,7 +52,7 @@ v0.18.2 | February xx, 2024
 * Convert unit of the power capacities to ``MW`` instead of that of the storage power sensor [see `PR #979 <https://github.com/FlexMeasures/flexmeasures/pull/979>`_]
 * Automatically update table navigation in the UI without requiring users to hard refresh their browser [see `PR #961 <https://github.com/FlexMeasures/flexmeasures/pull/961>`_]
 * Updated documentation to enhance clarity for integrating plugins within the FlexMeasures Docker container [see `PR #958 <https://github.com/FlexMeasures/flexmeasures/pull/958>`_]
-
+* Support defining the ``site-power-capacity`` as a sensor [see `PR #987 <https://github.com/FlexMeasures/flexmeasures/pull/987>`_]
 
 v0.18.1 | January 15, 2024
 ============================

--- a/flexmeasures/conftest.py
+++ b/flexmeasures/conftest.py
@@ -1140,6 +1140,14 @@ def capacity_sensors(db, add_battery_assets, setup_sources):
         attributes={"consumption_is_positive": True},
     )
 
+    power_capacity_sensor = Sensor(
+        name="power capacity",
+        generic_asset=battery,
+        unit="kW",
+        event_resolution="PT15M",
+        attributes={"consumption_is_positive": True},
+    )
+
     db.session.add_all([production_capacity_sensor, consumption_capacity_sensor])
     db.session.flush()
 
@@ -1181,6 +1189,23 @@ def capacity_sensors(db, add_battery_assets, setup_sources):
     db.session.add_all(beliefs)
     db.session.commit()
 
+    values = [225] * 4 * 4 + [200] * 4 * 4
+
+    beliefs = [
+        TimedBelief(
+            event_start=dt,
+            belief_horizon=parse_duration("PT0M"),
+            event_value=val,
+            sensor=power_capacity_sensor,
+            source=setup_sources["Seita"],
+        )
+        for dt, val in zip(time_slots, values)
+    ]
+    db.session.add_all(beliefs)
+    db.session.commit()
+
     yield dict(
-        production=production_capacity_sensor, consumption=consumption_capacity_sensor
+        production=production_capacity_sensor,
+        consumption=consumption_capacity_sensor,
+        power_capacity=power_capacity_sensor,
     )

--- a/flexmeasures/conftest.py
+++ b/flexmeasures/conftest.py
@@ -1155,7 +1155,7 @@ def capacity_sensors(db, add_battery_assets, setup_sources):
         datetime(2015, 1, 2), datetime(2015, 1, 2, 7, 45), freq="15T"
     ).tz_localize("Europe/Amsterdam")
 
-    values = [199] * 4 * 4 + [300] * 4 * 4
+    values = [200] * 4 * 4 + [300] * 4 * 4
 
     beliefs = [
         TimedBelief(
@@ -1189,7 +1189,7 @@ def capacity_sensors(db, add_battery_assets, setup_sources):
     db.session.add_all(beliefs)
     db.session.commit()
 
-    values = [225] * 4 * 4 + [200] * 4 * 4
+    values = [225] * 4 * 4 + [199] * 4 * 4
 
     beliefs = [
         TimedBelief(

--- a/flexmeasures/conftest.py
+++ b/flexmeasures/conftest.py
@@ -1155,7 +1155,7 @@ def capacity_sensors(db, add_battery_assets, setup_sources):
         datetime(2015, 1, 2), datetime(2015, 1, 2, 7, 45), freq="15T"
     ).tz_localize("Europe/Amsterdam")
 
-    values = [200] * 4 * 4 + [300] * 4 * 4
+    values = [199] * 4 * 4 + [300] * 4 * 4
 
     beliefs = [
         TimedBelief(

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -122,16 +122,19 @@ class MetaStorageScheduler(Scheduler):
                 "Power capacity is not defined in the sensor attributes or the flex-model."
             )
 
-        if isinstance(power_capacity_in_mw, ur.Quantity):
-            power_capacity_in_mw = power_capacity_in_mw.magnitude
-
-        if not (
-            isinstance(power_capacity_in_mw, float)
-            or isinstance(power_capacity_in_mw, int)
+        if isinstance(power_capacity_in_mw, float) or isinstance(
+            power_capacity_in_mw, int
         ):
-            raise ValueError(
-                "The only supported types for the power capacity are int and float."
-            )
+            power_capacity_in_mw = ur.Quantity(f"{power_capacity_in_mw} MW")
+
+        power_capacity_in_mw = get_continuous_series_sensor_or_quantity(
+            quantity_or_sensor=power_capacity_in_mw,
+            actuator=sensor,
+            unit="MW",
+            query_window=(start, end),
+            resolution=resolution,
+            beliefs_before=belief_time,
+        )
 
         # Check for known prices or price forecasts, trimming planning window accordingly
         up_deviation_prices, (start, end) = get_prices(

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -1529,7 +1529,7 @@ def get_efficiency_problem_device_constraints(
     _, battery = get_sensors_from_db(db, add_battery_assets)
     tz = pytz.timezone("Europe/Amsterdam")
     start = tz.localize(datetime(2015, 1, 1))
-    end = tz.localize(datetime(2015, 1, 1))
+    end = tz.localize(datetime(2015, 1, 2))
     resolution = timedelta(minutes=15)
     base_flex_model = {
         "soc-max": 2,

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -1478,10 +1478,7 @@ def test_battery_power_capacity_as_sensor(
 def test_battery_bothways_power_capacity_as_sensor(
     db, add_battery_assets, add_inflexible_device_forecasts, capacity_sensors
 ):
-    """
-    Check that the charging and discharging power capacities are limited by the
-    the
-    """
+    """Check that the charging and discharging power capacities are limited by the power capacity."""
     epex_da, battery = get_sensors_from_db(
         db, add_battery_assets, battery_name="Test battery"
     )

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -25,7 +25,6 @@ from flexmeasures.utils.calculations import (
     apply_stock_changes_and_losses,
     integrate_time_series,
 )
-from flexmeasures.data.services.time_series import simplify_index
 from flexmeasures.tests.utils import get_test_sensor
 
 
@@ -1518,7 +1517,6 @@ def test_battery_bothways_power_capacity_as_sensor(
         .event_value.values
     )
 
-    simplify_index(capacity_sensors["production"].search_beliefs())
     assert all(device_constraints["derivative min"].values >= -max_capacity)
     assert all(device_constraints["derivative max"].values <= max_capacity)
 

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -25,6 +25,7 @@ from flexmeasures.utils.calculations import (
     apply_stock_changes_and_losses,
     integrate_time_series,
 )
+from flexmeasures.data.services.time_series import simplify_index
 from flexmeasures.tests.utils import get_test_sensor
 
 
@@ -1475,13 +1476,60 @@ def test_battery_power_capacity_as_sensor(
     assert all(device_constraints["derivative max"].values == expected_consumption)
 
 
+def test_battery_bothways_power_capacity_as_sensor(
+    db, add_battery_assets, add_inflexible_device_forecasts, capacity_sensors
+):
+    """
+    Check that the charging and discharging power capacities are limited by the
+    the
+    """
+    epex_da, battery = get_sensors_from_db(
+        db, add_battery_assets, battery_name="Test battery"
+    )
+
+    tz = pytz.timezone("Europe/Amsterdam")
+    start = tz.localize(datetime(2015, 1, 2))
+    end = tz.localize(datetime(2015, 1, 2, 7, 45))
+    resolution = timedelta(minutes=15)
+    soc_at_start = 10
+
+    flex_model = {
+        "soc-at-start": soc_at_start,
+        "roundtrip-efficiency": "100%",
+        "prefer-charging-sooner": False,
+    }
+
+    flex_model["power-capacity"] = {"sensor": capacity_sensors["production"].id}
+    flex_model["consumption-capacity"] = {"sensor": capacity_sensors["consumption"].id}
+    flex_model["production-capacity"] = {
+        "sensor": capacity_sensors["power_capacity"].id
+    }
+
+    scheduler: Scheduler = StorageScheduler(
+        battery, start, end, resolution, flex_model=flex_model
+    )
+
+    data_to_solver = scheduler._prepare()
+    device_constraints = data_to_solver[5][0]
+
+    max_capacity = (
+        capacity_sensors["power_capacity"]
+        .search_beliefs(event_starts_after=start, event_ends_before=end)
+        .event_value.values
+    )
+
+    simplify_index(capacity_sensors["production"].search_beliefs())
+    assert all(device_constraints["derivative min"].values >= -max_capacity)
+    assert all(device_constraints["derivative max"].values <= max_capacity)
+
+
 def get_efficiency_problem_device_constraints(
     extra_flex_model, efficiency_sensors, add_battery_assets, db
 ) -> pd.DataFrame:
     _, battery = get_sensors_from_db(db, add_battery_assets)
     tz = pytz.timezone("Europe/Amsterdam")
     start = tz.localize(datetime(2015, 1, 1))
-    end = tz.localize(datetime(2015, 1, 2))
+    end = tz.localize(datetime(2015, 1, 1))
     resolution = timedelta(minutes=15)
     base_flex_model = {
         "soc-max": 2,

--- a/flexmeasures/data/models/planning/utils.py
+++ b/flexmeasures/data/models/planning/utils.py
@@ -373,7 +373,7 @@ def get_continuous_series_sensor_or_quantity(
     resolution: timedelta,
     beliefs_before: datetime | None = None,
     fallback_attribute: str | None = None,
-    max_value: float | int = np.nan,
+    max_value: float | int | pd.Series = np.nan,
 ) -> pd.Series:
     """Creates a time series from a quantity or sensor within a specified window,
     falling back to a given `fallback_attribute` and making sure no values exceed `max_value`.
@@ -409,6 +409,6 @@ def get_continuous_series_sensor_or_quantity(
     return time_series
 
 
-def nanmin_of_series_and_value(s: pd.Series, value: float) -> pd.Series:
+def nanmin_of_series_and_value(s: pd.Series, value: float | pd.Series) -> pd.Series:
     """Perform a nanmin between a Series and a float."""
     return s.fillna(value).clip(upper=value)


### PR DESCRIPTION
## Description

As pointed out by the issue https://github.com/FlexMeasures/flexmeasures/issues/984, the field `power-capacity` could be passed as a sensor but internally, the storage scheduler wouldn't support it. This PR fetches the data from the sensor and uses it to cap the maximum import/export capacities.

## Related Items

Closes https://github.com/FlexMeasures/flexmeasures/issues/984

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
