### PR TITLE
Allow installing dependencies in docker-compose worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command:
     - |
-      pip install -r instance/requirements.txt
+      pip install -r /usr/var/flexmeasures-instance/requirements.txt
       flexmeasures db upgrade
       flexmeasures add toy-account --name 'Docker Toy Account'
       gunicorn --bind 0.0.0.0:5000 --worker-tmp-dir /dev/shm --workers 2 --threads 4 wsgi:application
@@ -88,11 +88,10 @@ services:
     volumes:
       # a place for config and plugin code
       - ./flexmeasures-instance/:/usr/var/flexmeasures-instance/:ro
-      - ./flexmeasures-instance/:/app/instance/:ro
     entrypoint: ["/bin/sh", "-c"]
     command: 
     - |
-      pip install -r instance/requirements.txt
+      pip install -r /usr/var/flexmeasures-instance/requirements.txt
       flexmeasures jobs run-worker --name flexmeasures-worker --queue forecasting\|scheduling
   test-db:
     image: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,12 @@ services:
     volumes:
       # a place for config and plugin code
       - ./flexmeasures-instance/:/usr/var/flexmeasures-instance/:ro
-    command: flexmeasures jobs run-worker --name flexmeasures-worker --queue forecasting\|scheduling
+      - ./flexmeasures-instance/:/app/instance/:ro
+    entrypoint: ["/bin/sh", "-c"]
+    command: 
+    - |
+      pip install -r instance/requirements.txt
+      flexmeasures jobs run-worker --name flexmeasures-worker --queue forecasting\|scheduling
   test-db:
     image: postgres
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,8 @@ services:
       FLEXMEASURES_REDIS_PASSWORD: fm-redis-pass
       LOGGING_LEVEL: INFO
     volumes:
-      # a place for config and plugin code - the mount point is for running the FlexMeasures CLI, the 2nd for gunicorn
+      # a place for config and plugin code, and custom requirements.txt
+      # the 1st mount point is for running the FlexMeasures CLI, the 2nd for gunicorn
       - ./flexmeasures-instance/:/usr/var/flexmeasures-instance/:ro
       - ./flexmeasures-instance/:/app/instance/:ro
     entrypoint: ["/bin/sh", "-c"]
@@ -86,7 +87,7 @@ services:
       FLEXMEASURES_ENV: development
       LOGGING_LEVEL: INFO 
     volumes:
-      # a place for config and plugin code
+      # a place for config and plugin code, and custom requirements.txt
       - ./flexmeasures-instance/:/usr/var/flexmeasures-instance/:ro
     entrypoint: ["/bin/sh", "-c"]
     command: 

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -12,6 +12,11 @@ New features
 * Add option `droplevels` to the `PandasReporter` to drop all the levels except the `event_start` and `event_value` [see `PR #1043 <https://github.com/FlexMeasures/flexmeasures/pull/1043/>`_]
 * `PandasReporter` accepts the parameter `use_latest_version_only` to filter input data [see `PR #1045 <https://github.com/FlexMeasures/flexmeasures/pull/1045/>`_]
 
+Infrastructure / Support
+----------------------
+
+* Allow installing dependencies in docker-compose worker [see `PR #1057 <https://github.com/FlexMeasures/flexmeasures/pull/1057/>`_]
+
 
 v0.21.0 | April 16, 2024
 ============================


### PR DESCRIPTION
## Description

Updated docker-compose.yml to allow installing dependencies also in the worker.
This enables running the ENTSOE plugin in the worker (by including the entsoe-py dependency).
See https://github.com/SeitaBV/flexmeasures-entsoe/issues/37.

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
