### PR TITLE
Update docs with screenshots

### DIFF
--- a/documentation/views/account.rst
+++ b/documentation/views/account.rst
@@ -6,3 +6,21 @@ This is the account overview page:
 .. image:: https://github.com/FlexMeasures/screenshots/raw/main/screenshot_account.png
     :align: center
 ..    :scale: 40%
+
+|
+|
+
+This is the current User overview page:
+
+.. image:: https://github.com/FlexMeasures/screenshots/raw/main/screenshot-user-overview.png
+    :align: center
+..    :scale: 40%
+
+|
+|
+
+This is the account audit log page:
+
+.. image:: https://github.com/FlexMeasures/screenshots/raw/main/screenshot-account-auditlog.PNG
+    :align: center
+..    :scale: 40%

--- a/documentation/views/asset-data.rst
+++ b/documentation/views/asset-data.rst
@@ -20,6 +20,24 @@ This includes the possibility to specify which sensors the asset page should sho
 |
 |
 
+For each asset, you can also visit a status page to see if your data connectivity and recent jobs are okay. This is how data connectivity status looks like on the building asset from our tutorial:
+
+.. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/screenshot_building_status.png
+    :align: center
+..    :scale: 40%
+
+|
+|
+
+This is how the audit log looks for the history of actions taken on an asset:
+
+.. image:: https://github.com/FlexMeasures/screenshots/raw/main/screenshot-auditlog.PNG
+    :align: center
+..    :scale: 40%
+
+|
+|
+
 .. note:: It is possible to overlay data for multiple sensors, by setting the `sensors_to_show` attribute to a nested list. For example, ``{"sensor_to_show": [3, [2, 4]]}`` would show the data for sensor 4 laid over the data for sensor 2.
 .. note:: While it is possible to show an arbitrary number of sensors this way, we recommend showing only the most crucial ones for faster loading, less page scrolling, and generally, a quick grasp of what the asset is up to.
 .. note:: Asset attributes can be edited through the CLI as well, with the CLI command ``flexmeasures edit attribute``.


### PR DESCRIPTION
## Description

- Added  data connectivity and audit log screenshosts to Assets & sensor data UI page.
- Added User overview and  account audit log screenshots to the account UI page.


## How to test

Navigate to the  [Assets & sensor data UI page](https://flexmeasures.readthedocs.io/en/latest/views/asset-data.html) or [acount page](https://flexmeasures.readthedocs.io/en/latest/views/account.html) and verify the new image and text are correctly displayed


---

- [ ] I agree to contribute to the project under Apache 2 License. 
- [ ] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
