### PR TITLE
Add MailHog to Docker Compose for Local Email Testing and Remove Version Directive

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,3 @@
-version: "3.4"
-
-# ------------------------------------------------------------------
-# This runs your local FlexMeasures code in a docker compose stack.
-# Two FlexMeasures instances are spun up, one for serving the web
-# UI & API, one to work on computation jobs.
-# The server is adding a toy account when it starts.
-# (user: toy-user@flexmeasures.io, password: toy-password)
-# 
-# Instead of local code (which is useful for development purposes),
-# you can also use the official (and stable) FlexMeasures docker image
-# (lfenergy/flexmeasures). Replace the two `build` directives with
-# an `image` directive.
-# ------------------------------------------------------------------
-
 services:
   dev-db:
     image: postgres
@@ -35,6 +20,12 @@ services:
       - redis-cache:/data
     environment:
      - REDIS_REPLICATION_MODE=master
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+    restart: always
   server:
     build:
       context: .
@@ -45,6 +36,7 @@ services:
       - dev-db
       - test-db  # use -e SQLALCHEMY_TEST_DATABASE_URI=... to exec pytest
       - queue-db
+      - mailhog  # Added MailHog dependency
     restart: on-failure
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000/api/v3_0/health/ready"]
@@ -58,6 +50,8 @@ services:
       FLEXMEASURES_ENV: development
       FLEXMEASURES_REDIS_URL: queue-db
       FLEXMEASURES_REDIS_PASSWORD: fm-redis-pass
+      MAIL_SERVER: mailhog  # MailHog mail server
+      MAIL_PORT: 1025       # MailHog mail port
       LOGGING_LEVEL: INFO
     volumes:
       # a place for config and plugin code, and custom requirements.txt
@@ -85,6 +79,8 @@ services:
       FLEXMEASURES_REDIS_PASSWORD: fm-redis-pass
       SECRET_KEY: notsecret
       FLEXMEASURES_ENV: development
+      MAIL_SERVER: mailhog  # MailHog mail server
+      MAIL_PORT: 1025       # MailHog mail port
       LOGGING_LEVEL: INFO 
     volumes:
       # a place for config and plugin code, and custom requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,16 @@
+# ------------------------------------------------------------------
+# This runs your local FlexMeasures code in a docker compose stack.
+# Two FlexMeasures instances are spun up, one for serving the web
+# UI & API, one to work on computation jobs.
+# The server is adding a toy account when it starts.
+# (user: toy-user@flexmeasures.io, password: toy-password)
+# 
+# Instead of local code (which is useful for development purposes),
+# you can also use the official (and stable) FlexMeasures docker image
+# (lfenergy/flexmeasures). Replace the two `build` directives with
+# an `image` directive.
+# ------------------------------------------------------------------
+
 services:
   dev-db:
     image: postgres

--- a/documentation/dev/docker-compose.rst
+++ b/documentation/dev/docker-compose.rst
@@ -46,12 +46,13 @@ Check ``docker ps`` or ``docker-compose ps`` to see if your containers are runni
 .. code-block:: bash
 
     $ docker ps
