### PR TITLE
fix modal dialogues opening/closing for Bootstrap5

### DIFF
--- a/flexmeasures/ui/templates/admin/upload.html
+++ b/flexmeasures/ui/templates/admin/upload.html
@@ -63,14 +63,14 @@
                                     </thead>
                                     <tbody id ="clients-table"> </tbody>
                                 </table>
-                                <a class="btn btn-default" href="#" role="button" data-toggle="modal" data-target="#editClientModal" id="button-add-client">
+                                <a class="btn btn-default" href="#" role="button" data-bs-toggle="modal" data-bs-target="#editClientModal" id="button-add-client">
                                     <span class="fa fa-plus" aria-hidden="true"></span> Add
                                 </a>
                                 <div class="modal fade" id="editClientModal" tabindex="-1" role="dialog" aria-labelledby="editClientModalLabel">
                                     <div class="modal-dialog" role="document">
                                         <div class="modal-content">
                                             <div class="modal-header">
-                                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                                <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
                                                     <span aria-hidden="true">&times;</span>
                                                 </button>
                                                 <h4 class="modal-title" id="editClientModalLabel">
@@ -112,8 +112,8 @@
                                                 </form>
                                             </div>
                                             <div class="modal-footer">
-                                                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                                                <button type="button" class="btn btn-primary" id="edit-client-form-save" data-dismiss="modal">Save</button>
+                                                <button type="button" class="btn btn-default" data-bs-dismiss="modal">Cancel</button>
+                                                <button type="button" class="btn btn-primary" id="edit-client-form-save" data-bs-dismiss="modal">Save</button>
                                             </div>
                                         </div>
                                     </div>
@@ -128,8 +128,8 @@
                                                 <form id="remove-client-form">
                                                     <input type="hidden" name="id" id="remove-client-id"/>
                                                 </form>
-                                                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                                                <button type="button" class="btn btn-danger" id="button-remove-client" data-dismiss="modal">Remove</button>
+                                                <button type="button" class="btn btn-default" data-bs-dismiss="modal">Cancel</button>
+                                                <button type="button" class="btn btn-danger" id="button-remove-client" data-bs-dismiss="modal">Remove</button>
                                             </div>
                                         </div>
                                     </div>
@@ -187,8 +187,8 @@
                                                 </form>
                                             </div>
                                             <div class="modal-footer">
-                                                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                                                <button type="button" class="btn btn-primary" id="edit-client-data-set-form-save" data-dismiss="modal">Save</button>
+                                                <button type="button" class="btn btn-default" data-bs-dismiss="modal">Cancel</button>
+                                                <button type="button" class="btn btn-primary" id="edit-client-data-set-form-save" data-bs-dismiss="modal">Save</button>
                                             </div>
                                         </div>
                                     </div>
@@ -209,14 +209,14 @@
                                             </thead>
                                             <tbody id ="markets-table"> </tbody>
                                     </table>
-                                    <a class="btn btn-default" href="#" role="button" data-toggle="modal" data-target="#editMarketModal" id="button-add-market">
+                                    <a class="btn btn-default" href="#" role="button" data-bs-toggle="modal" data-bs-target="#editMarketModal" id="button-add-market">
                                             <span class="fa fa-plus" aria-hidden="true"></span> Add
                                     </a>
                                     <div class="modal fade" id="editMarketModal" tabindex="-1" role="dialog" aria-labelledby="editMarketModalLabel">
                                             <div class="modal-dialog" role="document">
                                                     <div class="modal-content">
                                                             <div class="modal-header">
-                                                                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                                                    <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
                                                                             <span aria-hidden="true">&times;</span>
                                                                     </button>
                                                                     <h4 class="modal-title" id="editMarketModalLabel">
@@ -242,8 +242,8 @@
                                                                     </form>
                                                             </div>
                                                             <div class="modal-footer">
-                                                                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                                                                    <button type="button" class="btn btn-primary" id="edit-market-form-save" data-dismiss="modal">Save</button>
+                                                                    <button type="button" class="btn btn-default" data-bs-dismiss="modal">Cancel</button>
+                                                                    <button type="button" class="btn btn-primary" id="edit-market-form-save" data-bs-dismiss="modal">Save</button>
                                                             </div>
                                                     </div>
                                             </div>
