### PR TITLE
Update toy tutorial

### DIFF
--- a/documentation/tut/toy-example-expanded.rst
+++ b/documentation/tut/toy-example-expanded.rst
@@ -117,6 +117,12 @@ In the case of the scheduler that we ran in the previous tutorial, which did not
 
 .. note:: You can add arbitrary sensors to a chart using the attribute ``sensors_to_show``. See :ref:`view_asset-data` for more.
 
+A nice feature is that you can check the data connectivity status of your building asset. Now that we have made the schedule, both lamps are green. You can also view it in `FlexMeasures UI <http://localhost:5000/assets/1/status>`_ :
+
+.. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/screenshot_building_status.png
+    :align: center
+|
+
 We hope this part of the tutorial shows how to incorporate a limited grid connection rather easily with FlexMeasures. There are more ways to model such settings, but this is a straightforward one.
 
 This tutorial showed a quick way to add an inflexible load (like solar power) and a grid connection.

--- a/documentation/tut/toy-example-setup.rst
+++ b/documentation/tut/toy-example-setup.rst
@@ -173,18 +173,44 @@ If you want, you can inspect what you created:
 
     All assets:
     
-    ID  Name         Type     Location
+    ID  Name           Type     Location
     ----  -----------  -------  -----------------
-    2  toy-battery  battery  (52.374, 4.88969)
-    3  toy-solar    solar    (52.374, 4.88969)
+    2  toy-building   building  (52.374, 4.88969)
+    3  toy-battery    battery   (52.374, 4.88969)
+    4  toy-solar      solar     (52.374, 4.88969)
 
 .. code-block:: bash
 
     $ flexmeasures show asset --id 2
 
     =========================
-    Asset toy-battery (ID: 2)
+    Asset toy-building (ID: 2)
     =========================
+
+    Type      Location           Attributes
+    -------   -----------------  ----------------------------
+    building  (52.374, 4.88969)
+
+    ====================================
+    Child assets of toy-building (ID: 2)
+    ====================================
+
+    Type     Location           Attributes
+    -------  -----------------  -------------------------------
+    battery  (52.374, 4.88969)  capacity_in_mw: 0.5
+                                min_soc_in_mwh: 0.05
+                                max_soc_in_mwh: 0.45
+                                sensors_to_show: [56, [58, 57]]
+    solar    (52.374, 4.88969)
+
+    No sensors in asset ...
+
+    $ flexmeasures show asset --id 3
+
+    ==================================
+    Asset toy-battery (ID: 3)
+    Child of asset toy-building (ID: 2)
+    ==================================
 
     Type     Location           Attributes
     -------  -----------------  ----------------------------
@@ -193,12 +219,17 @@ If you want, you can inspect what you created:
                                 max_soc_in_mwh: 0.45
                                 sensors_to_show: [1, [3, 2]]
 
+    ====================================
+    Child assets of toy-battery (ID: 3)
+    ====================================
+
+    No children assets ...
+
     All sensors in asset:
     
     ID  Name         Unit    Resolution    Timezone          Attributes
     ----  -----------  ------  ------------  ----------------  ------------
     2  discharging  MW      15 minutes    Europe/Amsterdam
-
 
 
 Yes, that is quite a large battery :)

--- a/documentation/tut/toy-example-setup.rst
+++ b/documentation/tut/toy-example-setup.rst
@@ -195,13 +195,10 @@ If you want, you can inspect what you created:
     Child assets of toy-building (ID: 2)
     ====================================
 
-    Type     Location           Attributes
-    -------  -----------------  -------------------------------
-    battery  (52.374, 4.88969)  capacity_in_mw: 0.5
-                                min_soc_in_mwh: 0.05
-                                max_soc_in_mwh: 0.45
-                                sensors_to_show: [56, [58, 57]]
-    solar    (52.374, 4.88969)
+    Id       Name               Type
+    -------  -----------------  ----------------------------
+    3        toy-battery        battery
+    4        toy-solar          solar
 
     No sensors in asset ...
 

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -2007,6 +2007,10 @@ def add_toy_account(kind: str, name: str):
         unit: str = "MW",
         **asset_attributes,
     ):
+        asset_kwargs = dict()
+        if asset_attributes.get("parent_asset_id"):
+            asset_kwargs["parent_asset_id"] = asset_attributes.pop("parent_asset_id")
+
         asset = get_or_create_model(
             GenericAsset,
             name=asset_name,
@@ -2014,6 +2018,7 @@ def add_toy_account(kind: str, name: str):
             owner=db.session.get(Account, account_id),
             latitude=location[0],
             longitude=location[1],
+            **asset_kwargs,
         )
         if len(asset_attributes) > 0:
             asset.attributes = asset_attributes
@@ -2031,6 +2036,17 @@ def add_toy_account(kind: str, name: str):
         )
         return sensor
 
+    # create building asset
+    building_asset = get_or_create_model(
+        GenericAsset,
+        name="toy-building",
+        generic_asset_type=asset_types["building"],
+        owner=db.session.get(Account, account_id),
+        latitude=location[0],
+        longitude=location[1],
+    )
+    db.session.flush()
+
     if kind == "battery":
         # create battery
         discharging_sensor = create_asset_with_one_sensor(
@@ -2040,13 +2056,12 @@ def add_toy_account(kind: str, name: str):
             capacity_in_mw=0.5,
             min_soc_in_mwh=0.05,
             max_soc_in_mwh=0.45,
+            parent_asset_id=building_asset.id,
         )
 
         # create solar
         production_sensor = create_asset_with_one_sensor(
-            "toy-solar",
-            "solar",
-            "production",
+            "toy-solar", "solar", "production", parent_asset_id=building_asset.id
         )
 
         # add day-ahead price sensor and PV production sensor to show on the battery's asset page
