### PR TITLE
Drop deprecated app.schedulers and app.reporters attributes

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -23,7 +23,7 @@ Infrastructure / Support
 * ``flexmeasures show beliefs`` uses the entity path (`<Account>/../<Sensor>`) in case of duplicated sensors [see `PR #1026 <https://github.com/FlexMeasures/flexmeasures/pull/1026/>`_]
 * Add ``--resolution`` option to ``flexmeasures show chart`` to produce charts in different time resolutions [see `PR #1007 <https://github.com/FlexMeasures/flexmeasures/pull/1007/>`_]
 * Add ``FLEXMEASURES_JSON_COMPACT`` config setting and deprecate ``JSONIFY_PRETTYPRINT_REGULAR`` setting [see `PR #1090 <https://github.com/FlexMeasures/flexmeasures/pull/1090/>`_]
-* Removed depectrated ``app.schedulers`` and ``app.forecasters`` (use ``app.data_generators["scheduler"]`` and ``app.data_generators["forecaster"]`` instead) [see `PR #1098 <https://github.com/FlexMeasures/flexmeasures/pull/1098/>`_]
+* Removed deprecated ``app.schedulers`` and ``app.forecasters`` (use ``app.data_generators["scheduler"]`` and ``app.data_generators["forecaster"]`` instead) [see `PR #1098 <https://github.com/FlexMeasures/flexmeasures/pull/1098/>`_]
 
 
 v0.21.0 | May 16, 2024

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -23,6 +23,7 @@ Infrastructure / Support
 * ``flexmeasures show beliefs`` uses the entity path (`<Account>/../<Sensor>`) in case of duplicated sensors [see `PR #1026 <https://github.com/FlexMeasures/flexmeasures/pull/1026/>`_]
 * Add ``--resolution`` option to ``flexmeasures show chart`` to produce charts in different time resolutions [see `PR #1007 <https://github.com/FlexMeasures/flexmeasures/pull/1007/>`_]
 * Add ``FLEXMEASURES_JSON_COMPACT`` config setting and deprecate ``JSONIFY_PRETTYPRINT_REGULAR`` setting [see `PR #1090 <https://github.com/FlexMeasures/flexmeasures/pull/1090/>`_]
+* Removed depectrated ``app.schedulers`` and ``app.forecasters`` (use ``app.data_generators["scheduler"]`` and ``app.data_generators["forecaster"]`` instead) [see `PR #1098 <https://github.com/FlexMeasures/flexmeasures/pull/1098/>`_]
 
 
 v0.21.0 | May 16, 2024

--- a/flexmeasures/app.py
+++ b/flexmeasures/app.py
@@ -142,18 +142,6 @@ def create(  # noqa C901
     )  # use copy to avoid mutating app.reporters
     app.data_generators["scheduler"] = schedulers
 
-    # deprecated: app.reporters and app.schedulers
-    app.reporters = reporters
-    app.schedulers = schedulers
-
-    def get_reporters():
-        app.logger.warning(
-            '`app.reporters` is deprecated. Use `app.data_generators["reporter"]` instead.'
-        )
-        return app.data_generators["reporter"]
-
-    setattr(app, "reporters", get_reporters())
-
     # add auth policy
 
     from flexmeasures.auth import register_at as register_auth_at

--- a/flexmeasures/utils/plugin_utils.py
+++ b/flexmeasures/utils/plugin_utils.py
@@ -114,13 +114,10 @@ def register_plugins(app: Flask):  # noqa: C901
         plugin_schedulers = get_classes_module(module.__name__, Scheduler)
 
         # add DataGenerators
-        # for legacy, we still maintain app.reporters and app.schedulers
         if plugin_reporters:
             app.data_generators["reporter"].update(plugin_reporters)
-            app.reporters.update(plugin_reporters)
         if plugin_schedulers:
             app.data_generators["scheduler"].update(plugin_schedulers)
-            app.schedulers.update(plugin_schedulers)
 
         app.config["LOADED_PLUGINS"][plugin_name] = plugin_version
     app.logger.info(f"Loaded plugins: {app.config['LOADED_PLUGINS']}")


### PR DESCRIPTION
These attributes have been deprecated a few versions and the deprecation logic seemed also not 100% correct.