### PR TITLE
Fix status page scheduling_forecasting_jobs table sorting

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -24,6 +24,10 @@ Infrastructure / Support
 * Add ``--resolution`` option to ``flexmeasures show chart`` to produce charts in different time resolutions [see `PR #1007 <https://github.com/FlexMeasures/flexmeasures/pull/1007/>`_]
 * Add ``FLEXMEASURES_JSON_COMPACT`` config setting and deprecate ``JSONIFY_PRETTYPRINT_REGULAR`` setting [see `PR #1090 <https://github.com/FlexMeasures/flexmeasures/pull/1090/>`_]
 
+Bugfixes
+-----------
+* Fix ordering of jobs on the asset status page [see `PR #1106 <https://github.com/FlexMeasures/flexmeasures/pull/1106>`_]
+
 
 v0.21.0 | May 16, 2024
 ============================

--- a/flexmeasures/ui/templates/views/status.html
+++ b/flexmeasures/ui/templates/views/status.html
@@ -68,6 +68,7 @@
                             <th class="text-right no-sort">Status</th>
                             <th class="text-right">Info</th>
                             <th class="d-none">URL</th>
+                            <th class="d-none">Created at for sort</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -118,6 +119,9 @@
                             <td class="hidden d-none invisible" style="display:none;">
                                 /tasks/0/view/job/{{ job_data.job_id }}
                             </td>
+                            <td class="hidden d-none invisible" style="display:none;">
+                                {{ job_data.enqueued_at }}
+                            </td>
                         </tr>
                         {% endfor %}
                     </tbody>
@@ -133,7 +137,7 @@
 <!-- sort scheduling and forecasting jobs by 'Created at' column -->
 <script>
     $(document).ready(function() {
-        $('#scheduling_forecasting_jobs').DataTable({"order": [[ 0, "desc" ]]});
+        $('#scheduling_forecasting_jobs').DataTable({"order": [[ 6, "desc" ]]});
     });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Description

Fix status page jobs table sorting - previously it was sorted by the Create-At column, that contains the human-readable text, so "3 minutes ago" was below "An hour ago" and also "36 minutes ago".

## Look & Feel

Jobs table is sorted according to job enqueued_at datetime

## How to test

Add some jobs so that one of them was added a minute ago and another one - a few minutes ago. Verify that first job is above the second one.

## Further Improvements

-

## Related Items

-

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
