### PR TITLE
Add behind-the-meter concept to main line of FlexMeasures' purpose

### DIFF
--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -278,3 +278,7 @@ balancer
 url
 HTTPS
 Werkzeug
+DSOs
+BTM
+FTM
+EV

--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,8 @@
 [![Coverage](https://coveralls.io/repos/github/FlexMeasures/flexmeasures/badge.svg)](https://coveralls.io/github/FlexMeasures/flexmeasures)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/6095/badge)](https://bestpractices.coreinfrastructure.org/projects/6095)
 
-The *FlexMeasures Platform* is the intelligent & developer-friendly EMS (energy management system) to support real-time energy flexibility apps, rapidly and scalable. 
+*FlexMeasures* is an intelligent EMS (energy management system) to optimize behind-the-meter energy flexibility.
+Build your smart energy apps & services with FlexMeasures as backend for real-time orchestration! 
 
 In a nutshell, FlexMeasures turns data into optimized schedules for flexible assets like batteries and heat pumps, or for flexible industry processes:
 

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -18,7 +18,7 @@ Bugfixes
 Infrastructure / Support
 ----------------------
 
-* Include started, deferred and scheduled jobs in the overview printed by the CLI command ``flexmeasures jobs show-queues` [see `PR #1036 <https://github.com/FlexMeasures/flexmeasures/pull/1036/>`_]
+* Include started, deferred and scheduled jobs in the overview printed by the CLI command ``flexmeasures jobs show-queues`` [see `PR #1036 <https://github.com/FlexMeasures/flexmeasures/pull/1036/>`_]
 
 
 v0.20.1 | April XX, 2024

--- a/documentation/concepts/flexibility.rst
+++ b/documentation/concepts/flexibility.rst
@@ -12,6 +12,18 @@ Here, we define a few terms around this idea, which come up in other parts of th
     :depth: 2
 
 
+Behind-the-meter and front-of-the-meter
+----------------------------------------
+
+In the energy sector, we draw a distinction between behind-the-meter (BTM) and front-of-the-meter (FTM) optimization. As usual, the distinction isn't always clear, but we can give the general definition and the focus for FlexMeasures (BTM).
+
+BTM optimization describes the optimization of assets connected on a site behind the main meter (which has the connection to the rest of the electricity grid). Think of local solar, heating, EV charging and even batteries. A (dynamic) tariff and limits to the grid connection often complete the picture, which can become quite complex and also rewarding to get right.
+
+On the other hand, there is front-of-the-meter (FTM) optimization, which relates to grid-level optimization as is the work of utilities, DSOs and TSOs. Think of large-scale generation and its role in wholesale markets, managing transmission lines. But also, flexible grid-level assets like batteries and solar parks might belong here, and you might find that FlexMeasures can help to optimize some of these assets if you model the circumstances correctly.
+
+When we focus on the situation behind the meter, do we ignore everything else? Not at all. It simply means to prioritize the local orchestration modeling, and then add services which the site can offer to the grid. For instance, using a dynamic tariff can already help the grid. Obeying (flexible) grid capacity constraints, as well, of course. Going further, extra flexibility can be offered explicitly to congestion markets/auctions, which is part of `FlexMeasures' roadmap <https://flexmeasures.io/roadmap/>`_. (Note: For a distinction between implicit and explicit flexibility, read on below).
+
+
 Flexibility opportunities and activation
 -----------------------------------------
 

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -1,9 +1,10 @@
 Welcome to the FlexMeasures documentation!
 ===================================================================
 
-FlexMeasures is the intelligent & developer-friendly EMS to support real-time energy flexibility apps, rapidly and scalable.
+*FlexMeasures* is an intelligent EMS to optimize behind-the-meter energy flexibility.
+Build your smart energy apps & services with FlexMeasures as backend for real-time orchestration! 
 
-The problem it helps you to solve is: **What are the best times to run flexible assets, such as batteries or heat pumps?**
+The problem FlexMeasures helps you to solve is: **What are the best times to power flexible assets, such as batteries or heat pumps?**
 
 In a nutshell, FlexMeasures turns data into optimized schedules for flexible assets.
 *Why?* Planning ahead allows flexible assets to serve the whole system with their flexibility, e.g. by shifting energy consumption to more optimal times. For the asset owners, this creates CO₂ savings but also monetary value (e.g. through self-consumption, dynamic tariffs and grid incentives).


### PR DESCRIPTION
Add behind-the-meter concept to main line of FlexMeasures' purpose andd also explain it

## Description

We might not be clear enough where FlexMeasures is mostly useful for (optimizing sites, behind-the-meter as first principle).

## Look & Feel

This is a change to documentation (index page and concepts) and Readme.

## How to test

Build docs and browse.