### PR TITLE
fix modal dialogues closing button style for Bootstrap5

### DIFF
--- a/flexmeasures/ui/static/css/flexmeasures.css
+++ b/flexmeasures/ui/static/css/flexmeasures.css
@@ -1026,15 +1026,6 @@ body .dataTables_wrapper .dataTables_paginate .paginate_button.current:hover {
     z-index: 999992 !important;
 }
 
-.close:focus, .close:hover {
-    color: var(--red);
-    transition: .3s;
-    -webkit-transition: .3s;
-    -moz-transition: .3s;
-    -ms-transition: .3s;
-    -o-transition: .3s;
-}
-
 /* ---- End Modal ---- */
 
 

--- a/flexmeasures/ui/templates/admin/upload.html
+++ b/flexmeasures/ui/templates/admin/upload.html
@@ -70,13 +70,11 @@
                                     <div class="modal-dialog" role="document">
                                         <div class="modal-content">
                                             <div class="modal-header">
-                                                <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
-                                                    <span aria-hidden="true">&times;</span>
-                                                </button>
                                                 <h4 class="modal-title" id="editClientModalLabel">
                                                     <span id="add-client-header">Add a client</span>
                                                     <span id="edit-client-header">Edit <span id="edit-client-name-header"> </span></span>
                                                 </h4>
+                                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                                             </div>
                                             <div class="modal-body">
                                                 <form id="edit-client-form" enctype="multipart/form-data" class="form-horizontal">
@@ -138,12 +136,10 @@
                                     <div class="modal-dialog modal-lg" id="edit-client-data-set-modal-dialog" role="document">
                                         <div class="modal-content">
                                             <div class="modal-header">
-                                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                                                    <span aria-hidden="true">&times;</span>
-                                                </button>
                                                 <h4 class="modal-title" id="editClientDataSetModalLabel">
                                                     <span id="edit-client-data-set-name-header"> </span> for <span id="edit-client-data-set-owner-header"> </span>
                                                 </h4>
+                                                <button type="button" class="btn-close" data-dismiss="modal" aria-label="Close"></button>
                                             </div>
                                             <div class="modal-body">
                                                 <div id="client-data-set-plot" class="data-set-plot edit-data-set-hideable"> </div>
@@ -216,13 +212,11 @@
                                             <div class="modal-dialog" role="document">
                                                     <div class="modal-content">
                                                             <div class="modal-header">
-                                                                    <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
-                                                                            <span aria-hidden="true">&times;</span>
-                                                                    </button>
                                                                     <h4 class="modal-title" id="editMarketModalLabel">
                                                                             <span id="add-market-header">Add a market</span>
                                                                             <span id="edit-market-header">Edit market &ldquo;<span id="edit-market-name-header"> </span>&rdquo;</span>
                                                                     </h4>
+                                                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                                                             </div>
                                                             <div class="modal-body">
                                                                     <form id="edit-market-form" enctype="multipart/form-data" class="form-horizontal">
@@ -268,12 +262,10 @@
                                             <div class="modal-dialog modal-lg" id="edit-market-data-set-modal-dialog" role="document">
                                                     <div class="modal-content">
                                                             <div class="modal-header">
-                                                                    <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
-                                                                            <span aria-hidden="true">&times;</span>
-                                                                    </button>
                                                                     <h4 class="modal-title" id="editMarketDataSetModalLabel">
                                                                             <span id="edit-market-data-set-name-header"> </span> for <span id="edit-market-data-set-owner-header"> </span>
                                                                     </h4>
+                                                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                                                             </div>
                                                             <div class="modal-body">
                                                                     <div id="market-data-set-plot" class="data-set-plot edit-data-set-hideable"> </div>

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -707,10 +707,8 @@
                 <div class="modal-content">
 
                 <div class="modal-header">
-                    <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                    </button>
                     <h4 class="modal-title" id="modalLabelLarge">About FlexMeasures</h4>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
 
                 <div class="modal-body">
@@ -777,10 +775,8 @@
                 <div class="modal-content">
 
                 <div class="modal-header">
-                    <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                    </button>
                     <h4 class="modal-title" id="modalLabelLarge">Credits</h4>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
 
                 <div class="modal-body">

--- a/flexmeasures/ui/templates/rq_dashboard/base.html
+++ b/flexmeasures/ui/templates/rq_dashboard/base.html
@@ -45,7 +45,7 @@
                     <div class="modal-content">
                         <div class="modal-header">
                             <h3>Do you really want to <span id="confirmation-modal-action"></span>?</h3>
-                            <button type="button" class="close" data-bs-dismiss="modal" aria-hidden="true">&times;</button>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-hidden="true"></button>
                         </div>
                         <div class="modal-footer">
                             <button type="button" id="confirmation-modal-no" class="btn">No</button>


### PR DESCRIPTION
## Description

In the [move to Bootstrap5](https://github.com/FlexMeasures/flexmeasures/pull/1058), some things were left over, this being one of them. The styling of the close button changed, now done by the `btn-close` class.

## Look & Feel

Open modals from the footer (e.g. "About FlexMeasures") or in the RQ dashboard (e.g. deleting/re-queueing jobs) - the "X" should be on the top right, look good and work. 

## How to test

The X should not look good before the PR and be wrongly positioned, but with it, it should be okay.