### PR TITLE
Support new single-belief fast track in timely-beliefs

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -3,8 +3,25 @@
 FlexMeasures Changelog
 **********************
 
+v0.23.0 | August XX, 2024
+============================
+
+New features
+-------------
+
+Infrastructure / Support
+----------------------
+* Support new single-belief fast track (looking uup only one belief) [see `PR #1067 <https://github.com/FlexMeasures/flexmeasures/pull/1067>`_]
+
+
+Bugfixes
+-----------
+
+
 v0.22.0 | June 29, 2024
 ============================
+
+.. note:: Read more on these features on `the FlexMeasures blog <https://flexmeasures.io/022-editing-flex-context/>`_.
 
 New features
 -------------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -12,10 +12,14 @@ New features
 Infrastructure / Support
 ----------------------
 * Support new single-belief fast track (looking uup only one belief) [see `PR #1067 <https://github.com/FlexMeasures/flexmeasures/pull/1067>`_]
+* Add new annotation types: ``"error"`` and ``"warning"`` [see `PR #1131 <https://github.com/FlexMeasures/flexmeasures/pull/1131>`_]
+* Removed deprecated ``app.schedulers`` and ``app.forecasters`` (use ``app.data_generators["scheduler"]`` and ``app.data_generators["forecaster"]`` instead) [see `PR #1098 <https://github.com/FlexMeasures/flexmeasures/pull/1098/>`_]
 
 
 Bugfixes
 -----------
+* Allow reassigning a public asset to private ownership using the ``flexmeasures edit transfer-ownership`` CLI command [see `PR #1123 <https://github.com/FlexMeasures/flexmeasures/pull/1123>`_]
+* Fix missing value on spring :abbr:`DST (Daylight Saving Time)` transition for ``PandasReporter`` using daily sensor as input [see `PR #1122 <https://github.com/FlexMeasures/flexmeasures/pull/1122>`_]
 
 
 v0.22.0 | June 29, 2024
@@ -42,15 +46,11 @@ Infrastructure / Support
 * ``flexmeasures show beliefs`` uses the entity path (`<Account>/../<Sensor>`) in case of duplicated sensors [see `PR #1026 <https://github.com/FlexMeasures/flexmeasures/pull/1026/>`_]
 * Add ``--resolution`` option to ``flexmeasures show chart`` to produce charts in different time resolutions [see `PR #1007 <https://github.com/FlexMeasures/flexmeasures/pull/1007/>`_]
 * Add ``FLEXMEASURES_JSON_COMPACT`` config setting and deprecate ``JSONIFY_PRETTYPRINT_REGULAR`` setting [see `PR #1090 <https://github.com/FlexMeasures/flexmeasures/pull/1090/>`_]
-* Removed deprecated ``app.schedulers`` and ``app.forecasters`` (use ``app.data_generators["scheduler"]`` and ``app.data_generators["forecaster"]`` instead) [see `PR #1098 <https://github.com/FlexMeasures/flexmeasures/pull/1098/>`_]
-* Add new annotation types: ``"error"`` and ``"warning"`` [see `PR #1131 <https://github.com/FlexMeasures/flexmeasures/pull/1131>`_]
 
 Bugfixes
 -----------
 * Fix ordering of jobs on the asset status page [see `PR #1106 <https://github.com/FlexMeasures/flexmeasures/pull/1106>`_]
 * Relax max staleness for status page using 2 * event_resolution as default instead of immediate staleness [see `PR #1108 <https://github.com/FlexMeasures/flexmeasures/pull/1108>`_]
-* Fix missing value on spring :abbr:`DST (Daylight Saving Time)` transition for ``PandasReporter`` using daily sensor as input [see `PR #1122 <https://github.com/FlexMeasures/flexmeasures/pull/1122>`_]
-* Allow reassigning a public asset to private ownership using the ``flexmeasures edit transfer-ownership`` CLI command [see `PR #1123 <https://github.com/FlexMeasures/flexmeasures/pull/1123>`_]
 
 
 v0.21.0 | May 16, 2024

