### PR TITLE
Introduce FLEXMEASURES_JSON_COMPACT setting

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -21,6 +21,7 @@ Infrastructure / Support
 * ``PandasReporter`` accepts the parameter ``use_latest_version_only`` to filter input data [see `PR #1045 <https://github.com/FlexMeasures/flexmeasures/pull/1045/>`_]
 * ``flexmeasures show beliefs`` uses the entity path (`<Account>/../<Sensor>`) in case of duplicated sensors [see `PR #1026 <https://github.com/FlexMeasures/flexmeasures/pull/1026/>`_]
 * Add ``--resolution`` option to ``flexmeasures show chart`` to produce charts in different time resolutions [see `PR #1007 <https://github.com/FlexMeasures/flexmeasures/pull/1007/>`_]
+* Add ``FLEXMEASURES_JSON_COMPACT`` config setting and deprecate ``JSONIFY_PRETTYPRINT_REGULAR`` setting [see `PR #1090 <https://github.com/FlexMeasures/flexmeasures/pull/1090/>`_]
 
 
 v0.21.0 | May 16, 2024

--- a/flexmeasures/app.py
+++ b/flexmeasures/app.py
@@ -160,6 +160,19 @@ def create(  # noqa C901
 
     register_auth_at(app)
 
+    # This needs to happen here because for unknown reasons, Security(app)
+    # and FlaskJSON() will set this to False on their own
+    if app.config.get("FLEXMEASURES_JSON_COMPACT", False) in (
+        True,
+        "True",
+        "true",
+        "1",
+        "yes",
+    ):
+        app.json.compact = True
+    else:
+        app.json.compact = False
+
     # Register the CLI
 
     from flexmeasures.cli import register_at as register_cli_at

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -71,8 +71,6 @@ class Config(object):
 
     MAPBOX_ACCESS_TOKEN: str | None = None
 
-    JSONIFY_PRETTYPRINT_REGULAR: bool = False
-
     RQ_DASHBOARD_POLL_INTERVAL: int = (
         3000  # Web interface poll period for updates in ms
     )
@@ -130,6 +128,7 @@ class Config(object):
         currencysymbolmap="5.1.0",
         # todo: expand with other js versions used in FlexMeasures
     )
+    FLEXMEASURES_JSON_COMPACT = False
 
     FLEXMEASURES_FALLBACK_REDIRECT: bool = False
 
@@ -182,9 +181,9 @@ class DevelopmentConfig(Config):
     SQLALCHEMY_ECHO: bool = False
     PROPAGATE_EXCEPTIONS: bool = True
     # PRESERVE_CONTEXT_ON_EXCEPTION: bool = False  # might need this to make our transaction handling work in debug mode
-    JSONIFY_PRETTYPRINT_REGULAR: bool = True
     FLEXMEASURES_MODE: str = "development"
     FLEXMEASURES_PROFILE_REQUESTS: bool = True
+    FLEXMEASURES_JSON_COMPACT = False
 
 
 class TestingConfig(Config):

--- a/flexmeasures/utils/config_utils.py
+++ b/flexmeasures/utils/config_utils.py
@@ -176,11 +176,18 @@ def read_env_vars(app: Flask):
     - Logging settings
     - access tokens
     - plugins (handled in plugin utils)
+    - json compactness
     """
     for var in (
         required
         + list(warnable.keys())
-        + ["LOGGING_LEVEL", "MAPBOX_ACCESS_TOKEN", "SENTRY_SDN", "FLEXMEASURES_PLUGINS"]
+        + [
+            "LOGGING_LEVEL",
+            "MAPBOX_ACCESS_TOKEN",
+            "SENTRY_SDN",
+            "FLEXMEASURES_PLUGINS",
+            "FLEXMEASURES_JSON_COMPACT",
+        ]
     ):
         app.config[var] = os.getenv(var, app.config.get(var, None))
     # DEBUG in env can come in as a string ("True") so make sure we don't trip here

--- a/flexmeasures/utils/flexmeasures_inflection.py
+++ b/flexmeasures/utils/flexmeasures_inflection.py
@@ -107,7 +107,7 @@ def human_sorted(alist: list, attr: Any | None = None, reverse: bool = False):
             # List of objects, to be sorted by attribute
             sorted_list = sorted(
                 alist,
-                key=lambda k: natural_keys(str(getattr(k, attr))),
+                key=lambda k: natural_keys(str(getattr(k, str(attr)))),
                 reverse=reverse,
             )
     return sorted_list


### PR DESCRIPTION
## Description

Happening in a move to deprecate JSONIFY_PRETTYPRINT_REGULAR. 
We saw this deprecation warning in our server logs a lot, so it's good to move on from it.

The new setting is so we can still control it (i.e. in production you might want to read nicely). 

Per default, the setting is `True`as it saves on IO volume. It is only `False` for development. Should it also be `False` during testing?

## How to test

In a development environment, the default should be to not compact the JSON:

```
± curl -H "Content-Type: application/json" localhost:5000/api/ping
{
  "message": "The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.",
  "status": 404
}
```

We can enforce compact JSON:

```
± export FLEXMEASURES_JSON_COMPACT=True; flexmeasures run

± curl -H "Content-Type: application/json" localhost:5000/api/ping
{"message":"The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.","status":404}
```

And the other way around:

```
± export FLEXMEASURES_JSON_COMPACT=False; flexmeasures run

± curl -H "Content-Type: application/json" localhost:5000/api/ping
{
  "message": "The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.",
  "status": 404
}
```

Remember to unset this in your bash session:

```
± unset FLEXMEASURES_JSON_COMPACT
```
