### PR TITLE
API endpoint for scheduling asset

### DIFF
--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -15,6 +15,7 @@ from flexmeasures.auth.decorators import permission_required_for_context
 from flexmeasures.data import db
 from flexmeasures.data.models.user import Account
 from flexmeasures.data.models.generic_assets import GenericAsset
+from flexmeasures.data.schemas.sensors import SensorIdField
 from flexmeasures.data.schemas.times import AwareDateTimeField, PlanningDurationField
 from flexmeasures.data.schemas.generic_assets import GenericAssetSchema as AssetSchema
 from flexmeasures.data.services.scheduling import create_scheduling_job
@@ -490,8 +491,14 @@ class AssetAPI(FlaskView):
         :status 422: UNPROCESSABLE_ENTITY
         """
         end_of_schedule = start_of_schedule + duration
+        for sensor_flex_model in flex_model:
+            sensor_id = sensor_flex_model.get("sensor")
+            if sensor_id is None:
+                return invalid_flex_config(f"Missing 'sensor' in flex-model list item: {sensor_flex_model}.")
+            sensor = SensorIdField().deserialize(sensor_id)
+
         scheduler_kwargs = dict(
-            asset_or_sensor=asset,
+            asset_or_sensor=sensor,
             start=start_of_schedule,
             end=end_of_schedule,
             resolution=sensor.event_resolution,

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -497,25 +497,25 @@ class AssetAPI(FlaskView):
                 return invalid_flex_config(f"Missing 'sensor' in flex-model list item: {sensor_flex_model}.")
             sensor = SensorIdField().deserialize(sensor_id)
 
-        scheduler_kwargs = dict(
-            asset_or_sensor=sensor,
-            start=start_of_schedule,
-            end=end_of_schedule,
-            resolution=sensor.event_resolution,
-            belief_time=belief_time,  # server time if no prior time was sent
-            flex_model=flex_model,
-            flex_context=flex_context,
-        )
-
-        try:
-            job = create_scheduling_job(
-                **scheduler_kwargs,
-                enqueue=True,
+            scheduler_kwargs = dict(
+                asset_or_sensor=sensor,
+                start=start_of_schedule,
+                end=end_of_schedule,
+                resolution=sensor.event_resolution,
+                belief_time=belief_time,  # server time if no prior time was sent
+                flex_model=flex_model,
+                flex_context=flex_context,
             )
-        except ValidationError as err:
-            return invalid_flex_config(err.messages)
-        except ValueError as err:
-            return invalid_flex_config(str(err))
+
+            try:
+                job = create_scheduling_job(
+                    **scheduler_kwargs,
+                    enqueue=True,
+                )
+            except ValidationError as err:
+                return invalid_flex_config(err.messages)
+            except ValueError as err:
+                return invalid_flex_config(str(err))
 
         db.session.commit()
 

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
 import json
 
 from flask import current_app
@@ -12,7 +15,7 @@ from flexmeasures.auth.decorators import permission_required_for_context
 from flexmeasures.data import db
 from flexmeasures.data.models.user import Account
 from flexmeasures.data.models.generic_assets import GenericAsset
-from flexmeasures.data.schemas import AwareDateTimeField
+from flexmeasures.data.schemas.times import AwareDateTimeField, PlanningDurationField
 from flexmeasures.data.schemas.generic_assets import GenericAssetSchema as AssetSchema
 from flexmeasures.api.common.schemas.generic_assets import AssetIdField
 from flexmeasures.api.common.schemas.users import AccountIdField
@@ -321,7 +324,7 @@ class AssetAPI(FlaskView):
 
     @route("/<id>/schedules/trigger", methods=["POST"])
     @use_kwargs(
-        {"sensor": SensorIdField(data_key="id")},
+        {"asset": AssetIdField(data_key="id")},
         location="path",
     )
     @use_kwargs(
@@ -338,16 +341,16 @@ class AssetAPI(FlaskView):
         },
         location="json",
     )
-    @permission_required_for_context("create-children", ctx_arg_name="sensor")
+    @permission_required_for_context("create-children", ctx_arg_name="asset")
     def trigger_schedule(
-            self,
-            sensor: Sensor,
-            start_of_schedule: datetime,
-            duration: timedelta,
-            belief_time: datetime | None = None,
-            flex_model: dict | None = None,
-            flex_context: dict | None = None,
-            **kwargs,
+        self,
+        asset: GenericAsset,
+        start_of_schedule: datetime,
+        duration: timedelta,
+        belief_time: datetime | None = None,
+        flex_model: dict | None = None,
+        flex_context: dict | None = None,
+        **kwargs,
     ):
         """
         Trigger FlexMeasures to create a schedule.

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -497,6 +497,8 @@ class AssetAPI(FlaskView):
                 return invalid_flex_config(f"Missing 'sensor' in flex-model list item: {sensor_flex_model}.")
             sensor = SensorIdField().deserialize(sensor_id)
 
+            # todo make sure each sensor lives under the asset
+
             scheduler_kwargs = dict(
                 asset_or_sensor=sensor,
                 start=start_of_schedule,
@@ -519,6 +521,7 @@ class AssetAPI(FlaskView):
 
         db.session.commit()
 
+        # todo: make a 'done job' and pass that job's ID here
         response = dict(schedule=job.id)
         d, s = request_processed()
         return dict(**response, **d), s

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -7,7 +7,7 @@ from flask import current_app
 from flask_classful import FlaskView, route
 from flask_security import auth_required
 from flask_json import as_json
-from marshmallow import fields
+from marshmallow import fields, ValidationError
 from webargs.flaskparser import use_kwargs, use_args
 from sqlalchemy import select, delete
 
@@ -17,8 +17,13 @@ from flexmeasures.data.models.user import Account
 from flexmeasures.data.models.generic_assets import GenericAsset
 from flexmeasures.data.schemas.times import AwareDateTimeField, PlanningDurationField
 from flexmeasures.data.schemas.generic_assets import GenericAssetSchema as AssetSchema
+from flexmeasures.data.services.scheduling import create_scheduling_job
 from flexmeasures.api.common.schemas.generic_assets import AssetIdField
 from flexmeasures.api.common.schemas.users import AccountIdField
+from flexmeasures.api.common.responses import (
+    invalid_flex_config,
+    request_processed,
+)
 from flexmeasures.utils.coding_utils import flatten_unique
 from flexmeasures.ui.utils.view_utils import set_session_variables
 
@@ -486,7 +491,7 @@ class AssetAPI(FlaskView):
         """
         end_of_schedule = start_of_schedule + duration
         scheduler_kwargs = dict(
-            sensor=sensor,
+            asset_or_sensor=asset,
             start=start_of_schedule,
             end=end_of_schedule,
             resolution=sensor.event_resolution,

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -363,7 +363,7 @@ class SensorAPI(FlaskView):
         """
         end_of_schedule = start_of_schedule + duration
         scheduler_kwargs = dict(
-            sensor=sensor,
+            asset_or_sensor=sensor,
             start=start_of_schedule,
             end=end_of_schedule,
             resolution=sensor.event_resolution,
@@ -465,7 +465,6 @@ class SensorAPI(FlaskView):
                 )
                 return unrecognized_event(job.meta["fallback_job_id"], "fallback-job")
 
-        scheduler_info_msg = ""
         scheduler_info = job.meta.get("scheduler_info", dict(scheduler=""))
         scheduler_info_msg = f"{scheduler_info['scheduler']} was used."
 


### PR DESCRIPTION
## Description

Schedule an asset using a flex-model that consists of a list of flex-models for individual power sensors.

## Look & Feel

URI: `assets/801/schedules/trigger`

Body:
```
{
    "flex-model" : [
        {"sensor" : 1, "power-capacity" : "1MW"},
        {"sensor" : 2, "power-capacity" : "10kW"},
        {"sensor" : 3, "soc-at-start" : 10.0},
    ],
    "flex-context" : {
        "consumption-price-sensor" : 8,
        "production-price-sensor" : 9,
        "inflexible-device-sensors" : [14, 15]
    }
}
```

## Further Improvements

- [ ] Tests
  - [ ] integration test that resembles toy tutorial case (battery + solar + EV)
  - [ ] test with more than 2 flexible sensors
- [ ] Check flexible (and inflexible?) sensors fall under asset
- [ ] Unpack flex-model into one flex-model per sensor
- [ ] Dependent scheduling jobs
- [ ] Documentation of endpoint
- [ ] Marshmallow validation

And follow-up issues:

- [ ] CLI needs option to set model and context from file (editable?)
- [ ] Extend tutorial



## Related Items

Closes #485.