@@ -2118,7 +2133,7 @@ def add_toy_account(kind: str, name: str):
         grid_connection_capacity = get_or_create_model(
             Sensor,
             name="grid connection capacity",
-            generic_asset=nl_zone,
+            generic_asset=building_asset,
             timezone="Europe/Amsterdam",
             event_resolution="P1Y",
             unit="MW",
@@ -2146,9 +2161,7 @@ def add_toy_account(kind: str, name: str):
         db.session.commit()
 
         headroom = create_asset_with_one_sensor(
-            "toy-battery",
-            "battery",
-            "headroom",
+            "toy-battery", "battery", "headroom", parent_asset_id=building_asset.id
         )
 
         db.session.commit()

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -2005,11 +2005,12 @@ def add_toy_account(kind: str, name: str):
         asset_type: str,
         sensor_name: str,
         unit: str = "MW",
+        parent_asset_id: int | None = None,
         **asset_attributes,
     ):
         asset_kwargs = dict()
-        if asset_attributes.get("parent_asset_id"):
-            asset_kwargs["parent_asset_id"] = asset_attributes.pop("parent_asset_id")
+        if parent_asset_id is not None:
+            asset_kwargs["parent_asset_id"] = parent_asset_id
 
         asset = get_or_create_model(
             GenericAsset,
@@ -2053,10 +2054,10 @@ def add_toy_account(kind: str, name: str):
             "toy-battery",
             "battery",
             "discharging",
+            parent_asset_id=building_asset.id,
             capacity_in_mw=0.5,
             min_soc_in_mwh=0.05,
             max_soc_in_mwh=0.45,
-            parent_asset_id=building_asset.id,
         )
 
         # create solar

--- a/flexmeasures/cli/data_show.py
+++ b/flexmeasures/cli/data_show.py
@@ -188,9 +188,14 @@ def show_generic_asset(asset):
     """
     Show asset info and list sensors
     """
-    click.echo(f"======{len(asset.name) * '='}========")
+    separator_num = 18 if asset.parent_asset is not None else 8
+    click.echo(f"======{len(asset.name) * '='}{separator_num * '='}")
     click.echo(f"Asset {asset.name} (ID: {asset.id})")
-    click.echo(f"======{len(asset.name) * '='}========\n")
+    if asset.parent_asset is not None:
+        click.echo(
+            f"Child of asset {asset.parent_asset.name} (ID: {asset.parent_asset.id})"
+        )
+    click.echo(f"======{len(asset.name) * '='}{separator_num * '='}\n")
 
     asset_data = [
         (
@@ -200,6 +205,25 @@ def show_generic_asset(asset):
         )
     ]
     click.echo(tabulate(asset_data, headers=["Type", "Location", "Attributes"]))
+
+    child_asset_data = [
+        (
+            child.generic_asset_type.name,
+            child.location,
+            "".join([f"{k}: {v}\n" for k, v in child.attributes.items()]),
+        )
+        for child in asset.child_assets
+    ]
+    click.echo()
+    click.echo(f"======{len(asset.name) * '='}===================")
+    click.echo(f"Child assets of {asset.name} (ID: {asset.id})")
+    click.echo(f"======{len(asset.name) * '='}===================\n")
+    if child_asset_data:
+        click.echo(
+            tabulate(child_asset_data, headers=["Type", "Location", "Attributes"])
+        )
+    else:
+        click.secho("No children assets ...", **MsgStyle.WARN)
 
     click.echo()
     sensors = db.session.scalars(

--- a/flexmeasures/cli/data_show.py
+++ b/flexmeasures/cli/data_show.py
@@ -208,9 +208,9 @@ def show_generic_asset(asset):
 
     child_asset_data = [
         (
+            child.id,
+            child.name,
             child.generic_asset_type.name,
-            child.location,
-            "".join([f"{k}: {v}\n" for k, v in child.attributes.items()]),
         )
         for child in asset.child_assets
     ]
@@ -219,9 +219,7 @@ def show_generic_asset(asset):
     click.echo(f"Child assets of {asset.name} (ID: {asset.id})")
     click.echo(f"======{len(asset.name) * '='}===================\n")
     if child_asset_data:
-        click.echo(
-            tabulate(child_asset_data, headers=["Type", "Location", "Attributes"])
-        )
+        click.echo(tabulate(child_asset_data, headers=["Id", "Name", "Type"]))
     else:
         click.secho("No children assets ...", **MsgStyle.WARN)
 


### PR DESCRIPTION
## Description

Update add_toy_account function to create building asset first and add other assets as its children.

This should apply to battery and reporter cases. Plus in reporter case it is also necessary to move grid_connection_capacity sensor to building asset instead of Transmission zone.

Add building status page screenshot to the end of tutorial with comment like "A nice feature is that you can check the data connectivity status of your building asset. Now that we have made the schedule, both lamps are green."

## Look & Feel

There should be new screenshot in the end of https://flexmeasures.readthedocs.io/en/latest/tut/toy-example-expanded.html

## How to test

Follow toy tutorial instructions and check that all assets are created under Building asset

## Further Improvements

-

## Related Items

-

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