--- a/flexmeasures/data/migrations/versions/3eb0564948ca_add_search_index_for_single_belief_.py
+++ b/flexmeasures/data/migrations/versions/3eb0564948ca_add_search_index_for_single_belief_.py
@@ -1,0 +1,29 @@
+"""add search index for single-belief search
+
+Revision ID: 3eb0564948ca
+Revises: 126d65cbe6b4
+Create Date: 2024-05-12 15:45:25.337949
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "3eb0564948ca"
+down_revision = "126d65cbe6b4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("timed_belief", schema=None) as batch_op:
+        batch_op.create_index(
+            "timed_belief_search_session_singleevent_idx",
+            ["event_start", "sensor_id"],
+            unique=False,
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("timed_belief", schema=None) as batch_op:
+        batch_op.drop_index("timed_belief_search_session_singleevent_idx")

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -332,10 +332,10 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
         :param beliefs_before: only return beliefs formed before this datetime (inclusive)
         :param horizons_at_least: only return beliefs with a belief horizon equal or greater than this timedelta (for example, use timedelta(0) to get ante knowledge time beliefs)
         :param horizons_at_most: only return beliefs with a belief horizon equal or less than this timedelta (for example, use timedelta(0) to get post knowledge time beliefs)
-        :param source: search only beliefs by this source (pass the DataSource, or its name or id) or list of sources
+        :param source: search only beliefs by this source (pass the DataSource, or its name or id) or list of sources. Without this set and a most recent parameter used (see below), the results can be of any source.
         :param most_recent_beliefs_only: only return the most recent beliefs for each event from each source (minimum belief horizon). Defaults to True.
-        :param most_recent_events_only: only return (post knowledge time) beliefs for the most recent event (maximum event start)
-        :param most_recent_only: only return a single belief, the most recent from the most recent event. Fastest method if you only need one.
+        :param most_recent_events_only: only return (post knowledge time) beliefs for the most recent event (maximum event start). Defaults to False.
+        :param most_recent_only: only return a single belief, the most recent from the most recent event. Fastest method if you only need one. Defaults to False. To use, also set most_recent_beliefs_only=False. Use with care when data uses cumulative probability (more than one belief per event_start and horizon).
         :param one_deterministic_belief_per_event: only return a single value per event (no probabilistic distribution and only 1 source)
         :param one_deterministic_belief_per_event_per_source: only return a single value per event per source (no probabilistic distribution)
         :param as_json: return beliefs in JSON format (e.g. for use in charts) rather than as BeliefsDataFrame

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -316,7 +316,7 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
         | None = None,
         most_recent_beliefs_only: bool = True,
         most_recent_events_only: bool = False,
-        most_recent_only: bool = None,  # deprecated
+        most_recent_only: bool = False,
         one_deterministic_belief_per_event: bool = False,
         one_deterministic_belief_per_event_per_source: bool = False,
         as_json: bool = False,
@@ -333,22 +333,15 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
         :param horizons_at_least: only return beliefs with a belief horizon equal or greater than this timedelta (for example, use timedelta(0) to get ante knowledge time beliefs)
         :param horizons_at_most: only return beliefs with a belief horizon equal or less than this timedelta (for example, use timedelta(0) to get post knowledge time beliefs)
         :param source: search only beliefs by this source (pass the DataSource, or its name or id) or list of sources
-        :param most_recent_beliefs_only: only return the most recent beliefs for each event from each source (minimum belief horizon)
+        :param most_recent_beliefs_only: only return the most recent beliefs for each event from each source (minimum belief horizon). Defaults to True.
         :param most_recent_events_only: only return (post knowledge time) beliefs for the most recent event (maximum event start)
+        :param most_recent_only: only return a single belief, the most recent from the most recent event. Fastest method if you only need one.
         :param one_deterministic_belief_per_event: only return a single value per event (no probabilistic distribution and only 1 source)
         :param one_deterministic_belief_per_event_per_source: only return a single value per event per source (no probabilistic distribution)
         :param as_json: return beliefs in JSON format (e.g. for use in charts) rather than as BeliefsDataFrame
         :param resolution: optionally set the resolution of data being displayed
         :returns: BeliefsDataFrame or JSON string (if as_json is True)
         """
