### PR TITLE
Feature/revised asset groups

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -28,6 +28,7 @@ Bugfixes
 Infrastructure / Support
 ----------------------
 
+* Align map layers with custom asset types in the UI's dashboard, also facilitating capturing asset types defined within FlexMeasures plugins [see `PR #1017 <https://github.com/FlexMeasures/flexmeasures/pull/1017>`_]
 * Improve processing time for deleting beliefs via CLI [see `PR #1005 <https://github.com/FlexMeasures/flexmeasures/pull/1005>`_]
 * Support deleting beliefs via CLI for all offspring assets at once [see `PR #1003 <https://github.com/FlexMeasures/flexmeasures/pull/1003>`_]
 * Add setting ``FLEXMEASURES_FORCE_HTTPS`` to explicitly toggle if HTTPS should be used for all requests [see `PR #1008 <https://github.com/FlexMeasures/flexmeasures/pull/1008>`_]

--- a/flexmeasures/ui/templates/views/new_dashboard.html
+++ b/flexmeasures/ui/templates/views/new_dashboard.html
@@ -111,7 +111,6 @@
     // create markers, keep them in separate lists (by asset type) to be put into layers
 
     {% for asset_group_name in asset_groups %}
-    {% if asset_group_name not in aggregate_type_groups %}
         var {{ asset_groups[asset_group_name].parameterized_name }}_markers = [];
     
     {% for asset in asset_groups[asset_group_name].assets if asset.location %}
@@ -161,7 +160,6 @@
     {{ asset_groups[asset_group_name].parameterized_name }}_markers.push(marker_for_{{ (asset.id) }});
                 }
     {% endfor %}
-    {% endif %}
     {% endfor %}
 
     // create Map with tiles
@@ -178,13 +176,11 @@
 
     // add a layer for each asset type
     {% for asset_group_name in asset_groups %}
-    {% if asset_group_name not in aggregate_type_groups %}
     {% if asset_groups[asset_group_name].count > 0 %}
     var {{ asset_groups[asset_group_name].parameterized_name }}_layer = new L.LayerGroup({{ asset_groups[asset_group_name].parameterized_name }}_markers);
     mcgLayerSupportGroup.checkIn({{ asset_groups[asset_group_name].parameterized_name }}_layer);
     control.addOverlay({{ asset_groups[asset_group_name].parameterized_name }}_layer, "{{ asset_group_name | capitalize }}")
     {{ asset_groups[asset_group_name].parameterized_name }}_layer.addTo(assetMap);
-    {% endif %}
     {% endif %}
     {% endfor %}
     mcgLayerSupportGroup.addTo(assetMap);

--- a/flexmeasures/ui/utils/view_utils.py
+++ b/flexmeasures/ui/utils/view_utils.py
@@ -167,29 +167,26 @@ def asset_icon_name(asset_type_name: str) -> str:
     becomes (for a battery):
         <i class="icon-battery"></i>
     """
-    # power asset exceptions
-    if "evse" in asset_type_name.lower() or "charge point" in asset_type_name.lower():
-        return "icon-charging_station"
-    if "project" in asset_type_name.lower():
-        return "icon-calculator"
-    if "tariff" in asset_type_name.lower():
-        return "icon-time"
-    if "site" in asset_type_name.lower():
-        return "icon-empty-marker"
-    if "scenario" in asset_type_name.lower():
-        return "icon-binoculars"
-    # weather exceptions
-    if asset_type_name == "irradiance":
-        return "wi wi-horizon-alt"
-    elif asset_type_name == "temperature":
-        return "wi wi-thermometer"
-    elif asset_type_name == "wind direction":
-        return "wi wi-wind-direction"
-    elif asset_type_name == "wind speed":
-        return "wi wi-strong-wind"
-    # aggregation exceptions
-    elif asset_type_name == "renewables":
-        return "icon-wind"
+    icon_mapping = {
+        # site structure
+        "evse": "icon-charging_station",
+        "charge point": "icon-charging_station",
+        "project": "icon-calculator",
+        "tariff": "icon-time",
+        "renewables": "icon-wind",
+        "site": "icon-empty-marker",
+        "scenario": "icon-binoculars",
+        # weather
+        "irradiance": "wi wi-horizon-alt",
+        "temperature": "wi wi-thermometer",
+        "wind direction": "wi wi-wind-direction",
+        "wind speed": "wi wi-strong-wind",
+    }
+
+    for asset_group_name, icon_name in icon_mapping.items():
+        if asset_group_name in asset_type_name.lower():
+            return icon_name
+
     return f"icon-{asset_type_name}"
 
 

--- a/flexmeasures/ui/utils/view_utils.py
+++ b/flexmeasures/ui/utils/view_utils.py
@@ -168,8 +168,16 @@ def asset_icon_name(asset_type_name: str) -> str:
         <i class="icon-battery"></i>
     """
     # power asset exceptions
-    if "evse" in asset_type_name.lower():
+    if "evse" in asset_type_name.lower() or "charge point" in asset_type_name.lower():
         return "icon-charging_station"
+    if "project" in asset_type_name.lower():
+        return "icon-calculator"
+    if "tariff" in asset_type_name.lower():
+        return "icon-time"
+    if "site" in asset_type_name.lower():
+        return "icon-empty-marker"
+    if "scenario" in asset_type_name.lower():
+        return "icon-binoculars"
     # weather exceptions
     if asset_type_name == "irradiance":
         return "wi wi-horizon-alt"


### PR DESCRIPTION
## Description

Allow custom asset groups to swallow default asset groups based on asset type. This is useful for plugins to e.g. override the default asset groups.

## Look & Feel

Before:

![image](https://github.com/FlexMeasures/flexmeasures/assets/30658763/20f54ebd-9bd0-4dd5-bdae-47f134f48933)

After:

![image](https://github.com/FlexMeasures/flexmeasures/assets/30658763/9c5a8d85-3dc4-425e-9ad7-65dab233b476)

## How to test

Example flexmeasures.cfg entry:

```
FLEXMEASURES_ASSET_TYPE_GROUPS = {
    "projects": ["smartbuilding.simulation"],
    "scenarios": ["smartbuilding.scenario"],
    "sites": ["smartbuilding.site"],
    "renewables": ["solar", "wind", "smartbuilding.PV"],
    "buildings": ["building", "smartbuilding.building"],
    "batteries": ["battery", "smartbuilding.battery"],
    "charge points": ["one-way_evse", "two-way_evse", "smartbuilding.chargepoint"],
}
```

Note that the *Tariffs* group is shown in both images, but not defined here in the config, nor is it swallowed by one of the custom groups. It is coming from the asset type *tariff* (asset types are shown pluralized and capitalized when shown as a group on the dashboard).

## Further Improvements

It would be nice to be able to assign default icons to asset types, for example, using Font Awesome strings, in the database table for asset types. But this would be a larger project, also involving UI work.

