### PR TITLE
show (sensor name + asset name) in tooltip

### DIFF
--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -458,7 +458,7 @@ def chart_for_multiple_sensors(
         # Set up shared tooltip
         shared_tooltip = [
             dict(
-                field="sensor.name",
+                field="sensor.description",
                 type="nominal",
                 title="Sensor",
             ),


### PR DESCRIPTION
## Description

This PR adds the asset name to the title of the tooltip to improve the identification of the lines. This is useful when we have a lot of sensors and the share colors which makes the legend misleading. 

With the parent-child asset structure, we could find duplicates in graphs for complex topologies. For now, I wouldn't follow up on that. In the future, we can use the function that is used to simplify entity paths.


### Before
![image](https://github.com/FlexMeasures/flexmeasures/assets/84775131/d933d6ff-e17a-472f-bb69-8e99379ca0e1)


### After
![image](https://github.com/FlexMeasures/flexmeasures/assets/84775131/465ea64e-5d2a-44e2-82ec-a3c09721a7f9)

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
