### PR TITLE
Price and inflexible device sensors data to connectivity table on asset status page

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,6 +13,7 @@ New features
 * On the asset page, facilitate comparison by showing the two default sensors together if they record the same unit [see `PR #1066 <https://github.com/FlexMeasures/flexmeasures/pull/1066>`_]
 * Flex-context (price sensors and inflexible device sensors) can now be set on the asset page (and are part of GenericAsset model) [see `PR #1059 <https://github.com/FlexMeasures/flexmeasures/pull/1059/>`_]
 * On the asset page's default view, facilitate comparison by showing the two default sensors together if they record the same unit [see `PR #1066 <https://github.com/FlexMeasures/flexmeasures/pull/1066>`_]
+* Add flex-context sensors to status page [see `PR #1102 <https://github.com/FlexMeasures/flexmeasures/pull/1102>`_]
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/api/common/schemas/tests/test_sensor_data_schema.py
+++ b/flexmeasures/api/common/schemas/tests/test_sensor_data_schema.py
@@ -11,9 +11,6 @@ from flexmeasures.api.common.schemas.sensor_data import (
     PostSensorDataSchema,
     GetSensorDataSchema,
 )
-from flexmeasures.data.models.generic_assets import (
-    GenericAssetInflexibleSensorRelationship,
-)
 from flexmeasures.data.models.time_series import Sensor
 from flexmeasures.data.services.forecasting import create_forecasting_jobs
 from flexmeasures.data.services.scheduling import create_scheduling_job
