### PR TITLE
get public assets

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -23,6 +23,7 @@ v0.19.2 | March 1, 2024
 ============================
 
 * Upgrade timely-beliefs to enhance our main time series query and fix a database index on time series data, leading to significantly better performance [see `PR #992 <https://github.com/FlexMeasures/flexmeasures/pull/992>`_]
+* Fix server error on loading the asset page for a public asset, due to a bug in the breadcrumb's sibling navigation [see `PR #991 <https://github.com/FlexMeasures/flexmeasures/pull/991>`_]
 
 
 v0.19.1 | February 26, 2024

--- a/flexmeasures/ui/utils/breadcrumb_utils.py
+++ b/flexmeasures/ui/utils/breadcrumb_utils.py
@@ -73,6 +73,8 @@ def get_siblings(entity: Sensor | Asset | Account | None) -> list[dict]:
     if isinstance(entity, Asset):
         if entity.parent_asset is not None:
             sibling_assets = entity.parent_asset.child_assets
+        elif entity.owner is not None:
+            sibling_assets = entity.owner.generic_assets
         else:
             session = current_app.db.session
             sibling_assets = session.scalars(

--- a/flexmeasures/ui/utils/breadcrumb_utils.py
+++ b/flexmeasures/ui/utils/breadcrumb_utils.py
@@ -78,7 +78,7 @@ def get_siblings(entity: Sensor | Asset | Account | None) -> list[dict]:
         else:
             session = current_app.db.session
             sibling_assets = session.scalars(
-                select(Asset).where(Asset.owner is None)
+                select(Asset).filter(Asset.account_id.is_(None))
             ).all()
 
         siblings = [

--- a/flexmeasures/ui/utils/breadcrumb_utils.py
+++ b/flexmeasures/ui/utils/breadcrumb_utils.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from sqlalchemy import select
 from flexmeasures import Sensor, Asset, Account
 from flexmeasures.utils.flexmeasures_inflection import human_sorted
-from flask import url_for
+from flask import url_for, current_app
 
 
 def get_breadcrumb_info(entity: Sensor | Asset | Account | None) -> dict:
@@ -73,7 +74,11 @@ def get_siblings(entity: Sensor | Asset | Account | None) -> list[dict]:
         if entity.parent_asset is not None:
             sibling_assets = entity.parent_asset.child_assets
         else:
-            sibling_assets = entity.owner.generic_assets
+            session = current_app.db.session
+            sibling_assets = session.scalars(
+                select(Asset).where(Asset.owner is None)
+            ).all()
+
         siblings = [
             {
                 "url": url_for("AssetCrudUI:get", id=asset.id),


### PR DESCRIPTION
> [!NOTE]
> This PR needs to be backported to version v.0.19.X

## Description

This PR introduces a fix to the bug  in https://github.com/FlexMeasures/flexmeasures/issues/991, which describes that the asset page for public assets doesn't work.

## Related Items

Closes https://github.com/FlexMeasures/flexmeasures/issues/991


---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
