### PR TITLE
fix _clean_belief_dataframe for a BDF with a single index.

### DIFF
--- a/flexmeasures/data/models/reporting/pandas_reporter.py
+++ b/flexmeasures/data/models/reporting/pandas_reporter.py
@@ -168,9 +168,18 @@ class PandasReporter(Reporter):
         # filing the missing indexes with default values:
         if "belief_time" not in bdf.index.names:
             if belief_horizon is not None:
-                belief_time = (
-                    bdf["event_start"] + +bdf.event_resolution - belief_horizon
-                )
+
+                # In case that all the index but `event_start` are dropped
+                if (
+                    isinstance(bdf.index, pd.DatetimeIndex)
+                    and bdf.index.name == "event_start"
+                ):
+                    event_start = bdf.index
+                else:
+                    event_start = bdf.index.get_event_values("event_start")
+
+                belief_time = event_start + bdf.event_resolution - belief_horizon
+
             else:
                 belief_time = [belief_time] * len(bdf)
             bdf["belief_time"] = belief_time


### PR DESCRIPTION
## Description

The use of `belief_horizon` on the `PandasReporter`, introduced in https://github.com/FlexMeasures/flexmeasures/pull/1013, didn't handle BDFs with single index.

There's no need to backport it as we haven't shipped this feature yet. 

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
