### PR TITLE
Support start_time and end_time query parameters

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -9,8 +9,8 @@ v0.21.0 | April XX, 2024
 New features
 -------------   
 
-* Add asset/<id>/status page to view asset statuses [see `PR #41 <https://github.com/FlexMeasures/flexmeasures/pull/941/>`_]
-* Support start_date and end_date query parameters for GET asset/<id> [see `PR #1030 <https://github.com/FlexMeasures/flexmeasures/pull/1030/>`_]
+* Add `asset/<id>/status` page to view asset statuses [see `PR #41 <https://github.com/FlexMeasures/flexmeasures/pull/941/>`_]
+* Support `start_date` and `end_date` query parameters for the asset page [see `PR #1030 <https://github.com/FlexMeasures/flexmeasures/pull/1030/>`_]
 
 Bugfixes
 -----------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -10,6 +10,7 @@ New features
 -------------   
 
 * Add asset/<id>/status page to view asset statuses [see `PR #41 <https://github.com/FlexMeasures/flexmeasures/pull/941/>`_]
+* Support start_date and end_date query parameters for GET asset/<id> [see `PR #1030 <https://github.com/FlexMeasures/flexmeasures/pull/1030/>`_]
 
 Bugfixes
 -----------

--- a/flexmeasures/data/schemas/__init__.py
+++ b/flexmeasures/data/schemas/__init__.py
@@ -7,4 +7,9 @@ from .generic_assets import GenericAssetIdField as AssetIdField
 from .locations import LatitudeField, LongitudeField
 from .sensors import SensorIdField, QuantityOrSensor
 from .sources import DataSourceIdField as SourceIdField
-from .times import AwareDateTimeField, DurationField, TimeIntervalField
+from .times import (
+    AwareDateTimeField,
+    DurationField,
+    TimeIntervalField,
+    StartEndTimeSchema,
+)

--- a/flexmeasures/data/schemas/times.py
+++ b/flexmeasures/data/schemas/times.py
@@ -4,7 +4,7 @@ import json
 from datetime import datetime, timedelta
 
 from flask import current_app
-from marshmallow import fields, Schema
+from marshmallow import fields, Schema, validates_schema
 from marshmallow.exceptions import ValidationError
 import isodate
 from isodate.isoerror import ISO8601Error
@@ -108,3 +108,19 @@ class TimeIntervalField(MarshmallowClickMixin, fields.Dict):
             raise ValidationError()
 
         return TimeIntervalSchema().load(v)
+
+
+class StartEndTimeSchema(Schema):
+    start_time = AwareDateTimeField(required=False)
+    end_time = AwareDateTimeField(required=False)
+
+    @validates_schema
+    def validate(self, data, **kwargs):
+        if not (data.get("start_time") or data.get("end_time")):
+            return
+        if not (data.get("start_time") and data.get("end_time")):
+            raise ValidationError(
+                "Both start_time and end_time must be provided together."
+            )
+        if data["start_time"] >= data["end_time"]:
+            raise ValidationError("start_time must be before end_time.")

--- a/flexmeasures/ui/crud/assets.py
+++ b/flexmeasures/ui/crud/assets.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import json
 
-from flask import url_for, current_app
+from flask import url_for, current_app, request
 from flask_classful import FlaskView, route
 from flask_wtf import FlaskForm
 from flask_security import login_required, current_user
@@ -269,8 +269,11 @@ class AssetCrudUI(FlaskView):
 
     @login_required
     def get(self, id: str):
-        """GET from /assets/<id> where id can be 'new' (and thus the form for asset creation is shown)"""
-
+        """GET from /assets/<id> where id can be 'new' (and thus the form for asset creation is shown)
+        The following query parameters are supported:
+         - start_time: minimum time of the events to be shown
+         - end_time: maximum time of the events to be shown
+        """
         if id == "new":
             if not user_can_create_assets():
                 return unauthorized_handler(None, [])
@@ -300,6 +303,8 @@ class AssetCrudUI(FlaskView):
             mapboxAccessToken=current_app.config.get("MAPBOX_ACCESS_TOKEN", ""),
             user_can_create_assets=user_can_create_assets(),
             user_can_delete_asset=user_can_delete(asset),
