### PR TITLE
[Reporting] Define belief horizon for the PandasReporter output beliefs

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -12,6 +12,7 @@ New features
 
 * Add command ``flexmeasures edit transfer-ownership`` to transfer the ownership of an asset and its children from one account to another[see `PR #983 <https://github.com/FlexMeasures/flexmeasures/pull/983>`_]
 * Support defining the ``site-power-capacity``, ``site-consumption-capacity`` and ``site-production-capacity`` as a sensor in the API and CLI [see `PR #985 <https://github.com/FlexMeasures/flexmeasures/pull/985>`_]
+* Support saving beliefs with a ``belief-horizon`` in the  ``PandasReporter``[see `PR #1013 <https://github.com/FlexMeasures/flexmeasures/pull/1013>`_]
 
 
 Infrastructure / Support

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -12,7 +12,7 @@ New features
 
 * Add command ``flexmeasures edit transfer-ownership`` to transfer the ownership of an asset and its children from one account to another[see `PR #983 <https://github.com/FlexMeasures/flexmeasures/pull/983>`_]
 * Support defining the ``site-power-capacity``, ``site-consumption-capacity`` and ``site-production-capacity`` as a sensor in the API and CLI [see `PR #985 <https://github.com/FlexMeasures/flexmeasures/pull/985>`_]
-* Support saving beliefs with a ``belief-horizon`` in the  ``PandasReporter``[see `PR #1013 <https://github.com/FlexMeasures/flexmeasures/pull/1013>`_]
+* Support saving beliefs with a ``belief_horizon`` in the ``PandasReporter``[see `PR #1013 <https://github.com/FlexMeasures/flexmeasures/pull/1013>`_]
 
 
 Infrastructure / Support

--- a/flexmeasures/data/models/reporting/pandas_reporter.py
+++ b/flexmeasures/data/models/reporting/pandas_reporter.py
@@ -87,6 +87,7 @@ class PandasReporter(Reporter):
 
         resolution: timedelta | None = kwargs.get("resolution", None)
         belief_time: datetime | None = kwargs.get("belief_time", None)
+        belief_horizon: timedelta | None = kwargs.get("belief_horizon", None)
         output: list[dict[str, Any]] = kwargs.get("output")
 
         # by default, use the minimum resolution among the output sensors
@@ -117,10 +118,14 @@ class PandasReporter(Reporter):
                 output_data = output_data.rename(columns={column: "event_value"})[
                     ["event_value"]
                 ]
-                output_data = self._clean_belief_dataframe(output_data, belief_time)
+                output_data = self._clean_belief_dataframe(
+                    output_data, belief_time, belief_horizon
+                )
 
             elif isinstance(output_data, tb.BeliefsSeries):
-                output_data = self._clean_belief_series(output_data, belief_time)
+                output_data = self._clean_belief_series(
+                    output_data, belief_time, belief_horizon
+                )
 
             result["data"] = output_data
 
@@ -129,11 +134,16 @@ class PandasReporter(Reporter):
         return results
 
     def _clean_belief_series(
-        self, belief_series: tb.BeliefsSeries, belief_time: datetime
+        self,
+        belief_series: tb.BeliefsSeries,
+        belief_time: datetime | None = None,
+        belief_horizon: timedelta | None = None,
     ) -> tb.BeliefsDataFrame:
         """Create a BeliefDataFrame from a BeliefsSeries creating the necessary indexes."""
 
         belief_series = belief_series.to_frame("event_value")
+        if belief_horizon is not None:
+            belief_time = belief_series["event_start"] + belief_horizon
         belief_series["belief_time"] = belief_time
         belief_series["cumulative_probability"] = 0.5
         belief_series["source"] = self.data_source
@@ -144,13 +154,21 @@ class PandasReporter(Reporter):
         return belief_series
 
     def _clean_belief_dataframe(
-        self, bdf: tb.BeliefsDataFrame, belief_time: datetime
+        self,
+        bdf: tb.BeliefsDataFrame,
+        belief_time: datetime | None = None,
+        belief_horizon: timedelta | None = None,
     ) -> tb.BeliefsDataFrame:
         """Add missing indexes to build a proper BeliefDataFrame."""
 
         # filing the missing indexes with default values:
         if "belief_time" not in bdf.index.names:
-            bdf["belief_time"] = [belief_time] * len(bdf)
+            if belief_horizon is not None:
+                belief_time = bdf["event_start"] + belief_horizon
+            else:
+                belief_time = [belief_time] * len(bdf)
+            bdf["belief_time"] = belief_time
+
             bdf = bdf.set_index("belief_time", append=True)
 
         if "cumulative_probability" not in bdf.index.names:
@@ -249,7 +267,6 @@ class PandasReporter(Reporter):
             kwargs = self._process_pandas_kwargs(
                 transformation.get("kwargs", {}), method
             )
-
             self.data[df_output] = getattr(self.data[df_input], method)(*args, **kwargs)
 
             previous_df = df_output

--- a/flexmeasures/data/models/reporting/pandas_reporter.py
+++ b/flexmeasures/data/models/reporting/pandas_reporter.py
@@ -143,7 +143,11 @@ class PandasReporter(Reporter):
 
         belief_series = belief_series.to_frame("event_value")
         if belief_horizon is not None:
-            belief_time = belief_series["event_start"] + belief_horizon
+            belief_time = (
+                belief_series["event_start"]
+                + belief_series.event_resolution
+                - belief_horizon
+            )
         belief_series["belief_time"] = belief_time
         belief_series["cumulative_probability"] = 0.5
         belief_series["source"] = self.data_source
@@ -164,7 +168,9 @@ class PandasReporter(Reporter):
         # filing the missing indexes with default values:
         if "belief_time" not in bdf.index.names:
             if belief_horizon is not None:
-                belief_time = bdf["event_start"] + belief_horizon
+                belief_time = (
+                    bdf["event_start"] + +bdf.event_resolution - belief_horizon
+                )
             else:
                 belief_time = [belief_time] * len(bdf)
             bdf["belief_time"] = belief_time

--- a/flexmeasures/data/schemas/reporting/__init__.py
+++ b/flexmeasures/data/schemas/reporting/__init__.py
@@ -36,6 +36,7 @@ class ReporterParametersSchema(Schema):
 
     resolution = DurationField(required=False)
     belief_time = AwareDateTimeField(required=False)
+    belief_horizon = DurationField(required=False)
 
 
 class BeliefsSearchConfigSchema(Schema):


### PR DESCRIPTION
The belief time of the output of the `PandasReporter`could be set already. However, it's very handy to provide the belief horizon instead. This PR allows passing the belief horizon, a timedelta.

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures