### PR TITLE
Feature: show default sensors of the same unit together

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -8,7 +8,7 @@ v0.22.0 | June XX, 2024
 
 New features
 -------------
-* On the asset page, facilitate comparison by showing default sensors of the same unit together [see `PR #1066 <https://github.com/FlexMeasures/flexmeasures/pull/1066>`_]
+* On the asset page, facilitate comparison by showing the two default sensors together if they record the same unit [see `PR #1066 <https://github.com/FlexMeasures/flexmeasures/pull/1066>`_]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -3,8 +3,13 @@
 FlexMeasures Changelog
 **********************
 
+v0.22.0 | June XX, 2024
+============================
+
 * On the asset page, facilitate comparison by showing default sensors of the same unit together [see `PR #1066 <https://github.com/FlexMeasures/flexmeasures/pull/1066>`_]
-v0.21.0 | April 16, 2024
+
+
+v0.21.0 | May 16, 2024
 ============================
 
 .. note:: Read more on these features on `the FlexMeasures blog <https://flexmeasures.io/021-service-better-status-and-audit/>`_.
@@ -14,11 +19,11 @@ v0.21.0 | April 16, 2024
 New features
 -------------   
 
-* Add `asset/<id>/status` page to view asset statuses [see `PR #41 <https://github.com/FlexMeasures/flexmeasures/pull/941/>`_ and `PR #1035 <https://github.com/FlexMeasures/flexmeasures/pull/1035/>`_]
+* Add `asset/<id>/status` page to view asset statuses [see `PR #41 <https://github.com/FlexMeasures/flexmeasures/pull/941>`_ and `PR #1035 <https://github.com/FlexMeasures/flexmeasures/pull/1035>`_]
 * Add `account/<id>/auditlog` and `user/<id>/auditlog` to view user and account related actions [see `PR #1042 <https://github.com/FlexMeasures/flexmeasures/pull/1042>`_]
-* Support `start_date` and `end_date` query parameters for the asset page [see `PR #1030 <https://github.com/FlexMeasures/flexmeasures/pull/1030/>`_]
-* In plots, add the asset name to the title of the tooltip to improve the identification of the lines [see `PR #1054 <https://github.com/FlexMeasures/flexmeasures/pull/1054/>`_]
-* On asset page, show sensor IDs in sensor table [see `PR #1053 <https://github.com/FlexMeasures/flexmeasures/pull/1053/>`_]
+* Support `start_date` and `end_date` query parameters for the asset page [see `PR #1030 <https://github.com/FlexMeasures/flexmeasures/pull/1030>`_]
+* In plots, add the asset name to the title of the tooltip to improve the identification of the lines [see `PR #1054 <https://github.com/FlexMeasures/flexmeasures/pull/1054>`_]
+* On asset page, show sensor IDs in sensor table [see `PR #1053 <https://github.com/FlexMeasures/flexmeasures/pull/1053>`_]
 
 Bugfixes
 -----------
@@ -28,8 +33,8 @@ Bugfixes
 Infrastructure / Support
 ----------------------
 
-* Include started, deferred and scheduled jobs in the overview printed by the CLI command ``flexmeasures jobs show-queues`` [see `PR #1036 <https://github.com/FlexMeasures/flexmeasures/pull/1036/>`_]
-* Make it as convenient to clear deferred or scheduled jobs from a queue as it was to clear failed jobs from a queue [see `PR #1037 <https://github.com/FlexMeasures/flexmeasures/pull/1037/>`_]
+* Include started, deferred and scheduled jobs in the overview printed by the CLI command ``flexmeasures jobs show-queues`` [see `PR #1036 <https://github.com/FlexMeasures/flexmeasures/pull/1036>`_]
+* Make it as convenient to clear deferred or scheduled jobs from a queue as it was to clear failed jobs from a queue [see `PR #1037 <https://github.com/FlexMeasures/flexmeasures/pull/1037>`_]
 
 
 v0.20.1 | May 7, 2024
@@ -38,7 +43,7 @@ v0.20.1 | May 7, 2024
 Bugfixes
 -----------
 