+            event_starts_after=request.args.get("start_time"),
+            event_ends_before=request.args.get("end_time"),
         )
 
     @login_required

--- a/flexmeasures/ui/crud/assets.py
+++ b/flexmeasures/ui/crud/assets.py
@@ -16,7 +16,7 @@ from flexmeasures.auth.policy import user_has_admin_access
 from flexmeasures.data import db
 from flexmeasures.auth.error_handling import unauthorized_handler
 from flexmeasures.auth.policy import check_access
-from flexmeasures.data.schemas import AwareDateTimeField
+from flexmeasures.data.schemas import StartEndTimeSchema
 from flexmeasures.data.models.generic_assets import (
     GenericAssetType,
     GenericAsset,
@@ -269,17 +269,11 @@ class AssetCrudUI(FlaskView):
             user_can_create_assets=user_can_create_assets(),
         )
 
-    @use_kwargs(
-        {
-            "start_time": AwareDateTimeField(format="iso", required=False),
-            "end_time": AwareDateTimeField(format="iso", required=False),
-        },
-        location="query",
-    )
+    @use_kwargs(StartEndTimeSchema, location="query")
     @login_required
     def get(self, id: str, **kwargs):
         """GET from /assets/<id> where id can be 'new' (and thus the form for asset creation is shown)
-        The following query parameters are supported:
+        The following query parameters are supported (should be used only together):
          - start_time: minimum time of the events to be shown
          - end_time: maximum time of the events to be shown
         """

--- a/flexmeasures/ui/crud/assets.py
+++ b/flexmeasures/ui/crud/assets.py
@@ -7,6 +7,7 @@ from flask import url_for, current_app, request
 from flask_classful import FlaskView, route
 from flask_wtf import FlaskForm
 from flask_security import login_required, current_user
+from webargs.flaskparser import use_kwargs
 from wtforms import StringField, DecimalField, SelectField
 from wtforms.validators import DataRequired, optional
 from sqlalchemy import select
@@ -15,6 +16,7 @@ from flexmeasures.auth.policy import user_has_admin_access
 from flexmeasures.data import db
 from flexmeasures.auth.error_handling import unauthorized_handler
 from flexmeasures.auth.policy import check_access
+from flexmeasures.data.schemas import AwareDateTimeField
 from flexmeasures.data.models.generic_assets import (
     GenericAssetType,
     GenericAsset,
@@ -267,8 +269,15 @@ class AssetCrudUI(FlaskView):
             user_can_create_assets=user_can_create_assets(),
         )
 
+    @use_kwargs(
+        {
+            "start_time": AwareDateTimeField(format="iso", required=False),
+            "end_time": AwareDateTimeField(format="iso", required=False),
+        },
+        location="query",
+    )
     @login_required