-        # todo: deprecate the 'most_recent_only' argument in favor of 'most_recent_beliefs_only' (announced v0.8.0)
-        most_recent_beliefs_only = tb_utils.replace_deprecated_argument(
-            "most_recent_only",
-            most_recent_only,
-            "most_recent_beliefs_only",
-            most_recent_beliefs_only,
-            required_argument=False,
-        )
         bdf = TimedBelief.search(
             sensors=self,
             event_starts_after=event_starts_after,
@@ -360,6 +353,7 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
             source=source,
             most_recent_beliefs_only=most_recent_beliefs_only,
             most_recent_events_only=most_recent_events_only,
+            most_recent_only=most_recent_only,
             one_deterministic_belief_per_event=one_deterministic_belief_per_event,
             one_deterministic_belief_per_event_per_source=one_deterministic_belief_per_event_per_source,
             resolution=resolution,
@@ -647,7 +641,7 @@ class TimedBelief(db.Model, tb.TimedBeliefDBMixin):
         exclude_source_types: list[str] | None = None,
         most_recent_beliefs_only: bool = True,
         most_recent_events_only: bool = False,
-        most_recent_only: bool = None,  # deprecated
+        most_recent_only: bool = False,
         one_deterministic_belief_per_event: bool = False,
         one_deterministic_belief_per_event_per_source: bool = False,
         resolution: str | timedelta = None,
@@ -668,8 +662,9 @@ class TimedBelief(db.Model, tb.TimedBeliefDBMixin):
         :param user_source_ids: Optional list of user source ids to query only specific user sources
         :param source_types: Optional list of source type names to query only specific source types *
         :param exclude_source_types: Optional list of source type names to exclude specific source types *
-        :param most_recent_beliefs_only: only return the most recent beliefs for each event from each source (minimum belief horizon)
+        :param most_recent_beliefs_only: only return the most recent beliefs for each event from each source (minimum belief horizon). Defaults to True.
         :param most_recent_events_only: only return (post knowledge time) beliefs for the most recent event (maximum event start)
+        :param most_recent_only: only return a single belief, the most recent from the most recent event. Fastest method if you only need one.
         :param one_deterministic_belief_per_event: only return a single value per event (no probabilistic distribution and only 1 source)
         :param one_deterministic_belief_per_event_per_source: only return a single value per event per source (no probabilistic distribution)
         :param resolution: Optional timedelta or pandas freqstr used to resample the results **
@@ -688,14 +683,6 @@ class TimedBelief(db.Model, tb.TimedBeliefDBMixin):
             sensor,
             "sensors",
             sensors,
-        )
-        # todo: deprecate the 'most_recent_only' argument in favor of 'most_recent_beliefs_only' (announced v0.8.0)
-        most_recent_beliefs_only = tb_utils.replace_deprecated_argument(
-            "most_recent_only",
-            most_recent_only,
-            "most_recent_beliefs_only",
-            most_recent_beliefs_only,
-            required_argument=False,
         )
 
         # convert to list
@@ -731,6 +718,7 @@ class TimedBelief(db.Model, tb.TimedBeliefDBMixin):
                 source=parsed_sources,
                 most_recent_beliefs_only=most_recent_beliefs_only,
                 most_recent_events_only=most_recent_events_only,
+                most_recent_only=most_recent_only,
                 custom_filter_criteria=source_criteria,
                 custom_join_targets=custom_join_targets,
             )

--- a/requirements/3.10/app.txt
+++ b/requirements/3.10/app.txt
@@ -323,7 +323,7 @@ tabulate==0.9.0
     # via -r requirements/app.in
 threadpoolctl==3.4.0
     # via scikit-learn
-timely-beliefs[forecast]==2.3.0
+timely-beliefs[forecast]==3.0.0
     # via -r requirements/app.in
 timetomodel==0.7.3
     # via -r requirements/app.in

--- a/requirements/3.11/app.txt
+++ b/requirements/3.11/app.txt
@@ -321,7 +321,7 @@ tabulate==0.9.0
     # via -r requirements/app.in
 threadpoolctl==3.4.0
     # via scikit-learn
-timely-beliefs[forecast]==2.3.0
+timely-beliefs[forecast]==3.0.0
     # via -r requirements/app.in
 timetomodel==0.7.3
     # via -r requirements/app.in

--- a/requirements/3.8/app.txt
+++ b/requirements/3.8/app.txt
@@ -336,7 +336,7 @@ tabulate==0.9.0
     # via -r requirements/app.in
 threadpoolctl==3.4.0
     # via scikit-learn