@@ -283,14 +280,8 @@ def test_build_asset_status_data(
 
     asset.consumption_price_sensor_id = wind_sensor.id
     asset.production_price_sensor_id = production_price_sensor.id
+    asset.inflexible_device_sensors = [temperature_sensor]
     db.session.add(asset)
-
-    asset_inflexible_temperature_sensor_relationship = (
-        GenericAssetInflexibleSensorRelationship(
-            generic_asset_id=asset.id, inflexible_sensor_id=temperature_sensor.id
-        )
-    )
-    db.session.add(asset_inflexible_temperature_sensor_relationship)
 
     wind_speed_res, temperature_res = {"staleness": True}, {"staleness": False}
     production_price_res = {"staleness": True}
@@ -307,14 +298,14 @@ def test_build_asset_status_data(
             "name": "wind speed",
             "id": wind_sensor.id,
             "asset_name": asset.name,
-            "relation": "ownership;consumption price",
+            "relation": "included device;consumption price",
         },
         {
             **temperature_res,
             "name": "temperature",
             "id": temperature_sensor.id,
             "asset_name": asset.name,
-            "relation": "ownership;inflexible device",
+            "relation": "included device;inflexible device",
         },
         {
             **production_price_res,

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -265,6 +265,7 @@ class GenericAsset(db.Model, AuthModelMixin):
 
         from flexmeasures.data.models.time_series import Sensor
 
+        # Need to load consumption_price_sensor manually as generic_asset does not get to SQLAlchemy session context.
         if self.consumption_price_sensor_id and not self.consumption_price_sensor:
             self.consumption_price_sensor = Sensor.query.get(
                 self.consumption_price_sensor_id
@@ -280,6 +281,7 @@ class GenericAsset(db.Model, AuthModelMixin):
 
         from flexmeasures.data.models.time_series import Sensor
 
+        # Need to load production_price_sensor manually as generic_asset does not get to SQLAlchemy session context.
         if self.production_price_sensor_id and not self.production_price_sensor:
             self.production_price_sensor = Sensor.query.get(
                 self.production_price_sensor_id
@@ -298,6 +300,7 @@ class GenericAsset(db.Model, AuthModelMixin):
 
         from flexmeasures.data.models.time_series import Sensor
 
+        # Need to load inflexible_device_sensors manually as generic_asset does not get to SQLAlchemy session context.
         if not self.inflexible_device_sensors:
             self.inflexible_device_sensors = (
                 db.session.query(Sensor)

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -262,6 +262,13 @@ class GenericAsset(db.Model, AuthModelMixin):
 
     def get_consumption_price_sensor(self):
         """Searches for consumption_price_sensor upwards on the asset tree"""
+
+        from flexmeasures.data.models.time_series import Sensor
+
+        if self.consumption_price_sensor_id and not self.consumption_price_sensor:
+            self.consumption_price_sensor = Sensor.query.get(
+                self.consumption_price_sensor_id
+            )
         if self.consumption_price_sensor:
             return self.consumption_price_sensor
         if self.parent_asset:
@@ -270,6 +277,13 @@ class GenericAsset(db.Model, AuthModelMixin):
 
     def get_production_price_sensor(self):
         """Searches for production_price_sensor upwards on the asset tree"""
+
+        from flexmeasures.data.models.time_series import Sensor
+
+        if self.production_price_sensor_id and not self.production_price_sensor:
+            self.production_price_sensor = Sensor.query.get(
+                self.production_price_sensor_id
+            )
         if self.production_price_sensor:
             return self.production_price_sensor
         if self.parent_asset:
@@ -281,6 +295,22 @@ class GenericAsset(db.Model, AuthModelMixin):
         Searches for inflexible_device_sensors upwards on the asset tree
         This search will stop once any sensors are found (will not aggregate towards the top of the tree)
         """
+
+        from flexmeasures.data.models.time_series import Sensor
+
+        if not self.inflexible_device_sensors:
+            self.inflexible_device_sensors = (
+                db.session.query(Sensor)
+                .join(
+                    GenericAssetInflexibleSensorRelationship,
+                    GenericAssetInflexibleSensorRelationship.inflexible_sensor_id
+                    == Sensor.id,
+                )
+                .filter(
+                    GenericAssetInflexibleSensorRelationship.generic_asset_id == self.id
+                )
+                .all()
+            )
         if self.inflexible_device_sensors:
             return self.inflexible_device_sensors
         if self.parent_asset:

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -179,7 +179,7 @@ def _get_sensor_asset_relation(
     """Get the relation of a sensor to an asset."""
     relations = list()
     if sensor.generic_asset_id == asset.id:
-        relations.append("ownership")
+        relations.append("included device")
     if asset.consumption_price_sensor_id == sensor.id:
         relations.append("consumption price")
     if asset.production_price_sensor_id == sensor.id:

--- a/flexmeasures/ui/crud/assets/forms.py
+++ b/flexmeasures/ui/crud/assets/forms.py
@@ -18,11 +18,7 @@ from typing import Optional
 
 from flexmeasures.auth.policy import user_has_admin_access
 from flexmeasures.data import db
-from flexmeasures.data.models.generic_assets import (
-    GenericAsset,
-    GenericAssetType,
-    GenericAssetInflexibleSensorRelationship,
-)
+from flexmeasures.data.models.generic_assets import GenericAsset, GenericAssetType
 from flexmeasures.data.models.user import Account
 from flexmeasures.data.models.time_series import Sensor
 from flexmeasures.ui.crud.assets.utils import (
@@ -154,25 +150,9 @@ class AssetForm(FlaskForm):
         allowed_inflexible_sensor_data = get_allowed_inflexible_sensor_data(account_id)
         linked_sensor_data = {}
         if asset:
-            linked_sensors = (
-                db.session.query(
-                    GenericAssetInflexibleSensorRelationship.inflexible_sensor_id,
-                    Sensor.name,
-                )
-                .join(
-                    Sensor,
-                    GenericAssetInflexibleSensorRelationship.inflexible_sensor_id
-                    == Sensor.id,
-                )
-                .filter(
-                    GenericAssetInflexibleSensorRelationship.generic_asset_id
-                    == asset.id
-                )
-                .all()
-            )
+            linked_sensors = asset.get_inflexible_device_sensors()
             linked_sensor_data = {
-                sensor_id: f"{asset.name}:{sensor_name}"
-                for sensor_id, sensor_name in linked_sensors
+                sensor.id: f"{asset.name}:{sensor.name}" for sensor in linked_sensors
             }
 
         all_sensor_data = {**allowed_inflexible_sensor_data, **linked_sensor_data}

--- a/flexmeasures/ui/templates/views/status.html
+++ b/flexmeasures/ui/templates/views/status.html
@@ -25,6 +25,7 @@
                         <tr>
                             <th>Name</th>
                             <th>Asset name</th>
+                            <th>Relation to asset</th>
                             <th class="no-sort" title="This is the knowledge time of the most recent event recorded">Time of last value</th>
                             <th class="text-right no-sort">Status</th>
                             <th class="d-none">URL</th>
@@ -39,6 +40,8 @@
                             <td>
                                 {{ sensor.asset_name }}
                             </td>
+                            <td>
+                                {{ sensor.relation }}
                             <td>
                                 <span title="{{ sensor['staleness_since'] }}">{{ sensor["staleness_since"] | naturalized_datetime }}</span>
                             </td>


### PR DESCRIPTION
## Description

Start adding consumption and production price sensors + inflexible device sensors linked to an asset to asset status page

## Look & Feel

On asset status page there is a new column "Relation to asset" that shows if an asset owns this sensor, or this sensor is linked to asset via consumption / production_price_sensor_id or inflexible_device_sensors

## How to test

Open status page for some asset without linked price / inflexible device sensors.
Verify that "Data connectivity" table contains only this asset sensors + their relation to an asset is "included device".
Update an asset - e.g set some of its sensors as a consumption price sensor. Check that this sensor ownership on a status page now equals to "ownership; consumption price".
Update an asset - add some other asset sensor as its e.g inflexible device sensor. Check that this sensor appears on asset status page with "inflexible device" ownership

## Further Improvements

-

## Related Items

-

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