-    def get(self, id: str):
+    def get(self, id: str, **kwargs):
         """GET from /assets/<id> where id can be 'new' (and thus the form for asset creation is shown)
         The following query parameters are supported:
          - start_time: minimum time of the events to be shown

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -46,11 +46,6 @@
     {% endblock %}
 </head>
 
-<script>
-    // Define picker as a global variable
-    var picker;
-</script>
-
 <body>
 
     {% block body %}
@@ -196,6 +191,10 @@
     {% block sensorChartSetup %}
 
     <!-- Render Charts -->
+    <script>
+        // Define picker as a global variable so that other code on the page can access it, e.g. get the times
+        var picker;
+    </script>
     <script type="module" type="text/javascript">
 
     // Import local js (the FM version is used for cache-busting, causing the browser to fetch the updated version from the server)

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -46,6 +46,11 @@
     {% endblock %}
 </head>
 
+<script>
+    // Define picker as a global variable
+    var picker;
+</script>
+
 <body>
 
     {% block body %}
@@ -349,7 +354,7 @@
 
     // Create date range picker and the logic for a new date range selection (mostly, fetching data and displaying the chart for it)
     const date = Date();
-    const picker = new Litepicker({
+    picker = new Litepicker({
         element: document.getElementById('datepicker'),
         plugins: ['ranges', 'keyboardnav'],
         ranges: {

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -147,6 +147,61 @@
                 <span class="sr-only">Loading...</span>
             </div>
             <div id="sensorchart" class="card" style="width: 100%;"></div>
+            <div class="row">
+                <div class="copy-url" title="Click to copy URL to clipboard">
+                    <script>
+                        function toIsoString(date) {
+                            var tzo = -date.getTimezoneOffset(),
+                                dif = tzo >= 0 ? '+' : '-',
+                                pad = function(num) {
+                                    return (num < 10 ? '0' : '') + num;
+                                };
+
+                            return date.getFullYear() +
+                                '-' + pad(date.getMonth() + 1) +
+                                '-' + pad(date.getDate()) +
+                                'T' + pad(date.getHours()) +
+                                ':' + pad(date.getMinutes()) +
+                                ':' + pad(date.getSeconds()) +
+                                dif + pad(Math.floor(Math.abs(tzo) / 60)) +
+                                ':' + pad(Math.abs(tzo) % 60);
+                        }
+                        function copyUrl(event) {
+                            event.preventDefault();
+
+                            if (!window.getSelection) {
+                                alert('Please copy the URL from the location bar.');
+                                return;
+                            }
+                            const dummy = document.createElement('p');
+
+                            var startDate = toIsoString(picker.getStartDate().toJSDate());
+                            var endDate = toIsoString(picker.getEndDate().toJSDate());
+                            var base_url = window.location.href.split("?")[0];
+                            dummy.textContent = `${base_url}?start_time=${startDate}&end_time=${endDate}`
+                            document.body.appendChild(dummy);
+
+                            const range = document.createRange();
+                            range.setStartBefore(dummy);
+                            range.setEndAfter(dummy);
+
+                            const selection = window.getSelection();
+                            // First clear, in case the user already selected some other text
+                            selection.removeAllRanges();
+                            selection.addRange(range);
+
+                            document.execCommand('copy');
+                            document.body.removeChild(dummy);
+
+                            $("#message").show().delay(1000).fadeOut();
+                        }
+                    </script>
+                    <a href="#" onclick="copyUrl(event)" style="display: block; text-align: center;">
+                        <i class="fa fa-link"></i>
+                    </a>
+                    <div id="message" style="display: none; text-align: center;">URL to this view has been copied to your clipboard.</div>
+                </div>
+            </div>
             <div class="sensors-asset card">
                 <h3>All sensors for {{ asset.name }}</h3>
                 <table class="table table-striped table-responsive paginate nav-on-click" title="View data">
@@ -234,36 +289,6 @@
                         {% endfor %}
                     </tbody>
                 </table>
-            </div>
-        </div>
-        <div class="row">
-            <div class="copy-url" title="Click to copy URL to clipboard">
-                <script>
-                    function copyUrl() {
-                        if (!window.getSelection) {
-                            alert('Please copy the URL from the location bar.');
-                            return;
-                        }
-                        const dummy = document.createElement('p');
-                        dummy.textContent = window.location.href;
-                        document.body.appendChild(dummy);
-
-                        const range = document.createRange();
-                        range.setStartBefore(dummy);
-                        range.setEndAfter(dummy);
-
-                        const selection = window.getSelection();
-                        // First clear, in case the user already selected some other text
-                        selection.removeAllRanges();
-                        selection.addRange(range);
-
-                        document.execCommand('copy');
-                        document.body.removeChild(dummy);
-                    }
-                </script>
-                <a href="#" onclick="copyUrl()">
-                    <i class="fa fa-link"></i>
-                </a>
             </div>
         </div>
         <div class="col-sm-2">

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -176,7 +176,10 @@
                             const dummy = document.createElement('p');
 
                             var startDate = encodeURIComponent(toIsoString(picker.getStartDate().toJSDate()));
-                            var endDate = encodeURIComponent(toIsoString(picker.getEndDate().toJSDate()));
+                            // add 1 day to end date as datepicker does not include the end date day
+                            var endDate = picker.getEndDate();
+                            endDate.setDate(endDate.getDate() + 1);
+                            endDate = encodeURIComponent(toIsoString(endDate.toJSDate()));
                             var base_url = window.location.href.split("?")[0];
                             dummy.textContent = `${base_url}?start_time=${startDate}&end_time=${endDate}`
                             document.body.appendChild(dummy);

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -236,6 +236,36 @@
                 </table>
             </div>
         </div>
+        <div class="row">
+            <div class="copy-url" title="Click to copy URL to clipboard">
+                <script>
+                    function copyUrl() {
+                        if (!window.getSelection) {
+                            alert('Please copy the URL from the location bar.');
+                            return;
+                        }
+                        const dummy = document.createElement('p');
+                        dummy.textContent = window.location.href;
+                        document.body.appendChild(dummy);
+
+                        const range = document.createRange();
+                        range.setStartBefore(dummy);
+                        range.setEndAfter(dummy);
+
+                        const selection = window.getSelection();
+                        // First clear, in case the user already selected some other text
+                        selection.removeAllRanges();
+                        selection.addRange(range);
+
+                        document.execCommand('copy');
+                        document.body.removeChild(dummy);
+                    }
+                </script>
+                <a href="#" onclick="copyUrl()">
+                    <i class="fa fa-link"></i>
+                </a>
+            </div>
+        </div>
         <div class="col-sm-2">
             <div class="replay-container">
                 <div id="replay" title="Press 'p' to play/pause/resume or 's' to stop." class="stopped"></div>

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -148,7 +148,7 @@
             </div>
             <div id="sensorchart" class="card" style="width: 100%;"></div>
             <div class="row">
-                <div class="copy-url" title="Click to copy URL to clipboard">
+                <div class="copy-url" title="Click to copy the URL to the current time range to clipboard.">
                     <script>
                         function toIsoString(date) {
                             var tzo = -date.getTimezoneOffset(),
@@ -175,8 +175,8 @@
                             }
                             const dummy = document.createElement('p');
 
-                            var startDate = toIsoString(picker.getStartDate().toJSDate());
-                            var endDate = toIsoString(picker.getEndDate().toJSDate());
+                            var startDate = encodeURIComponent(toIsoString(picker.getStartDate().toJSDate()));
+                            var endDate = encodeURIComponent(toIsoString(picker.getEndDate().toJSDate()));
                             var base_url = window.location.href.split("?")[0];
                             dummy.textContent = `${base_url}?start_time=${startDate}&end_time=${endDate}`
                             document.body.appendChild(dummy);
@@ -199,7 +199,7 @@
                     <a href="#" onclick="copyUrl(event)" style="display: block; text-align: center;">
                         <i class="fa fa-link"></i>
                     </a>
-                    <div id="message" style="display: none; text-align: center;">URL to this view has been copied to your clipboard.</div>
+                    <div id="message" style="display: none; text-align: center;">The URL to the time range currently shown has been copied to your clipboard.</div>
                 </div>
             </div>
             <div class="sensors-asset card">

--- a/flexmeasures/ui/tests/test_asset_crud.py
+++ b/flexmeasures/ui/tests/test_asset_crud.py
@@ -85,6 +85,54 @@ def test_asset_page(db, client, setup_assets, requests_mock, as_prosumer_user1):
     )
 
 
+@pytest.mark.parametrize(
+    "args, error",
+    [
+        (
+            {"start_time": "2022-10-01T00:00:00+02:00"},
+            "Both start_time and end_time must be provided together.",
+        ),
+        (
+            {"end_time": "2022-10-01T00:00:00+02:00"},
+            "Both start_time and end_time must be provided together.",
+        ),
+        (
+            {
+                "start_time": "2022-10-01T00:00:00+02:00",
+                "end_time": "2022-10-01T00:00:00+02:00",
+            },
+            "start_time must be before end_time.",
+        ),
+        (
+            {
+                "start_time": "2022-10-01T00:00:00",
+                "end_time": "2022-10-02T00:00:00+02:00",
+            },
+            "Not a valid aware datetime",
+        ),
+    ],
+)
+def test_asset_page_dates_validation(
+    db, client, setup_assets, requests_mock, as_prosumer_user1, args, error
+):
+    user = find_user_by_email("test_prosumer_user@seita.nl")
+    asset = user.account.generic_assets[0]
+    db.session.expunge(user)
+    mock_asset = mock_asset_response(as_list=False)
+
+    requests_mock.get(f"{api_path_assets}/{asset.id}", status_code=200, json=mock_asset)
+    asset_page = client.get(
+        url_for(
+            "AssetCrudUI:get",
+            id=asset.id,
+            **args,
+        ),
+        follow_redirects=True,
+    )
+    assert error.encode() in asset_page.data
+    assert "UNPROCESSABLE_ENTITY".encode() in asset_page.data
+
+
 def test_edit_asset(db, client, setup_assets, requests_mock, as_admin):
     mock_asset = mock_asset_response(as_list=False)
     requests_mock.patch(f"{api_path_assets}/1", status_code=200, json=mock_asset)

--- a/flexmeasures/ui/tests/test_asset_crud.py
+++ b/flexmeasures/ui/tests/test_asset_crud.py
@@ -67,8 +67,8 @@ def test_asset_page(db, client, setup_assets, requests_mock, as_prosumer_user1):
         url_for(
             "AssetCrudUI:get",
             id=asset.id,
-            start_time="2022-10-01T00:00:00",
-            end_time="2022-10-02T:00:00",
+            start_time="2022-10-01T00:00:00+02:00",
+            end_time="2022-10-02T00:00:00+02:00",
         ),
         follow_redirects=True,
     )
@@ -76,9 +76,13 @@ def test_asset_page(db, client, setup_assets, requests_mock, as_prosumer_user1):
     assert str(mock_asset["latitude"]).encode() in asset_page.data
     assert str(mock_asset["longitude"]).encode() in asset_page.data
     assert (
-        "storeStartDate = new Date('2022-10-01T00:00:00')".encode() in asset_page.data
+        "storeStartDate = new Date('2022-10-01T00:00:00+02:00')".encode()
+        in asset_page.data
     )
-    assert "storeEndDate = new Date('2022-10-02T:00:00')".encode() in asset_page.data
+    assert (
+        "storeEndDate = new Date('2022-10-02T00:00:00+02:00')".encode()
+        in asset_page.data
+    )
 
 
 def test_edit_asset(db, client, setup_assets, requests_mock, as_admin):

--- a/flexmeasures/ui/tests/test_asset_crud.py
+++ b/flexmeasures/ui/tests/test_asset_crud.py
@@ -64,11 +64,21 @@ def test_asset_page(db, client, setup_assets, requests_mock, as_prosumer_user1):
 
     requests_mock.get(f"{api_path_assets}/{asset.id}", status_code=200, json=mock_asset)
     asset_page = client.get(
-        url_for("AssetCrudUI:get", id=asset.id), follow_redirects=True
+        url_for(
+            "AssetCrudUI:get",
+            id=asset.id,
+            start_time="2022-10-01T00:00:00",
+            end_time="2022-10-02T:00:00",
+        ),
+        follow_redirects=True,
     )
     assert ("Edit %s" % mock_asset["name"]).encode() in asset_page.data
     assert str(mock_asset["latitude"]).encode() in asset_page.data
     assert str(mock_asset["longitude"]).encode() in asset_page.data
+    assert (
+        "storeStartDate = new Date('2022-10-01T00:00:00')".encode() in asset_page.data
+    )
+    assert "storeEndDate = new Date('2022-10-02T:00:00')".encode() in asset_page.data
 
 
 def test_edit_asset(db, client, setup_assets, requests_mock, as_admin):

--- a/flexmeasures/ui/utils/view_utils.py
+++ b/flexmeasures/ui/utils/view_utils.py
@@ -29,8 +29,13 @@ def render_flexmeasures_template(html_filename: str, **variables):
     ):
         variables["documentation_exists"] = True
 
-    variables["event_starts_after"] = session.get("event_starts_after")
-    variables["event_ends_before"] = session.get("event_ends_before")
+    # use event_starts_after and event_ends_before from session if not given
+    variables["event_starts_after"] = variables.get(
+        "event_starts_after", session.get("event_starts_after")
+    )
+    variables["event_ends_before"] = variables.get(
+        "event_ends_before", session.get("event_ends_before")
+    )
     variables["chart_type"] = session.get("chart_type", "bar_chart")
 
     variables["page"] = html_filename.split("/")[-1].replace(".html", "")


### PR DESCRIPTION
## Description

Support start_time and end_time query parameters for *GET /assets/\<id\>* call

## Look & Feel

.

## How to test

Pass new parameters to *GET /assets/\<id\>*, check we get data that is more recent than start_time and older than end_time

## Further Improvements

.

## Related Items

.

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