-timely-beliefs[forecast]==2.3.0
+timely-beliefs[forecast]==3.0.0
     # via -r requirements/app.in
 timetomodel==0.7.3
     # via -r requirements/app.in

--- a/requirements/3.9/app.txt
+++ b/requirements/3.9/app.txt
@@ -326,7 +326,7 @@ tabulate==0.9.0
     # via -r requirements/app.in
 threadpoolctl==3.4.0
     # via scikit-learn
-timely-beliefs[forecast]==2.3.0
+timely-beliefs[forecast]==3.0.0
     # via -r requirements/app.in
 timetomodel==0.7.3
     # via -r requirements/app.in

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -35,7 +35,7 @@ pyomo>=5.6
 tabulate
 timetomodel>=0.7.3
 # significantly faster db queries
-timely-beliefs[forecast]>=2.2
+timely-beliefs[forecast]>=3.0
 python-dotenv
 # a backport, not needed in Python3.8
 importlib_metadata


### PR DESCRIPTION
## Description

Support `most_recent_only`, including a new index for it. This is most helpful for the status page, where we only want to look up the most recent event.
This PR also stops a previous, very old, deprecation of the same name.

See https://github.com/SeitaBV/timely-beliefs/pull/179 for more info.

## Look & Feel

If the status page lists a couple sensors, the speed difference should be palpable.

In tests, I saw search time drop from 300 milliseconds to below 30 milliseconds (only when adding the index, though)

## How to test

Here is my test code in the FlexMeasures shell. Pick any sensor that has significant data.

First test with sensor 4, a sensor with 250K rows (not too many) and only one source, convenient to test with no other filters (like `source`).

```
± flexmeasures shell
>>> from flexmeasures.data.models.time_series import Sensor
>>> from datetime import datetime
>>> s4 = Sensor.query.get(4)
>>> # testing how it was before this PR when querying one row, this was ca. 300ms 
>>> time1 = datetime.now(); s4.search_beliefs(most_recent_events_only=True, most_recent_beliefs_only=True); print(f"Time: {datetime.now()-time1}") 
>>> # testing this PR's new fast track. 20-30 ms with the index (was up to 400 without).
>>> time1 = datetime.now(); s4.search_beliefs(most_recent_only=True, most_recent_beliefs_only=False); print(f"Time: {datetime.now()-time1}") 
```

Now I tested with a sensor which has millions of records (sensor 5), and to begin with we select the data source which is responsible for most of them (44, Seita scheduler):

```
>>> from flexmeasures.data.models.time_series import Sensor
>>> from flexmeasures.data.models.data_sources import DataSource
>>> from datetime import datetime
>>> s5 = Sensor.query.get(5)
>>> ds12 = DataSource.query.get(12)
>>> # Here, the two approaches are the same, as we tell the query which data source to use. Both need ca 250ms 
>>> time1 = datetime.now(); s5.search_beliefs(most_recent_events_only=True, most_recent_beliefs_only=True, source=ds12); print(f"Time: {datetime.now()-time1}")
>>> time1 = datetime.now(); s5.search_beliefs(most_recent_only=True, most_recent_beliefs_only=False, source=ds12); print(f"Time: {datetime.now()-time1}")
>>> # Now we leave out the data source, the first query is 1.5 seconds and returns 5 rows, one per data source
>>> time1 = datetime.now(); s5.search_beliefs(most_recent_events_only=True, most_recent_beliefs_only=True); print(f"Time: {datetime.now()-time1}")
>>> # The new-style query with the data source manages it in ca 265ms
>>> time1 = datetime.now(); s5.search_beliefs(most_recent_only=True, most_recent_beliefs_only=False, ds=ds12); print(f"Time: {datetime.now()-time1}")
>>> # Interesting: when we leave the data source out from the new-style query, we go down to ca 15ms(!!) as the index fits exactly. In this example, it also happens to be the same row
>>> time1 = datetime.now(); s5.search_beliefs(most_recent_only=True, most_recent_beliefs_only=False); print(f"Time: {datetime.now()-time1}")
``` 

I cannot explain all differences at the moment, but giving a source changes the setup.
Adding a source to the index stops applying to the first case (sensor 4).
I can't go further with this than where I am now. 
