### PR TITLE
Update sensor urls and links in Documentation

### DIFF
--- a/documentation/tut/toy-example-expanded.rst
+++ b/documentation/tut/toy-example-expanded.rst
@@ -63,7 +63,7 @@ Setting the data source type to "forecaster" helps FlexMeasures to visually dist
     $ flexmeasures add beliefs --sensor 3 --source 4 solar-tomorrow.csv --timezone Europe/Amsterdam
     Successfully created beliefs
 
-The one-hour CSV data is automatically resampled to the 15-minute resolution of the sensor that is recording solar production. We can see solar production in the `FlexMeasures UI <http://localhost:5000/sensors/3/>`_ :
+The one-hour CSV data is automatically resampled to the 15-minute resolution of the sensor that is recording solar production. We can see solar production in the `FlexMeasures UI <http://localhost:5000/sensors/3>`_ :
 
 .. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/sensor-data-production.png
     :align: center
@@ -85,13 +85,13 @@ Now, we'll reschedule the battery while taking into account the solar production
         --soc-at-start 50% --roundtrip-efficiency 90%
     New schedule is stored.
 
-We can see the updated scheduling in the `FlexMeasures UI <http://localhost:5000/sensors/2/>`_ :
+We can see the updated scheduling in the `FlexMeasures UI <http://localhost:5000/sensors/2>`_ :
 
 .. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/sensor-data-charging-with-solar.png
     :align: center
 |
 
-The `asset page for the battery <http://localhost:5000/assets/1/>`_ now shows the solar data, too:
+The `asset page for the battery <http://localhost:5000/assets/3>`_ now shows the solar data, too:
 
 .. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/asset-view-with-solar.png
     :align: center
@@ -117,7 +117,7 @@ In the case of the scheduler that we ran in the previous tutorial, which did not
 
 .. note:: You can add arbitrary sensors to a chart using the attribute ``sensors_to_show``. See :ref:`view_asset-data` for more.
 
-A nice feature is that you can check the data connectivity status of your building asset. Now that we have made the schedule, both lamps are green. You can also view it in `FlexMeasures UI <http://localhost:5000/assets/1/status>`_ :
+A nice feature is that you can check the data connectivity status of your building asset. Now that we have made the schedule, both lamps are green. You can also view it in `FlexMeasures UI <http://localhost:5000/assets/2/status>`_ :
 
 .. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/screenshot_building_status.png
     :align: center

--- a/documentation/tut/toy-example-from-scratch.rst
+++ b/documentation/tut/toy-example-from-scratch.rst
@@ -62,7 +62,7 @@ Great. Let's see what we made:
 
 Here, negative values denote output from the grid, so that's when the battery gets charged.
 
-We can also look at the charging schedule in the `FlexMeasures UI <http://localhost:5000/sensors/2/>`_ (reachable via the asset page for the battery):
+We can also look at the charging schedule in the `FlexMeasures UI <http://localhost:5000/sensors/2>`_ (reachable via the asset page for the battery):
 
 .. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/sensor-data-charging.png
     :align: center
@@ -70,7 +70,7 @@ We can also look at the charging schedule in the `FlexMeasures UI <http://localh
 
 Recall that we only asked for a 12 hour schedule here. We started our schedule *after* the high price peak (at 4am) and it also had to end *before* the second price peak fully realized (at 8pm). Our scheduler didn't have many opportunities to optimize, but it found some. For instance, it does buy at the lowest price (at 2pm) and sells it off at the highest price within the given 12 hours (at 6pm).
 
-The `asset page for the battery <http://localhost:5000/assets/2/>`_ shows both prices and the schedule.
+The `asset page for the battery <http://localhost:5000/assets/3>`_ shows both prices and the schedule.
 
 .. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/asset-view-without-solar.png
     :align: center

--- a/documentation/tut/toy-example-process.rst
+++ b/documentation/tut/toy-example-process.rst
@@ -92,7 +92,7 @@ Finally, we'll schedule the process using the SHIFTABLE policy.
 Results
 ---------
 
