### PR TITLE
feature: Add `--resolution` option to flexmeasures show chart

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,6 +13,9 @@ New features
 * `PandasReporter` accepts the parameter `use_latest_version_only` to filter input data [see `PR #1045 <https://github.com/FlexMeasures/flexmeasures/pull/1045/>`_]
 
 
+* Add ``--resolution`` option to ``flexmeasures show chart`` to produce charts in different time resolutions [see `PR #XX <https://github.com/FlexMeasures/flexmeasures/pull/XX/>`_]
+
+
 v0.21.0 | April 16, 2024
 ============================
 

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -4,6 +4,12 @@
 FlexMeasures CLI Changelog
 **********************
 
+since v.0.22.0 | June XX, 2024
+=================================
+
+
+* Add ``--resolution`` option to ``flexmeasures show chart`` to produce charts in different time resolutions.
+
 
 since v.0.21.0 | April 16, 2024
 =================================

--- a/flexmeasures/cli/data_show.py
+++ b/flexmeasures/cli/data_show.py
@@ -381,6 +381,13 @@ def list_data_sources(source: DataSource | None = None, show_attributes: bool = 
     " now (current time), id (id of the sensor or asset), entity_type (either 'asset' or 'sensor')"
     " Example: 'result_file_$entity_type_$id_$now.csv' -> 'result_file_asset_1_2023-08-24T14:47:08' ",
 )
+@click.option(
+    "--resolution",
+    "resolution",
+    type=DurationField(),
+    required=False,
+    help="Resolution of the data. If not set, defaults to the minimum resolution of the sensor data.",
+)
 def chart(
     sensors: list[Sensor] | None = None,
     assets: list[GenericAsset] | None = None,
@@ -390,11 +397,12 @@ def chart(
     height: int | None = None,
     width: int | None = None,
     filename_template: str | None = None,
+    resolution: timedelta | None = None,
 ):
     """
     Export sensor or asset charts in PNG or SVG formats. For example:
 
-        flexmeasures show chart --start 2023-08-15T00:00:00+02:00 --end 2023-08-16T00:00:00+02:00 --asset 1 --sensor 3
+        flexmeasures show chart --start 2023-08-15T00:00:00+02:00 --end 2023-08-16T00:00:00+02:00 --asset 1 --sensor 3 --resolution P1D
     """
 
     datetime_format = "%Y-%m-%dT%H:%M:%S"
@@ -448,6 +456,7 @@ def chart(
             event_ends_before=end,
             beliefs_before=belief_time,
             include_data=True,
+            resolution=resolution,
         )
 
         # remove formatType as it relies on a custom JavaScript function

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -331,6 +331,7 @@ class GenericAsset(db.Model, AuthModelMixin):
         | None = None,
         include_data: bool = False,
         dataset_name: str | None = None,
+        resolution: str | timedelta | None = None,
         **kwargs,
     ) -> dict:
         """Create a vega-lite chart showing sensor data.
@@ -343,6 +344,7 @@ class GenericAsset(db.Model, AuthModelMixin):
         :param source: search only beliefs by this source (pass the DataSource, or its name or id) or list of sources
         :param include_data: if True, include data in the chart, or if False, exclude data
         :param dataset_name: optionally name the dataset used in the chart (the default name is sensor_<id>)
+        :param resolution: optionally set the resolution of data being displayed
         :returns: JSON string defining vega-lite chart specs
         """
         sensors = flatten_unique(self.sensors_to_show)
@@ -373,6 +375,7 @@ class GenericAsset(db.Model, AuthModelMixin):
                 beliefs_after=beliefs_after,
                 beliefs_before=beliefs_before,
                 source=source,
+                resolution=resolution,
             )
 
             # Combine chart specs and data
@@ -401,6 +404,7 @@ class GenericAsset(db.Model, AuthModelMixin):
         most_recent_beliefs_only: bool = True,
         most_recent_events_only: bool = False,
         as_json: bool = False,
