### PR TITLE
Feature/merge time series schemas

### DIFF
--- a/documentation/api/change_log.rst
+++ b/documentation/api/change_log.rst
@@ -6,6 +6,33 @@ API change log
 .. note:: The FlexMeasures API follows its own versioning scheme. This is also reflected in the URL (e.g. `/api/v3_0`), allowing developers to upgrade at their own pace.
 
 
+v3.0-19 | 2024-08-09
+""""""""""""""""""""
+
+- Allow setting a SoC unit directly in some fields (formerly ``Float`` fields, and now ``Quantity`` fields), while still falling back on the contents of the ``soc-unit`` field, for backwards compatibility:
+
+  - ``soc-at-start``
+  - ``soc-min``
+  - ``soc-max``
+
+- Allow setting a unit directly in fields that already supported passing a time series:
+
+  - ``soc-maxima``
+  - ``soc-minima``
+  - ``soc-targets``
+
+- Allow passing a time series in fields that formerly only accepted passing a fixed quantity or a sensor reference:
+
+  - ``power-capacity``
+  - ``consumption-capacity``
+  - ``production-capacity``
+  - ``charging-efficiency``
+  - ``discharging-efficiency``
+  - ``storage-efficiency``
+  - ``soc-gain``
+  - ``soc-usage``
+
+
 v3.0-18 | 2024-03-07
 """"""""""""""""""""
 - Add support for providing a sensor definition to the ``soc-minima``, ``soc-maxima`` and ``soc-targets`` flex-model fields for `/sensors/<id>/schedules/trigger` (POST).

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -11,7 +11,7 @@ New features
 -------------
 * Add basic sensor info to sensor page [see `PR #1115 <https://github.com/FlexMeasures/flexmeasures/pull/1115>`_]
 * Support zoom-in action on the asset and sensor charts [see `PR #1130 <https://github.com/FlexMeasures/flexmeasures/pull/1130>`_]
-* Allow three ways of passing a variable quantity in most of the ``flex-model`` and ``flex-context`` fields [see `PR #1127 <https://github.com/FlexMeasures/flexmeasures/pull/1127>`_]
+* Introduce the ``VariableQuantityField`` to allow three ways of passing a variable quantity in most of the ``flex-model`` and ``flex-context`` fields [see `PR #1127 <https://github.com/FlexMeasures/flexmeasures/pull/1127>`_]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -8,6 +8,7 @@ v0.23.0 | August XX, 2024
 
 New features
 -------------
+* Allow three ways of passing a variable quantity in most of the ``flex-model`` and ``flex-context`` fields [see `PR #1127 <https://github.com/FlexMeasures/flexmeasures/pull/1127>`_]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -12,7 +12,7 @@ New features
 
 Infrastructure / Support
 ----------------------
-* Support new single-belief fast track (looking uup only one belief) [see `PR #1067 <https://github.com/FlexMeasures/flexmeasures/pull/1067>`_]
+* Support new single-belief fast track (looking up only one belief) [see `PR #1067 <https://github.com/FlexMeasures/flexmeasures/pull/1067>`_]
 * Add new annotation types: ``"error"`` and ``"warning"`` [see `PR #1131 <https://github.com/FlexMeasures/flexmeasures/pull/1131>`_]
 * Removed deprecated ``app.schedulers`` and ``app.forecasters`` (use ``app.data_generators["scheduler"]`` and ``app.data_generators["forecaster"]`` instead) [see `PR #1098 <https://github.com/FlexMeasures/flexmeasures/pull/1098/>`_]
 

--- a/documentation/features/scheduling.rst
+++ b/documentation/features/scheduling.rst
@@ -98,25 +98,25 @@ and what constraints or preferences should be taken into account.
      - Example value
      - Description 
    * - ``soc-at-start``
-     - ``"3.1"``
+     - ``"3.1 kWh"``
      - The (estimated) state of charge at the beginning of the schedule (defaults to 0).
    * - ``soc-unit``
      - ``"kWh"`` or ``"MWh"``
-     - The unit in which all SoC related flex-model values are to be interpreted.
+     - The unit used to interpret any SoC related flex-model value that does not mention a unit itself (only applies to numeric values, so not to string values).
    * - ``soc-min``
-     - ``"2.5"``
+     - ``"2.5 kWh"``
      - A constant lower boundary for all values in the schedule (defaults to 0).
    * - ``soc-max``
-     - ``"7"``
+     - ``"7 kWh"``
      - A constant upper boundary for all values in the schedule (defaults to max soc target, if provided)
    * - ``soc-minima``
-     - ``[{"datetime": "2024-02-05T08:00:00+01:00", value: 8.2}]``
+     - ``[{"datetime": "2024-02-05T08:00:00+01:00", value: "8.2 kWh"}]``
      - Set point(s) that form lower boundaries, e.g. to target a full car battery in the morning. Can be single values or a range (defaults to NaN values).
    * - ``soc-maxima``
-     - ``{"value": 51, "start": "2024-02-05T12:00:00+01:00","end": "2024-02-05T13:30:00+01:00"}``
+     - ``{"value": "51 kWh", "start": "2024-02-05T12:00:00+01:00", "end": "2024-02-05T13:30:00+01:00"}``
      - Set point(s) that form upper boundaries at certain times. Can be single values or a range (defaults to NaN values).
    * - ``soc-targets``
-     - ``[{"datetime": "2024-02-05T08:00:00+01:00", value: 3.2}]``
+     - ``[{"datetime": "2024-02-05T08:00:00+01:00", value: "3.2 kWh"}]``
      - Exact set point(s) that the scheduler needs to realize (defaults to NaN values).
    * - ``soc-gain``
      - ``.1kWh`` 

--- a/documentation/features/scheduling.rst
+++ b/documentation/features/scheduling.rst
@@ -113,6 +113,7 @@ and what constraints or preferences should be taken into account.
    * - ``soc-unit``
      - ``"kWh"`` or ``"MWh"``
      - The unit used to interpret any SoC related flex-model value that does not mention a unit itself (only applies to numeric values, so not to string values).
+       However, we advise to mention the unit in each field explicitly (for instance, ``"3.1 kWh"`` rather than ``3.1``).
    * - ``soc-min``
      - ``"2.5 kWh"``
      - A constant lower boundary for all values in the schedule (defaults to 0).

--- a/documentation/tut/flex-model-v2g.rst
+++ b/documentation/tut/flex-model-v2g.rst
@@ -33,9 +33,8 @@ Constraining the cycling to occur within a static 25-85% SoC range can be modell
 
     {
         "flex-model": {
-            "soc-min": 15,
-            "soc-max": 51,
-            "soc-unit": "kWh"
+            "soc-min": "15 kWh",
+            "soc-max": "51 kWh"
         }
     }
 
@@ -50,16 +49,15 @@ To enable a temporary target SoC of more than 85% (for car reservations, see the
 
     {
         "flex-model": {
-            "soc-min": 15,
-            "soc-max": 60,
+            "soc-min": "15 kWh",
+            "soc-max": "60 kWh",
             "soc-maxima": [
                 {
-                    "value": 51,
+                    "value": "51 kWh",
                     "start": "2024-02-04T10:35:00+01:00",
                     "end": "2024-02-05T04:25:00+01:00"
                 }
-            ],
-            "soc-unit": "kWh"
+            ]
         }
     }
 
@@ -80,7 +78,7 @@ Given a reservation for 8 AM on February 5th, constraint 2 can be modelled throu
         "flex-model": {
             "soc-minima": [
                 {
-                    "value": 57,
+                    "value": "57 kWh",
                     "datetime": "2024-02-05T08:00:00+01:00"
                 }
             ]
@@ -88,7 +86,7 @@ Given a reservation for 8 AM on February 5th, constraint 2 can be modelled throu
     }
 
 This constraint also signals that if the car is not plugged out of the Charge Point at 8 AM, the scheduler is in principle allowed to start discharging immediately afterwards.
-To make sure the car remains at 95% SoC for some time, additional soc-minima constraints should be set accordingly, taking into account the scheduling resolution (here, 5 minutes). For example, to keep it charged (nearly) fully until 8.15 AM:
+To make sure the car remains at or above 95% SoC for some time, additional soc-minima constraints should be set accordingly, taking into account the scheduling resolution (here, 5 minutes). For example, to keep it charged (nearly) fully until 8.15 AM:
 
 .. code-block:: json
 
@@ -96,7 +94,7 @@ To make sure the car remains at 95% SoC for some time, additional soc-minima con
         "flex-model": {
             "soc-minima": [
                 {
-                    "value": 57,
+                    "value": "57 kWh",
                     "start": "2024-02-05T08:00:00+01:00",
                     "end": "2024-02-05T08:15:00+01:00"
                 }
@@ -104,6 +102,28 @@ To make sure the car remains at 95% SoC for some time, additional soc-minima con
         }
     }
 
+The car may still charge and discharge within those 15 minutes, but it won't go below 95%.
+Alternatively, to keep the car from discharging altogether during that time, limit the ``production-capacity`` (likewise, use the ``consumption-capacity`` to prevent any charging):
+
+.. code-block:: json
+
+    {
+        "flex-model": {
+            "soc-minima": [
+                {
+                    "value": "57 kWh",
+                    "datetime": "2024-02-05T08:00:00+01:00"
+                }
+            ],
+            "production-capacity": [
+                {
+                    "value": "0 kW",
+                    "start": "2024-02-05T08:00:00+01:00",
+                    "end": "2024-02-05T08:15:00+01:00"
+                }
+            ]
+        }
+    }
 
 .. _earning_by_cycling:
 