-The image below shows the resulting schedules following each of the three policies. You will see similar results in your `FlexMeasures UI <http://localhost:5000/assets/4/>`_. 
+The image below shows the resulting schedules following each of the three policies. You will see similar results in your `FlexMeasures UI <http://localhost:5000/assets/5>`_. 
 
  
 .. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/asset-view-process.png

--- a/documentation/tut/toy-example-reporter.rst
+++ b/documentation/tut/toy-example-reporter.rst
@@ -123,7 +123,6 @@ Finally, we can create the reporter with the following command:
 
 .. code-block:: bash
 
-    $ TOMORROW=$(date --date="next day" '+%Y-%m-%d')
     $ flexmeasures add report --reporter AggregatorReporter \
        --parameters headroom-parameters.json --config headroom-config.json \
        --start-offset DB,1D --end-offset DB,2D \

--- a/documentation/tut/toy-example-reporter.rst
+++ b/documentation/tut/toy-example-reporter.rst
@@ -78,7 +78,7 @@ That's because reporters belong to a bigger category of classes that also contai
 
 .. code-block:: bash
 
-    $ flexmeasures show data-sources --show-attributes --id 5
+    $ flexmeasures show data-sources --show-attributes --id 6
 
          ID  Name          Type      User ID    Model           Version    Attributes                                  
        ----  ------------  --------  ---------  --------------  ---------  -----------------------------------------   
@@ -129,7 +129,7 @@ Finally, we can create the reporter with the following command:
        --start-offset DB,1D --end-offset DB,2D \
        --resolution PT15M
 
-Now we can visualize the headroom in the following `link <http://localhost:5000/sensor/8/>`_, which should resemble the following image.
+Now we can visualize the headroom in the following `link <http://localhost:5000/sensors/8>`_, which should resemble the following image.
 
 .. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/sensor-data-headroom.png
     :align: center
@@ -184,7 +184,7 @@ Create report:
        --start-offset DB,1D --end-offset DB,2D
 
 
-Check the results `here <http://localhost:5000/sensor/9/>`_. The image should be similar to the one below.
+Check the results `here <http://localhost:5000/sensors/9>`_. The image should be similar to the one below.
 
 .. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/sensor-data-inflexible.png
     :align: center
@@ -211,7 +211,7 @@ Create report:
        --parameters breakable-parameters.json \
        --start-offset DB,1D --end-offset DB,2D
 
-Check the results `here <http://localhost:5000/sensor/10/>`_. The image should be similar to the one below.
+Check the results `here <http://localhost:5000/sensors/10>`_. The image should be similar to the one below.
 
 
 .. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/sensor-data-breakable.png
@@ -239,7 +239,7 @@ Create report:
        --parameters shiftable-parameters.json \
        --start-offset DB,1D --end-offset DB,2D
 
-Check the results `here <http://localhost:5000/sensor/11/>`_. The image should be similar to the one below.
+Check the results `here <http://localhost:5000/sensors/11>`_. The image should be similar to the one below.
 
 
 .. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/sensor-data-shiftable.png

--- a/documentation/tut/toy-example-setup.rst
+++ b/documentation/tut/toy-example-setup.rst
@@ -323,7 +323,7 @@ Let's look at the price data we just loaded:
 
 
 
-Again, we can also view these prices in the `FlexMeasures UI <http://localhost:5000/sensors/1/>`_:
+Again, we can also view these prices in the `FlexMeasures UI <http://localhost:5000/sensors/1>`_:
 
 .. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/sensor-data-prices.png
     :align: center


### PR DESCRIPTION
## Description

- Updated URLs across documentation files to remove trailing slashes.
- Corrected asset IDs in documentation examples.
- Updated commands to reflect changes in the FlexMeasures setup.


## How to test

- No specific tests required. Manual verification of URLs and commands in the [documentation](https://flexmeasures.readthedocs.io/en/latest/tut/toy-example-setup.html).




---

- [ ] I agree to contribute to the project under Apache 2 License. 
- [ ] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
