### PR TITLE
correct how favicon can be customized (use FlexMeasures UI Blueprint,…

### DIFF
--- a/documentation/plugin/customisation.rst
+++ b/documentation/plugin/customisation.rst
@@ -208,8 +208,9 @@ Then, overwrite the ``/favicon.ico`` route which FlexMeasures uses to get the fa
 .. code-block:: python
 
     from flask import send_from_directory
+    from flexmeasures.ui import flexmeasures_ui
 
-    @our_client_bp.route("/favicon.ico")
+    @flexmeasures_ui.route("/favicon.ico")
     def favicon():
         return send_from_directory(
             our_client_bp.static_folder,


### PR DESCRIPTION
## Description

Correct how favicon can be customized (use FlexMeasures UI Blueprint not the plugin one)

## Look & Feel

Plugins can change favicon.

## How to test

Follow steps at https://flexmeasures.readthedocs.io/en/latest/plugin/customisation.html#using-a-custom-favicon-icon, which this PR updates. (I did this in our smartbuildings plugin, which you can easily check)