--- a/documentation/tut/forecasting_scheduling.rst
+++ b/documentation/tut/forecasting_scheduling.rst
@@ -108,18 +108,17 @@ Here, we extend that (storage) example with an additional target value, represen
     {
         "start": "2015-06-02T10:00:00+00:00",
         "flex-model": {
-            "soc-at-start": 12.1,
-            "soc-unit": "kWh"
+            "soc-at-start": "12.1 kWh",
             "soc-targets": [
                 {
-                    "value": 25,
+                    "value": "25 kWh",
                     "datetime": "2015-06-02T16:00:00+00:00"
                 }
         }
     }
 
 
-We now have described the state of charge at 10am to be ``12.1``. In addition, we requested that it should be ``25`` at 4pm.
+We now have described the state of charge at 10am to be ``"12.1 kWh"``. In addition, we requested that it should be ``"25 kWh"`` at 4pm.
 For instance, this could mean that a car should be charged at 90% at that time.
 
 If FlexMeasures receives this message, a scheduling job will be made and put into the queue. In turn, the scheduling job creates a proposed schedule. We'll look a bit deeper into those further down in :ref:`getting_schedules`.

--- a/documentation/tut/posting_data.rst
+++ b/documentation/tut/posting_data.rst
@@ -287,8 +287,7 @@ The endpoint also allows to limit the flexibility range and also to set target v
         {
             "start": "2015-06-02T10:00:00+00:00",
             "flex-model": {
-                "soc-at-start": 12.1,
-                "soc-unit": "kWh"
+                "soc-at-start": "12.1 kWh"
             }
         }
 

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -279,8 +279,7 @@ class SensorAPI(FlaskView):
             {
                 "start": "2015-06-02T10:00:00+00:00",
                 "flex-model": {
-                    "soc-at-start": 12.1,
-                    "soc-unit": "kWh"
+                    "soc-at-start": "12.1 kWh"
                 }
             }
 
@@ -311,17 +310,16 @@ class SensorAPI(FlaskView):
                 "start": "2015-06-02T10:00:00+00:00",
                 "duration": "PT24H",
                 "flex-model": {
-                    "soc-at-start": 12.1,
-                    "soc-unit": "kWh",
+                    "soc-at-start": "12.1 kWh",
                     "soc-targets": [
                         {
-                            "value": 25,
+                            "value": "25 kWh",
                             "datetime": "2015-06-02T16:00:00+00:00"
                         },
                     ],
                     "soc-minima": {"sensor" : 300},
-                    "soc-min": 10,
-                    "soc-max": 25,
+                    "soc-min": "10 kWh",
+                    "soc-max": "25 kWh",
                     "charging-efficiency": "120%",
                     "discharging-efficiency": {"sensor": 98},
                     "storage-efficiency": 0.9999,

--- a/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
+++ b/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
@@ -46,7 +46,7 @@ def test_get_schedule_wrong_job_id(
             message_for_trigger_schedule(),
             "soc-min",
             "not-a-float",
-            "Not a valid number",
+            "Not a valid quantity",
         ),
         (message_for_trigger_schedule(), "soc-unit", "MWH", "Must be one of"),
         # todo: add back test in case we stop grandfathering ignoring too-far-into-the-future targets, or amend otherwise

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -62,7 +62,7 @@ from flexmeasures.data.schemas import (
     LongitudeField,
     SensorIdField,
     TimeIntervalField,
-    QuantityOrSensor,
+    TimeSeriesOrQuantityOrSensor,
 )
 from flexmeasures.data.schemas.sources import DataSourceIdField
 from flexmeasures.data.schemas.times import TimeIntervalSchema
@@ -1123,7 +1123,7 @@ def create_schedule(ctx):
 @click.option(
     "--site-power-capacity",
     "site_power_capacity",
-    type=QuantityOrSensor("MW"),
+    type=TimeSeriesOrQuantityOrSensor("MW"),
     required=False,
     default=None,
     help="Site consumption/production power capacity. Provide this as a quantity in power units (e.g. 1 MW or 1000 kW)"
@@ -1133,7 +1133,7 @@ def create_schedule(ctx):
 @click.option(
     "--site-consumption-capacity",
     "site_consumption_capacity",
-    type=QuantityOrSensor("MW"),
+    type=TimeSeriesOrQuantityOrSensor("MW"),
     required=False,
     default=None,
     help="Site consumption power capacity. Provide this as a quantity in power units (e.g. 1 MW or 1000 kW)"
@@ -1143,7 +1143,7 @@ def create_schedule(ctx):
 @click.option(
     "--site-production-capacity",
     "site_production_capacity",
-    type=QuantityOrSensor("MW"),
+    type=TimeSeriesOrQuantityOrSensor("MW"),
     required=False,
     default=None,
     help="Site production power capacity. Provide this as a quantity in power units (e.g. 1 MW or 1000 kW)"
@@ -1208,7 +1208,7 @@ def create_schedule(ctx):
 @click.option(
     "--charging-efficiency",
     "charging_efficiency",
-    type=QuantityOrSensor("%"),
+    type=TimeSeriesOrQuantityOrSensor("%"),
     required=False,
     default=None,
     help="Storage charging efficiency to use for the schedule."
@@ -1218,7 +1218,7 @@ def create_schedule(ctx):
 @click.option(
     "--discharging-efficiency",
     "discharging_efficiency",
-    type=QuantityOrSensor("%"),
+    type=TimeSeriesOrQuantityOrSensor("%"),
     required=False,
     default=None,
     help="Storage discharging efficiency to use for the schedule."
@@ -1228,7 +1228,7 @@ def create_schedule(ctx):
 @click.option(
     "--soc-gain",
     "soc_gain",
-    type=QuantityOrSensor("MW"),
+    type=TimeSeriesOrQuantityOrSensor("MW"),
     required=False,
     default=None,
     help="Specify the State of Charge (SoC) gain as a quantity in power units (e.g. 1 MW or 1000 kW)"
@@ -1238,7 +1238,7 @@ def create_schedule(ctx):
 @click.option(
     "--soc-usage",
     "soc_usage",
-    type=QuantityOrSensor("MW"),
+    type=TimeSeriesOrQuantityOrSensor("MW"),
     required=False,
     default=None,
     help="Specify the State of Charge (SoC) usage as a quantity in power units (e.g. 1 MW or 1000 kW) "
@@ -1248,7 +1248,7 @@ def create_schedule(ctx):
 @click.option(
     "--storage-power-capacity",
     "storage_power_capacity",
-    type=QuantityOrSensor("MW"),
+    type=TimeSeriesOrQuantityOrSensor("MW"),
     required=False,
     default=None,
     help="Storage consumption/production power capacity. Provide this as a quantity in power units (e.g. 1 MW or 1000 kW)"
@@ -1258,7 +1258,7 @@ def create_schedule(ctx):
 @click.option(
     "--storage-consumption-capacity",
     "storage_consumption_capacity",
-    type=QuantityOrSensor("MW"),
+    type=TimeSeriesOrQuantityOrSensor("MW"),
     required=False,
     default=None,
     help="Storage consumption power capacity. Provide this as a quantity in power units (e.g. 1 MW or 1000 kW)"
@@ -1268,7 +1268,7 @@ def create_schedule(ctx):
 @click.option(
     "--storage-production-capacity",
     "storage_production_capacity",
-    type=QuantityOrSensor("MW"),
+    type=TimeSeriesOrQuantityOrSensor("MW"),
     required=False,
     default=None,
     help="Storage production power capacity. Provide this as a quantity in power units (e.g. 1 MW or 1000 kW)"
@@ -1278,7 +1278,7 @@ def create_schedule(ctx):
 @click.option(
     "--storage-efficiency",
     "storage_efficiency",
-    type=QuantityOrSensor("%", default_src_unit="dimensionless"),
+    type=TimeSeriesOrQuantityOrSensor("%", default_src_unit="dimensionless"),
     required=False,
     default="100%",
     help="Storage efficiency (e.g. 95% or 0.95) to use for the schedule,"
@@ -1421,7 +1421,7 @@ def add_schedule_for_storage(  # noqa C901
                 else:
                     unit = "MW"
 
-                scheduling_kwargs[key][field_name] = QuantityOrSensor(unit)._serialize(
+                scheduling_kwargs[key][field_name] = TimeSeriesOrQuantityOrSensor(unit)._serialize(
                     value, None, None
                 )
 

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -1421,9 +1421,9 @@ def add_schedule_for_storage(  # noqa C901
                 else:
                     unit = "MW"
 
-                scheduling_kwargs[key][field_name] = TimeSeriesOrQuantityOrSensor(unit)._serialize(
-                    value, None, None
-                )
+                scheduling_kwargs[key][field_name] = TimeSeriesOrQuantityOrSensor(
+                    unit
+                )._serialize(value, None, None)
 
     if as_job:
         job = create_scheduling_job(asset_or_sensor=power_sensor, **scheduling_kwargs)

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -62,7 +62,7 @@ from flexmeasures.data.schemas import (
     LongitudeField,
     SensorIdField,
     TimeIntervalField,
-    TimeSeriesOrQuantityOrSensor,
+    VariableQuantityField,
 )
 from flexmeasures.data.schemas.sources import DataSourceIdField
 from flexmeasures.data.schemas.times import TimeIntervalSchema
@@ -1123,7 +1123,7 @@ def create_schedule(ctx):
 @click.option(
     "--site-power-capacity",
     "site_power_capacity",
-    type=TimeSeriesOrQuantityOrSensor("MW"),
+    type=VariableQuantityField("MW"),
     required=False,
     default=None,
     help="Site consumption/production power capacity. Provide this as a quantity in power units (e.g. 1 MW or 1000 kW)"
@@ -1133,7 +1133,7 @@ def create_schedule(ctx):
 @click.option(
     "--site-consumption-capacity",
     "site_consumption_capacity",
-    type=TimeSeriesOrQuantityOrSensor("MW"),
+    type=VariableQuantityField("MW"),
     required=False,
     default=None,
     help="Site consumption power capacity. Provide this as a quantity in power units (e.g. 1 MW or 1000 kW)"
@@ -1143,7 +1143,7 @@ def create_schedule(ctx):
 @click.option(
     "--site-production-capacity",
     "site_production_capacity",
-    type=TimeSeriesOrQuantityOrSensor("MW"),
+    type=VariableQuantityField("MW"),
     required=False,
     default=None,
     help="Site production power capacity. Provide this as a quantity in power units (e.g. 1 MW or 1000 kW)"
@@ -1208,7 +1208,7 @@ def create_schedule(ctx):
 @click.option(
     "--charging-efficiency",
     "charging_efficiency",
-    type=TimeSeriesOrQuantityOrSensor("%"),
+    type=VariableQuantityField("%"),
     required=False,
     default=None,
     help="Storage charging efficiency to use for the schedule."
@@ -1218,7 +1218,7 @@ def create_schedule(ctx):
 @click.option(
     "--discharging-efficiency",
     "discharging_efficiency",
-    type=TimeSeriesOrQuantityOrSensor("%"),
+    type=VariableQuantityField("%"),
     required=False,
     default=None,
     help="Storage discharging efficiency to use for the schedule."
@@ -1228,7 +1228,7 @@ def create_schedule(ctx):
 @click.option(
     "--soc-gain",
     "soc_gain",
-    type=TimeSeriesOrQuantityOrSensor("MW"),
+    type=VariableQuantityField("MW"),
     required=False,
     default=None,
     help="Specify the State of Charge (SoC) gain as a quantity in power units (e.g. 1 MW or 1000 kW)"
@@ -1238,7 +1238,7 @@ def create_schedule(ctx):
 @click.option(
     "--soc-usage",
     "soc_usage",
-    type=TimeSeriesOrQuantityOrSensor("MW"),
+    type=VariableQuantityField("MW"),
     required=False,
     default=None,
     help="Specify the State of Charge (SoC) usage as a quantity in power units (e.g. 1 MW or 1000 kW) "
@@ -1248,7 +1248,7 @@ def create_schedule(ctx):
 @click.option(
     "--storage-power-capacity",
     "storage_power_capacity",
-    type=TimeSeriesOrQuantityOrSensor("MW"),
+    type=VariableQuantityField("MW"),
     required=False,
     default=None,
     help="Storage consumption/production power capacity. Provide this as a quantity in power units (e.g. 1 MW or 1000 kW)"
@@ -1258,7 +1258,7 @@ def create_schedule(ctx):
 @click.option(
     "--storage-consumption-capacity",
     "storage_consumption_capacity",
-    type=TimeSeriesOrQuantityOrSensor("MW"),
+    type=VariableQuantityField("MW"),
     required=False,
     default=None,
     help="Storage consumption power capacity. Provide this as a quantity in power units (e.g. 1 MW or 1000 kW)"
@@ -1268,7 +1268,7 @@ def create_schedule(ctx):
 @click.option(
     "--storage-production-capacity",
     "storage_production_capacity",
-    type=TimeSeriesOrQuantityOrSensor("MW"),
+    type=VariableQuantityField("MW"),
     required=False,
     default=None,
     help="Storage production power capacity. Provide this as a quantity in power units (e.g. 1 MW or 1000 kW)"
@@ -1278,7 +1278,7 @@ def create_schedule(ctx):
 @click.option(
     "--storage-efficiency",
     "storage_efficiency",
-    type=TimeSeriesOrQuantityOrSensor("%", default_src_unit="dimensionless"),
+    type=VariableQuantityField("%", default_src_unit="dimensionless"),
     required=False,
     default="100%",
     help="Storage efficiency (e.g. 95% or 0.95) to use for the schedule,"
@@ -1421,7 +1421,7 @@ def add_schedule_for_storage(  # noqa C901
                 else:
                     unit = "MW"
 
-                scheduling_kwargs[key][field_name] = TimeSeriesOrQuantityOrSensor(
+                scheduling_kwargs[key][field_name] = VariableQuantityField(
                     unit
                 )._serialize(value, None, None)
 

--- a/flexmeasures/conftest.py
+++ b/flexmeasures/conftest.py
@@ -819,6 +819,19 @@ def create_test_battery_assets(
     )
     db.session.add(test_battery_sensor)
 
+    test_battery_sensor_kw = Sensor(
+        name="power (kW)",
+        generic_asset=test_battery,
+        event_resolution=timedelta(minutes=15),
+        unit="kW",
+        attributes=dict(
+            daily_seasonality=True,
+            weekly_seasonality=True,
+            yearly_seasonality=True,
+        ),
+    )
+    db.session.add(test_battery_sensor_kw)
+
     test_battery_no_prices = GenericAsset(
         name="Test battery with no known prices",
         owner=setup_accounts["Prosumer"],

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -27,7 +27,7 @@ from flexmeasures.data.schemas.scheduling.storage import StorageFlexModelSchema
 from flexmeasures.data.schemas.scheduling import FlexContextSchema
 from flexmeasures.utils.time_utils import get_max_planning_horizon
 from flexmeasures.utils.coding_utils import deprecated
-from flexmeasures.utils.unit_utils import ur
+from flexmeasures.utils.unit_utils import ur, convert_units
 
 
 class MetaStorageScheduler(Scheduler):
@@ -592,6 +592,7 @@ class StorageFallbackScheduler(MetaStorageScheduler):
         storage_schedule = fallback_charging_policy(
             sensor, device_constraints[0], start, end, resolution
         )
+        storage_schedule = convert_units(storage_schedule, "MW", sensor.unit)
 
         # Round schedule
         if self.round_to_decimals:
@@ -649,6 +650,7 @@ class StorageScheduler(MetaStorageScheduler):
 
         # Obtain the storage schedule from all device schedules within the EMS
         storage_schedule = ems_schedule[0]
+        storage_schedule = convert_units(storage_schedule, "MW", sensor.unit)
 
         # Round schedule
         if self.round_to_decimals:

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -473,7 +473,7 @@ class MetaStorageScheduler(Scheduler):
 
         self.ensure_soc_min_max()
 
-        # Now it's time to check if our flex configurations holds up to schemas
+        # Now it's time to check if our flex configuration holds up to schemas
         self.flex_model = StorageFlexModelSchema(
             start=self.start, sensor=self.sensor, default_soc_unit=self.flex_model["soc-unit"]
         ).load(self.flex_model)

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -470,6 +470,9 @@ class MetaStorageScheduler(Scheduler):
                 self.flex_model["soc-unit"] = self.sensor.unit
             elif self.sensor.unit in ("MW", "kW"):
                 self.flex_model["soc-unit"] = self.sensor.unit + "h"
+            else:
+                # todo: raise? Surely we must have a unit.
+                pass
 
         self.ensure_soc_min_max()
 

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -457,7 +457,7 @@ class MetaStorageScheduler(Scheduler):
             else:
                 self.flex_model["soc-at-start"] = 0
         # soc-unit
-        if "soc-unit" not in self.flex_model or self.flex_model["soc-unit"] is None:
+        if self.flex_model.get("soc-unit") is None:
             if self.sensor.unit in ("MWh", "kWh"):
                 self.flex_model["soc-unit"] = self.sensor.unit
             elif self.sensor.unit in ("MW", "kW"):

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -475,7 +475,7 @@ class MetaStorageScheduler(Scheduler):
 
         # Now it's time to check if our flex configurations holds up to schemas
         self.flex_model = StorageFlexModelSchema(
-            start=self.start, sensor=self.sensor
+            start=self.start, sensor=self.sensor, default_soc_unit=self.flex_model["soc-unit"]
         ).load(self.flex_model)
         self.flex_context = FlexContextSchema().load(self.flex_context)
 

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -420,17 +420,7 @@ class MetaStorageScheduler(Scheduler):
     def persist_flex_model(self):
         """Store new soc info as GenericAsset attributes"""
         self.sensor.generic_asset.set_attribute("soc_datetime", self.start.isoformat())
-        soc_unit = self.flex_model.get("soc_unit")
-        if soc_unit == "kWh":
-            self.sensor.generic_asset.set_attribute(
-                "soc_in_mwh", self.flex_model["soc_at_start"] / 1000
-            )
-        elif soc_unit == "MWh":
-            self.sensor.generic_asset.set_attribute(
-                "soc_in_mwh", self.flex_model["soc_at_start"]
-            )
-        else:
-            raise NotImplementedError(f"Unsupported SoC unit '{soc_unit}'.")
+        self.sensor.generic_asset.set_attribute("soc_in_mwh", self.flex_model["soc_at_start"])
 
     def deserialize_flex_config(self):
         """

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -456,15 +456,6 @@ class MetaStorageScheduler(Scheduler):
                 )
             else:
                 self.flex_model["soc-at-start"] = 0
-        # soc-unit
-        if self.flex_model.get("soc-unit") is None:
-            if self.sensor.unit in ("MWh", "kWh"):
-                self.flex_model["soc-unit"] = self.sensor.unit
-            elif self.sensor.unit in ("MW", "kW"):
-                self.flex_model["soc-unit"] = self.sensor.unit + "h"
-            else:
-                # todo: raise? Surely we must have a unit.
-                pass
 
         self.ensure_soc_min_max()
 
@@ -472,7 +463,7 @@ class MetaStorageScheduler(Scheduler):
         self.flex_model = StorageFlexModelSchema(
             start=self.start,
             sensor=self.sensor,
-            default_soc_unit=self.flex_model["soc-unit"],
+            default_soc_unit=self.flex_model.get("soc-unit"),
         ).load(self.flex_model)
         self.flex_context = FlexContextSchema().load(self.flex_context)
 

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -420,7 +420,9 @@ class MetaStorageScheduler(Scheduler):
     def persist_flex_model(self):
         """Store new soc info as GenericAsset attributes"""
         self.sensor.generic_asset.set_attribute("soc_datetime", self.start.isoformat())
-        self.sensor.generic_asset.set_attribute("soc_in_mwh", self.flex_model["soc_at_start"])
+        self.sensor.generic_asset.set_attribute(
+            "soc_in_mwh", self.flex_model["soc_at_start"]
+        )
 
     def deserialize_flex_config(self):
         """
@@ -468,7 +470,9 @@ class MetaStorageScheduler(Scheduler):
 
         # Now it's time to check if our flex configuration holds up to schemas
         self.flex_model = StorageFlexModelSchema(
-            start=self.start, sensor=self.sensor, default_soc_unit=self.flex_model["soc-unit"]
+            start=self.start,
+            sensor=self.sensor,
+            default_soc_unit=self.flex_model["soc-unit"],
         ).load(self.flex_model)
         self.flex_context = FlexContextSchema().load(self.flex_context)
 

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -117,7 +117,7 @@ class MetaStorageScheduler(Scheduler):
             power_capacity_in_mw = ur.Quantity(f"{power_capacity_in_mw} MW")
 
         power_capacity_in_mw = get_continuous_series_sensor_or_quantity(
-            quantity_or_sensor=power_capacity_in_mw,
+            variable_quantity=power_capacity_in_mw,
             actuator=sensor,
             unit="MW",
             query_window=(start, end),
@@ -183,7 +183,7 @@ class MetaStorageScheduler(Scheduler):
         # fetch SOC constraints from sensors
         if isinstance(soc_targets, Sensor):
             soc_targets = get_continuous_series_sensor_or_quantity(
-                quantity_or_sensor=soc_targets,
+                variable_quantity=soc_targets,
                 actuator=sensor,
                 unit="MWh",
                 query_window=(start, end),
@@ -194,7 +194,7 @@ class MetaStorageScheduler(Scheduler):
             )
         if isinstance(soc_minima, Sensor):
             soc_minima = get_continuous_series_sensor_or_quantity(
-                quantity_or_sensor=soc_minima,
+                variable_quantity=soc_minima,
                 actuator=sensor,
                 unit="MWh",
                 query_window=(start, end),
@@ -205,7 +205,7 @@ class MetaStorageScheduler(Scheduler):
             )
         if isinstance(soc_maxima, Sensor):
             soc_maxima = get_continuous_series_sensor_or_quantity(
-                quantity_or_sensor=soc_maxima,
+                variable_quantity=soc_maxima,
                 actuator=sensor,
                 unit="MWh",
                 query_window=(start, end),
@@ -236,7 +236,7 @@ class MetaStorageScheduler(Scheduler):
             device_constraints[0]["derivative min"] = (
                 -1
             ) * get_continuous_series_sensor_or_quantity(
-                quantity_or_sensor=production_capacity,
+                variable_quantity=production_capacity,
                 actuator=sensor,
                 unit="MW",
                 query_window=(start, end),
@@ -251,7 +251,7 @@ class MetaStorageScheduler(Scheduler):
             device_constraints[0][
                 "derivative max"
             ] = get_continuous_series_sensor_or_quantity(
-                quantity_or_sensor=consumption_capacity,
+                variable_quantity=consumption_capacity,
                 actuator=sensor,
                 unit="MW",
                 query_window=(start, end),
@@ -269,7 +269,7 @@ class MetaStorageScheduler(Scheduler):
         for is_usage, soc_delta in zip([False, True], [soc_gain, soc_usage]):
             for component in soc_delta:
                 stock_delta_series = get_continuous_series_sensor_or_quantity(
-                    quantity_or_sensor=component,
+                    variable_quantity=component,
                     actuator=sensor,
                     unit="MW",
                     query_window=(start, end),
@@ -295,7 +295,7 @@ class MetaStorageScheduler(Scheduler):
 
         # Apply round-trip efficiency evenly to charging and discharging
         charging_efficiency = get_continuous_series_sensor_or_quantity(
-            quantity_or_sensor=self.flex_model.get("charging_efficiency"),
+            variable_quantity=self.flex_model.get("charging_efficiency"),
             actuator=sensor,
             unit="dimensionless",
             query_window=(start, end),
@@ -304,7 +304,7 @@ class MetaStorageScheduler(Scheduler):
             fallback_attribute="charging-efficiency",
         ).fillna(1)
         discharging_efficiency = get_continuous_series_sensor_or_quantity(
-            quantity_or_sensor=self.flex_model.get("discharging_efficiency"),
+            variable_quantity=self.flex_model.get("discharging_efficiency"),
             actuator=sensor,
             unit="dimensionless",
             query_window=(start, end),
@@ -333,7 +333,7 @@ class MetaStorageScheduler(Scheduler):
         ):
             device_constraints[0]["efficiency"] = (
                 get_continuous_series_sensor_or_quantity(
-                    quantity_or_sensor=storage_efficiency,
+                    variable_quantity=storage_efficiency,
                     actuator=sensor,
                     unit="dimensionless",
                     query_window=(start, end),
@@ -372,7 +372,7 @@ class MetaStorageScheduler(Scheduler):
         )
 
         ems_power_capacity_in_mw = get_continuous_series_sensor_or_quantity(
-            quantity_or_sensor=self.flex_context.get("ems_power_capacity_in_mw"),
+            variable_quantity=self.flex_context.get("ems_power_capacity_in_mw"),
             actuator=sensor.generic_asset,
             unit="MW",
             query_window=(start, end),
@@ -382,7 +382,7 @@ class MetaStorageScheduler(Scheduler):
         )
 
         ems_constraints["derivative max"] = get_continuous_series_sensor_or_quantity(
-            quantity_or_sensor=self.flex_context.get("ems_consumption_capacity_in_mw"),
+            variable_quantity=self.flex_context.get("ems_consumption_capacity_in_mw"),
             actuator=sensor.generic_asset,
             unit="MW",
             query_window=(start, end),
@@ -394,7 +394,7 @@ class MetaStorageScheduler(Scheduler):
         ems_constraints["derivative min"] = (
             -1
         ) * get_continuous_series_sensor_or_quantity(
-            quantity_or_sensor=self.flex_context.get("ems_production_capacity_in_mw"),
+            variable_quantity=self.flex_context.get("ems_production_capacity_in_mw"),
             actuator=sensor.generic_asset,
             unit="MW",
             query_window=(start, end),

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -1724,10 +1724,10 @@ def test_battery_stock_delta_sensor(
     "gain,usage,expected_delta",
     [
         (["1 MW"], ["1MW"], 0),  # delta stock is 0 (1 MW - 1 MW)
-        (["0.5 MW", "0.5 MW"], [], 1),  # 1 MW stock gain
+        (["0.5 MW", "0.5 MW"], None, 1),  # 1 MW stock gain
         (["100 kW"], None, 0.1),  # 100 MW stock gain
-        (None, ["100 kW"], -0.1),  # 100 kW stock loss
-        ([], [], None),  # no gain defined -> no gain or loss happens
+        (None, ["100 kW"], -0.1),  # 100 kW stock usage
+        (None, None, None),  # no gain/usage defined -> no gain or usage happens
     ],
 )
 def test_battery_stock_delta_quantity(
@@ -1736,7 +1736,7 @@ def test_battery_stock_delta_quantity(
     """
     Test the stock gain field when a constant value is provided.
 
-    We expect a constant gain/loss to happen in every time period equal to the energy
+    We expect a constant gain/usage to happen in every time period equal to the energy
     value provided.
     """
     _, battery = get_sensors_from_db(db, add_battery_assets)

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -674,6 +674,7 @@ def test_soc_bounds_timeseries(db, add_battery_assets):
     resolution = timedelta(hours=1)
 
     # soc parameters
+    soc_unit = "MWh"
     soc_at_start = battery.get_attribute("soc_in_mwh")
     soc_min = 0.5
     soc_max = 4.5
@@ -697,6 +698,7 @@ def test_soc_bounds_timeseries(db, add_battery_assets):
         return soc_schedule
 
     flex_model = {
+        "soc-unit": soc_unit,
         "soc-at-start": soc_at_start,
         "soc-min": soc_min,
         "soc-max": soc_max,
@@ -715,6 +717,7 @@ def test_soc_bounds_timeseries(db, add_battery_assets):
     soc_targets = [{"datetime": "2015-01-02T19:00:00+01:00", "value": 2.0}]
 
     flex_model = {
+        "soc-unit": soc_unit,
         "soc-at-start": soc_at_start,
         "soc-min": soc_min,
         "soc-max": soc_max,

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -26,7 +26,7 @@ from flexmeasures.utils.calculations import (
     integrate_time_series,
 )
 from flexmeasures.tests.utils import get_test_sensor
-from flexmeasures.utils.unit_utils import convert_units
+from flexmeasures.utils.unit_utils import convert_units, ur
 
 TOLERANCE = 0.00001
 
@@ -1019,10 +1019,14 @@ def test_infeasible_problem_error(db, add_battery_assets):
         compute_schedule(flex_model)
 
 
-def get_sensors_from_db(db, battery_assets, battery_name="Test battery"):
+def get_sensors_from_db(
+    db, battery_assets, battery_name="Test battery", power_sensor_name="power"
+):
     # get the sensors from the database
     epex_da = get_test_sensor(db)
-    battery = battery_assets[battery_name].sensors[0]
+    battery = [
+        s for s in battery_assets[battery_name].sensors if s.name == power_sensor_name
+    ][0]
     assert battery.get_attribute("market_id") == epex_da.id
 
     return epex_da, battery
@@ -2041,3 +2045,84 @@ def test_soc_maxima_minima_targets(db, add_battery_assets, soc_sensors):
     # this yields the same results as with the SOC targets
     # because soc-maxima = soc-minima = soc-targets
     assert all(abs(soc[9:].values - values[:-1]) < 1e-5)
+
+
+@pytest.mark.parametrize("unit", [None, "MWh", "kWh"])
+@pytest.mark.parametrize("soc_unit", ["kWh", "MWh"])
+@pytest.mark.parametrize("power_sensor_name", ["power", "power (kW)"])
+def test_battery_storage_different_units(
+    add_battery_assets,
+    db,
+    power_sensor_name,
+    soc_unit,
+    unit,
+):
+    """
+    Test scheduling a 1 MWh battery for 2h with a low -> high price transition with
+    different units for the soc-min, soc-max, soc-at-start and power sensor.
+    """
+
+    soc_min = ur.Quantity("100 kWh")
+    soc_max = ur.Quantity("1 MWh")
+    soc_at_start = ur.Quantity("100 kWh")
+
+    if unit is not None:
+        soc_min = str(soc_min.to(unit))
+        soc_max = str(soc_max.to(unit))
+        soc_at_start = str(soc_at_start.to(unit))
+    else:
+        soc_min = soc_min.to(soc_unit).magnitude
+        soc_max = soc_max.to(soc_unit).magnitude
+        soc_at_start = soc_at_start.to(soc_unit).magnitude
+
+    epex_da, battery = get_sensors_from_db(
+        db,
+        add_battery_assets,
+        battery_name="Test battery",
+        power_sensor_name=power_sensor_name,
+    )
+    tz = pytz.timezone("Europe/Amsterdam")
+
+    # transition from cheap to expensive (90 -> 100)
+    start = tz.localize(datetime(2015, 1, 2, 14, 0, 0))
+    end = tz.localize(datetime(2015, 1, 2, 16, 0, 0))
+    resolution = timedelta(minutes=15)
+
+    flex_model = {
+        "soc-min": soc_min,
+        "soc-max": soc_max,
+        "soc-at-start": soc_at_start,
+        "soc-unit": soc_unit,
+        "roundtrip-efficiency": 1,
+        "storage-efficiency": 1,
+        "power-capacity": "1 MW",
+    }
+
+    scheduler: Scheduler = StorageScheduler(
+        battery,
+        start,
+        end,
+        resolution,
+        flex_model=flex_model,
+        flex_context={
+            "site-power-capacity": "1 MW",
+        },
+    )
+    schedule = scheduler.compute()
+
+    if power_sensor_name == "power (kW)":
+        schedule /= 1000
+
+    # charge fully in the cheap price period (100 kWh -> 1000kWh)
+    assert schedule[:4].sum() * 0.25 == 0.9
+
+    # discharge fully in the expensive price period (1000 kWh -> 100 kWh)
+    assert schedule[4:].sum() * 0.25 == -0.9
+
+    if isinstance(soc_at_start, str):
+        soc_at_start = ur.Quantity(soc_at_start).to("MWh").magnitude
+    elif isinstance(soc_at_start, float) or isinstance(soc_at_start, int):
+        soc_at_start = soc_at_start * convert_units(1, soc_unit, "MWh")
+
+    # Check if constraints were met
+    check_constraints(battery, schedule, soc_at_start)

--- a/flexmeasures/data/models/planning/utils.py
+++ b/flexmeasures/data/models/planning/utils.py
@@ -326,7 +326,7 @@ def get_quantity_from_attribute(
 
 
 def get_series_from_quantity_or_sensor(
-    quantity_or_sensor: Sensor | ur.Quantity,
+    variable_quantity: Sensor | list[dict] | ur.Quantity,
     unit: ur.Quantity | str,
     query_window: tuple[datetime, datetime],
     resolution: timedelta,
@@ -337,8 +337,11 @@ def get_series_from_quantity_or_sensor(
     """
     Get a time series given a quantity or sensor defined on a time window.
 
-    :param quantity_or_sensor:      A pint Quantity or timely-beliefs Sensor, measuring e.g. power capacity
-                                    or efficiency.
+    :param variable_quantity:       Variable quantity measuring e.g. power capacity or efficiency.
+                                    One of the following types:
+                                    - a timely-beliefs Sensor recording the data
+                                    - a list of dictionaries representing a time series specification
+                                    - a pint Quantity representing a fixed quantity
     :param unit:                    Unit of the output data.
     :param query_window:            Tuple representing the start and end of the requested data.
     :param resolution:              Time resolution of the requested data.
@@ -352,15 +355,15 @@ def get_series_from_quantity_or_sensor(
     start, end = query_window
     index = initialize_index(start=start, end=end, resolution=resolution)
 
-    if isinstance(quantity_or_sensor, ur.Quantity):
-        if np.isnan(quantity_or_sensor.magnitude):
+    if isinstance(variable_quantity, ur.Quantity):
+        if np.isnan(variable_quantity.magnitude):
             magnitude = np.nan
         else:
-            magnitude = quantity_or_sensor.to(unit).magnitude
+            magnitude = variable_quantity.to(unit).magnitude
         time_series = pd.Series(magnitude, index=index)
-    elif isinstance(quantity_or_sensor, Sensor):
+    elif isinstance(variable_quantity, Sensor):
         bdf: tb.BeliefsDataFrame = TimedBelief.search(
-            quantity_or_sensor,
+            variable_quantity,
             event_starts_after=query_window[0],
             event_ends_before=query_window[1],
             resolution=resolution,
@@ -372,18 +375,25 @@ def get_series_from_quantity_or_sensor(
         if as_instantaneous_events:
             bdf = bdf.resample_events(timedelta(0), boundary_policy=boundary_policy)
         time_series = simplify_index(bdf).reindex(index).squeeze()
-        time_series = convert_units(time_series, quantity_or_sensor.unit, unit)
+        time_series = convert_units(time_series, variable_quantity.unit, unit)
+    elif isinstance(variable_quantity, list):
+        time_series = pd.Series(np.nan, index=index)
+        for event in variable_quantity:
+            value = event["value"]
+            start = event["start"]
+            end = event["end"]
+            time_series[start : end - resolution] = value
 
     else:
         raise TypeError(
-            f"quantity_or_sensor {quantity_or_sensor} should be a pint Quantity or timely-beliefs Sensor"
+            f"quantity_or_sensor {variable_quantity} should be a pint Quantity or timely-beliefs Sensor"
         )
 
     return time_series
 
 
 def get_continuous_series_sensor_or_quantity(
-    quantity_or_sensor: Sensor | ur.Quantity | None,
+    variable_quantity: Sensor | list[dict] | ur.Quantity | None,
     actuator: Sensor | Asset,
     unit: ur.Quantity | str,
     query_window: tuple[datetime, datetime],
@@ -394,10 +404,10 @@ def get_continuous_series_sensor_or_quantity(
     as_instantaneous_events: bool = False,
     boundary_policy: str | None = None,
 ) -> pd.Series:
-    """Creates a time series from a quantity or sensor within a specified window,
+    """Creates a time series from a sensor, time series specification, or quantity within a specified window,
     falling back to a given `fallback_attribute` and making sure no values exceed `max_value`.
 
-    :param quantity_or_sensor:      The quantity or sensor containing the data.
+    :param variable_quantity:       A sensor recording the data, a time series specification or a fixed quantity.
     :param actuator:                The actuator from which relevant defaults are retrieved.
     :param unit:                    The desired unit of the data.
     :param query_window:            The time window (start, end) to query the data.
@@ -409,15 +419,15 @@ def get_continuous_series_sensor_or_quantity(
                                     interpreted as the desired frequency of the data.
     :returns:                       time series data with missing values handled based on the chosen method.
     """
-    if quantity_or_sensor is None:
-        quantity_or_sensor = get_quantity_from_attribute(
+    if variable_quantity is None:
+        variable_quantity = get_quantity_from_attribute(
             entity=actuator,
             attribute=fallback_attribute,
             unit=unit,
         )
 
     time_series = get_series_from_quantity_or_sensor(
-        quantity_or_sensor=quantity_or_sensor,
+        variable_quantity=variable_quantity,
         unit=unit,
         query_window=query_window,
         resolution=resolution,

--- a/flexmeasures/data/schemas/__init__.py
+++ b/flexmeasures/data/schemas/__init__.py
@@ -5,7 +5,7 @@ Data schemas (Marshmallow)
 from .account import AccountIdField
 from .generic_assets import GenericAssetIdField as AssetIdField
 from .locations import LatitudeField, LongitudeField
-from .sensors import SensorIdField, TimeSeriesOrQuantityOrSensor
+from .sensors import SensorIdField, VariableQuantityField
 from .sources import DataSourceIdField as SourceIdField
 from .times import (
     AwareDateTimeField,

--- a/flexmeasures/data/schemas/__init__.py
+++ b/flexmeasures/data/schemas/__init__.py
@@ -5,7 +5,7 @@ Data schemas (Marshmallow)
 from .account import AccountIdField
 from .generic_assets import GenericAssetIdField as AssetIdField
 from .locations import LatitudeField, LongitudeField
-from .sensors import SensorIdField, QuantityOrSensor
+from .sensors import SensorIdField, TimeSeriesOrQuantityOrSensor
 from .sources import DataSourceIdField as SourceIdField
 from .times import (
     AwareDateTimeField,

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -1,6 +1,6 @@
 from marshmallow import Schema, fields, validate
 
-from flexmeasures.data.schemas.sensors import QuantityOrSensor, SensorIdField
+from flexmeasures.data.schemas.sensors import TimeSeriesOrQuantityOrSensor, SensorIdField
 
 
 class FlexContextSchema(Schema):
@@ -8,19 +8,19 @@ class FlexContextSchema(Schema):
     This schema lists fields that can be used to describe sensors in the optimised portfolio
     """
 
-    ems_power_capacity_in_mw = QuantityOrSensor(
+    ems_power_capacity_in_mw = TimeSeriesOrQuantityOrSensor(
         "MW",
         required=False,
         data_key="site-power-capacity",
         validate=validate.Range(min=0),
     )
-    ems_production_capacity_in_mw = QuantityOrSensor(
+    ems_production_capacity_in_mw = TimeSeriesOrQuantityOrSensor(
         "MW",
         required=False,
         data_key="site-production-capacity",
         validate=validate.Range(min=0),
     )
-    ems_consumption_capacity_in_mw = QuantityOrSensor(
+    ems_consumption_capacity_in_mw = TimeSeriesOrQuantityOrSensor(
         "MW",
         required=False,
         data_key="site-consumption-capacity",

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -1,7 +1,7 @@
 from marshmallow import Schema, fields, validate
 
 from flexmeasures.data.schemas.sensors import (
-    TimeSeriesOrQuantityOrSensor,
+    VariableQuantityField,
     SensorIdField,
 )
 
@@ -11,19 +11,19 @@ class FlexContextSchema(Schema):
     This schema lists fields that can be used to describe sensors in the optimised portfolio
     """
 
-    ems_power_capacity_in_mw = TimeSeriesOrQuantityOrSensor(
+    ems_power_capacity_in_mw = VariableQuantityField(
         "MW",
         required=False,
         data_key="site-power-capacity",
         validate=validate.Range(min=0),
     )
-    ems_production_capacity_in_mw = TimeSeriesOrQuantityOrSensor(
+    ems_production_capacity_in_mw = VariableQuantityField(
         "MW",
         required=False,
         data_key="site-production-capacity",
         validate=validate.Range(min=0),
     )
-    ems_consumption_capacity_in_mw = TimeSeriesOrQuantityOrSensor(
+    ems_consumption_capacity_in_mw = VariableQuantityField(
         "MW",
         required=False,
         data_key="site-consumption-capacity",

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -1,6 +1,9 @@
 from marshmallow import Schema, fields, validate
 
-from flexmeasures.data.schemas.sensors import TimeSeriesOrQuantityOrSensor, SensorIdField
+from flexmeasures.data.schemas.sensors import (
+    TimeSeriesOrQuantityOrSensor,
+    SensorIdField,
+)
 
 
 class FlexContextSchema(Schema):

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -15,7 +15,7 @@ from marshmallow.validate import OneOf, ValidationError
 
 from flexmeasures.data.models.time_series import Sensor
 from flexmeasures.data.schemas.units import QuantityField
-from flexmeasures.data.schemas.sensors import TimeSeriesOrQuantityOrSensor, TimeSeriesOrQuantityOrSensor
+from flexmeasures.data.schemas.sensors import TimeSeriesOrQuantityOrSensor
 
 from flexmeasures.utils.unit_utils import ur
 

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -15,7 +15,7 @@ from marshmallow.validate import OneOf, ValidationError
 
 from flexmeasures.data.models.time_series import Sensor
 from flexmeasures.data.schemas.units import QuantityField
-from flexmeasures.data.schemas.sensors import TimeSeriesOrQuantityOrSensor
+from flexmeasures.data.schemas.sensors import VariableQuantityField
 
 from flexmeasures.utils.unit_utils import ur
 
@@ -78,26 +78,26 @@ class StorageFlexModelSchema(Schema):
         data_key="soc-max",
     )
 
-    power_capacity_in_mw = TimeSeriesOrQuantityOrSensor(
+    power_capacity_in_mw = VariableQuantityField(
         "MW", required=False, data_key="power-capacity"
     )
 
-    consumption_capacity = TimeSeriesOrQuantityOrSensor(
+    consumption_capacity = VariableQuantityField(
         "MW", data_key="consumption-capacity", required=False
     )
-    production_capacity = TimeSeriesOrQuantityOrSensor(
+    production_capacity = VariableQuantityField(
         "MW", data_key="production-capacity", required=False
     )
 
     # Timezone placeholders for the soc_maxima, soc_minima and soc_targets fields are overridden in __init__
-    soc_maxima = TimeSeriesOrQuantityOrSensor(
+    soc_maxima = VariableQuantityField(
         to_unit="MWh",
         default_src_unit="dimensionless",  # placeholder, overridden in __init__
         timezone="placeholder",
         data_key="soc-maxima",
     )
 
-    soc_minima = TimeSeriesOrQuantityOrSensor(
+    soc_minima = VariableQuantityField(
         to_unit="MWh",
         default_src_unit="dimensionless",  # placeholder, overridden in __init__
         timezone="placeholder",
@@ -105,7 +105,7 @@ class StorageFlexModelSchema(Schema):
         value_validator=validate.Range(min=0),
     )
 
-    soc_targets = TimeSeriesOrQuantityOrSensor(
+    soc_targets = VariableQuantityField(
         to_unit="MWh",
         default_src_unit="dimensionless",  # placeholder, overridden in __init__
         timezone="placeholder",
@@ -122,10 +122,10 @@ class StorageFlexModelSchema(Schema):
         data_key="soc-unit",
     )
 
-    charging_efficiency = TimeSeriesOrQuantityOrSensor(
+    charging_efficiency = VariableQuantityField(
         "%", data_key="charging-efficiency", required=False
     )
-    discharging_efficiency = TimeSeriesOrQuantityOrSensor(
+    discharging_efficiency = VariableQuantityField(
         "%", data_key="discharging-efficiency", required=False
     )
 
@@ -133,19 +133,19 @@ class StorageFlexModelSchema(Schema):
         data_key="roundtrip-efficiency", required=False
     )
 
-    storage_efficiency = TimeSeriesOrQuantityOrSensor(
+    storage_efficiency = VariableQuantityField(
         "%", default_src_unit="dimensionless", data_key="storage-efficiency"
     )
     prefer_charging_sooner = fields.Bool(data_key="prefer-charging-sooner")
 
     soc_gain = fields.List(
-        TimeSeriesOrQuantityOrSensor("MW"),
+        VariableQuantityField("MW"),
         data_key="soc-gain",
         required=False,
         validate=validate.Length(min=1),
     )
     soc_usage = fields.List(
-        TimeSeriesOrQuantityOrSensor("MW"),
+        VariableQuantityField("MW"),
         data_key="soc-usage",
         required=False,
         validate=validate.Length(min=1),
@@ -162,21 +162,21 @@ class StorageFlexModelSchema(Schema):
         """Pass the schedule's start, so we can use it to validate soc-target datetimes."""
         self.start = start
         self.sensor = sensor
-        self.soc_maxima = TimeSeriesOrQuantityOrSensor(
+        self.soc_maxima = VariableQuantityField(
             to_unit="MWh",
             default_src_unit=default_soc_unit,
             timezone=sensor.timezone,
             data_key="soc-maxima",
         )
 
-        self.soc_minima = TimeSeriesOrQuantityOrSensor(
+        self.soc_minima = VariableQuantityField(
             to_unit="MWh",
             default_src_unit=default_soc_unit,
             timezone=sensor.timezone,
             data_key="soc-minima",
             value_validator=validate.Range(min=0),
         )
-        self.soc_targets = TimeSeriesOrQuantityOrSensor(
+        self.soc_targets = VariableQuantityField(
             to_unit="MWh",
             default_src_unit=default_soc_unit,
             timezone=sensor.timezone,

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -15,7 +15,7 @@ from marshmallow.validate import OneOf, ValidationError
 
 from flexmeasures.data.models.time_series import Sensor
 from flexmeasures.data.schemas.units import QuantityField
-from flexmeasures.data.schemas.sensors import QuantityOrSensor, TimeSeriesOrSensor
+from flexmeasures.data.schemas.sensors import TimeSeriesOrQuantityOrSensor, TimeSeriesOrQuantityOrSensor
 
 from flexmeasures.utils.unit_utils import ur
 
@@ -59,30 +59,30 @@ class StorageFlexModelSchema(Schema):
     soc_min = fields.Float(validate=validate.Range(min=0), data_key="soc-min")
     soc_max = fields.Float(data_key="soc-max")
 
-    power_capacity_in_mw = QuantityOrSensor(
+    power_capacity_in_mw = TimeSeriesOrQuantityOrSensor(
         "MW", required=False, data_key="power-capacity"
     )
 
-    consumption_capacity = QuantityOrSensor(
+    consumption_capacity = TimeSeriesOrQuantityOrSensor(
         "MW", data_key="consumption-capacity", required=False
     )
-    production_capacity = QuantityOrSensor(
+    production_capacity = TimeSeriesOrQuantityOrSensor(
         "MW", data_key="production-capacity", required=False
     )
 
     # Timezone placeholder for the soc_maxima, soc_minima and soc_targets fields are overridden in __init__
-    soc_maxima = TimeSeriesOrSensor(
+    soc_maxima = TimeSeriesOrQuantityOrSensor(
         to_unit="MWh", timezone="placeholder", data_key="soc-maxima"
     )
 
-    soc_minima = TimeSeriesOrSensor(
+    soc_minima = TimeSeriesOrQuantityOrSensor(
         to_unit="MWh",
         timezone="placeholder",
         data_key="soc-minima",
         value_validator=validate.Range(min=0),
     )
 
-    soc_targets = TimeSeriesOrSensor(
+    soc_targets = TimeSeriesOrQuantityOrSensor(
         to_unit="MWh", timezone="placeholder", data_key="soc-targets"
     )
 
@@ -96,10 +96,10 @@ class StorageFlexModelSchema(Schema):
         data_key="soc-unit",
     )  # todo: allow unit to be set per field, using QuantityField("%", validate=validate.Range(min=0, max=1))
 
-    charging_efficiency = QuantityOrSensor(
+    charging_efficiency = TimeSeriesOrQuantityOrSensor(
         "%", data_key="charging-efficiency", required=False
     )
-    discharging_efficiency = QuantityOrSensor(
+    discharging_efficiency = TimeSeriesOrQuantityOrSensor(
         "%", data_key="discharging-efficiency", required=False
     )
 
@@ -107,31 +107,31 @@ class StorageFlexModelSchema(Schema):
         data_key="roundtrip-efficiency", required=False
     )
 
-    storage_efficiency = QuantityOrSensor(
+    storage_efficiency = TimeSeriesOrQuantityOrSensor(
         "%", default_src_unit="dimensionless", data_key="storage-efficiency"
     )
     prefer_charging_sooner = fields.Bool(data_key="prefer-charging-sooner")
 
-    soc_gain = fields.List(QuantityOrSensor("MW"), data_key="soc-gain", required=False)
+    soc_gain = fields.List(TimeSeriesOrQuantityOrSensor("MW"), data_key="soc-gain", required=False)
     soc_usage = fields.List(
-        QuantityOrSensor("MW"), data_key="soc-usage", required=False
+        TimeSeriesOrQuantityOrSensor("MW"), data_key="soc-usage", required=False
     )
 
     def __init__(self, start: datetime, sensor: Sensor, *args, **kwargs):
         """Pass the schedule's start, so we can use it to validate soc-target datetimes."""
         self.start = start
         self.sensor = sensor
-        self.soc_maxima = TimeSeriesOrSensor(
+        self.soc_maxima = TimeSeriesOrQuantityOrSensor(
             to_unit="MWh", timezone=sensor.timezone, data_key="soc-maxima"
         )
 
-        self.soc_minima = TimeSeriesOrSensor(
+        self.soc_minima = TimeSeriesOrQuantityOrSensor(
             to_unit="MWh",
             timezone=sensor.timezone,
             data_key="soc-minima",
             value_validator=validate.Range(min=0),
         )
-        self.soc_targets = TimeSeriesOrSensor(
+        self.soc_targets = TimeSeriesOrQuantityOrSensor(
             to_unit="MWh", timezone=sensor.timezone, data_key="soc-targets"
         )
 

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -63,7 +63,9 @@ class StorageFlexModelSchema(Schema):
     )
 
     soc_min = QuantityField(
-        validate=validate.Range(min=0),  # change to min=ur.Quantity("0 MWh") in case return_magnitude=False
+        validate=validate.Range(
+            min=0
+        ),  # change to min=ur.Quantity("0 MWh") in case return_magnitude=False
         to_unit="MWh",
         default_src_unit="dimensionless",  # placeholder, overridden in __init__
         return_magnitude=True,
@@ -143,7 +145,14 @@ class StorageFlexModelSchema(Schema):
         TimeSeriesOrQuantityOrSensor("MW"), data_key="soc-usage", required=False
     )
 
-    def __init__(self, start: datetime, sensor: Sensor, *args, default_soc_unit: str | None = None, **kwargs):
+    def __init__(
+        self,
+        start: datetime,
+        sensor: Sensor,
+        *args,
+        default_soc_unit: str | None = None,
+        **kwargs,
+    ):
         """Pass the schedule's start, so we can use it to validate soc-target datetimes."""
         self.start = start
         self.sensor = sensor

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -139,10 +139,16 @@ class StorageFlexModelSchema(Schema):
     prefer_charging_sooner = fields.Bool(data_key="prefer-charging-sooner")
 
     soc_gain = fields.List(
-        TimeSeriesOrQuantityOrSensor("MW"), data_key="soc-gain", required=False
+        TimeSeriesOrQuantityOrSensor("MW"),
+        data_key="soc-gain",
+        required=False,
+        validate=validate.Length(min=1),
     )
     soc_usage = fields.List(
-        TimeSeriesOrQuantityOrSensor("MW"), data_key="soc-usage", required=False
+        TimeSeriesOrQuantityOrSensor("MW"),
+        data_key="soc-usage",
+        required=False,
+        validate=validate.Length(min=1),
     )
 
     def __init__(

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -120,6 +120,7 @@ class StorageFlexModelSchema(Schema):
             ]
         ),
         data_key="soc-unit",
+        required=False,
     )
 
     charging_efficiency = VariableQuantityField(

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -163,6 +163,14 @@ class StorageFlexModelSchema(Schema):
         """Pass the schedule's start, so we can use it to validate soc-target datetimes."""
         self.start = start
         self.sensor = sensor
+
+        # guess default soc-unit
+        if default_soc_unit is None:
+            if self.sensor.unit in ("MWh", "kWh"):
+                default_soc_unit = self.sensor.unit
+            elif self.sensor.unit in ("MW", "kW"):
+                default_soc_unit = self.sensor.unit + "h"
+
         self.soc_maxima = VariableQuantityField(
             to_unit="MWh",
             default_src_unit=default_soc_unit,

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -185,12 +185,9 @@ class StorageFlexModelSchema(Schema):
 
         super().__init__(*args, **kwargs)
         if default_soc_unit is not None:
-            setattr(self.fields["soc_at_start"], "default_src_unit", default_soc_unit)
-            setattr(self.fields["soc_min"], "default_src_unit", default_soc_unit)
-            setattr(self.fields["soc_max"], "default_src_unit", default_soc_unit)
-            setattr(self.fields["soc_minima"], "default_src_unit", default_soc_unit)
-            setattr(self.fields["soc_maxima"], "default_src_unit", default_soc_unit)
-            setattr(self.fields["soc_targets"], "default_src_unit", default_soc_unit)
+            for field in self.fields.keys():
+                if field.startswith("soc_"):
+                    setattr(self.fields[field], "default_src_unit", default_soc_unit)
 
     @validates_schema
     def check_whether_targets_exceed_max_planning_horizon(self, data: dict, **kwargs):

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -112,7 +112,9 @@ class StorageFlexModelSchema(Schema):
     )
     prefer_charging_sooner = fields.Bool(data_key="prefer-charging-sooner")
 
-    soc_gain = fields.List(TimeSeriesOrQuantityOrSensor("MW"), data_key="soc-gain", required=False)
+    soc_gain = fields.List(
+        TimeSeriesOrQuantityOrSensor("MW"), data_key="soc-gain", required=False
+    )
     soc_usage = fields.List(
         TimeSeriesOrQuantityOrSensor("MW"), data_key="soc-usage", required=False
     )

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -54,10 +54,27 @@ class StorageFlexModelSchema(Schema):
     You can use StorageScheduler.deserialize_flex_config to get that filled in.
     """
 
-    soc_at_start = fields.Float(required=True, data_key="soc-at-start")
+    soc_at_start = QuantityField(
+        required=True,
+        to_unit="MWh",
+        default_src_unit="dimensionless",  # placeholder, overridden in __init__
+        return_magnitude=True,
+        data_key="soc-at-start",
+    )
 
-    soc_min = fields.Float(validate=validate.Range(min=0), data_key="soc-min")
-    soc_max = fields.Float(data_key="soc-max")
+    soc_min = QuantityField(
+        validate=validate.Range(min=0),
+        to_unit="MWh",
+        default_src_unit="dimensionless",  # placeholder, overridden in __init__
+        return_magnitude=True,
+        data_key="soc-min",
+    )
+    soc_max = QuantityField(
+        to_unit="MWh",
+        default_src_unit="dimensionless",  # placeholder, overridden in __init__
+        return_magnitude=True,
+        data_key="soc-max",
+    )
 
     power_capacity_in_mw = TimeSeriesOrQuantityOrSensor(
         "MW", required=False, data_key="power-capacity"
@@ -72,18 +89,25 @@ class StorageFlexModelSchema(Schema):
 
     # Timezone placeholders for the soc_maxima, soc_minima and soc_targets fields are overridden in __init__
     soc_maxima = TimeSeriesOrQuantityOrSensor(
-        to_unit="MWh", timezone="placeholder", data_key="soc-maxima"
+        to_unit="MWh",
+        default_src_unit="dimensionless",  # placeholder, overridden in __init__
+        timezone="placeholder",
+        data_key="soc-maxima",
     )
 
     soc_minima = TimeSeriesOrQuantityOrSensor(
         to_unit="MWh",
+        default_src_unit="dimensionless",  # placeholder, overridden in __init__
         timezone="placeholder",
         data_key="soc-minima",
         value_validator=validate.Range(min=0),
     )
 
     soc_targets = TimeSeriesOrQuantityOrSensor(
-        to_unit="MWh", timezone="placeholder", data_key="soc-targets"
+        to_unit="MWh",
+        default_src_unit="dimensionless",  # placeholder, overridden in __init__
+        timezone="placeholder",
+        data_key="soc-targets",
     )
 
     soc_unit = fields.Str(
@@ -94,7 +118,7 @@ class StorageFlexModelSchema(Schema):
             ]
         ),
         data_key="soc-unit",
-    )  # todo: allow unit to be set per field, using QuantityField("%", validate=validate.Range(min=0, max=1))
+    )
 
     charging_efficiency = TimeSeriesOrQuantityOrSensor(
         "%", data_key="charging-efficiency", required=False
@@ -145,6 +169,13 @@ class StorageFlexModelSchema(Schema):
         )
 
         super().__init__(*args, **kwargs)
+        if default_soc_unit is not None:
+            setattr(self.fields["soc_at_start"], "default_src_unit", default_soc_unit)
+            setattr(self.fields["soc_min"], "default_src_unit", default_soc_unit)
+            setattr(self.fields["soc_max"], "default_src_unit", default_soc_unit)
+            setattr(self.fields["soc_minima"], "default_src_unit", default_soc_unit)
+            setattr(self.fields["soc_maxima"], "default_src_unit", default_soc_unit)
+            setattr(self.fields["soc_targets"], "default_src_unit", default_soc_unit)
 
     @validates_schema
     def check_whether_targets_exceed_max_planning_horizon(self, data: dict, **kwargs):

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -70,7 +70,7 @@ class StorageFlexModelSchema(Schema):
         "MW", data_key="production-capacity", required=False
     )
 
-    # Timezone placeholder for the soc_maxima, soc_minima and soc_targets fields are overridden in __init__
+    # Timezone placeholders for the soc_maxima, soc_minima and soc_targets fields are overridden in __init__
     soc_maxima = TimeSeriesOrQuantityOrSensor(
         to_unit="MWh", timezone="placeholder", data_key="soc-maxima"
     )
@@ -119,22 +119,29 @@ class StorageFlexModelSchema(Schema):
         TimeSeriesOrQuantityOrSensor("MW"), data_key="soc-usage", required=False
     )
 
-    def __init__(self, start: datetime, sensor: Sensor, *args, **kwargs):
+    def __init__(self, start: datetime, sensor: Sensor, *args, default_soc_unit: str | None = None, **kwargs):
         """Pass the schedule's start, so we can use it to validate soc-target datetimes."""
         self.start = start
         self.sensor = sensor
         self.soc_maxima = TimeSeriesOrQuantityOrSensor(
-            to_unit="MWh", timezone=sensor.timezone, data_key="soc-maxima"
+            to_unit="MWh",
+            default_src_unit=default_soc_unit,
+            timezone=sensor.timezone,
+            data_key="soc-maxima",
         )
 
         self.soc_minima = TimeSeriesOrQuantityOrSensor(
             to_unit="MWh",
+            default_src_unit=default_soc_unit,
             timezone=sensor.timezone,
             data_key="soc-minima",
             value_validator=validate.Range(min=0),
         )
         self.soc_targets = TimeSeriesOrQuantityOrSensor(
-            to_unit="MWh", timezone=sensor.timezone, data_key="soc-targets"
+            to_unit="MWh",
+            default_src_unit=default_soc_unit,
+            timezone=sensor.timezone,
+            data_key="soc-targets",
         )
 
         super().__init__(*args, **kwargs)

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -72,18 +72,18 @@ class StorageFlexModelSchema(Schema):
 
     # Timezone placeholder for the soc_maxima, soc_minima and soc_targets fields are overridden in __init__
     soc_maxima = TimeSeriesOrSensor(
-        unit="MWh", timezone="placeholder", data_key="soc-maxima"
+        to_unit="MWh", timezone="placeholder", data_key="soc-maxima"
     )
 
     soc_minima = TimeSeriesOrSensor(
-        unit="MWh",
+        to_unit="MWh",
         timezone="placeholder",
         data_key="soc-minima",
         value_validator=validate.Range(min=0),
     )
 
     soc_targets = TimeSeriesOrSensor(
-        unit="MWh", timezone="placeholder", data_key="soc-targets"
+        to_unit="MWh", timezone="placeholder", data_key="soc-targets"
     )
 
     soc_unit = fields.Str(
@@ -122,17 +122,17 @@ class StorageFlexModelSchema(Schema):
         self.start = start
         self.sensor = sensor
         self.soc_maxima = TimeSeriesOrSensor(
-            unit="MWh", timezone=sensor.timezone, data_key="soc-maxima"
+            to_unit="MWh", timezone=sensor.timezone, data_key="soc-maxima"
         )
 
         self.soc_minima = TimeSeriesOrSensor(
-            unit="MWh",
+            to_unit="MWh",
             timezone=sensor.timezone,
             data_key="soc-minima",
             value_validator=validate.Range(min=0),
         )
         self.soc_targets = TimeSeriesOrSensor(
-            unit="MWh", timezone=sensor.timezone, data_key="soc-targets"
+            to_unit="MWh", timezone=sensor.timezone, data_key="soc-targets"
         )
 
         super().__init__(*args, **kwargs)

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -63,7 +63,7 @@ class StorageFlexModelSchema(Schema):
     )
 
     soc_min = QuantityField(
-        validate=validate.Range(min=0),
+        validate=validate.Range(min=0),  # change to min=ur.Quantity("0 MWh") in case return_magnitude=False
         to_unit="MWh",
         default_src_unit="dimensionless",  # placeholder, overridden in __init__
         return_magnitude=True,
@@ -226,33 +226,8 @@ class StorageFlexModelSchema(Schema):
     @post_load
     def post_load_sequence(self, data: dict, **kwargs) -> dict:
         """Perform some checks and corrections after we loaded."""
-        # currently we only handle MWh internally
-        # TODO: review when we moved away from capacity having to be described in MWh
-        if data.get("soc_unit") == "kWh":
-            data["soc_at_start"] /= 1000.0
-            if data.get("soc_min") is not None:
-                data["soc_min"] /= 1000.0
-            if data.get("soc_max") is not None:
-                data["soc_max"] /= 1000.0
-            if (
-                not isinstance(data.get("soc_targets"), Sensor)
-                and data.get("soc_targets") is not None
-            ):
-                for target in data["soc_targets"]:
-                    target["value"] /= 1000.0
-            if (
-                not isinstance(data.get("soc_minima"), Sensor)
-                and data.get("soc_minima") is not None
-            ):
-                for minimum in data["soc_minima"]:
-                    minimum["value"] /= 1000.0
-            if (
-                not isinstance(data.get("soc_maxima"), Sensor)
-                and data.get("soc_maxima") is not None
-            ):
-                for maximum in data["soc_maxima"]:
-                    maximum["value"] /= 1000.0
-            data["soc_unit"] = "MWh"
+        # currently we only handle MWh internally, and the conversion to MWh happened during deserialization
+        data["soc_unit"] = "MWh"
 
         # Convert efficiency to dimensionless (to the (0,1] range)
         if data.get("roundtrip_efficiency") is not None:

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -351,6 +351,18 @@ class TimeSeriesOrSensor(MarshmallowClickMixin, fields.Field):
                 f"Unsupported value type. `{type(value)}` was provided but only dict and list are supported."
             )
 
+    def _serialize(
+        self, value: ur.Quantity | Sensor, attr, data, **kwargs
+    ) -> str | dict[str, int]:
+        if isinstance(value, ur.Quantity):
+            return str(value.to(self.to_unit))
+        elif isinstance(value, Sensor):
+            return dict(sensor=value.id)
+        else:
+            raise FMValidationError(
+                "Serialized Quantity Or Sensor needs to be of type int, float or Sensor"
+            )
+
     def convert(self, value, param, ctx, **kwargs):
         # case that the click default is defined in numeric values
         if not isinstance(value, str):

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -314,8 +314,8 @@ class TimeSeriesOrSensor(MarshmallowClickMixin, fields.Field):
 
     @with_appcontext_if_needed()
     def _deserialize(
-        self, value: str | dict[str, int], attr, obj, **kwargs
-    ) -> list[dict] | Sensor:
+        self, value: dict[str, int] | list[dict] | str, attr, obj, **kwargs
+    ) -> list[dict] | Sensor | ur.Quantity:
 
         if isinstance(value, dict):
             if "sensor" not in value:

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+
+from flask import current_app
 from marshmallow import (
     Schema,
     fields,
@@ -321,3 +323,22 @@ class RepurposeValidatorToIgnoreSensors(validate.Validator):
         if not isinstance(value, Sensor):
             self.original_validator(value)
         return value
+
+
+class QuantityOrSensor(TimeSeriesOrQuantityOrSensor):
+    def __init__(self, *args, **kwargs):
+        """Deprecated class. Use `TimeSeriesOrQuantityOrSensor` instead."""
+        current_app.logger.warning(
+            f"Class `TimeSeriesOrSensor` is deprecated. Use `TimeSeriesOrQuantityOrSensor` instead."
+        )
+        super().__init__(*args, **kwargs)
+
+
+class TimeSeriesOrSensor(TimeSeriesOrQuantityOrSensor):
+    def __init__(self, *args, **kwargs):
+        """Deprecated class. Use `TimeSeriesOrQuantityOrSensor` instead."""
+        current_app.logger.warning(
+            f"Class `TimeSeriesOrSensor` is deprecated. Use `TimeSeriesOrQuantityOrSensor` instead."
+        )
+        super().__init__(*args, **kwargs)
+

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -344,4 +344,3 @@ class TimeSeriesOrSensor(TimeSeriesOrQuantityOrSensor):
             f"Class `TimeSeriesOrSensor` is deprecated. Use `TimeSeriesOrQuantityOrSensor` instead."
         )
         super().__init__(*args, **kwargs)
-

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -289,7 +289,7 @@ class QuantityOrSensor(MarshmallowClickMixin, fields.Field):
 class TimeSeriesOrSensor(MarshmallowClickMixin, fields.Field):
     def __init__(
         self,
-        unit,
+        to_unit,
         *args,
         timezone: str | None = None,
         value_validator: Validator | None = None,
@@ -302,7 +302,7 @@ class TimeSeriesOrSensor(MarshmallowClickMixin, fields.Field):
         super().__init__(*args, **kwargs)
         self.timezone = timezone
         self.value_validator = value_validator
-        self.unit = ur.Quantity(unit)
+        self.unit = ur.Quantity(to_unit)
 
     @with_appcontext_if_needed()
     def _deserialize(

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -246,11 +246,9 @@ class TimeSeriesOrQuantityOrSensor(MarshmallowClickMixin, fields.Field):
                 raise FMValidationError(
                     "Dictionary provided but `sensor` key not found."
                 )
-
             sensor = SensorIdField(unit=self.to_unit)._deserialize(
                 value["sensor"], None, None
             )
-
             return sensor
 
         elif isinstance(value, list):
@@ -261,7 +259,6 @@ class TimeSeriesOrQuantityOrSensor(MarshmallowClickMixin, fields.Field):
                     )
                 )
             )
-
             return field._deserialize(value, None, None)
 
         elif isinstance(value, str):

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -332,7 +332,7 @@ class QuantityOrSensor(TimeSeriesOrQuantityOrSensor):
     def __init__(self, *args, **kwargs):
         """Deprecated class. Use `TimeSeriesOrQuantityOrSensor` instead."""
         current_app.logger.warning(
-            f"Class `TimeSeriesOrSensor` is deprecated. Use `TimeSeriesOrQuantityOrSensor` instead."
+            "Class `TimeSeriesOrSensor` is deprecated. Use `TimeSeriesOrQuantityOrSensor` instead."
         )
         super().__init__(*args, **kwargs)
 
@@ -341,6 +341,6 @@ class TimeSeriesOrSensor(TimeSeriesOrQuantityOrSensor):
     def __init__(self, *args, **kwargs):
         """Deprecated class. Use `TimeSeriesOrQuantityOrSensor` instead."""
         current_app.logger.warning(
-            f"Class `TimeSeriesOrSensor` is deprecated. Use `TimeSeriesOrQuantityOrSensor` instead."
+            "Class `TimeSeriesOrSensor` is deprecated. Use `TimeSeriesOrQuantityOrSensor` instead."
         )
         super().__init__(*args, **kwargs)

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -351,6 +351,20 @@ class TimeSeriesOrSensor(MarshmallowClickMixin, fields.Field):
                 f"Unsupported value type. `{type(value)}` was provided but only dict and list are supported."
             )
 
+    def convert(self, value, param, ctx, **kwargs):
+        # case that the click default is defined in numeric values
+        if not isinstance(value, str):
+            return super().convert(value, param, ctx, **kwargs)
+
+        _value = re.match(r"sensor:(\d+)", value)
+
+        if _value is not None:
+            _value = {"sensor": int(_value.groups()[0])}
+        else:
+            _value = value
+
+        return super().convert(_value, param, ctx, **kwargs)
+
 
 class RepurposeValidatorToIgnoreSensors(validate.Validator):
     """Validator that executes another validator (the one you initialize it with) only on non-Sensor values."""

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -259,7 +259,7 @@ class QuantityOrSensor(MarshmallowClickMixin, fields.Field):
             )
 
     def _serialize(
-        self, value: ur.Quantity | dict[str, Sensor], attr, data, **kwargs
+        self, value: ur.Quantity | Sensor, attr, data, **kwargs
     ) -> str | dict[str, int]:
         if isinstance(value, ur.Quantity):
             return str(value.to(self.to_unit))

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -241,9 +241,8 @@ class TimeSeriesOrQuantityOrSensor(MarshmallowClickMixin, fields.Field):
         For example, validate=validate.Range(min=0) will raise a ValidationError in case of negative quantities,
         but will let pass any sensor that has recorded negative values.
 
-        :param to_unit:             Unit in which the sensor or quantity should be convertible to.
-                                    - Time series are assumed to be passed without a unit, so they aren't checked for convertibility.
-                                    - Quantities will already be converted to the given unit.
+        :param to_unit:             Unit in which the time series, quantity or sensor should be convertible to.
+                                    - Time series and quantities are converted to the given unit.
                                     - Sensors are checked for convertibility, but the original sensor is returned, so its values are not yet converted.
         :param default_src_unit:    What unit to use in case of getting a numeric value. Does not apply to time series or sensors.
         :param return_magnitude:    In case of getting a time series, whether the result should include the magnitude of each quantity, or each Quantity object itself

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -222,7 +222,7 @@ class SensorIdField(MarshmallowClickMixin, fields.Int):
         return sensor.id
 
 
-class TimeSeriesOrQuantityOrSensor(MarshmallowClickMixin, fields.Field):
+class VariableQuantityField(MarshmallowClickMixin, fields.Field):
     def __init__(
         self,
         to_unit,
@@ -233,7 +233,9 @@ class TimeSeriesOrQuantityOrSensor(MarshmallowClickMixin, fields.Field):
         value_validator: Validator | None = None,
         **kwargs,
     ):
-        """Field for validating, serializing and deserializing a quantity, sensor or time series.
+        """Field for validating, serializing and deserializing a variable quantity.
+
+        A variable quantity can be represented by a fixed quantity, sensor or time series.
 
         # todo: Sensor should perhaps deserialize already to sensor data
 
@@ -366,19 +368,19 @@ class RepurposeValidatorToIgnoreSensors(validate.Validator):
         return value
 
 
-class QuantityOrSensor(TimeSeriesOrQuantityOrSensor):
+class QuantityOrSensor(VariableQuantityField):
     def __init__(self, *args, **kwargs):
-        """Deprecated class. Use `TimeSeriesOrQuantityOrSensor` instead."""
+        """Deprecated class. Use `VariableQuantityField` instead."""
         current_app.logger.warning(
-            "Class `TimeSeriesOrSensor` is deprecated. Use `TimeSeriesOrQuantityOrSensor` instead."
+            "Class `TimeSeriesOrSensor` is deprecated. Use `VariableQuantityField` instead."
         )
         super().__init__(*args, **kwargs)
 
 
-class TimeSeriesOrSensor(TimeSeriesOrQuantityOrSensor):
+class TimeSeriesOrSensor(VariableQuantityField):
     def __init__(self, *args, **kwargs):
-        """Deprecated class. Use `TimeSeriesOrQuantityOrSensor` instead."""
+        """Deprecated class. Use `VariableQuantityField` instead."""
         current_app.logger.warning(
-            "Class `TimeSeriesOrSensor` is deprecated. Use `TimeSeriesOrQuantityOrSensor` instead."
+            "Class `TimeSeriesOrSensor` is deprecated. Use `VariableQuantityField` instead."
         )
         super().__init__(*args, **kwargs)

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -295,9 +295,16 @@ class TimeSeriesOrSensor(MarshmallowClickMixin, fields.Field):
         value_validator: Validator | None = None,
         **kwargs,
     ):
-        """
-        The timezone is only used in case a time series is specified and one
-        of the *timed events* in the time series uses a nominal duration, such as "P1D".
+        """Field for validating, serializing and deserializing a quantity, sensor or time series.
+
+        NB any validators passed are only applied to Quantities.
+        For example, validate=validate.Range(min=0) will raise a ValidationError in case of negative quantities,
+        but will let pass any sensor that has recorded negative values.
+
+        :param to_unit:             Unit in which the sensor or quantity should be convertible to.
+        :param default_src_unit:    What unit to use in case of getting a numeric value.
+        :param timezone:            Only used in case a time series is specified and one of the *timed events*
+                                    in the time series uses a nominal duration, such as "P1D".
         """
         super().__init__(*args, **kwargs)
         self.timezone = timezone

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -302,7 +302,7 @@ class TimeSeriesOrSensor(MarshmallowClickMixin, fields.Field):
         super().__init__(*args, **kwargs)
         self.timezone = timezone
         self.value_validator = value_validator
-        self.unit = ur.Quantity(to_unit)
+        self.to_unit = ur.Quantity(to_unit)
 
     @with_appcontext_if_needed()
     def _deserialize(
@@ -315,7 +315,7 @@ class TimeSeriesOrSensor(MarshmallowClickMixin, fields.Field):
                     "Dictionary provided but `sensor` key not found."
                 )
 
-            sensor = SensorIdField(unit=self.unit)._deserialize(
+            sensor = SensorIdField(unit=self.to_unit)._deserialize(
                 value["sensor"], None, None
             )
 

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+import numbers
 
 from flask import current_app
 from marshmallow import (
@@ -274,7 +274,7 @@ class VariableQuantityField(MarshmallowClickMixin, fields.Field):
             return self._deserialize_list(value)
         elif isinstance(value, str):
             return self._deserialize_str(value)
-        elif self.default_src_unit is not None:
+        elif isinstance(value, numbers.Real) and self.default_src_unit is not None:
             return self._deserialize_numeric(value, attr, obj, **kwargs)
         else:
             raise FMValidationError(
@@ -318,8 +318,10 @@ class VariableQuantityField(MarshmallowClickMixin, fields.Field):
                 f"Cannot convert value `{value}` to '{self.to_unit}'"
             ) from e
 
-    def _deserialize_numeric(self, value: Any, attr, obj, **kwargs) -> ur.Quantity:
-        """Try to deserialize any other value (e.g. numeric) to a Quantity, using the default_src_unit."""
+    def _deserialize_numeric(
+        self, value: numbers.Real, attr, obj, **kwargs
+    ) -> ur.Quantity:
+        """Try to deserialize a numeric value to a Quantity, using the default_src_unit."""
         return self._deserialize(
             f"{value} {self.default_src_unit}", attr, obj, **kwargs
         )

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -352,15 +352,19 @@ class TimeSeriesOrSensor(MarshmallowClickMixin, fields.Field):
             )
 
     def _serialize(
-        self, value: ur.Quantity | Sensor, attr, data, **kwargs
+        self, value: ur.Quantity | Sensor | pd.Series, attr, data, **kwargs
     ) -> str | dict[str, int]:
         if isinstance(value, ur.Quantity):
             return str(value.to(self.to_unit))
         elif isinstance(value, Sensor):
             return dict(sensor=value.id)
+        elif isinstance(value, pd.Series):
+            raise NotImplementedError(
+                "Serialization of a time series from a Pandas Series is not implemented yet."
+            )
         else:
             raise FMValidationError(
-                "Serialized Quantity Or Sensor needs to be of type int, float or Sensor"
+                "Serialized quantity, sensor or time series needs to be of type int, float, Sensor or pandas.Series."
             )
 
     def convert(self, value, param, ctx, **kwargs):

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -259,6 +259,10 @@ class TimeSeriesOrQuantityOrSensor(MarshmallowClickMixin, fields.Field):
         self.to_unit = ur.Quantity(to_unit)
         self.default_src_unit = default_src_unit
         self.return_magnitude = return_magnitude
+        if self.return_magnitude is True:
+            current_app.logger.warning(
+                "Deserialized time series will include Quantity objects in the future. Set `return_magnitude=False` to trigger the new behaviour."
+            )
 
     @with_appcontext_if_needed()
     def _deserialize(
@@ -276,10 +280,6 @@ class TimeSeriesOrQuantityOrSensor(MarshmallowClickMixin, fields.Field):
             return sensor
 
         elif isinstance(value, list):
-            if self.return_magnitude is True:
-                current_app.logger.warning(
-                    "Deserialized time series will include Quantity objects in the future. Set `return_magnitude=False` to trigger the new behaviour."
-                )
             field = fields.List(
                 fields.Nested(
                     TimedEventSchema(

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -249,12 +249,11 @@ class QuantityOrSensor(MarshmallowClickMixin, fields.Field):
                 raise FMValidationError(
                     f"Cannot convert value `{value}` to '{self.to_unit}'"
                 ) from e
+        elif self.default_src_unit is not None:
+            return self._deserialize(
+                f"{value} {self.default_src_unit}", attr, obj, **kwargs
+            )
         else:
-            if self.default_src_unit is not None:
-                return self._deserialize(
-                    f"{value} {self.default_src_unit}", attr, obj, **kwargs
-                )
-
             raise FMValidationError(
                 f"Unsupported value type. `{type(value)}` was provided but only dict and str are supported."
             )

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -259,10 +259,6 @@ class TimeSeriesOrQuantityOrSensor(MarshmallowClickMixin, fields.Field):
         self.to_unit = ur.Quantity(to_unit)
         self.default_src_unit = default_src_unit
         self.return_magnitude = return_magnitude
-        if self.return_magnitude is True:
-            current_app.logger.warning(
-                "Deserialized time series will include Quantity objects in the future. Set `return_magnitude=False` to trigger the new behaviour."
-            )
 
     @with_appcontext_if_needed()
     def _deserialize(
@@ -280,6 +276,10 @@ class TimeSeriesOrQuantityOrSensor(MarshmallowClickMixin, fields.Field):
             return sensor
 
         elif isinstance(value, list):
+            if self.return_magnitude is True:
+                current_app.logger.warning(
+                    "Deserialized time series will include Quantity objects in the future. Set `return_magnitude=False` to trigger the new behaviour."
+                )
             field = fields.List(
                 fields.Nested(
                     TimedEventSchema(

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -355,7 +355,7 @@ class TimeSeriesOrSensor(MarshmallowClickMixin, fields.Field):
 
         else:
             raise FMValidationError(
-                f"Unsupported value type. `{type(value)}` was provided but only dict and list are supported."
+                f"Unsupported value type. `{type(value)}` was provided but only dict, list and str are supported."
             )
 
     def _serialize(

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -223,7 +223,10 @@ class TimeSeriesOrQuantityOrSensor(MarshmallowClickMixin, fields.Field):
         but will let pass any sensor that has recorded negative values.
 
         :param to_unit:             Unit in which the sensor or quantity should be convertible to.
-        :param default_src_unit:    What unit to use in case of getting a numeric value.
+                                    - Time series are assumed to be passed without a unit, so they aren't checked for convertibility.
+                                    - Quantities will already be converted to the given unit.
+                                    - Sensors are checked for convertibility, but the original sensor is returned, so its values are not yet converted.
+        :param default_src_unit:    What unit to use in case of getting a numeric value. Does not apply to time series or sensors.
         :param timezone:            Only used in case a time series is specified and one of the *timed events*
                                     in the time series uses a nominal duration, such as "P1D".
         """

--- a/flexmeasures/data/schemas/tests/test_scheduling.py
+++ b/flexmeasures/data/schemas/tests/test_scheduling.py
@@ -204,7 +204,7 @@ def test_efficiency_pair(
     def load_schema():
         flex_model = {
             "storage-efficiency": 1,
-            "soc-at-start": 0,
+            "soc-at-start": "0 MWh",
         }
         for f in fields:
             flex_model[f] = "90%"

--- a/flexmeasures/data/schemas/tests/test_sensor.py
+++ b/flexmeasures/data/schemas/tests/test_sensor.py
@@ -1,6 +1,6 @@
 import pytest
 from flexmeasures import Sensor
-from flexmeasures.data.schemas.sensors import QuantityOrSensor
+from flexmeasures.data.schemas.sensors import TimeSeriesOrQuantityOrSensor
 from flexmeasures.utils.unit_utils import ur
 from marshmallow import ValidationError
 
@@ -27,7 +27,7 @@ def test_quantity_or_sensor_deserialize(
     setup_dummy_sensors, sensor_id, src_quantity, dst_unit, fails
 ):
 
-    schema = QuantityOrSensor(to_unit=dst_unit)
+    schema = TimeSeriesOrQuantityOrSensor(to_unit=dst_unit)
 
     try:
         if sensor_id is None:
@@ -55,7 +55,7 @@ def test_quantity_or_sensor_conversion(
     setup_dummy_sensors, src_quantity, expected_magnitude
 ):
 
-    schema = QuantityOrSensor(to_unit="MW")
+    schema = TimeSeriesOrQuantityOrSensor(to_unit="MW")
     assert schema.deserialize(src_quantity).magnitude == expected_magnitude
 
 
@@ -81,7 +81,7 @@ def test_quantity_or_sensor_field(
     setup_dummy_sensors, sensor_id, input_param, dst_unit, fails, db
 ):
 
-    field = QuantityOrSensor(to_unit=dst_unit)
+    field = TimeSeriesOrQuantityOrSensor(to_unit=dst_unit)
 
     try:
         if sensor_id is None:

--- a/flexmeasures/data/schemas/tests/test_sensor.py
+++ b/flexmeasures/data/schemas/tests/test_sensor.py
@@ -1,6 +1,6 @@
 import pytest
 from flexmeasures import Sensor
-from flexmeasures.data.schemas.sensors import TimeSeriesOrQuantityOrSensor
+from flexmeasures.data.schemas.sensors import QuantityOrSensor
 from flexmeasures.utils.unit_utils import ur
 from marshmallow import ValidationError
 
@@ -27,7 +27,7 @@ def test_quantity_or_sensor_deserialize(
     setup_dummy_sensors, sensor_id, src_quantity, dst_unit, fails
 ):
 
-    schema = TimeSeriesOrQuantityOrSensor(to_unit=dst_unit)
+    schema = QuantityOrSensor(to_unit=dst_unit)
 
     try:
         if sensor_id is None:
@@ -55,7 +55,7 @@ def test_quantity_or_sensor_conversion(
     setup_dummy_sensors, src_quantity, expected_magnitude
 ):
 
-    schema = TimeSeriesOrQuantityOrSensor(to_unit="MW")
+    schema = QuantityOrSensor(to_unit="MW")
     assert schema.deserialize(src_quantity).magnitude == expected_magnitude
 
 
@@ -81,7 +81,7 @@ def test_quantity_or_sensor_field(
     setup_dummy_sensors, sensor_id, input_param, dst_unit, fails, db
 ):
 
-    field = TimeSeriesOrQuantityOrSensor(to_unit=dst_unit)
+    field = QuantityOrSensor(to_unit=dst_unit)
 
     try:
         if sensor_id is None:

--- a/flexmeasures/data/schemas/tests/test_sensor.py
+++ b/flexmeasures/data/schemas/tests/test_sensor.py
@@ -1,6 +1,9 @@
 import pytest
 from flexmeasures import Sensor
-from flexmeasures.data.schemas.sensors import QuantityOrSensor, TimeSeriesOrQuantityOrSensor
+from flexmeasures.data.schemas.sensors import (
+    QuantityOrSensor,
+    TimeSeriesOrQuantityOrSensor,
+)
 from flexmeasures.utils.unit_utils import ur
 from marshmallow import ValidationError
 
@@ -107,9 +110,7 @@ def test_quantity_or_sensor_field(
         ([{"value": "1 MW", "datetime": "2024-07-21T00:15+07"}], "MWh", True),
     ],
 )
-def test_time_series_field(
-    input_param, dst_unit, fails, db
-):
+def test_time_series_field(input_param, dst_unit, fails, db):
 
     field = TimeSeriesOrQuantityOrSensor(
         to_unit=dst_unit,

--- a/flexmeasures/data/schemas/tests/test_sensor.py
+++ b/flexmeasures/data/schemas/tests/test_sensor.py
@@ -2,7 +2,7 @@ import pytest
 from flexmeasures import Sensor
 from flexmeasures.data.schemas.sensors import (
     QuantityOrSensor,
-    TimeSeriesOrQuantityOrSensor,
+    VariableQuantityField,
 )
 from flexmeasures.utils.unit_utils import ur
 from marshmallow import ValidationError
@@ -112,7 +112,7 @@ def test_quantity_or_sensor_field(
 )
 def test_time_series_field(input_param, dst_unit, fails, db):
 
-    field = TimeSeriesOrQuantityOrSensor(
+    field = VariableQuantityField(
         to_unit=dst_unit,
         default_src_unit="MWh",
         return_magnitude=False,

--- a/flexmeasures/data/schemas/tests/test_sensor.py
+++ b/flexmeasures/data/schemas/tests/test_sensor.py
@@ -111,7 +111,11 @@ def test_time_series_field(
     input_param, dst_unit, fails, db
 ):
 
-    field = TimeSeriesOrQuantityOrSensor(to_unit=dst_unit, default_src_unit="MWh")
+    field = TimeSeriesOrQuantityOrSensor(
+        to_unit=dst_unit,
+        default_src_unit="MWh",
+        return_magnitude=False,
+    )
 
     try:
         val = field.convert(input_param, None, None)

--- a/flexmeasures/data/schemas/units.py
+++ b/flexmeasures/data/schemas/units.py
@@ -67,10 +67,16 @@ class QuantityField(MarshmallowClickMixin, fields.Str):
             q = ur.Quantity(value).to(self.to_unit)
         elif self.default_src_unit is not None:
             q = self._deserialize(
-                f"{value} {self.default_src_unit}", attr, obj, **kwargs, return_magnitude=False
+                f"{value} {self.default_src_unit}",
+                attr,
+                obj,
+                **kwargs,
+                return_magnitude=False,
             )
         else:
-            q = self._deserialize(f"{value}", attr, obj, **kwargs, return_magnitude=False)
+            q = self._deserialize(
+                f"{value}", attr, obj, **kwargs, return_magnitude=False
+            )
         if return_magnitude:
             return q.magnitude
         return q

--- a/flexmeasures/data/schemas/units.py
+++ b/flexmeasures/data/schemas/units.py
@@ -62,6 +62,8 @@ class QuantityField(MarshmallowClickMixin, fields.Str):
         if return_magnitude is None:
             return_magnitude = self.return_magnitude
         if isinstance(value, str):
+            if not is_valid_unit(value):
+                raise ValidationError("Not a valid quantity")
             q = ur.Quantity(value).to(self.to_unit)
         elif self.default_src_unit is not None:
             q = self._deserialize(


### PR DESCRIPTION
## Description

- [x] Merge two core schemata used to specify time series data in a flex model, namely `QuantityOrSensor` and `TimeSeriesOrSensor`.
- [x] Named new schema `VariableQuantityField`.
- [x] Backward compatibility: deprecate old schemas, but keep them functioning for now (while logging a deprecation warning).
- [x] Allow setting a SoC unit directly in some fields (formerly `Float` fields, and now `Quantity` fields), while still falling back on the contents of the `soc-unit` field, for backwards compatibility:
  - `soc-at-start`
  - `soc-min`
  - `soc-max`
- [x] Allow setting a unit directly in fields that already supported passing a time series:
  - `soc-maxima`
  - `soc-minima`
  - `soc-targets`
- [x] Allow passing a time series in fields that formerly only accepted passing a fixed quantity or a sensor reference:
  - `power-capacity`
  - `consumption-capacity`
  - `production-capacity`
  - `charging-efficiency`
  - `discharging-efficiency`
  - `storage-efficiency`
  - `soc-gain`
  - `soc-usage`
- [x] Revise docs in `flex-model-v2g.rst` with regards to passing dynamic power constraints as part of the flex-model
- [x] Remove all but one mention of the `soc-unit` field from the docs (still works under the hood) 
- [x] Add test cases for passing a time series to the new schema


## Look & Feel

Synchronizes support for specifying time series data in a flex model in three distinct ways:

- As a constant quantity, such as:
  ```
  "10 kW"
  ```
- As a time series, such as (NB the below example assumes the unit is specified via a separate field):
  ```
  [
      {
          "value": 51,
          "start": "2024-02-04T10:35:00+01:00",
          "end": "2024-02-05T04:25:00+01:00"
      }
  ]
  ```
- As a sensor, such as:
  ```
  {
      "sensor": 101
  }
  ```

## How to test

See https://github.com/FlexMeasures/flexmeasures/pull/1127/files#diff-1f68bebf4090d2608b43200311d3ebd3e0ad637e2e16cc6a9b14bffaa29757f3R2177

## Further Improvements

- Documentation update regarding variable quantity fields moved to #1138.
- Documentation update regarding scheduling in different units moved to #1139.

## Related Items

- Closes #386.
- Closes #1109.
