### PR TITLE
fix: unable to click child assets table

### DIFF
--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -195,6 +195,7 @@
                             <th>Account</th>
                             <th>Sensors</th>
                             <th class="hidden">URL</th>
+                            <th class="no-sort"></th>
                         </tr>
                     </thead>
                     <tbody>


### PR DESCRIPTION
>[!IMPORTANT]
> This was introduced in v0.20.0 so we need to backport to v0.20.1.

## Description

Lately, I found that I couldn't click the child assets table rows to go to the their asset page.

![image](https://github.com/FlexMeasures/flexmeasures/assets/84775131/875bd2d6-f62e-4658-9d9a-f7e4ae686394)

## How to test

* Go to the _asset page_ of an Asset with children and click one of the rows to go to the its asset page.

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
