### PR TITLE
Use 2 times sensor resolution instead of instant staleness as default

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -27,6 +27,7 @@ Infrastructure / Support
 Bugfixes
 -----------
 * Fix ordering of jobs on the asset status page [see `PR #1106 <https://github.com/FlexMeasures/flexmeasures/pull/1106>`_]
+* Relax max staleness for status page using 2 * event_resolution as default instead of immediate staleness [see `PR #1108 <https://github.com/FlexMeasures/flexmeasures/pull/1108>`_]
 
 
 v0.21.0 | May 16, 2024

--- a/flexmeasures/api/common/schemas/tests/test_sensor_data_schema.py
+++ b/flexmeasures/api/common/schemas/tests/test_sensor_data_schema.py
@@ -258,6 +258,46 @@ def test_get_status(
     assert sensor_status["stale"] == expected_stale
 
 
+@pytest.mark.parametrize(
+    "now, expected_staleness, expected_stale, expected_stale_reason",
+    [
+        # sensor resolution is 15 min
+        (
+            # Last event start at 2016-01-02T07:45+01, with knowledge time 2016-01-02T08:00+01, 29 minutes ago
+            "2016-01-02T08:29+01",
+            timedelta(minutes=29),
+            False,
+            "not more than 30 minutes old",
+        ),
+        (
+            # Last event start at 2016-01-02T07:45+01, with knowledge time 2016-01-02T08:00+01, 31 minutes ago
+            "2016-01-02T08:31+01",
+            timedelta(minutes=31),
+            True,
+            "more than 30 minutes old",
+        ),
+    ],
+)
+def test_get_status_no_status_specs(
+    capacity_sensors,
+    now,
+    expected_staleness,
+    expected_stale,
+    expected_stale_reason,
+):
+    sensor = capacity_sensors["production"]
+    now = pd.Timestamp(now)
+    sensor_status = get_status(
+        sensor=sensor,
+        status_specs=None,
+        now=now,
+    )
+
+    assert sensor_status["staleness"] == expected_staleness
+    assert sensor_status["stale"] == expected_stale
+    assert sensor_status["reason"] == expected_stale_reason
+
+
 def test_build_asset_status_data(mock_get_status, add_weather_sensors):
     asset = add_weather_sensors["asset"]
 

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -4,6 +4,7 @@ import json
 import hashlib
 from datetime import datetime, timedelta
 from flask import current_app
+from isodate import duration_isoformat
 from timely_beliefs import BeliefsDataFrame
 
 from humanize.time import naturaldelta
@@ -127,8 +128,11 @@ def get_status_specs(sensor: Sensor) -> dict:
         if sensor.knowledge_horizon_fnc == "x_days_ago_at_y_oclock":
             status_specs = {"staleness_search": {}, "max_staleness": "P1D"}
         else:
-            # Default to status specs indicating immediate staleness after knowledge time
-            status_specs = {"staleness_search": {}, "max_staleness": "PT0H"}
+            # Default to status specs indicating staleness after knowledge time + 2 sensor resolutions
+            status_specs = {
+                "staleness_search": {},
+                "max_staleness": duration_isoformat(sensor.event_resolution * 2),
+            }
     return status_specs
 
 


### PR DESCRIPTION
## Description

Right now, the max_staleness for non-future sensors defaults to PT0H ("immediate staleness after knowledge time", see data/services/sensors.py:get_status_specs).

The consequence is that we show red lights a bit too eagerly, I believe. Hovering over a red traffic light (even green ones) says "More than a moment old". This should be more informative.

I suggest changing the default to adding 2 times the resolution.

## Look & Feel

You should start getting "More than a [event_resolution * 2] old" instead of "More than a moment old" for sensors without status_specs in attributes when hovering over traffic light.

## How to test

Open status page for an asset with some sensor without status_specs in attributes. This sensor should also have some data in db. Hover over corresponding green / red lamp and verify that you get "More than a [event_resolution * 2] old" instead of "More than a moment old".

## Further Improvements

-

## Related Items

-

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
