### PR TITLE
Fix/assign ownership

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -32,6 +32,7 @@ Bugfixes
 * Fix ordering of jobs on the asset status page [see `PR #1106 <https://github.com/FlexMeasures/flexmeasures/pull/1106>`_]
 * Relax max staleness for status page using 2 * event_resolution as default instead of immediate staleness [see `PR #1108 <https://github.com/FlexMeasures/flexmeasures/pull/1108>`_]
 * Fix missing value on spring :abbr:`DST (Daylight Saving Time)` transition for ``PandasReporter`` using daily sensor as input [see `PR #1122 <https://github.com/FlexMeasures/flexmeasures/pull/1122>`_]
+* Allow reassigning a public asset to private ownership using the ``flexmeasures edit transfer-ownership`` CLI command [see `PR #1123 <https://github.com/FlexMeasures/flexmeasures/pull/1123>`_]
 
 
 v0.21.0 | May 16, 2024

--- a/flexmeasures/cli/data_edit.py
+++ b/flexmeasures/cli/data_edit.py
@@ -282,7 +282,9 @@ def transfer_ownership(asset: Asset, new_owner: Account):
     def transfer_ownership_recursive(asset: Asset, account: Account):
         AssetAuditLog.add_record(
             asset,
-            f"Transferred ownership for asset '{asset.name}': {asset.id} from '{asset.owner.name}': {asset.owner.id} to '{account.name}': {account.id}",
+            f"Transferred ownership for asset '{asset.name}': {asset.id} from '{asset.owner.name}': {asset.owner.id} to '{account.name}': {account.id}"
+            if asset.owner is not None
+            else f"Assign ownership to public asset '{asset.name}': {asset.id} to '{account.name}': {account.id}",
         )
 
         asset.owner = account

--- a/flexmeasures/cli/data_edit.py
+++ b/flexmeasures/cli/data_edit.py
@@ -282,7 +282,7 @@ def transfer_ownership(asset: Asset, new_owner: Account):
     def transfer_ownership_recursive(asset: Asset, account: Account):
         AssetAuditLog.add_record(
             asset,
-            f"Transfered ownership for asset '{asset.name}': {asset.id} from '{asset.owner.name}': {asset.owner.id} to '{account.name}': {account.id}",
+            f"Transferred ownership for asset '{asset.name}': {asset.id} from '{asset.owner.name}': {asset.owner.id} to '{account.name}': {account.id}",
         )
 
         asset.owner = account
@@ -291,7 +291,7 @@ def transfer_ownership(asset: Asset, new_owner: Account):
 
     transfer_ownership_recursive(asset, new_owner)
     click.secho(
-        f"Success! Asset `{asset}` ownership was transfered to account `{new_owner}`.",
+        f"Success! Asset `{asset}` ownership was transferred to account `{new_owner}`.",
         **MsgStyle.SUCCESS,
     )
 

--- a/flexmeasures/cli/tests/test_data_edit.py
+++ b/flexmeasures/cli/tests/test_data_edit.py
@@ -198,7 +198,7 @@ def test_transfer_ownership(app, db, add_asset_with_children, add_alternative_ac
         assert child.owner == new_account
 
     for child_asset in (parent, *parent.child_assets):
-        event = f"Transfered ownership for asset '{child_asset.name}': {child_asset.id} from '{old_account.name}': {old_account.id} to '{new_account.name}': {new_account.id}"
+        event = f"Transferred ownership for asset '{child_asset.name}': {child_asset.id} from '{old_account.name}': {old_account.id} to '{new_account.name}': {new_account.id}"
         assert db.session.execute(
             select(AssetAuditLog).filter_by(
                 affected_asset_id=child_asset.id,


### PR DESCRIPTION
## Description

Transferring ownership from a public asset to a private asset (i.e. assigning ownership) with the `flexmeasures edit transfer-ownership` CLI command failed on printing the name (and ID) of the current owner.