-    CONTAINER ID   IMAGE                 COMMAND                  CREATED          STATUS                             PORTS                    NAMES
-    beb9bf567303   flexmeasures_server   "bash -c 'flexmeasur…"   44 seconds ago   Up 38 seconds (health: starting)   0.0.0.0:5000->5000/tcp   flexmeasures-server-1
-    e36cd54a7fd5   flexmeasures_worker   "flexmeasures jobs r…"   44 seconds ago   Up 5 seconds                       5000/tcp                 flexmeasures-worker-1
-    c9985de27f68   postgres              "docker-entrypoint.s…"   45 seconds ago   Up 40 seconds                      5432/tcp                 flexmeasures-test-db-1
-    03582d37230e   postgres              "docker-entrypoint.s…"   45 seconds ago   Up 40 seconds                      5432/tcp                 flexmeasures-dev-db-1
-    792ec3d86e71   redis                 "docker-entrypoint.s…"   45 seconds ago   Up 40 seconds                      0.0.0.0:6379->6379/tcp   flexmeasures-queue-db-1
+    CONTAINER ID   IMAGE                 COMMAND                  CREATED          STATUS                             PORTS                                            NAMES
+    beb9bf567303   flexmeasures_server   "bash -c 'flexmeasur…"   44 seconds ago   Up 38 seconds (health: starting)   0.0.0.0:5000->5000/tcp                           flexmeasures-server-1
+    e36cd54a7fd5   flexmeasures_worker   "flexmeasures jobs r…"   44 seconds ago   Up 5 seconds                       5000/tcp                                         flexmeasures-worker-1
+    c9985de27f68   postgres              "docker-entrypoint.s…"   45 seconds ago   Up 40 seconds                      5432/tcp                                         flexmeasures-test-db-1
+    03582d37230e   postgres              "docker-entrypoint.s…"   45 seconds ago   Up 40 seconds                      5432/tcp                                         flexmeasures-dev-db-1
+    25024ada1590   mailhog/mailhog       "MailHog"                45 seconds ago   Up 40 seconds                      0.0.0.0:1025->1025/tcp, 0.0.0.0:8025->8025/tcp   flexmeasures-mailhog-1
+    792ec3d86e71   redis                 "docker-entrypoint.s…"   45 seconds ago   Up 40 seconds                      0.0.0.0:6379->6379/tcp                           flexmeasures-queue-db-1
 
 
 The FlexMeasures server container has a health check implemented, which is reflected in this output and you can see which ports are available on your machine to interact.
@@ -146,6 +147,12 @@ Like in the original toy tutorial, we can also check in the server container's `
 .. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/sensor-data-charging.png
     :align: center
 
+Email Testing
+----------------------------------
+
+To test email functionality, MailHog is included in the Docker Compose stack. You can view the emails sent by the application by navigating to http://localhost:8025/ in your browser.
+
+To verify this setup, try changing a user's password in the application. This action will trigger an email, which you can then view in `MailHog <http://localhost:8025/>`_.
 
 Scripting with the Docker stack
 ----------------------------------

--- a/documentation/dev/setup-and-guidelines.rst
+++ b/documentation/dev/setup-and-guidelines.rst
@@ -166,6 +166,18 @@ A rolling log file handler is used, so if ``flexmeasures.log`` gets to a few meg
 The default logging level is ``WARNING``. To see more, you can update this with the config setting ``LOGGING_LEVEL``, e.g. to ``INFO`` or ``DEBUG``
 
 
+Mocking an Email Server for Development
+--------------------------------
+
+To handle emails locally during development, you can use MailHog. Follow these steps to set it up:
+
+.. code-block:: bash
+
+   $ docker run -p 8025:8025 -p 1025:1025 --name mailhog mailhog/mailhog
+   $ export MAIL_PORT=1025  # Add this to your local flexmeasures.cfg
+
+Now, emails (e.g., password-reset) are being sent via this local server. Go to http://localhost:8025.
+
 Tests
 -----
 
@@ -304,3 +316,4 @@ I added this to my ~/.bashrc, so I only need to type ``fm`` to get started and h
 
 
 .. note:: All paths depend on your local environment, of course.
+


### PR DESCRIPTION
## Description

- Updated docker-compose.yml to add MailHog service for local email testing.
        - Added the mailhog service with ports 1025 and 8025.
        - Set MAIL_SERVER and MAIL_PORT environment variables for the server and worker services.
- Removed version directive from the docker-compose.yml.
- Added a section "Mocking an Email Server for Development" to setup-and-guideline.rst.
- Updated docker-compose.rst with documentation for using MailHog.

## Look & Feel

Access the MailHog web interface at http://localhost:8025/ to view sent emails 

## How to test

- Start the Docker Compose stack
- Trigger an email action in the application (e.g., password reset).
- Open http://localhost:8025/ to verify the email is received by MailHog.
 
## Further Improvements

Potential improvements to be done in the same PR or follow up Issues/Discussions/PRs.

## Related Items

Closes Issue #1051

---

- [ ] I agree to contribute to the project under Apache 2 License. 
- [ ] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
