### PR TITLE
[UI] Update the URL `start` and `end` of the asset page when the time period is updated

### DIFF
--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -166,6 +166,23 @@
                                 dif + pad(Math.floor(Math.abs(tzo) / 60)) +
                                 ':' + pad(Math.abs(tzo) % 60);
                         }
+
+                        $(window).ready(() => {
+                            picker.on('selected', (startDate, endDate) => {
+                                startDate = encodeURIComponent(toIsoString(startDate.toJSDate()));
+                                // add 1 day to end date as datepicker does not include the end date day
+                                endDate = endDate.toJSDate();
+                                endDate.setDate(endDate.getDate() + 1);
+                                endDate = encodeURIComponent(toIsoString(endDate));
+                                var base_url = window.location.href.split("?")[0];
+                                var new_url = `${base_url}?start_time=${startDate}&end_time=${endDate}`;
+                                
+                                // change current url without reloading the page
+                                window.history.pushState({}, null, new_url);
+                            });
+
+                        });
+
                         function copyUrl(event) {
                             event.preventDefault();
 


### PR DESCRIPTION
## Description

For some reason I don't understand yet, when I refreshed the asset page, the period moved to the latest data instead of keeping the view on the same period. This is why I thought of updating the URL with the start and end dates when an event on the date-picker was caught.

To test this feature, you can go to any asset page and select a time range. The URL should take the values that you selected but the page shouldn't refresh. Following that, you can refresh the page manually to check if the parameters are passed properly.


---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