-* Prevent **p**lay/**p**ause/**s**top of replays when editing a text field in the UI [see `PR #1024 <https://github.com/FlexMeasures/flexmeasures/pull/1024>`_]
+* Prevent **p**\ lay/**p**\ ause/**s**\ top of replays when editing a text field in the UI [see `PR #1024 <https://github.com/FlexMeasures/flexmeasures/pull/1024>`_]
 * Skip unit conversion of :abbr:`SoC (state of charge)` related fields that are defined as sensors in a ``flex-model`` (specifically, ``soc-maxima``, ``soc-minima`` and ``soc-targets`` [see `PR #1047 <https://github.com/FlexMeasures/flexmeasures/pull/1047>`_]
 
 

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -19,7 +19,7 @@ v0.21.0 | May 16, 2024
 New features
 -------------   
 
-* Add `asset/<id>/status` page to view asset statuses [see `PR #41 <https://github.com/FlexMeasures/flexmeasures/pull/941>`_ and `PR #1035 <https://github.com/FlexMeasures/flexmeasures/pull/1035>`_]
+* Add `asset/<id>/status` page to view asset statuses [see `PR #941 <https://github.com/FlexMeasures/flexmeasures/pull/941>`_ and `PR #1035 <https://github.com/FlexMeasures/flexmeasures/pull/1035>`_]
 * Add `account/<id>/auditlog` and `user/<id>/auditlog` to view user and account related actions [see `PR #1042 <https://github.com/FlexMeasures/flexmeasures/pull/1042>`_]
 * Support `start_date` and `end_date` query parameters for the asset page [see `PR #1030 <https://github.com/FlexMeasures/flexmeasures/pull/1030>`_]
 * In plots, add the asset name to the title of the tooltip to improve the identification of the lines [see `PR #1054 <https://github.com/FlexMeasures/flexmeasures/pull/1054>`_]

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -3,6 +3,7 @@
 FlexMeasures Changelog
 **********************
 
+* On the asset page, facilitate comparison by showing default sensors of the same unit together [see `PR #1066 <https://github.com/FlexMeasures/flexmeasures/pull/1066>`_]
 v0.21.0 | April 16, 2024
 ============================
 

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -502,7 +502,7 @@ class GenericAsset(db.Model, AuthModelMixin):
             sensors_to_show = [40, 35, 41, [42, 44], 43, 45]
 
         In case the field is missing, defaults to two of the asset's sensors,
-        which will be shown together (e.g. sharing the same y-axes) in case they share the same unit.
+        which will be shown together (e.g. sharing the same y-axis) in case they share the same unit.
         """
         if not self.has_attribute("sensors_to_show"):
             sensors_to_show = self.sensors[:2]

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -488,7 +488,6 @@ class GenericAsset(db.Model, AuthModelMixin):
         is set by the "sensors_to_show" field of the asset's "attributes" column.
         Valid sensors either belong to the asset itself, to other assets in the same account,
         or to public assets. In play mode, sensors from different accounts can be added.
-        In case the field is missing, defaults to two of the asset's sensors.
 
         Sensor ids can be nested to denote that sensors should be 'shown together',
         for example, layered rather than vertically concatenated.
@@ -502,9 +501,19 @@ class GenericAsset(db.Model, AuthModelMixin):
 
             sensors_to_show = [40, 35, 41, [42, 44], 43, 45]
 
+        In case the field is missing, defaults to two of the asset's sensors,
+        which will be shown together (e.g. sharing the same y-axes) in case they share the same unit.
         """
         if not self.has_attribute("sensors_to_show"):
-            return self.sensors[:2]
+            sensors_to_show = self.sensors[:2]
+            if (
+                len(sensors_to_show) == 2
+                and sensors_to_show[0].unit == sensors_to_show[1].unit
+            ):
+                # Sensors are shown together (e.g. they can share the same y-axis)
+                return [sensors_to_show]
+            # Otherwise, show separately
+            return sensors_to_show
 
         # Only allow showing sensors from assets owned by the user's organization,
         # except in play mode, where any sensor may be shown


### PR DESCRIPTION
## Description

In case of an asset with two power sensors (or two price sensors, two temperature sensors, or any two sensors sharing the same unit), the asset's data chart more often than not becomes more insightful when the plots of the sensor data—two sensors are shown by default—overlap, and thus share the same y-axis.

## Look & Feel

Before:

![asset-40-Amsterdam-before](https://github.com/FlexMeasures/flexmeasures/assets/30658763/8602f1f4-1f47-42ce-9293-f96d2cd855c2)

After:

![asset-40-Amsterdam-after](https://github.com/FlexMeasures/flexmeasures/assets/30658763/35b25215-0a4c-4de3-8ac5-7649fb4be6a1)