+        resolution: timedelta | None = None,
     ) -> BeliefsDataFrame | str:
         """Search all beliefs about events for all sensors of this asset
 
@@ -416,6 +420,7 @@ class GenericAsset(db.Model, AuthModelMixin):
         :param source: search only beliefs by this source (pass the DataSource, or its name or id) or list of sources
         :param most_recent_events_only: only return (post knowledge time) beliefs for the most recent event (maximum event start)
         :param as_json: return beliefs in JSON format (e.g. for use in charts) rather than as BeliefsDataFrame
+        :param resolution: optionally set the resolution of data being displayed
         :returns: dictionary of BeliefsDataFrames or JSON string (if as_json is True)
         """
         bdf_dict = {}
@@ -433,6 +438,7 @@ class GenericAsset(db.Model, AuthModelMixin):
                 most_recent_beliefs_only=most_recent_beliefs_only,
                 most_recent_events_only=most_recent_events_only,
                 one_deterministic_belief_per_event_per_source=True,
+                resolution=resolution,
             )
         if as_json:
             from flexmeasures.data.services.time_series import simplify_index

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -314,8 +314,8 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
         most_recent_only: bool = None,  # deprecated
         one_deterministic_belief_per_event: bool = False,
         one_deterministic_belief_per_event_per_source: bool = False,
-        resolution: str | timedelta = None,
         as_json: bool = False,
+        resolution: str | timedelta | None = None,
     ) -> tb.BeliefsDataFrame | str:
         """Search all beliefs about events for this sensor.
 
@@ -333,6 +333,7 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
         :param one_deterministic_belief_per_event: only return a single value per event (no probabilistic distribution and only 1 source)
         :param one_deterministic_belief_per_event_per_source: only return a single value per event per source (no probabilistic distribution)
         :param as_json: return beliefs in JSON format (e.g. for use in charts) rather than as BeliefsDataFrame
+        :param resolution: optionally set the resolution of data being displayed
         :returns: BeliefsDataFrame or JSON string (if as_json is True)
         """
         # todo: deprecate the 'most_recent_only' argument in favor of 'most_recent_beliefs_only' (announced v0.8.0)
@@ -386,6 +387,7 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
         include_asset_annotations: bool = False,
         include_account_annotations: bool = False,
         dataset_name: str | None = None,
+        resolution: str | timedelta | None = None,
         **kwargs,
     ) -> dict:
         """Create a vega-lite chart showing sensor data.
@@ -402,6 +404,7 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
         :param include_asset_annotations: if True and include_data is True, include asset annotations in the chart, or if False, exclude them
         :param include_account_annotations: if True and include_data is True, include account annotations in the chart, or if False, exclude them
         :param dataset_name: optionally name the dataset used in the chart (the default name is sensor_<id>)
+        :param resolution: optionally set the resolution of data being displayed
         :returns: JSON string defining vega-lite chart specs
         """
 
@@ -433,6 +436,7 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
                 beliefs_before=beliefs_before,
                 most_recent_beliefs_only=most_recent_beliefs_only,
                 source=source,
+                resolution=resolution,
             )
 
             # Get annotations


### PR DESCRIPTION
`vl-convert` library, which is used to render the Vega-Lite chart specs uses a embedded node engine which has a very low memory limit. So far, this is not possible not change. The the memory limit is hit for large periods of data but we can downsample the data to a coarser resolution to reduce the memory usage. 

### How  to test? 

#### Asset Chart
```
flexmeasures show chart --start 2023-01-01T00:00:00+01:00 --end 2023-01-10T00:00:00+01:00 --asset 2387  --resolution P1D
``` 

#### Sensor Chart
```
flexmeasures show chart --start 2023-01-01T00:00:00+01:00 --end 2023-01-10T00:00:00+01:00 --sensor 16860  --resolution P1D
``` 


---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
