### PR TITLE
[Reporting] Fix `PandasReporter` input event resolution

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -17,8 +17,11 @@ New features
 * Support saving beliefs with a ``belief_horizon`` in the ``PandasReporter``[see `PR #1013 <https://github.com/FlexMeasures/flexmeasures/pull/1013>`_]
 * Skip the check of the output event resolution in any ``Reporter`` with the field ``check_output_resolution`` [see `PR #1009 <https://github.com/FlexMeasures/flexmeasures/pull/1009>`_]
 
+Bugfixes
+-----------
+* Use minimum event resolution of the input (instead of the output) sensors for the belief search parameters [see `PR #1010 <https://github.com/FlexMeasures/flexmeasures/pull/1010>`_]
 
-check_output_resolution
+
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/data/models/reporting/pandas_reporter.py
+++ b/flexmeasures/data/models/reporting/pandas_reporter.py
@@ -89,9 +89,9 @@ class PandasReporter(Reporter):
         belief_time: datetime | None = kwargs.get("belief_time", None)
         output: list[dict[str, Any]] = kwargs.get("output")
 
-        # by default, use the minimum resolution among the output sensors
+        # by default, use the minimum resolution among the input sensors
         if resolution is None:
-            resolution = min([o["sensor"].event_resolution for o in output])
+            resolution = min([i["sensor"].event_resolution for i in input])
 
         # fetch sensor data
         self.fetch_data(start, end, input, resolution, belief_time)
@@ -249,7 +249,6 @@ class PandasReporter(Reporter):
             kwargs = self._process_pandas_kwargs(
                 transformation.get("kwargs", {}), method
             )
-
             self.data[df_output] = getattr(self.data[df_input], method)(*args, **kwargs)
 
             previous_df = df_output


### PR DESCRIPTION
The `event_resolution` of the input data in the `PandasReporter` was determined as the minimum event resolution among the **output** sensors. This doesn't make much sense as we want to get all the input data in the most granular form. Later we can resample it.

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
