### PR TITLE
Scheduling jobs on status page

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -9,9 +9,8 @@ v0.21.0 | April XX, 2024
 New features
 -------------   
 
-* Add `asset/<id>/status` page to view asset statuses [see `PR #41 <https://github.com/FlexMeasures/flexmeasures/pull/941/>`_]
+* Add `asset/<id>/status` page to view asset statuses [see `PR #41 <https://github.com/FlexMeasures/flexmeasures/pull/941/>`_ and `PR #1035 <https://github.com/FlexMeasures/flexmeasures/pull/1035/>`_]
 * Support `start_date` and `end_date` query parameters for the asset page [see `PR #1030 <https://github.com/FlexMeasures/flexmeasures/pull/1030/>`_]
-* Add scheduling and forecasting job tables to `asset/<id>/status` [see `PR #1035 <https://github.com/FlexMeasures/flexmeasures/pull/1035/>`_]
 
 Bugfixes
 -----------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -11,6 +11,7 @@ New features
 
 * Add `asset/<id>/status` page to view asset statuses [see `PR #41 <https://github.com/FlexMeasures/flexmeasures/pull/941/>`_]
 * Support `start_date` and `end_date` query parameters for the asset page [see `PR #1030 <https://github.com/FlexMeasures/flexmeasures/pull/1030/>`_]
+* Add scheduling and forecasting job tables to `asset/<id>/status` [see `PR #1035 <https://github.com/FlexMeasures/flexmeasures/pull/1035/>`_]
 
 Bugfixes
 -----------

--- a/flexmeasures/api/common/schemas/tests/test_sensor_data_schema.py
+++ b/flexmeasures/api/common/schemas/tests/test_sensor_data_schema.py
@@ -314,5 +314,5 @@ def test_build_asset_jobs_data(db, app, add_battery_assets):
         else:
             assert job_data["job_id"] == scheduling_job.id
         assert job_data["status"] == "queued"
-        assert job_data["asset_type"] == "sensor"
+        assert job_data["sensor_or_asset_class"] == "sensor"
         assert job_data["asset_id"] == battery.id

--- a/flexmeasures/api/common/schemas/tests/test_sensor_data_schema.py
+++ b/flexmeasures/api/common/schemas/tests/test_sensor_data_schema.py
@@ -307,12 +307,12 @@ def test_build_asset_jobs_data(db, app, add_battery_assets):
     )
 
     jobs_data = build_asset_jobs_data(battery_asset)
-    assert sorted([j["job_type"] for j in jobs_data]) == ["forecasting", "scheduling"]
+    assert sorted([j["queue"] for j in jobs_data]) == ["forecasting", "scheduling"]
     for job_data in jobs_data:
-        if job_data["job_type"] == "forecasting":
+        if job_data["queue"] == "forecasting":
             assert job_data["job_id"] == forecasting_jobs[0].id
         else:
             assert job_data["job_id"] == scheduling_job.id
         assert job_data["status"] == "queued"
-        assert job_data["sensor_or_asset_class"] == "sensor"
+        assert job_data["asset_or_sensor_type"] == "sensor"
         assert job_data["asset_id"] == battery.id

--- a/flexmeasures/app.py
+++ b/flexmeasures/app.py
@@ -20,6 +20,8 @@ from flask_cors import CORS
 from redis import Redis
 from rq import Queue
 
