### PR TITLE
feature: tabulate queue info

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -18,6 +18,7 @@ Bugfixes
 Infrastructure / Support
 ----------------------
 
+* Include started, deferred and scheduled jobs in the overview printed by the CLI command ``flexmeasures jobs show-queues` [see `PR #1036 <https://github.com/FlexMeasures/flexmeasures/pull/1036/>`_]
 
 
 v0.20.0 | March 26, 2024

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -4,6 +4,12 @@
 FlexMeasures CLI Changelog
 **********************
 
+
+since v.0.21.0 | April 12, 2024
+=================================
+
+* Include started, deferred and scheduled jobs in the overview printed by the CLI command ``flexmeasures jobs show-queues`.
+
 since v.0.20.0 | March 26, 2024
 =================================
 

--- a/flexmeasures/cli/jobs.py
+++ b/flexmeasures/cli/jobs.py
@@ -12,6 +12,7 @@ from flask import current_app as app
 from flask.cli import with_appcontext
 from rq import Queue, Worker
 from sqlalchemy.orm import configure_mappers
+from tabulate import tabulate
 
 from flexmeasures.data.services.scheduling import handle_scheduling_exception
 from flexmeasures.data.services.forecasting import handle_forecasting_exception
@@ -98,10 +99,23 @@ def show_queues():
     """
 
     configure_mappers()
-    for q in app.queues.values():
-        click.echo(
-            f"Queue {q.name} has {q.count} jobs (and {q.failed_job_registry.count} jobs have failed)."
+    queue_data = [
+        (
+            q.name,
+            q.started_job_registry.count,
+            q.count,
+            q.deferred_job_registry.count,
+            q.scheduled_job_registry.count,
+            q.failed_job_registry.count,
         )
+        for q in app.queues.values()
+    ]
+    click.echo(
+        tabulate(
+            queue_data,
+            headers=["Queue", "Started", "Queued", "Deferred", "Scheduled", "Failed"],
+        )
+    )
 
 
 @fm_jobs.command("clear-queue")


### PR DESCRIPTION
## Description

Before this `flexmeasures jobs show-queues` only showed queued and failed jobs.

## Look & Feel

![image](https://github.com/FlexMeasures/flexmeasures/assets/30658763/4434e21c-80a6-4636-a736-3cf7d6a0fe5f)

