### PR TITLE
[Reporting] Define belief horizon for the `PandasReporter` output beliefs

### DIFF
--- a/flexmeasures/data/models/reporting/__init__.py
+++ b/flexmeasures/data/models/reporting/__init__.py
@@ -21,7 +21,7 @@ class Reporter(DataGenerator):
     _parameters_schema = ReporterParametersSchema()
     _config_schema = ReporterConfigSchema()
 
-    def _compute(self, **kwargs) -> List[Dict[str, Any]]:
+    def _compute(self, check_output_resolution=True, **kwargs) -> List[Dict[str, Any]]:
         """This method triggers the creation of a new report.
 
         The same object can generate multiple reports with different start, end, resolution
@@ -32,7 +32,7 @@ class Reporter(DataGenerator):
 
         for result in results:
             # checking that the event_resolution of the output BeliefDataFrame is equal to the one of the output sensor
-            assert (
+            assert check_output_resolution or (
                 result["sensor"].event_resolution == result["data"].event_resolution
             ), f"The resolution of the results ({result['data'].event_resolution}) should match that of the output sensor ({result['sensor'].event_resolution}, ID {result['sensor'].id})."
 

--- a/flexmeasures/data/models/reporting/pandas_reporter.py
+++ b/flexmeasures/data/models/reporting/pandas_reporter.py
@@ -87,11 +87,12 @@ class PandasReporter(Reporter):
 
         resolution: timedelta | None = kwargs.get("resolution", None)
         belief_time: datetime | None = kwargs.get("belief_time", None)
+        belief_horizon: timedelta | None = kwargs.get("belief_horizon", None)
         output: list[dict[str, Any]] = kwargs.get("output")
 
-        # by default, use the minimum resolution among the output sensors
+        # by default, use the minimum resolution among the input sensors
         if resolution is None:
-            resolution = min([o["sensor"].event_resolution for o in output])
+            resolution = min([i["sensor"].event_resolution for i in input])
 
         # fetch sensor data
         self.fetch_data(start, end, input, resolution, belief_time)
@@ -117,10 +118,14 @@ class PandasReporter(Reporter):
                 output_data = output_data.rename(columns={column: "event_value"})[
                     ["event_value"]
                 ]
-                output_data = self._clean_belief_dataframe(output_data, belief_time)
+                output_data = self._clean_belief_dataframe(
+                    output_data, belief_time, belief_horizon
+                )
 
             elif isinstance(output_data, tb.BeliefsSeries):
-                output_data = self._clean_belief_series(output_data, belief_time)
+                output_data = self._clean_belief_series(
+                    output_data, belief_time, belief_horizon
+                )
 
             result["data"] = output_data
 
@@ -129,11 +134,16 @@ class PandasReporter(Reporter):
         return results
 
     def _clean_belief_series(
-        self, belief_series: tb.BeliefsSeries, belief_time: datetime
+        self,
+        belief_series: tb.BeliefsSeries,
+        belief_time: datetime | None = None,
+        belief_horizon: timedelta | None = None,
     ) -> tb.BeliefsDataFrame:
         """Create a BeliefDataFrame from a BeliefsSeries creating the necessary indexes."""
 
         belief_series = belief_series.to_frame("event_value")
+        if belief_horizon is not None:
+            belief_time = belief_series["event_start"] + belief_horizon
         belief_series["belief_time"] = belief_time
         belief_series["cumulative_probability"] = 0.5
         belief_series["source"] = self.data_source
@@ -144,13 +154,21 @@ class PandasReporter(Reporter):
         return belief_series
 
     def _clean_belief_dataframe(
-        self, bdf: tb.BeliefsDataFrame, belief_time: datetime
+        self,
+        bdf: tb.BeliefsDataFrame,
+        belief_time: datetime | None = None,
+        belief_horizon: timedelta | None = None,
     ) -> tb.BeliefsDataFrame:
         """Add missing indexes to build a proper BeliefDataFrame."""
 
         # filing the missing indexes with default values:
         if "belief_time" not in bdf.index.names:
-            bdf["belief_time"] = [belief_time] * len(bdf)
+            if belief_horizon is not None:
+                belief_time = bdf["event_start"] + belief_horizon
+            else:
+                belief_time = [belief_time] * len(bdf)
+            bdf["belief_time"] = belief_time
+
             bdf = bdf.set_index("belief_time", append=True)
 
         if "cumulative_probability" not in bdf.index.names:
@@ -249,7 +267,6 @@ class PandasReporter(Reporter):
             kwargs = self._process_pandas_kwargs(
                 transformation.get("kwargs", {}), method
             )
-
             self.data[df_output] = getattr(self.data[df_input], method)(*args, **kwargs)
 
             previous_df = df_output


### PR DESCRIPTION
The belief time of the output of the `PandasReporter`could be set already. However, it's very handy to provide the belief horizon instead. This PR allows passing the belief horizon, a timedelta.

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
