### PR TITLE
docs: be more precise in flex-model field descriptions for StorageScheduler

### DIFF
--- a/documentation/features/scheduling.rst
+++ b/documentation/features/scheduling.rst
@@ -105,25 +105,25 @@ and what constraints or preferences should be taken into account.
      - The unit in which all SoC related flex-model values are to be interpreted.
    * - ``soc-min``
      - ``"2.5"``
-     - A constant lower boundary for all values in the schedule (defaults to 0).
+     - A constant and non-negotiable lower boundary for all values in the schedule (defaults to 0). If used, this is regarded as a physical boundary which is infeasible to breach.
    * - ``soc-max``
      - ``"7"``
-     - A constant upper boundary for all values in the schedule (defaults to max soc target, if provided)
+     - A constant and non-negotiable upper boundary for all values in the schedule (defaults to max soc target, if provided). If used, this is regarded as a physical boundary which is infeasible to breach.
    * - ``soc-minima``
      - ``[{"datetime": "2024-02-05T08:00:00+01:00", value: 8.2}]``
-     - Set point(s) that form lower boundaries, e.g. to target a full car battery in the morning. Can be single values or a range (defaults to NaN values).
+     - Set point(s) that form user-defined lower boundaries, e.g. to target a full car battery in the morning. Can be single values or a range (defaults to NaN values).
    * - ``soc-maxima``
      - ``{"value": 51, "start": "2024-02-05T12:00:00+01:00","end": "2024-02-05T13:30:00+01:00"}``
-     - Set point(s) that form upper boundaries at certain times. Can be single values or a range (defaults to NaN values).
+     - Set point(s) that form user-defined upper boundaries at certain times. Can be single values or a range (defaults to NaN values).
    * - ``soc-targets``
      - ``[{"datetime": "2024-02-05T08:00:00+01:00", value: 3.2}]``
-     - Exact set point(s) that the scheduler needs to realize (defaults to NaN values).
+     - Exact user-defined set point(s) that the scheduler needs to realize (defaults to NaN values).
    * - ``soc-gain``
      - ``.1kWh`` 
-     - Encode SoC gain per time step. A constant gain every time step, or see [#sensor_field]_.
+     - Encode SoC gain per time step. Useful if energy is created by an external process (in-flow). Denotes a constant gain every time step, or see [#sensor_field]_.
    * - ``soc-usage``
      - ``{"sensor": 23}`` 
-     - Encode SoC reduction per time step. A constant loss every time step, or see [#sensor_field]_.
+     - Encode SoC reduction per time step. Useful if energy is extracted by an external process (out-flow). Denotes a constant loss every time step, or see [#sensor_field]_.
    * - ``roundtrip-efficiency``
      - ``"90%"``
      - Below 100%, this represents roundtrip losses (of charging & discharging), usually used for batteries. Can be percent or ratio ``[0,1]`` (defaults to 100%).

--- a/requirements/3.10/app.txt
+++ b/requirements/3.10/app.txt
@@ -153,7 +153,6 @@ mako==1.3.2
     # via alembic
 markupsafe==2.1.5
     # via
-    #   flask-security-too
     #   jinja2
     #   mako
     #   sentry-sdk
@@ -325,7 +324,9 @@ tabulate==0.9.0
 threadpoolctl==3.4.0
     # via scikit-learn
 timely-beliefs[forecast]==2.3.0
-    # via -r requirements/app.in
+    # via
+    #   -r requirements/app.in
+    #   timely-beliefs
 timetomodel==0.7.3
     # via -r requirements/app.in
 tldextract==5.1.2

--- a/requirements/3.10/test.txt
+++ b/requirements/3.10/test.txt
@@ -21,7 +21,9 @@ click==8.1.7
     #   -c requirements/3.10/app.txt
     #   flask
 coverage[toml]==7.4.4
-    # via pytest-cov
+    # via
+    #   coverage
+    #   pytest-cov
 exceptiongroup==1.2.0
     # via pytest
 fakeredis==2.21.3


### PR DESCRIPTION
## Description

More clarity on some flex-model field descriptions, the idea came up when someone on the mailing list used `soc-min` and then `soc-at-start` below that, which is as of now infeasible for our storage scheduler.

I'm not quite happy with this PR yet, either.

Apparently, we are very hard on the `soc-min` and `soc-max` values, while we are (planning to be) softer on `soc-minima`, `soc-maxima` and `soc-targets`. I notice that the terms "min"/"minima" and "max"/"maxima" don't give that impression.

Example from a user perspective: If I prefer my EV battery to not be charged below 20%, I set that as `soc-min`. My intention is not that I bring the EV back to the charger at 10% and no schedule will be made until I bring it back up to 20%.
