### PR TITLE
Feature/planning/schedule sensor with different units

### DIFF
--- a/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
+++ b/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
@@ -46,7 +46,7 @@ def test_get_schedule_wrong_job_id(
             message_for_trigger_schedule(),
             "soc-min",
             "not-a-float",
-            "Not a valid number",
+            "Cannot interpret `not-a-float` as a quantity with valid units.",
         ),
         (message_for_trigger_schedule(), "soc-unit", "MWH", "Must be one of"),
         # todo: add back test in case we stop grandfathering ignoring too-far-into-the-future targets, or amend otherwise

--- a/flexmeasures/conftest.py
+++ b/flexmeasures/conftest.py
@@ -819,6 +819,19 @@ def create_test_battery_assets(
     )
     db.session.add(test_battery_sensor)
 
+    test_battery_sensor_kw = Sensor(
+        name="power (kW)",
+        generic_asset=test_battery,
+        event_resolution=timedelta(minutes=15),
+        unit="kW",
+        attributes=dict(
+            daily_seasonality=True,
+            weekly_seasonality=True,
+            yearly_seasonality=True,
+        ),
+    )
+    db.session.add(test_battery_sensor_kw)
+
     test_battery_no_prices = GenericAsset(
         name="Test battery with no known prices",
         owner=setup_accounts["Prosumer"],

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -27,7 +27,7 @@ from flexmeasures.data.schemas.scheduling.storage import StorageFlexModelSchema
 from flexmeasures.data.schemas.scheduling import FlexContextSchema
 from flexmeasures.utils.time_utils import get_max_planning_horizon
 from flexmeasures.utils.coding_utils import deprecated
-from flexmeasures.utils.unit_utils import ur
+from flexmeasures.utils.unit_utils import convert_units, ur
 
 
 class MetaStorageScheduler(Scheduler):
@@ -596,6 +596,8 @@ class StorageFallbackScheduler(MetaStorageScheduler):
             sensor, device_constraints[0], start, end, resolution
         )
 
+        storage_schedule = convert_units(storage_schedule, "MW", sensor.unit)
+
         # Round schedule
         if self.round_to_decimals:
             storage_schedule = storage_schedule.round(self.round_to_decimals)
@@ -656,6 +658,8 @@ class StorageScheduler(MetaStorageScheduler):
         # Round schedule
         if self.round_to_decimals:
             storage_schedule = storage_schedule.round(self.round_to_decimals)
+
+        storage_schedule = convert_units(storage_schedule, "MW", sensor.unit)
 
         if self.return_multiple:
             return [


### PR DESCRIPTION
## Description

This PR opens the door for scheduling in any  power units, for example, in *kW*.  Two changes were introduced for this purpose:
1) Transform the output of the solver from MW to the units of the power sensor.
2) Support defining the `soc-min`, `soc-max` and `soc-at-start` in arbitrary energy units.

## Pending tasks

- [ ] Add examples to the documentation
- [ ] Add a changelog entry

## Related Items

Closes https://github.com/FlexMeasures/flexmeasures/issues/386

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
