### PR TITLE
A quick solution to be able to prevent the flex-context part of the asset form

### DIFF
--- a/documentation/configuration.rst
+++ b/documentation/configuration.rst
@@ -664,3 +664,12 @@ FLEXMEASURES_API_SUNSET_LINK
 Allow to override the default sunset link for your clients.
 
 Default: ``None`` (defaults are set internally for each sunset API version, e.g. ``"https://flexmeasures.readthedocs.io/en/v0.13.0/api/v2_0.html"`` for v2.0)
+
+FLEXMEASURES_HIDE_FLEXCONTEXT_EDIT
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Hide the part of the asset form which lets one edit flex context sensors. 
+Why? Loading the page can take long when the number of sensors is very high (e.g. due to many KPIs being reported).
+This is a temporary solution for this problem until a better design is made.
+
+Default: ``False``

--- a/flexmeasures/ui/crud/assets/forms.py
+++ b/flexmeasures/ui/crud/assets/forms.py
@@ -170,8 +170,13 @@ class AssetForm(FlaskForm):
         asset: GenericAsset,
         account_id: Optional[int],
     ) -> None:
-        self.with_price_senors(asset, account_id)
-        self.with_inflexible_sensors(asset, account_id)
+        if current_app.config.get("FLEXMEASURES_SHOW_FLEXCONTEXT_EDIT", True):
+            self.with_price_senors(asset, account_id)
+            self.with_inflexible_sensors(asset, account_id)
+        else:
+            del self.inflexible_device_sensor_ids
+            del self.production_price_sensor_id
+            del self.consumption_price_sensor_id
 
 
 class NewAssetForm(AssetForm):

--- a/flexmeasures/ui/crud/assets/forms.py
+++ b/flexmeasures/ui/crud/assets/forms.py
@@ -170,13 +170,13 @@ class AssetForm(FlaskForm):
         asset: GenericAsset,
         account_id: Optional[int],
     ) -> None:
-        if current_app.config.get("FLEXMEASURES_SHOW_FLEXCONTEXT_EDIT", True):
-            self.with_price_senors(asset, account_id)
-            self.with_inflexible_sensors(asset, account_id)
-        else:
+        if current_app.config.get("FLEXMEASURES_HIDE_FLEXCONTEXT_EDIT", False):
             del self.inflexible_device_sensor_ids
             del self.production_price_sensor_id
             del self.consumption_price_sensor_id
+        else:
+            self.with_price_senors(asset, account_id)
+            self.with_inflexible_sensors(asset, account_id)
 
 
 class NewAssetForm(AssetForm):

--- a/flexmeasures/ui/crud/assets/forms.py
+++ b/flexmeasures/ui/crud/assets/forms.py
@@ -127,7 +127,9 @@ class AssetForm(FlaskForm):
                 for account in db.session.scalars(select(Account)).all()
             ]
 
-    def with_price_senors(self, asset: GenericAsset, account_id: Optional[int]) -> None:
+    def with_price_sensors(
+        self, asset: GenericAsset, account_id: Optional[int]
+    ) -> None:
         allowed_price_sensor_data = get_allowed_price_sensor_data(account_id)
         for sensor_name in ("production_price", "consumption_price"):
             sensor_id = getattr(asset, sensor_name + "_sensor_id") if asset else None
@@ -175,7 +177,7 @@ class AssetForm(FlaskForm):
             del self.production_price_sensor_id
             del self.consumption_price_sensor_id
         else:
-            self.with_price_senors(asset, account_id)
+            self.with_price_sensors(asset, account_id)
             self.with_inflexible_sensors(asset, account_id)
 
 

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -137,6 +137,7 @@
                                             disabled></input>
                                     </div>
                                 </div>
+                                {% if asset_form.consumption_price_sensor_id or asset_form.production_price_sensor_id or asset_form.inflexible_device_sensor_ids %}
                                 <div class="form-group form-group-bordered">
                                     <p>Fields in this section can form part of this asset's <a href="https://flexmeasures.readthedocs.io/en/latest/features/scheduling.html#the-flex-context">flex context</a>. They can also be set in a parent asset or in API requests that trigger schedules.</p>
                                     {% if asset_form.consumption_price_sensor_id %}
@@ -173,6 +174,7 @@
                                         </div>
                                     {% endif %}
                                 </div>
+                                {% endif %}
                                 <div class="form-group">
                                     {{ asset_form.attributes.label(class="col-sm-3 control-label") }}
                                     <div class="col-md-3">

--- a/flexmeasures/ui/tests/test_assets_forms.py
+++ b/flexmeasures/ui/tests/test_assets_forms.py
@@ -45,7 +45,7 @@ from flexmeasures.ui.tests.test_utils import NewAsset
         ),
     ],
 )
-def test_with_price_senors(
+def test_with_price_sensors(
     db,
     setup_generic_asset_types,
     setup_accounts,
@@ -78,7 +78,7 @@ def test_with_price_senors(
             "flexmeasures.ui.crud.assets.forms.get_allowed_price_sensor_data",
             return_value=allowed_price_sensor_data,
         ) as mock_method:
-            form.with_price_senors(new_asset_decorator.test_battery, 1)
+            form.with_price_sensors(new_asset_decorator.test_battery, 1)
             assert mock_method.called_once_with(1)
             # check production_price_sensor only as consumption_price is processed the same way
             assert form.production_price_sensor_id.choices == expect_choices


### PR DESCRIPTION
…, in case the database has many sensors per account

## Description

We have seen that loading the page can take long when the number of sensors is very high (e.g. due to many KPIs being reported)

## Look & Feel

Loading of the page should be normal again.

## How to test

Set the config setting `FLEXMEASURES_HIDE_FLEXCONTEXT_EDIT` to `True`.

## Further Improvements

A real solution might move the form to its own page and also look into smarter solutions to load possible sensors (e.g. limit the number)

