### PR TITLE
Improve processing time for deleting beliefs via CLI

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -17,7 +17,7 @@ New features
 Infrastructure / Support
 ----------------------
 
-
+* Improve processing time for deleting beliefs via CLI [see `PR #1005 <https://github.com/FlexMeasures/flexmeasures/pull/1005>`_]
 
 
 v0.19.2 | March 1, 2024

--- a/flexmeasures/cli/data_delete.py
+++ b/flexmeasures/cli/data_delete.py
@@ -312,14 +312,7 @@ def delete_beliefs(  # noqa: C901
     elif generic_assets:
         prompt = f"Delete all {num_beliefs_up_for_deletion} beliefs on sensors of {join_words_into_a_list([repr(asset) for asset in generic_assets])}?"
     click.confirm(prompt, abort=True)
-
-    # Delete all beliefs found by query
-    beliefs_up_for_deletion = db.session.scalars(q).all()
-    batch_size = 10000
-    for i, b in enumerate(beliefs_up_for_deletion, start=1):
-        if i % batch_size == 0 or i == num_beliefs_up_for_deletion:
-            click.echo(f"{i} beliefs processed ...")
-        db.session.delete(b)
+    db.session.execute(delete(TimedBelief).where(*entity_filters, *event_filters))
     click.secho(f"Removing {num_beliefs_up_for_deletion} beliefs ...")
     db.session.commit()
     num_beliefs_after = db.session.scalar(select(func.count()).select_from(q))

--- a/flexmeasures/data/models/planning/tests/conftest.py
+++ b/flexmeasures/data/models/planning/tests/conftest.py
@@ -15,7 +15,7 @@ from flexmeasures.data.models.time_series import Sensor, TimedBelief
 def app_with_each_solver(app, request):
     """Set up the app config to run with different solvers.
 
-    A test that uses this fixtures runs all of its test cases with HiGHS and then again with Cbc.
+    A test that uses this fixture runs all of its test cases with HiGHS and then again with Cbc.
     """
     original_solver = app.config["FLEXMEASURES_LP_SOLVER"]
     app.config["FLEXMEASURES_LP_SOLVER"] = request.param


### PR DESCRIPTION
I have used  the `where()` clause with `delete()` statement, to delete the beliefs based on `event_filters` and `entity_filters`. 

closes #1004 