@@ -258,8 +258,8 @@
                                                                     <form id="remove-market-form">
                                                                             <input type="hidden" name="id" id="remove-market-id"/>
                                                                     </form>
-                                                                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                                                                    <button type="button" class="btn btn-danger" id="button-remove-market" data-dismiss="modal">Remove</button>
+                                                                    <button type="button" class="btn btn-default" data-bs-dismiss="modal">Cancel</button>
+                                                                    <button type="button" class="btn btn-danger" id="button-remove-market" data-bs-dismiss="modal">Remove</button>
                                                             </div>
                                                     </div>
                                             </div>
@@ -268,7 +268,7 @@
                                             <div class="modal-dialog modal-lg" id="edit-market-data-set-modal-dialog" role="document">
                                                     <div class="modal-content">
                                                             <div class="modal-header">
-                                                                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                                                    <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
                                                                             <span aria-hidden="true">&times;</span>
                                                                     </button>
                                                                     <h4 class="modal-title" id="editMarketDataSetModalLabel">
@@ -316,8 +316,8 @@
                                                                     </form>
                                                             </div>
                                                             <div class="modal-footer">
-                                                                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                                                                    <button type="button" class="btn btn-primary" id="edit-market-data-set-form-save" data-dismiss="modal">Save</button>
+                                                                    <button type="button" class="btn btn-default" data-bs-dismiss="modal">Cancel</button>
+                                                                    <button type="button" class="btn btn-primary" id="edit-market-data-set-form-save" data-bs-dismiss="modal">Save</button>
                                                             </div>
                                                     </div>
                                             </div>

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -700,14 +700,14 @@
                 {% endblock copyright_notice %}
 
                 {% block about %}
-                <a href="#" data-toggle="modal" data-target="#About">About FlexMeasures</a>.
+                <a href="#" data-bs-toggle="modal" data-bs-target="#About">About FlexMeasures</a>.
                 <!-- The modal -->
                 <div class="modal fade" id="About" tabindex="-1" role="dialog" aria-labelledby="modalLabelLarge" aria-hidden="true">
                 <div class="modal-dialog modal-lg">
                 <div class="modal-content">
 
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                     </button>
                     <h4 class="modal-title" id="modalLabelLarge">About FlexMeasures</h4>
@@ -769,7 +769,7 @@
                 {% endblock about %}
 
                 {% block credits %}
-                <a href="#" data-toggle="modal" data-target="#Credits">Credits</a>.
+                <a href="#" data-bs-toggle="modal" data-bs-target="#Credits">Credits</a>.
 
                 <!-- The modal -->
                 <div class="modal fade" id="Credits" tabindex="-1" role="dialog" aria-labelledby="modalLabelLarge" aria-hidden="true">
@@ -777,7 +777,7 @@
                 <div class="modal-content">
 
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                     </button>
                     <h4 class="modal-title" id="modalLabelLarge">Credits</h4>

--- a/flexmeasures/ui/templates/rq_dashboard/base.html
+++ b/flexmeasures/ui/templates/rq_dashboard/base.html
@@ -45,7 +45,7 @@
                     <div class="modal-content">
                         <div class="modal-header">
                             <h3>Do you really want to <span id="confirmation-modal-action"></span>?</h3>
-                            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                            <button type="button" class="close" data-bs-dismiss="modal" aria-hidden="true">&times;</button>
                         </div>
                         <div class="modal-footer">
                             <button type="button" id="confirmation-modal-no" class="btn">No</button>


### PR DESCRIPTION
## Description

In the [move to Bootstrap5](https://github.com/FlexMeasures/flexmeasures/pull/1058), some things were left over, this being one of them. We mostly miss the added `-bs` identifier in `data-X` attributes which was added after Bootstrap 4.

## Look & Feel

Open modals from the footer (e.g. "About FlexMeasures") or in the RQ dashboard (e.g. deleting/re-queueing jobs). 

## How to test

This should not work before the PR, but with it, it should.
