### PR TITLE
Feature/save soc values as a sensor

### DIFF
--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -548,7 +548,9 @@ class StorageFallbackScheduler(MetaStorageScheduler):
         storage_schedule = fallback_charging_policy(
             sensor, device_constraints[0], start, end, resolution
         )
-        soc_schedule, soc_sensor = create_soc_schedule(sensor, storage_schedule, soc_at_start)
+        soc_schedule, soc_sensor = create_soc_schedule(
+            sensor, storage_schedule, soc_at_start
+        )
 
         # Round schedule
         if self.round_to_decimals:
@@ -566,7 +568,7 @@ class StorageFallbackScheduler(MetaStorageScheduler):
                     "name": "soc_schedule",
                     "sensor": soc_sensor,
                     "data": soc_schedule,
-                }
+                },
             ]
         else:
             return storage_schedule
@@ -612,7 +614,9 @@ class StorageScheduler(MetaStorageScheduler):
 
         # Obtain the storage schedule from all device schedules within the EMS
         storage_schedule = ems_schedule[0]
-        soc_schedule, soc_sensor = create_soc_schedule(sensor, storage_schedule, soc_at_start)
+        soc_schedule, soc_sensor = create_soc_schedule(
+            sensor, storage_schedule, soc_at_start
+        )
         # Round schedule
         if self.round_to_decimals:
             storage_schedule = storage_schedule.round(self.round_to_decimals)
@@ -629,7 +633,7 @@ class StorageScheduler(MetaStorageScheduler):
                     "name": "soc_schedule",
                     "sensor": soc_sensor,
                     "data": soc_schedule,
-                }
+                },
             ]
         else:
             return storage_schedule

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -21,6 +21,7 @@ from flexmeasures.data.models.planning.utils import (
     get_power_values,
     fallback_charging_policy,
     get_continuous_series_sensor_or_quantity,
+    create_soc_schedule,
 )
 from flexmeasures.data.models.planning.exceptions import InfeasibleProblemException
 from flexmeasures.data.schemas.scheduling.storage import StorageFlexModelSchema
@@ -547,10 +548,12 @@ class StorageFallbackScheduler(MetaStorageScheduler):
         storage_schedule = fallback_charging_policy(
             sensor, device_constraints[0], start, end, resolution
         )
+        soc_schedule, soc_sensor = create_soc_schedule(sensor, storage_schedule, soc_at_start)
 
         # Round schedule
         if self.round_to_decimals:
             storage_schedule = storage_schedule.round(self.round_to_decimals)
+            soc_schedule = soc_schedule.round(self.round_to_decimals)
 
         if self.return_multiple:
             return [
@@ -558,6 +561,11 @@ class StorageFallbackScheduler(MetaStorageScheduler):
                     "name": "storage_schedule",
                     "sensor": sensor,
                     "data": storage_schedule,
+                },
+                {
+                    "name": "soc_schedule",
+                    "sensor": soc_sensor,
+                    "data": soc_schedule,
                 }
             ]
         else:
@@ -604,10 +612,11 @@ class StorageScheduler(MetaStorageScheduler):
 
         # Obtain the storage schedule from all device schedules within the EMS
         storage_schedule = ems_schedule[0]
-
+        soc_schedule, soc_sensor = create_soc_schedule(sensor, storage_schedule, soc_at_start)
         # Round schedule
         if self.round_to_decimals:
             storage_schedule = storage_schedule.round(self.round_to_decimals)
+            soc_schedule = soc_schedule.round(self.round_to_decimals)
 
         if self.return_multiple:
             return [
@@ -615,6 +624,11 @@ class StorageScheduler(MetaStorageScheduler):
                     "name": "storage_schedule",
                     "sensor": sensor,
                     "data": storage_schedule,
+                },
+                {
+                    "name": "soc_schedule",
+                    "sensor": soc_sensor,
+                    "data": soc_schedule,
                 }
             ]
         else:

--- a/flexmeasures/data/models/planning/utils.py
+++ b/flexmeasures/data/models/planning/utils.py
@@ -431,13 +431,15 @@ def nanmin_of_series_and_value(s: pd.Series, value: float | pd.Series) -> pd.Ser
     return s.fillna(value).clip(upper=value)
 
 
-def create_soc_schedule(sensor: Sensor, data: pd.Series, soc_at_start: float) -> tuple[pd.Series, Sensor]:
+def create_soc_schedule(
+    sensor: Sensor, data: pd.Series, soc_at_start: float
+) -> tuple[pd.Series, Sensor]:
     """Generates a state of charge (SOC) schedule from provided data and creates or retrieves an SOC sensor."""
     asset = db.session.scalars(
-        select(Asset).filter_by(id=sensor.generic_asset_id)).one_or_none()
+        select(Asset).filter_by(id=sensor.generic_asset_id)
+    ).one_or_none()
 
-    soc_schedule = integrate_time_series(
-        data, soc_at_start, decimal_precision=6)
+    soc_schedule = integrate_time_series(data, soc_at_start, decimal_precision=6)
 
     soc_sensor = get_or_create_model(
         Sensor,


### PR DESCRIPTION
## Description

This PR introduces `create_soc_schedule`, a function to generate a state of charge (SOC) schedule from provided data. It also handles the creation or retrieval of the corresponding SOC sensor. 

## Look & Feel

This section can contain example pictures for UI, Input/Output for CLI, Request / Response for API endpoint, etc.

## How to test

Steps to test it or name of the tests functions.

The library [flexmeasures-client](https://github.com/FlexMeasures/flexmeasures-client/) can be useful to showcase new features. For example,
it can be used to set some example data to be used in a new UI feature.

## Further Improvements

Potential improvements to be done in the same PR or follow up Issues/Discussions/PRs.

## Related Items

Mention if this PR closes an Issue or Project.

---

- [ ] I agree to contribute to the project under Apache 2 License. 
- [ ] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
