### PR TITLE
Basic sensor info to sensor page

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -3,6 +3,20 @@
 FlexMeasures Changelog
 **********************
 
+v0.23.0 | July XX, 2024
+============================
+
+New features
+-------------
+* Add basic sensor info to sensor page [see `PR #1115 <https://github.com/FlexMeasures/flexmeasures/pull/1115>`_]
+
+Infrastructure / Support
+----------------------
+
+Bugfixes
+-----------
+
+
 v0.22.0 | June 29, 2024
 ============================
 

--- a/flexmeasures/ui/static/css/flexmeasures.css
+++ b/flexmeasures/ui/static/css/flexmeasures.css
@@ -1950,3 +1950,12 @@ body.touched [title]:hover:after {
     padding: 20px;
 }
 
+/* sensor-basic-info */
+.sensor-basic-info-container {
+    display: flex;
+}
+
+.sensor-basic-info {
+    flex: 1;
+    max-width: 50%;
+}

--- a/flexmeasures/ui/static/css/flexmeasures.css
+++ b/flexmeasures/ui/static/css/flexmeasures.css
@@ -1949,13 +1949,3 @@ body.touched [title]:hover:after {
 .table-responsive{
     padding: 20px;
 }
-
-/* sensor-basic-info */
-.sensor-basic-info-container {
-    display: flex;
-}
-
-.sensor-basic-info {
-    flex: 1;
-    max-width: 50%;
-}

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -329,9 +329,9 @@
         var dataDevPath = '/api/dev/asset/' + {{ asset.id }};
         var datasetName = 'asset_' + {{ asset.id }};
     {% elif active_page == "sensors" %}
-        var dataPath = '/api/dev/sensor/' + {{ sensor_id }};
-        var dataDevPath = '/api/dev/sensor/' + {{ sensor_id }};
-        var datasetName = 'sensor_' + {{ sensor_id }};
+        var dataPath = '/api/dev/sensor/' + {{ sensor.id }};
+        var dataDevPath = '/api/dev/sensor/' + {{ sensor.id }};
+        var datasetName = 'sensor_' + {{ sensor.id }};
     {% endif %}
     var elementId = 'sensorchart';
     var chartSpecsPath = dataPath + '/chart?';

--- a/flexmeasures/ui/templates/views/sensors.html
+++ b/flexmeasures/ui/templates/views/sensors.html
@@ -33,48 +33,26 @@
               <div class="alert alert-info" id="dstwarn" style="display:none;"></div>
               <div class="alert alert-info" id="sourcewarn" style="display:none;"></div>
           </div>
-          <style>
-            .container {
-                display: flex;
-            }
-
-            .sensor-basic-info {
-                flex: 1;
-                max-width: 50%;
-            }
-
-            .sensor-data {
-                flex: 1;
-            }
-        </style>
-          <div class="container">
+          <div class="sensor-basic-info-container">
             <div class="sensor-basic-info">
                 <h3>Sensor '{{ sensor["name"] }}' info</h3>
                 <table class="table table-striped">
-                    <thead>
-                        <tr>
-                            <th>Unit</th>
-                            <th>Event resolution</th>
-                            <th>Timezone</th>
-                            <th>Knowledge horizon type</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr title="View data">
-                            <td>
-                                {{ sensor.unit }}
-                            </td>
-                            <td>
-                                {{ sensor.event_resolution }}
-                            </td>
-                            <td>
-                                {{ sensor.timezone }}
-                            </td>
-                            <td>
-                                {{ sensor.knowledge_horizon_fnc }}
-                            </td>
-                        </tr>
-                    </tbody>
+                    <tr>
+                        <th>Unit</th>
+                        <td>{{ sensor.unit }}</td>
+                    </tr>
+                    <tr>
+                        <th>Event resolution</th>
+                        <td>{{ sensor.event_resolution }}</td>
+                    </tr>
+                    <tr>
+                        <th>Timezone</th>
+                        <td>{{ sensor.timezone }}</td>
+                    </tr>
+                    <tr>
+                        <th>Knowledge horizon type</th>
+                        <td>{{ sensor.knowledge_horizon_fnc }}</td>
+                    </tr>
                 </table>
             </div>
           </div>

--- a/flexmeasures/ui/templates/views/sensors.html
+++ b/flexmeasures/ui/templates/views/sensors.html
@@ -35,8 +35,9 @@
           </div>
           <div class="container">
             <div class="row">
+                <h3>{{ sensor.name }}</h3>
                 <div class="col-sm-6">
-                    <h3>Properties</h3>
+                    <h5>Properties</h5>
 
                     <table class="table table-striped">
                         <tr>

--- a/flexmeasures/ui/templates/views/sensors.html
+++ b/flexmeasures/ui/templates/views/sensors.html
@@ -33,6 +33,51 @@
               <div class="alert alert-info" id="dstwarn" style="display:none;"></div>
               <div class="alert alert-info" id="sourcewarn" style="display:none;"></div>
           </div>
+          <style>
+            .container {
+                display: flex;
+            }
+
+            .sensor-basic-info {
+                flex: 1;
+                max-width: 50%;
+            }
+
+            .sensor-data {
+                flex: 1;
+            }
+        </style>
+          <div class="container">
+            <div class="sensor-basic-info">
+                <h3>Sensor '{{ sensor["name"] }}' info</h3>
+                <table class="table table-striped">
+                    <thead>
+                        <tr>
+                            <th>Unit</th>
+                            <th>Event resolution</th>
+                            <th>Timezone</th>
+                            <th>Knowledge horizon type</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr title="View data">
+                            <td>
+                                {{ sensor.unit }}
+                            </td>
+                            <td>
+                                {{ sensor.event_resolution }}
+                            </td>
+                            <td>
+                                {{ sensor.timezone }}
+                            </td>
+                            <td>
+                                {{ sensor.knowledge_horizon_fnc }}
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+          </div>
           <div class="row on-top-md">
               <div class="col-sm-2">
                   <div class="sidepanel-container">

--- a/flexmeasures/ui/templates/views/sensors.html
+++ b/flexmeasures/ui/templates/views/sensors.html
@@ -33,9 +33,10 @@
               <div class="alert alert-info" id="dstwarn" style="display:none;"></div>
               <div class="alert alert-info" id="sourcewarn" style="display:none;"></div>
           </div>
-          <div class="sensor-basic-info-container">
-            <div class="sensor-basic-info">
+          <div class="container">
+            <div class="row">
                 <h3>Sensor '{{ sensor["name"] }}' info</h3>
+
                 <table class="table table-striped">
                     <tr>
                         <th>Unit</th>

--- a/flexmeasures/ui/templates/views/sensors.html
+++ b/flexmeasures/ui/templates/views/sensors.html
@@ -35,7 +35,7 @@
           </div>
           <div class="container">
             <div class="row">
-                <h3>Sensor '{{ sensor["name"] }}' info</h3>
+                <h3>Sensor '{{ sensor["name"] }}'</h3>
 
                 <table class="table table-striped">
                     <tr>

--- a/flexmeasures/ui/templates/views/sensors.html
+++ b/flexmeasures/ui/templates/views/sensors.html
@@ -35,7 +35,7 @@
           </div>
           <div class="container">
             <div class="row">
-                <h3>Sensor '{{ sensor["name"] }}'</h3>
+                <h3>Properties</h3>
 
                 <table class="table table-striped">
                     <tr>
@@ -43,7 +43,7 @@
                         <td>{{ sensor.unit }}</td>
                     </tr>
                     <tr>
-                        <th>Event resolution</th>
+                        <th>Event Resolution</th>
                         <td>{{ sensor.event_resolution }}</td>
                     </tr>
                     <tr>
@@ -51,7 +51,7 @@
                         <td>{{ sensor.timezone }}</td>
                     </tr>
                     <tr>
-                        <th>Knowledge horizon type</th>
+                        <th>Knowledge Horizon Type</th>
                         <td>{{ sensor.knowledge_horizon_fnc }}</td>
                     </tr>
                 </table>

--- a/flexmeasures/ui/templates/views/sensors.html
+++ b/flexmeasures/ui/templates/views/sensors.html
@@ -35,26 +35,28 @@
           </div>
           <div class="container">
             <div class="row">
-                <h3>Properties</h3>
+                <div class="col-sm-6">
+                    <h3>Properties</h3>
 
-                <table class="table table-striped">
-                    <tr>
-                        <th>Unit</th>
-                        <td>{{ sensor.unit }}</td>
-                    </tr>
-                    <tr>
-                        <th>Event Resolution</th>
-                        <td>{{ sensor.event_resolution }}</td>
-                    </tr>
-                    <tr>
-                        <th>Timezone</th>
-                        <td>{{ sensor.timezone }}</td>
-                    </tr>
-                    <tr>
-                        <th>Knowledge Horizon Type</th>
-                        <td>{{ sensor.knowledge_horizon_fnc }}</td>
-                    </tr>
-                </table>
+                    <table class="table table-striped">
+                        <tr>
+                            <th>Unit</th>
+                            <td>{{ sensor.unit }}</td>
+                        </tr>
+                        <tr>
+                            <th>Event Resolution</th>
+                            <td>{{ sensor.event_resolution }}</td>
+                        </tr>
+                        <tr>
+                            <th>Timezone</th>
+                            <td>{{ sensor.timezone }}</td>
+                        </tr>
+                        <tr>
+                            <th>Knowledge Horizon Type</th>
+                            <td>{{ sensor.knowledge_horizon_fnc }}</td>
+                        </tr>
+                    </table>
+                </div>
             </div>
           </div>
           <div class="row on-top-md">

--- a/flexmeasures/ui/views/sensors.py
+++ b/flexmeasures/ui/views/sensors.py
@@ -79,7 +79,6 @@ class SensorUI(FlaskView):
         sensor = db.session.get(Sensor, id)
         return render_flexmeasures_template(
             "views/sensors.html",
-            sensor_id=id,
             msg="",
             breadcrumb_info=get_breadcrumb_info(sensor),
             event_starts_after=request.args.get("start_time"),

--- a/flexmeasures/ui/views/sensors.py
+++ b/flexmeasures/ui/views/sensors.py
@@ -76,11 +76,13 @@ class SensorUI(FlaskView):
          - start_time: minimum time of the events to be shown
          - end_time: maximum time of the events to be shown
         """
+        sensor = db.session.get(Sensor, id)
         return render_flexmeasures_template(
             "views/sensors.html",
             sensor_id=id,
             msg="",
-            breadcrumb_info=get_breadcrumb_info(db.session.get(Sensor, id)),
+            breadcrumb_info=get_breadcrumb_info(sensor),
             event_starts_after=request.args.get("start_time"),
             event_ends_before=request.args.get("end_time"),
+            sensor=sensor,
         )


### PR DESCRIPTION
## Description

Right now, the sensor page only displays a chart.
We should add some basic info on top, in a blueish info box or so: Name (as heading), unit, resolution, timezone, knowledge horizon.

## Look & Feel

Table with basic sensor info was added on top of sensor page.

## How to test

Open some sensor page, verify that you get table with basic sensor info on top of the page.

## Further Improvements

-

## Related Items

-

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
