### PR TITLE
[Reporting] skip output event resolution in `PandasReporter`

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -15,7 +15,10 @@ New features
 * Add command ``flexmeasures edit transfer-ownership`` to transfer the ownership of an asset and its children from one account to another[see `PR #983 <https://github.com/FlexMeasures/flexmeasures/pull/983>`_]
 * Support defining the ``site-power-capacity``, ``site-consumption-capacity`` and ``site-production-capacity`` as a sensor in the API and CLI [see `PR #985 <https://github.com/FlexMeasures/flexmeasures/pull/985>`_]
 * Support saving beliefs with a ``belief_horizon`` in the ``PandasReporter``[see `PR #1013 <https://github.com/FlexMeasures/flexmeasures/pull/1013>`_]
+* Skip the check of the output event resolution in any ``Reporter`` with the field ``check_output_resolution`` [see `PR #1009 <https://github.com/FlexMeasures/flexmeasures/pull/1009>`_]
 
+
+check_output_resolution
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/data/models/reporting/__init__.py
+++ b/flexmeasures/data/models/reporting/__init__.py
@@ -21,7 +21,7 @@ class Reporter(DataGenerator):
     _parameters_schema = ReporterParametersSchema()
     _config_schema = ReporterConfigSchema()
 
-    def _compute(self, **kwargs) -> List[Dict[str, Any]]:
+    def _compute(self, check_output_resolution=True, **kwargs) -> List[Dict[str, Any]]:
         """This method triggers the creation of a new report.
 
         The same object can generate multiple reports with different start, end, resolution
@@ -32,7 +32,7 @@ class Reporter(DataGenerator):
 
         for result in results:
             # checking that the event_resolution of the output BeliefDataFrame is equal to the one of the output sensor
-            assert (
+            assert check_output_resolution or (
                 result["sensor"].event_resolution == result["data"].event_resolution
             ), f"The resolution of the results ({result['data'].event_resolution}) should match that of the output sensor ({result['sensor'].event_resolution}, ID {result['sensor'].id})."
 

--- a/flexmeasures/data/models/reporting/__init__.py
+++ b/flexmeasures/data/models/reporting/__init__.py
@@ -26,13 +26,15 @@ class Reporter(DataGenerator):
 
         The same object can generate multiple reports with different start, end, resolution
         and belief_time values.
+
+            check_output_resolution (default: True):  set to False to skip the validation of the output event_resolution.
         """
 
         results: List[Dict[str, Any]] = self._compute_report(**kwargs)
 
         for result in results:
             # checking that the event_resolution of the output BeliefDataFrame is equal to the one of the output sensor
-            assert check_output_resolution or (
+            assert not check_output_resolution or (
                 result["sensor"].event_resolution == result["data"].event_resolution
             ), f"The resolution of the results ({result['data'].event_resolution}) should match that of the output sensor ({result['sensor'].event_resolution}, ID {result['sensor'].id})."
 

--- a/flexmeasures/data/schemas/reporting/__init__.py
+++ b/flexmeasures/data/schemas/reporting/__init__.py
@@ -36,7 +36,7 @@ class ReporterParametersSchema(Schema):
 
     resolution = DurationField(required=False)
     belief_time = AwareDateTimeField(required=False)
-    check_output_resolution = fields.Bool(required=False, default=True)
+    check_output_resolution = fields.Bool(required=False)
     belief_horizon = DurationField(required=False)
 
 

--- a/flexmeasures/data/schemas/reporting/__init__.py
+++ b/flexmeasures/data/schemas/reporting/__init__.py
@@ -36,6 +36,7 @@ class ReporterParametersSchema(Schema):
 
     resolution = DurationField(required=False)
     belief_time = AwareDateTimeField(required=False)
+    check_output_resolution = fields.Bool(required=False, default=True)
 
 
 class BeliefsSearchConfigSchema(Schema):


### PR DESCRIPTION
Applying `resample` doesn't change the `event_resolution` but, sometimes, it's useful to use this function with different aggregation functions for different sensors. 

For instance, energy resampling should use sum whereas power could use mean/max/min.

The new argument `check_output_resolution` allows to skip the event resolution check of the `compute` step.

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