+from flexmeasures.data.services.job_cache import JobCache
+
 
 def create(  # noqa C901
     env: str | None = None,
@@ -100,6 +102,7 @@ def create(  # noqa C901
         # labelling=Queue(connection=redis_conn, name="labelling"),
         # alerting=Queue(connection=redis_conn, name="alerting"),
     )
+    app.job_cache = JobCache(app.redis_connection, app.queues)
 
     # Some basic security measures
 

--- a/flexmeasures/app.py
+++ b/flexmeasures/app.py
@@ -102,7 +102,7 @@ def create(  # noqa C901
         # labelling=Queue(connection=redis_conn, name="labelling"),
         # alerting=Queue(connection=redis_conn, name="alerting"),
     )
-    app.job_cache = JobCache(app.redis_connection, app.queues)
+    app.job_cache = JobCache(app.redis_connection)
 
     # Some basic security measures
 

--- a/flexmeasures/conftest.py
+++ b/flexmeasures/conftest.py
@@ -1095,7 +1095,7 @@ def clean_redis(app):
     app.queues["forecasting"].empty()
     for job_id in failed.get_job_ids():
         failed.remove(app.queues["forecasting"].fetch_job(job_id))
-    app.job_cache.connection.flushdb()
+    app.redis_connection.flushdb()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/flexmeasures/conftest.py
+++ b/flexmeasures/conftest.py
@@ -1095,6 +1095,7 @@ def clean_redis(app):
     app.queues["forecasting"].empty()
     for job_id in failed.get_job_ids():
         failed.remove(app.queues["forecasting"].fetch_job(job_id))
+    app.job_cache.connection.flushdb()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/flexmeasures/data/services/forecasting.py
+++ b/flexmeasures/data/services/forecasting.py
@@ -119,6 +119,7 @@ def create_forecasting_jobs(
         jobs.append(job)
         if enqueue:
             current_app.queues["forecasting"].enqueue_job(job)
+            current_app.job_cache.add(sensor_id, job.id)
     return jobs
 
 

--- a/flexmeasures/data/services/forecasting.py
+++ b/flexmeasures/data/services/forecasting.py
@@ -119,7 +119,9 @@ def create_forecasting_jobs(
         jobs.append(job)
         if enqueue:
             current_app.queues["forecasting"].enqueue_job(job)
-            current_app.job_cache.add(sensor_id, job.id, "forecasting", "sensor")
+            current_app.job_cache.add(
+                sensor_id, job.id, queue="forecasting", asset_or_sensor_type="sensor"
+            )
     return jobs
 
 

--- a/flexmeasures/data/services/forecasting.py
+++ b/flexmeasures/data/services/forecasting.py
@@ -119,7 +119,7 @@ def create_forecasting_jobs(
         jobs.append(job)
         if enqueue:
             current_app.queues["forecasting"].enqueue_job(job)
-            current_app.job_cache.add(sensor_id, job.id)
+            current_app.job_cache.add(sensor_id, job.id, "forecasting", "sensor")
     return jobs
 
 

--- a/flexmeasures/data/services/job_cache.py
+++ b/flexmeasures/data/services/job_cache.py
@@ -2,32 +2,38 @@
 Logic around storing and retrieving jobs from redis cache.
 """
 
+from rq.job import Job, NoSuchJobError
+
 
 class JobCache:
-    def __init__(self, connection, queues):
+    def __init__(self, connection):
         self.connection = connection
-        self.queues = queues
 
-    def add(self, sensor_id, job_id):
-        self.connection.sadd(sensor_id, job_id)
+    def _get_cache_key(self, asset_or_sensor_id, queue, asset_or_sensor_type):
+        return f"{queue}:{asset_or_sensor_type}:{asset_or_sensor_id}"
+
+    def add(self, asset_or_sensor_id, job_id, queue, asset_or_sensor_type):
+        cache_key = self._get_cache_key(asset_or_sensor_id, queue, asset_or_sensor_type)
+        self.connection.sadd(cache_key, job_id)
 
     def _get_job(self, job_id):
-        for queue in self.queues.values():
-            job = queue.fetch_job(job_id)
-            if job is not None:
-                return job
+        try:
+            job = Job.fetch(job_id, connection=self.connection)
+        except NoSuchJobError:
+            return None
+        return job
 
-    def get(self, sensor_id):
-        job_ids_to_remove = list()
-        jobs = list()
-        for job_id in self.connection.smembers(sensor_id):
+    def get(self, asset_or_sensor_id, queue, asset_or_sensor_type):
+        job_ids_to_remove, jobs = list(), list()
+        cache_key = self._get_cache_key(asset_or_sensor_id, queue, asset_or_sensor_type)
+        for job_id in self.connection.smembers(cache_key):
             job_id = job_id.decode("utf-8")
             job = self._get_job(job_id)
-            # remove job from cache if cant be found in any queue - was removed by TTL
+            # remove job from cache if cant be found - was removed by TTL
             if job is None:
                 job_ids_to_remove.append(job_id)
                 continue
             jobs.append(job)
         if job_ids_to_remove:
-            self.connection.srem(sensor_id, *job_ids_to_remove)
+            self.connection.srem(cache_key, *job_ids_to_remove)
         return jobs

--- a/flexmeasures/data/services/job_cache.py
+++ b/flexmeasures/data/services/job_cache.py
@@ -1,0 +1,33 @@
+"""
+Logic around storing and retrieving jobs from redis cache.
+"""
+
+
+class JobCache:
+    def __init__(self, connection, queues):
+        self.connection = connection
+        self.queues = queues
+
+    def add(self, sensor_id, job_id):
+        self.connection.sadd(sensor_id, job_id)
+
+    def _get_job(self, job_id):
+        for queue in self.queues.values():
+            job = queue.fetch_job(job_id)
+            if job is not None:
+                return job
+
+    def get(self, sensor_id):
+        job_ids_to_remove = list()
+        jobs = list()
+        for job_id in self.connection.smembers(sensor_id):
+            job_id = job_id.decode("utf-8")
+            job = self._get_job(job_id)
+            # remove job from cache if cant be found in any queue - was removed by TTL
+            if job is None:
+                job_ids_to_remove.append(job_id)
+                continue
+            jobs.append(job)
+        if job_ids_to_remove:
+            self.connection.srem(sensor_id, *job_ids_to_remove)
+        return jobs

--- a/flexmeasures/data/services/job_cache.py
+++ b/flexmeasures/data/services/job_cache.py
@@ -2,6 +2,8 @@
 Logic around storing and retrieving jobs from redis cache.
 """
 
+from __future__ import annotations
+
 import redis
 
 from redis.exceptions import ConnectionError

--- a/flexmeasures/data/services/scheduling.py
+++ b/flexmeasures/data/services/scheduling.py
@@ -198,10 +198,11 @@ def create_scheduling_job(
     )
     scheduler.deserialize_config()
 
+    asset_or_sensor_data = get_asset_or_sensor_ref(asset_or_sensor)
     job = Job.create(
         make_schedule,
         kwargs=dict(
-            asset_or_sensor=get_asset_or_sensor_ref(asset_or_sensor),
+            asset_or_sensor=asset_or_sensor_data,
             scheduler_specs=scheduler_specs,
             **scheduler_kwargs,
         ),
@@ -220,7 +221,7 @@ def create_scheduling_job(
         on_failure=Callback(trigger_optional_fallback),
     )
 
-    job.meta["asset_or_sensor"] = get_asset_or_sensor_ref(asset_or_sensor)
+    job.meta["asset_or_sensor"] = asset_or_sensor_data
     job.meta["scheduler_kwargs"] = scheduler_kwargs
     job.save_meta()
 
@@ -230,6 +231,12 @@ def create_scheduling_job(
     # with job_status=None, we ensure that only fresh new jobs are enqueued (in the contrary they should be requeued)
     if enqueue and not job_status:
         current_app.queues["scheduling"].enqueue_job(job)
+        current_app.job_cache.add(
+            asset_or_sensor_data["id"],
+            job.id,
+            "scheduling",
+            asset_or_sensor_data["class"].lower(),
+        )
 
     return job
 

--- a/flexmeasures/data/services/scheduling.py
+++ b/flexmeasures/data/services/scheduling.py
@@ -198,10 +198,11 @@ def create_scheduling_job(
     )
     scheduler.deserialize_config()
 
+    asset_or_sensor = get_asset_or_sensor_ref(asset_or_sensor)
     job = Job.create(
         make_schedule,
         kwargs=dict(
-            asset_or_sensor=get_asset_or_sensor_ref(asset_or_sensor),
+            asset_or_sensor=asset_or_sensor,
             scheduler_specs=scheduler_specs,
             **scheduler_kwargs,
         ),
@@ -220,7 +221,7 @@ def create_scheduling_job(
         on_failure=Callback(trigger_optional_fallback),
     )
 
-    job.meta["asset_or_sensor"] = get_asset_or_sensor_ref(asset_or_sensor)
+    job.meta["asset_or_sensor"] = asset_or_sensor
     job.meta["scheduler_kwargs"] = scheduler_kwargs
     job.save_meta()
 
@@ -230,6 +231,12 @@ def create_scheduling_job(
     # with job_status=None, we ensure that only fresh new jobs are enqueued (in the contrary they should be requeued)
     if enqueue and not job_status:
         current_app.queues["scheduling"].enqueue_job(job)
+        current_app.job_cache.add(
+            asset_or_sensor["id"],
+            job.id,
+            queue="scheduling",
+            asset_or_sensor_type=asset_or_sensor["class"].lower(),
+        )
 
     return job
 

--- a/flexmeasures/data/services/scheduling.py
+++ b/flexmeasures/data/services/scheduling.py
@@ -198,11 +198,11 @@ def create_scheduling_job(
     )
     scheduler.deserialize_config()
 
-    asset_or_sensor_data = get_asset_or_sensor_ref(asset_or_sensor)
+    asset_or_sensor = get_asset_or_sensor_ref(asset_or_sensor)
     job = Job.create(
         make_schedule,
         kwargs=dict(
-            asset_or_sensor=asset_or_sensor_data,
+            asset_or_sensor=asset_or_sensor,
             scheduler_specs=scheduler_specs,
             **scheduler_kwargs,
         ),
@@ -221,7 +221,7 @@ def create_scheduling_job(
         on_failure=Callback(trigger_optional_fallback),
     )
 
-    job.meta["asset_or_sensor"] = asset_or_sensor_data
+    job.meta["asset_or_sensor"] = asset_or_sensor
     job.meta["scheduler_kwargs"] = scheduler_kwargs
     job.save_meta()
 
@@ -232,10 +232,10 @@ def create_scheduling_job(
     if enqueue and not job_status:
         current_app.queues["scheduling"].enqueue_job(job)
         current_app.job_cache.add(
-            asset_or_sensor_data["id"],
+            asset_or_sensor["id"],
             job.id,
-            "scheduling",
-            asset_or_sensor_data["class"].lower(),
+            queue="scheduling",
+            asset_or_sensor_type=asset_or_sensor["class"].lower(),
         )
 
     return job

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -206,11 +206,12 @@ def build_asset_jobs_data(
     """Get all jobs data for an asset
     Returns a list of dictionaries, each containing the following keys:
     - job_id: id of a job
-    - job_type: type of a job (scheduling or forecasting)
-    - sensor_or_asset_class: type of an asset that is linked to the job (asset or sensor)
+    - queue: job queue (scheduling or forecasting)
+    - asset_or_sensor_type: type of an asset that is linked to the job (asset or sensor)
     - asset_id: id of sensor or asset
     - status: job status (e.g finished, failed, etc)
     - err: job error (equals to None when there was no error for a job)
+    - enqueued_at: time when the job was enqueued
     """
 
     jobs = list()
@@ -244,7 +245,8 @@ def build_asset_jobs_data(
         )
 
     jobs_data = list()
-    for job_type, sensor_or_asset_class, asset_id, jobs in jobs:
+    # Building the actual return list - we also unpack lists of jobs, each to its own entry, and we add error info
+    for queue, asset_or_sensor_type, asset_id, jobs in jobs:
         for job in jobs:
             e = job.meta.get(
                 "exception",
@@ -263,11 +265,12 @@ def build_asset_jobs_data(
             jobs_data.append(
                 {
                     "job_id": job.id,
-                    "job_type": job_type,
-                    "sensor_or_asset_class": sensor_or_asset_class,
+                    "queue": queue,
+                    "asset_or_sensor_type": asset_or_sensor_type,
                     "asset_id": asset_id,
                     "status": job.get_status(),
                     "err": job_err,
+                    "enqueued_at": job.enqueued_at,
                 }
             )
 

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -172,7 +172,7 @@ def get_status(
 def build_sensor_status_data(
     asset: Asset,
     now: datetime = None,
-) -> list:
+) -> list[dict]:
     """Get data connectivity status information for each sensor in given asset and its children
     Returns a list of dictionaries, each containing the following keys:
     - id: sensor id
@@ -202,16 +202,15 @@ def build_sensor_status_data(
 
 def build_asset_jobs_data(
     asset: Asset,
-) -> list:
-    """Get data connectivity status information for each sensor in given asset and its children
+) -> list[dict]:
+    """Get all jobs data for an asset
     Returns a list of dictionaries, each containing the following keys:
-    - id: sensor id
-    - name: sensor name
-    - asset_name: asset name
-    - staleness: staleness of the sensor (for how long the sensor data is stale)
-    - stale: whether the sensor is stale
-    - staleness_since: time since sensor data is considered stale
-    - reason: reason for staleness
+    - job_id: id of a job
+    - job_type: type of a job (scheduling or forecasting)
+    - sensor_or_asset_class: type of an asset that is linked to the job (asset or sensor)
+    - asset_id: id of sensor or asset
+    - status: job status (e.g finished, failed, etc)
+    - err: job error (equals to None when there was no error for a job)
     """
 
     jobs = list()
@@ -245,7 +244,7 @@ def build_asset_jobs_data(
         )
 
     jobs_data = list()
-    for job_type, asset_type, asset_id, jobs in jobs:
+    for job_type, sensor_or_asset_class, asset_id, jobs in jobs:
         for job in jobs:
             e = job.meta.get(
                 "exception",
@@ -265,7 +264,7 @@ def build_asset_jobs_data(
                 {
                     "job_id": job.id,
                     "job_type": job_type,
-                    "asset_type": asset_type,
+                    "sensor_or_asset_class": sensor_or_asset_class,
                     "asset_id": asset_id,
                     "status": job.get_status(),
                     "err": job_err,

--- a/flexmeasures/data/tests/test_job_cache.py
+++ b/flexmeasures/data/tests/test_job_cache.py
@@ -60,7 +60,9 @@ class TestJobCache(unittest.TestCase):
     def setUp(self):
         self.connection = MagicMock(spec_set=["sadd", "smembers", "srem"])
         self.job_cache = JobCache(self.connection)
-        self.job_cache.add("sensor_id", "job_id", "forecasting", "sensor")
+        self.job_cache.add(
+            "sensor_id", "job_id", queue="forecasting", asset_or_sensor_type="sensor"
+        )
         self.cache_key = "forecasting:sensor:sensor_id"
         self.mock_redis_job = MagicMock(spec_set=["fetch"])
 

--- a/flexmeasures/data/tests/test_job_cache.py
+++ b/flexmeasures/data/tests/test_job_cache.py
@@ -1,0 +1,80 @@
+# flake8: noqa: E402
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+from datetime import datetime, timedelta
+
+from flexmeasures.data.models.time_series import Sensor
+from flexmeasures.data.services.job_cache import JobCache
+from flexmeasures.data.services.forecasting import create_forecasting_jobs
+from flexmeasures.utils.time_utils import as_server_time
+
+
+def custom_model_params():
+    """little training as we have little data, turn off transformations until they let this test run (TODO)"""
+    return dict(
+        training_and_testing_period=timedelta(hours=2),
+        outcome_var_transformation=None,
+        regressor_transformation={},
+    )
+
+
+def test_cache_on_create_forecasting_jobs(db, run_as_cli, app, setup_test_data):
+    """Test we add job to cache on creating forecasting job + get job from cache"""
+    wind_device_1: Sensor = setup_test_data["wind-asset-1"].sensors[0]
+
+    job = create_forecasting_jobs(
+        start_of_roll=as_server_time(datetime(2015, 1, 1, 6)),
+        end_of_roll=as_server_time(datetime(2015, 1, 1, 7)),
+        horizons=[timedelta(hours=1)],
+        sensor_id=wind_device_1.id,
+        custom_model_params=custom_model_params(),
+    )
+
+    assert app.job_cache.get(wind_device_1.id) == [job[0]]
+
+
+class TestJobCache(unittest.TestCase):
+    def setUp(self):
+        self.connection = MagicMock(spec_set=["sadd", "smembers", "srem"])
+        self.queues = {
+            "forecasting": MagicMock(spec_set=["fetch_job"]),
+            "scheduling": MagicMock(spec_set=["fetch_job"]),
+        }
+        self.job_cache = JobCache(self.connection, self.queues)
+        self.job_cache.add("sensor_id", "job_id")
+
+    def test_add(self):
+        """Test adding to cache"""
+        self.connection.sadd.assert_called_with("sensor_id", "job_id")
+
+    def test_get_empty_queue(self):
+        """Test getting from cache with empty queue"""
+        self.queues["forecasting"].fetch_job.return_value = None
+        self.queues["scheduling"].fetch_job.return_value = None
+        self.connection.smembers.return_value = [b"job_id"]
+
+        assert self.job_cache.get("sensor_id") == []
+        assert self.connection.srem.call_count == 1
+
+    def test_get_non_empty_forecasting_queue(self):
+        """Test getting from cache with non empty forecasting queue"""
+        forecasting_job = MagicMock()
+        self.queues["forecasting"].fetch_job.return_value = forecasting_job
+        self.queues["scheduling"].fetch_job.return_value = None
+        self.connection.smembers.return_value = [b"job_id"]
+
+        assert self.job_cache.get("sensor_id") == [forecasting_job]
+        assert self.connection.srem.call_count == 0
+
+    def test_get_non_empty_scheduling_queue(self):
+        """Test getting from cache with non empty scheduling queue"""
+        scheduling_job = MagicMock()
+        self.queues["scheduling"].fetch_job.return_value = scheduling_job
+        self.queues["forecasting"].fetch_job.return_value = None
+        self.connection.smembers.return_value = [b"job_id"]
+
+        assert self.job_cache.get("sensor_id") == [scheduling_job]
+        assert self.connection.srem.call_count == 0

--- a/flexmeasures/data/tests/test_job_cache.py
+++ b/flexmeasures/data/tests/test_job_cache.py
@@ -1,15 +1,17 @@
 # flake8: noqa: E402
 from __future__ import annotations
 
+import pytest
 import pytz
 import unittest
 
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
+from redis.exceptions import ConnectionError
 from rq.job import NoSuchJobError
 
 from flexmeasures.data.models.time_series import Sensor
-from flexmeasures.data.services.job_cache import JobCache
+from flexmeasures.data.services.job_cache import JobCache, NoRedisConfigured
 from flexmeasures.data.services.forecasting import create_forecasting_jobs
 from flexmeasures.data.services.scheduling import create_scheduling_job
 from flexmeasures.utils.time_utils import as_server_time
@@ -58,20 +60,39 @@ def test_cache_on_create_scheduling_jobs(db, app, add_battery_assets, setup_test
 
 class TestJobCache(unittest.TestCase):
     def setUp(self):
-        self.connection = MagicMock(spec_set=["sadd", "smembers", "srem"])
+        self.connection = MagicMock(spec_set=["sadd", "smembers", "srem", "ping"])
         self.job_cache = JobCache(self.connection)
-        self.job_cache.add(
-            "sensor_id", "job_id", queue="forecasting", asset_or_sensor_type="sensor"
-        )
         self.cache_key = "forecasting:sensor:sensor_id"
         self.mock_redis_job = MagicMock(spec_set=["fetch"])
 
+    def test_no_redis_configured(self):
+        """Test raising NoRedisConfigured"""
+        self.connection.ping.side_effect = ConnectionError
+        with pytest.raises(NoRedisConfigured):
+            self.job_cache.add(
+                "sensor_id",
+                "job_id",
+                queue="forecasting",
+                asset_or_sensor_type="sensor",
+            )
+        self.connection.sadd.assert_not_called()
+
+        with pytest.raises(NoRedisConfigured):
+            self.job_cache.get("sensor_id", "forecasting", "sensor")
+        self.connection.smembers.assert_not_called()
+
     def test_add(self):
         """Test adding to cache"""
+        self.job_cache.add(
+            "sensor_id", "job_id", queue="forecasting", asset_or_sensor_type="sensor"
+        )
         self.connection.sadd.assert_called_with(self.cache_key, "job_id")
 
     def test_get_empty_queue(self):
         """Test getting from cache with empty queue"""
+        self.job_cache.add(
+            "sensor_id", "job_id", queue="forecasting", asset_or_sensor_type="sensor"
+        )
         self.connection.smembers.return_value = [b"job_id"]
 
         self.mock_redis_job.fetch.side_effect = NoSuchJobError
@@ -81,6 +102,9 @@ class TestJobCache(unittest.TestCase):
 
     def test_get_non_empty_queue(self):
         """Test getting from cache with non empty forecasting queue"""
+        self.job_cache.add(
+            "sensor_id", "job_id", queue="forecasting", asset_or_sensor_type="sensor"
+        )
         forecasting_job = MagicMock()
         self.connection.smembers.return_value = [b"job_id"]
 

--- a/flexmeasures/ui/crud/assets.py
+++ b/flexmeasures/ui/crud/assets.py
@@ -325,7 +325,7 @@ class AssetCrudUI(FlaskView):
         asset = process_internal_api_response(asset_dict, int(id), make_obj=True)
         status_data = build_sensor_status_data(asset)
 
-        # add data abount max_jobs_num forecasting and scheduling jobs
+        # add data about forecasting and scheduling jobs
         redis_connection_err = None
         scheduling_job_data, forecasting_job_data = list(), list()
         try:
@@ -333,15 +333,12 @@ class AssetCrudUI(FlaskView):
         except NoRedisConfigured as e:
             redis_connection_err = e.args[0]
         else:
-            max_jobs_num = 10
             scheduling_job_data = [
-                job_data
-                for job_data in jobs_data
-                if job_data["job_type"] == "scheduling"
-            ][:max_jobs_num]
+                jd for jd in jobs_data if jd["queue"] == "scheduling"
+            ]
             forecasting_job_data = [
-                job for job in jobs_data if job["job_type"] == "forecasting"
-            ][:max_jobs_num]
+                jd for jd in jobs_data if jd["queue"] == "forecasting"
+            ]
 
         return render_flexmeasures_template(
             "views/status.html",

--- a/flexmeasures/ui/crud/assets.py
+++ b/flexmeasures/ui/crud/assets.py
@@ -26,7 +26,10 @@ from flexmeasures.data.models.user import Account
 from flexmeasures.data.models.time_series import Sensor
 from flexmeasures.ui.utils.view_utils import render_flexmeasures_template
 from flexmeasures.ui.crud.api_wrapper import InternalApi
-from flexmeasures.data.services.sensors import build_sensor_status_data
+from flexmeasures.data.services.sensors import (
+    build_sensor_status_data,
+    build_asset_jobs_data,
+)
 
 
 """
@@ -321,8 +324,22 @@ class AssetCrudUI(FlaskView):
         asset = process_internal_api_response(asset_dict, int(id), make_obj=True)
         status_data = build_sensor_status_data(asset)
 
+        # add data abount max_jobs_num forecasting and scheduling jobs
+        jobs_data = build_asset_jobs_data(asset)
+        max_jobs_num = 10
+        scheduling_jobs = [job for job in jobs_data if job["job_type"] == "scheduling"][
+            :max_jobs_num
+        ]
+        forecasting_jobs = [
+            job for job in jobs_data if job["job_type"] == "forecasting"
+        ][:max_jobs_num]
+
         return render_flexmeasures_template(
-            "views/status.html", asset=asset, sensors=status_data
+            "views/status.html",
+            asset=asset,
+            sensors=status_data,
+            scheduling_jobs=scheduling_jobs,
+            forecasting_jobs=forecasting_jobs,
         )
 
     @login_required

--- a/flexmeasures/ui/crud/assets.py
+++ b/flexmeasures/ui/crud/assets.py
@@ -327,10 +327,10 @@ class AssetCrudUI(FlaskView):
         # add data abount max_jobs_num forecasting and scheduling jobs
         jobs_data = build_asset_jobs_data(asset)
         max_jobs_num = 10
-        scheduling_jobs = [job for job in jobs_data if job["job_type"] == "scheduling"][
-            :max_jobs_num
-        ]
-        forecasting_jobs = [
+        scheduling_job_data = [
+            job_data for job_data in jobs_data if job_data["job_type"] == "scheduling"
+        ][:max_jobs_num]
+        forecasting_job_data = [
             job for job in jobs_data if job["job_type"] == "forecasting"
         ][:max_jobs_num]
 
@@ -338,8 +338,8 @@ class AssetCrudUI(FlaskView):
             "views/status.html",
             asset=asset,
             sensors=status_data,
-            scheduling_jobs=scheduling_jobs,
-            forecasting_jobs=forecasting_jobs,
+            scheduling_job_data=scheduling_job_data,
+            forecasting_job_data=forecasting_job_data,
         )
 
     @login_required

--- a/flexmeasures/ui/templates/views/status.html
+++ b/flexmeasures/ui/templates/views/status.html
@@ -90,7 +90,7 @@
                                 </span>
                             </td>
                             <td class="hidden">
-                                https://seita.energy/tasks/0/view/job/{{ job_data.job_id }}
+                                /tasks/0/view/job/{{ job_data.job_id }}
                             </td>
                         </tr>
                         {% endfor %}
@@ -131,7 +131,7 @@
                                 </span>
                             </td>
                             <td class="hidden">
-                                https://seita.energy/tasks/0/view/job/{{ job_data.job_id }}
+                                /tasks/0/view/job/{{ job_data.job_id }}
                             </td>
                         </tr>
                         {% endfor %}

--- a/flexmeasures/ui/templates/views/status.html
+++ b/flexmeasures/ui/templates/views/status.html
@@ -8,6 +8,9 @@
 
 
 <div class="container-fluid">
+    <div>
+        <button type="button" class="btn" onclick="window.history.back();" style="margin-top: 20px;" >Back to asset page</button>
+    </div>
     <div class="row">
         <div class="alert alert-info" id="tzwarn" style="display:none;"></div>
         <div class="alert alert-info" id="dstwarn" style="display:none;"></div>

--- a/flexmeasures/ui/templates/views/status.html
+++ b/flexmeasures/ui/templates/views/status.html
@@ -160,7 +160,6 @@
 
 
 <!-- sort scheduling and forecasting jobs by 'Created at' column -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/floatthead/2.2.1/jquery.floatThead.min.js"></script>
 <script>
     $(document).ready(function() {
         $('#scheduling_jobs').DataTable({"order": [[ 3, "desc" ]]});

--- a/flexmeasures/ui/templates/views/status.html
+++ b/flexmeasures/ui/templates/views/status.html
@@ -55,6 +55,88 @@
                         {% endfor %}
                     </tbody>
                 </table>
+                <h3>Latest scheduling jobs of {{ asset.name }}</h3>
+                <table class="table table-striped table-responsive paginate nav-on-click">
+                    <thead>
+                        <tr>
+                            <th>Job id</th>
+                            <th>Asset id</th>
+                            <th>Asset type</th>
+                            <th class="text-right no-sort">Status</th>
+                            <th class="hidden">URL</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for job in scheduling_jobs: %}
+                        <tr title="View data">
+                            <td>
+                                {{ job.job_id }}
+                            </td>
+                            <td>
+                                {{ job.asset_id }}
+                            </td>
+                            <td>
+                                {{ job.asset_type }}
+                            </td>
+                            <td class="text-right">
+                                <span title="{{ job['err'] is none and job['status'] or job['status'] + ' : ' + job['err'] }}">
+                                    {% if job["status"] == "finished" %}
+                                    🟢
+                                    {% elif job["status"] == "failed" %}
+                                    🔴
+                                    {% else %}
+                                    🟡
+                                    {% endif %}
+                                </span>
+                            </td>
+                            <td class="hidden">
+                                https://seita.energy/tasks/0/view/job/{{ job.job_id }}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                <h3>Latest forecasting jobs of {{ asset.name }}</h3>
+                <table class="table table-striped table-responsive paginate nav-on-click">
+                    <thead>
+                        <tr>
+                            <th>Job id</th>
+                            <th>Asset id</th>
+                            <th>Asset type</th>
+                            <th class="text-right no-sort">Status</th>
+                            <th class="hidden">URL</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for job in forecasting_jobs: %}
+                        <tr title="View data">
+                            <td>
+                                {{ job.job_id }}
+                            </td>
+                            <td>
+                                {{ job.asset_id }}
+                            </td>
+                            <td>
+                                {{ job.asset_type }}
+                            </td>
+                            <td class="text-right">
+                                <span title="{{ job['err'] is none and job['status'] or job['status'] + ' : ' + job['err'] }}">
+                                    {% if job["status"] == "finished" %}
+                                    🟢
+                                    {% elif job["status"] == "failed" %}
+                                    🔴
+                                    {% else %}
+                                    🟡
+                                    {% endif %}
+                                </span>
+                            </td>
+                            <td class="hidden">
+                                https://seita.energy/tasks/0/view/job/{{ job.job_id }}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
             </div>
         </div>
     </div>

--- a/flexmeasures/ui/templates/views/status.html
+++ b/flexmeasures/ui/templates/views/status.html
@@ -2,7 +2,7 @@
 
 {% set active_page = "assets" %}
 
-{% block title %} {{asset.name}} {% endblock %}
+{% block title %} {{asset.name}} - Status {% endblock %}
 
 {% block divs %}
 
@@ -59,12 +59,13 @@
                     </tbody>
                 </table>
                 <h3>Latest scheduling jobs of {{ asset.name }}</h3>
-                <table class="table table-striped table-responsive paginate nav-on-click">
+                <table id="scheduling_jobs" class="table table-striped table-responsive paginate nav-on-click">
                     <thead>
                         <tr>
                             <th>Job id</th>
                             <th>Asset id</th>
                             <th>Sensor or asset</th>
+                            <th>Created at</th>
                             <th class="text-right no-sort">Status</th>
                             <th class="hidden">URL</th>
                         </tr>
@@ -79,7 +80,10 @@
                                 {{ job_data.asset_id }}
                             </td>
                             <td>
-                                {{ job_data.sensor_or_asset_class }}
+                                {{ job_data.asset_or_sensor_type }}
+                            </td>
+                            <td>
+                                {{ job_data.enqueued_at | naturalized_datetime }}
                             </td>
                             <td class="text-right">
                                 <span title="{{ job_data['err'] is none and job_data['status'] or job_data['status'] + ' : ' + job_data['err'] }}">
@@ -100,12 +104,13 @@
                     </tbody>
                 </table>
                 <h3>Latest forecasting jobs of {{ asset.name }}</h3>
-                <table class="table table-striped table-responsive paginate nav-on-click">
+                <table id="forecasting_jobs" class="table table-striped table-responsive paginate nav-on-click">
                     <thead>
                         <tr>
                             <th>Job id</th>
                             <th>Asset id</th>
                             <th>Sensor or asset</th>
+                            <th>Created at</th>
                             <th class="text-right no-sort">Status</th>
                             <th class="hidden">URL</th>
                         </tr>
@@ -120,7 +125,10 @@
                                 {{ job_data.asset_id }}
                             </td>
                             <td>
-                                {{ job_data.sensor_or_asset_class }}
+                                {{ job_data.asset_or_sensor_type }}
+                            </td>
+                            <td>
+                                {{ job_data.enqueued_at | naturalized_datetime }}
                             </td>
                             <td class="text-right">
                                 <span title="{{ job_data['err'] is none and job_data['status'] or job_data['status'] + ' : ' + job_data['err'] }}">
@@ -151,5 +159,13 @@
 </div>
 
 
+<!-- sort scheduling and forecasting jobs by 'Created at' column -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/floatthead/2.2.1/jquery.floatThead.min.js"></script>
+<script>
+    $(document).ready(function() {
+        $('#scheduling_jobs').DataTable({"order": [[ 3, "desc" ]]});
+        $('#forecasting_jobs').DataTable({"order": [[ 3, "desc" ]]});
+    });
+</script>
 
 {% endblock %}

--- a/flexmeasures/ui/templates/views/status.html
+++ b/flexmeasures/ui/templates/views/status.html
@@ -137,6 +137,9 @@
                         {% endfor %}
                     </tbody>
                 </table>
+                {% if redis_connection_err is not none %}
+                    <div class="warning">{{ redis_connection_err }}</div>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/flexmeasures/ui/templates/views/status.html
+++ b/flexmeasures/ui/templates/views/status.html
@@ -61,28 +61,28 @@
                         <tr>
                             <th>Job id</th>
                             <th>Asset id</th>
-                            <th>Asset type</th>
+                            <th>Sensor or asset</th>
                             <th class="text-right no-sort">Status</th>
                             <th class="hidden">URL</th>
                         </tr>
                     </thead>
                     <tbody>
-                        {% for job in scheduling_jobs: %}
+                        {% for job_data in scheduling_job_data: %}
                         <tr title="View data">
                             <td>
-                                {{ job.job_id }}
+                                {{ job_data.job_id }}
                             </td>
                             <td>
-                                {{ job.asset_id }}
+                                {{ job_data.asset_id }}
                             </td>
                             <td>
-                                {{ job.asset_type }}
+                                {{ job_data.sensor_or_asset_class }}
                             </td>
                             <td class="text-right">
-                                <span title="{{ job['err'] is none and job['status'] or job['status'] + ' : ' + job['err'] }}">
-                                    {% if job["status"] == "finished" %}
+                                <span title="{{ job_data['err'] is none and job_data['status'] or job_data['status'] + ' : ' + job_data['err'] }}">
+                                    {% if job_data["status"] == "finished" %}
                                     🟢
-                                    {% elif job["status"] == "failed" %}
+                                    {% elif job_data["status"] == "failed" %}
                                     🔴
                                     {% else %}
                                     🟡
@@ -90,7 +90,7 @@
                                 </span>
                             </td>
                             <td class="hidden">
-                                https://seita.energy/tasks/0/view/job/{{ job.job_id }}
+                                https://seita.energy/tasks/0/view/job/{{ job_data.job_id }}
                             </td>
                         </tr>
                         {% endfor %}
@@ -102,28 +102,28 @@
                         <tr>
                             <th>Job id</th>
                             <th>Asset id</th>
-                            <th>Asset type</th>
+                            <th>Sensor or asset</th>
                             <th class="text-right no-sort">Status</th>
                             <th class="hidden">URL</th>
                         </tr>
                     </thead>
                     <tbody>
-                        {% for job in forecasting_jobs: %}
+                        {% for job_data in forecasting_job_data: %}
                         <tr title="View data">
                             <td>
-                                {{ job.job_id }}
+                                {{ job_data.job_id }}
                             </td>
                             <td>
-                                {{ job.asset_id }}
+                                {{ job_data.asset_id }}
                             </td>
                             <td>
-                                {{ job.asset_type }}
+                                {{ job_data.sensor_or_asset_class }}
                             </td>
                             <td class="text-right">
-                                <span title="{{ job['err'] is none and job['status'] or job['status'] + ' : ' + job['err'] }}">
-                                    {% if job["status"] == "finished" %}
+                                <span title="{{ job_data['err'] is none and job_data['status'] or job_data['status'] + ' : ' + job_data['err'] }}">
+                                    {% if job_data["status"] == "finished" %}
                                     🟢
-                                    {% elif job["status"] == "failed" %}
+                                    {% elif job_data["status"] == "failed" %}
                                     🔴
                                     {% else %}
                                     🟡
@@ -131,7 +131,7 @@
                                 </span>
                             </td>
                             <td class="hidden">
-                                https://seita.energy/tasks/0/view/job/{{ job.job_id }}
+                                https://seita.energy/tasks/0/view/job/{{ job_data.job_id }}
                             </td>
                         </tr>
                         {% endfor %}

--- a/flexmeasures/ui/templates/views/status.html
+++ b/flexmeasures/ui/templates/views/status.html
@@ -82,11 +82,12 @@
                             <td>
                                 {{ job_data.asset_or_sensor_type }}
                             </td>
-                            <td>
+                            <td title="Enqueued at: {{ job_data.enqueued_at}}">
                                 {{ job_data.enqueued_at | naturalized_datetime }}
                             </td>
-                            <td class="text-right">
-                                <span title="{{ job_data['err'] is none and job_data['status'] or job_data['status'] + ' : ' + job_data['err'] }}">
+                            <td class="text-right"
+                                title="{{ job_data['err'] is none and job_data['status'] or job_data['status'] + ' : ' + job_data['err'] }}">
+                                <span>
                                     {% if job_data["status"] == "finished" %}
                                     🟢
                                     {% elif job_data["status"] == "failed" %}
@@ -127,11 +128,12 @@
                             <td>
                                 {{ job_data.asset_or_sensor_type }}
                             </td>
-                            <td>
+                            <td title="Enqueued at: {{ job_data.enqueued_at}}">
                                 {{ job_data.enqueued_at | naturalized_datetime }}
                             </td>
-                            <td class="text-right">
-                                <span title="{{ job_data['err'] is none and job_data['status'] or job_data['status'] + ' : ' + job_data['err'] }}">
+                            <td class="text-right"
+                                title="{{ job_data['err'] is none and job_data['status'] or job_data['status'] + ' : ' + job_data['err'] }}">
+                                <span>
                                     {% if job_data["status"] == "finished" %}
                                     🟢
                                     {% elif job_data["status"] == "failed" %}

--- a/logfile
+++ b/logfile
@@ -1,0 +1,9 @@
+2024-04-18 08:53:46.951 UTC [11611] LOG:  starting PostgreSQL 13.14 on x86_64-apple-darwin23.2.0, compiled by Apple clang version 15.0.0 (clang-1500.1.0.2.5), 64-bit
+2024-04-18 08:53:46.956 UTC [11611] LOG:  listening on IPv4 address "127.0.0.1", port 5432
+2024-04-18 08:53:46.956 UTC [11611] LOG:  listening on IPv6 address "::1", port 5432
+2024-04-18 08:53:46.959 UTC [11611] LOG:  listening on Unix socket "/tmp/.s.PGSQL.5432"
+2024-04-18 08:53:46.994 UTC [11612] LOG:  database system was shut down at 2024-04-17 19:13:40 UTC
+2024-04-18 08:53:47.035 UTC [11611] LOG:  database system is ready to accept connections
+2024-04-18 20:32:23.661 UTC [28169] ERROR:  duplicate key value violates unique constraint "timed_belief_pkey"
+2024-04-18 20:32:23.661 UTC [28169] DETAIL:  Key (source_id, event_start, belief_horizon, cumulative_probability, sensor_id)=(4, 2021-06-06 22:00:00+00, 00:00:00, 0.5, 1) already exists.
+2024-04-18 20:32:23.661 UTC [28169] STATEMENT:  INSERT INTO timed_belief (source_id, event_start, belief_horizon, cumulative_probability, event_value, sensor_id) VALUES (4, '2021-06-07T00:00:00+02:00'::timestamptz, '0 days 0.000000 seconds'::interval, 0.5, 600.0, 1)

--- a/logfile
+++ b/logfile
@@ -1,9 +1,0 @@
-2024-04-18 08:53:46.951 UTC [11611] LOG:  starting PostgreSQL 13.14 on x86_64-apple-darwin23.2.0, compiled by Apple clang version 15.0.0 (clang-1500.1.0.2.5), 64-bit
-2024-04-18 08:53:46.956 UTC [11611] LOG:  listening on IPv4 address "127.0.0.1", port 5432
-2024-04-18 08:53:46.956 UTC [11611] LOG:  listening on IPv6 address "::1", port 5432
-2024-04-18 08:53:46.959 UTC [11611] LOG:  listening on Unix socket "/tmp/.s.PGSQL.5432"
-2024-04-18 08:53:46.994 UTC [11612] LOG:  database system was shut down at 2024-04-17 19:13:40 UTC
-2024-04-18 08:53:47.035 UTC [11611] LOG:  database system is ready to accept connections
-2024-04-18 20:32:23.661 UTC [28169] ERROR:  duplicate key value violates unique constraint "timed_belief_pkey"
-2024-04-18 20:32:23.661 UTC [28169] DETAIL:  Key (source_id, event_start, belief_horizon, cumulative_probability, sensor_id)=(4, 2021-06-06 22:00:00+00, 00:00:00, 0.5, 1) already exists.
-2024-04-18 20:32:23.661 UTC [28169] STATEMENT:  INSERT INTO timed_belief (source_id, event_start, belief_horizon, cumulative_probability, event_value, sensor_id) VALUES (4, '2021-06-07T00:00:00+02:00'::timestamptz, '0 days 0.000000 seconds'::interval, 0.5, 600.0, 1)


### PR DESCRIPTION
## Description

Extend the current status page - add a simple table on the right of the data connectivity (or beneath) and show the last 10 or 20 jobs, with green or red lights, and with their status/error message available in a tool-tip or on click

## Look & Feel

New table on the status page, containing data about latest asset jobs

## How to test

Create some jobs for an asset, check they appear on status page of this asset

## Further Improvements

.

## Related Items

.

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
