### PR TITLE
Introduce FLEXMEASURES_FORCE_HTTPS 

### DIFF
--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -272,3 +272,9 @@ cron
 CSV
 UI
 frontend
+http
+https
+balancer
+url
+HTTPS
+Werkzeug

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -7,6 +7,8 @@ FlexMeasures Changelog
 v0.20.0 | April XX, 2024
 ============================
 
+.. warning:: From this version on, the config setting `FLEXMEASURES_FORCE_HTTPS` decides whether to enforce HTTPS on requests - and it defaults to `False`. Previously, this was governed by `Flask_ENV` or `FLEXMEASURES_ENV` being set to something else than "documentation" or "development". This new way is more clear, but you might be in need of using this setting before upgrading.
+
 New features
 -------------   
 

--- a/documentation/configuration.rst
+++ b/documentation/configuration.rst
@@ -458,7 +458,7 @@ Default: ``True``
 FLEXMEASURES_FORCE_HTTPS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Set to ``True`` if all requests should be forced to be https.
+Set to ``True`` if all requests should be forced to be HTTPS.
 
 Default: ``False``
 

--- a/documentation/configuration.rst
+++ b/documentation/configuration.rst
@@ -455,6 +455,14 @@ Allows users to make authenticated requests. If true, injects the Access-Control
 Default: ``True``
 
 
+FLEXMEASURES_FORCE_HTTPS
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Set to ``True`` if all requests should be forced to be https.
+
+Default: ``False``
+
+
 FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/flexmeasures/app.py
+++ b/flexmeasures/app.py
@@ -106,7 +106,7 @@ def create(  # noqa C901
     set_secret_key(app)
     if app.config.get("SECURITY_PASSWORD_SALT", None) is None:
         app.config["SECURITY_PASSWORD_SALT"] = app.config["SECRET_KEY"]
-    if app.config.get("FLEXMEASURES_ENV") not in ("documentation", "development"):
+    if app.config.get("FLEXMEASURES_FORCE_HTTPS", False):
         SSLify(app)
 
     # Prepare profiling, if needed

--- a/flexmeasures/ui/crud/api_wrapper.py
+++ b/flexmeasures/ui/crud/api_wrapper.py
@@ -57,12 +57,12 @@ class InternalApi(object):
         query: dict[str, Any] | None = None,
         do_not_raise_for: list | None = None,
     ) -> requests.Response:
-        url_root = self._url_root()
+        full_url = f"{self._url_root()}{url}"
         current_app.logger.debug(
-            f"{self._log_prefix} Calling GET to {url_root}{url} with query {query} ..."
+            f"{self._log_prefix} Calling GET to {full_url} with query {query} ..."
         )
         response = requests.get(
-            f"{url_root}{url}",
+            full_url,
             params=query,
             headers=self._auth_headers(),
         )
@@ -75,12 +75,12 @@ class InternalApi(object):
         args: dict | None = None,
         do_not_raise_for: list | None = None,
     ) -> requests.Response:
-        url_root = self._url_root()
+        full_url = f"{self._url_root()}{url}"
         current_app.logger.debug(
-            f"{self._log_prefix} Call POST to {url_root}{url} with json data {args} ..."
+            f"{self._log_prefix} Call POST to {full_url} with json data {args} ..."
         )
         response = requests.post(
-            f"{url_root}{url}",
+            full_url,
             headers=self._auth_headers(),
             json=args if args else {},
         )
@@ -93,12 +93,12 @@ class InternalApi(object):
         args: dict | None = None,
         do_not_raise_for: list | None = None,
     ) -> requests.Response:
-        url_root = self._url_root()
+        full_url = f"{self._url_root()}{url}"
         current_app.logger.debug(
-            f"{self._log_prefix} Calling PATCH to {url_root}{url} with json data {args} ..."
+            f"{self._log_prefix} Calling PATCH to {full_url} with json data {args} ..."
         )
         response = requests.patch(
-            f"{url_root}{url}",
+            full_url,
             headers=self._auth_headers(),
             json=args if args else {},
         )
@@ -110,12 +110,10 @@ class InternalApi(object):
         url: str,
         do_not_raise_for: list | None = None,
     ) -> requests.Response:
-        url_root = self._url_root()
-        current_app.logger.debug(
-            f"{self._log_prefix} Calling DELETE to {url_root}{url} ..."
-        )
+        full_url = f"{self._url_root()}{url}"
+        current_app.logger.debug(f"{self._log_prefix} Calling DELETE to {full_url} ...")
         response = requests.delete(
-            f"{url_root}{url}",
+            full_url,
             headers=self._auth_headers(),
         )
         self._maybe_raise(response, do_not_raise_for)

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -138,6 +138,8 @@ class Config(object):
     FLEXMEASURES_API_SUNSET_DATE: str | None = None  # e.g. 2023-05-01
     FLEXMEASURES_API_SUNSET_LINK: str | None = None  # e.g. https://flexmeasures.readthedocs.io/en/latest/api/introduction.html#deprecation-and-sunset
 
+    # if True, all requests are forced to be via HTTPS.
+    FLEXMEASURES_FORCE_HTTPS: bool = False
     # if True, the content could be accessed via HTTPS.
     FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY: bool = False
 


### PR DESCRIPTION
So we can control better when we want the app to answer to https. Apply in the internal API to solve a load balancer situation.

Closes https://github.com/SeitaBV/flexmeasures-cloudinfra/issues/132

## Description

Adding this new setting and make it the place in app.py where we apply FLASK_SSLIFY. Formerly, FLEXMEASURES_ENV was used, but now we can influence more directly.

In addition, the internal API (used in the UI to use the real API as much as possible) will also use this, even if behind a load balancer who redirects to http.

## Look & Feel

Should not change much for developers, as the default is `False`. Only in production we need to start using it explicitly.

## How to test

The real test might be in a load balancer environment.

## Further Improvements

Potential improvements to be done in the same PR or follow up Issues/Discussions/PRs.

