### PR TITLE
fix: Use scalars instead of scalar having limit constraint

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -26,6 +26,7 @@ v0.19.2 | March 1, 2024
 
 * Upgrade timely-beliefs to enhance our main time series query and fix a database index on time series data, leading to significantly better performance [see `PR #992 <https://github.com/FlexMeasures/flexmeasures/pull/992>`_]
 * Fix server error on loading the asset page for a public asset, due to a bug in the breadcrumb's sibling navigation [see `PR #991 <https://github.com/FlexMeasures/flexmeasures/pull/991>`_]
+* Restore compatibility with the `flexmeasures-openweathermap plugin <https://github.com/SeitaBV/flexmeasures-openweathermap>`_ by fixing the query for the closest weather sensor to a given asset [see `PR #997 <https://github.com/FlexMeasures/flexmeasures/pull/997>`_]
 
 
 v0.19.1 | February 26, 2024

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -531,7 +531,7 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
             account_id=account_id_filter,
         )
         if n == 1:
-            return db.session.scalar(query.limit(1)).first()
+            return db.session.scalars(query.limit(1)).first()
         else:
             return db.session.scalars(query.limit(n)).all()
 


### PR DESCRIPTION
This PR will fix the sqlalchmey query to get a closest weather sensor. 