### PR TITLE
fix: replay key conflict with text input

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -19,6 +19,15 @@ Infrastructure / Support
 
 
 
+v0.20.1 | April XX, 2024
+============================
+
+Bugfixes
+-----------
+
+* Prevent **p**lay/**p**ause/**s**top of replays when editing a text field in the UI [see `PR #1024 <https://github.com/FlexMeasures/flexmeasures/pull/1024>`_]
+
+
 v0.20.0 | March 26, 2024
 ============================
 

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -495,6 +495,10 @@
     });
 
     window.addEventListener('keypress', function(e) {
+        // Do nothing if typing in an input field or textarea
+        if (e.target.tagName.toLowerCase() === 'input' || e.target.tagName.toLowerCase() === 'textarea') {
+            return;
+        }
         // Start/pause/resume replay with 'p'
         if (e.key==='p') {
             toggleReplay();


### PR DESCRIPTION
## Description

Inputting a 'p' or an 's' while editing an attribute or filtering a listing on the asset page shouldn't trigger replay functionality.

## How to test

Go to an asset page and in the sensor listing filter records by the letter p or s. The replay shouldn't start or stop. Likewise for editing asset attributes.
