### PR TITLE
fix: support saving instantaneous beliefs as a list of one element

### DIFF
--- a/documentation/api/change_log.rst
+++ b/documentation/api/change_log.rst
@@ -5,6 +5,10 @@ API change log
 
 .. note:: The FlexMeasures API follows its own versioning scheme. This is also reflected in the URL (e.g. `/api/v3_0`), allowing developers to upgrade at their own pace.
 
+v3.0-19 | 2024-08-13
+""""""""""""""""""""
+
+-  Allow posting a single instantaneous belief as a list of one element to `/sensors/data` (POST).
 
 v3.0-18 | 2024-03-07
 """"""""""""""""""""

--- a/documentation/api/change_log.rst
+++ b/documentation/api/change_log.rst
@@ -12,14 +12,13 @@ v3.0-19 | 2024-08-13
 
 v3.0-18 | 2024-03-07
 """"""""""""""""""""
-- Add support for providing a sensor definition to the ``soc-minima``, ``soc-maxima`` and ``soc-targets`` flex-model fields for `/sensors/<id>/schedules/trigger` (POST).
 
+- Add support for providing a sensor definition to the ``soc-minima``, ``soc-maxima`` and ``soc-targets`` flex-model fields for `/sensors/<id>/schedules/trigger` (POST).
 
 v3.0-17 | 2024-02-26
 """"""""""""""""""""
 
 - Add support for providing a sensor definition to the ``site-power-capacity``, ``site-consumption-capacity`` and ``site-production-capacity`` flex-context fields for `/sensors/<id>/schedules/trigger` (POST).
-
 
 v3.0-16 | 2024-02-26
 """"""""""""""""""""
@@ -134,7 +133,6 @@ v3.0-1 | 2022-05-08
 """""""""""""""""""
 
 - Added REST endpoint for checking application health (readiness to accept requests): `/health/ready` (GET).
-
 
 v3.0-0 | 2022-03-25
 """""""""""""""""""

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -22,6 +22,7 @@ Infrastructure / Support
 Bugfixes
 -----------
 * Fix styling for User and Documentation menu items [see `PR #1140 <https://github.com/FlexMeasures/flexmeasures/pull/1140>`_]
+* Fix posting a single instantaneous belief [see `PR #1129 <https://github.com/FlexMeasures/flexmeasures/pull/1129>`_]
 * Allow reassigning a public asset to private ownership using the ``flexmeasures edit transfer-ownership`` CLI command [see `PR #1123 <https://github.com/FlexMeasures/flexmeasures/pull/1123>`_]
 * Fix missing value on spring :abbr:`DST (Daylight Saving Time)` transition for ``PandasReporter`` using daily sensor as input [see `PR #1122 <https://github.com/FlexMeasures/flexmeasures/pull/1122>`_]
 

--- a/flexmeasures/api/common/schemas/sensor_data.py
+++ b/flexmeasures/api/common/schemas/sensor_data.py
@@ -349,7 +349,7 @@ class PostSensorDataSchema(SensorDataDescriptionSchema):
         if event_resolution == timedelta(hours=0):
             if num_values > 1:
                 raise NotImplementedError(
-                    "Cannot save multiple instantaneous values that overlap. That is, two values spanning the same moment (a zero duration). Try sending a single value or defininin a non-zero duration."
+                    "Cannot save multiple instantaneous values that overlap. That is, two values spanning the same moment (a zero duration). Try sending a single value or definining a non-zero duration."
                 )
 
             dt_index = pd.date_range(

--- a/flexmeasures/api/common/schemas/sensor_data.py
+++ b/flexmeasures/api/common/schemas/sensor_data.py
@@ -347,9 +347,9 @@ class PostSensorDataSchema(SensorDataDescriptionSchema):
         event_resolution = sensor_data["duration"] / num_values
 
         if event_resolution == timedelta(hours=0):
-            if num_values <= 1:
+            if num_values > 1:
                 raise NotImplementedError(
-                    "Cannot save multiple instantaneous values simultaneously."
+                    "Cannot save multiple instantaneous values that overlap. That is, two values spanning the same moment (a zero duration). Try sending a single value or defininin a non-zero duration."
                 )
 
             dt_index = pd.date_range(

--- a/flexmeasures/api/common/schemas/sensor_data.py
+++ b/flexmeasures/api/common/schemas/sensor_data.py
@@ -347,9 +347,11 @@ class PostSensorDataSchema(SensorDataDescriptionSchema):
         event_resolution = sensor_data["duration"] / num_values
 
         if event_resolution == timedelta(hours=0):
-            assert (
-                num_values <= 1
-            ), "Cannot save multiple instantenous values simultaneously."
+            if num_values <= 1:
+                raise NotImplementedError(
+                    "Cannot save multiple instantaneous values simultaneously."
+                )
+
             dt_index = pd.date_range(
                 sensor_data["start"],
                 periods=num_values,

--- a/flexmeasures/api/v3_0/tests/conftest.py
+++ b/flexmeasures/api/v3_0/tests/conftest.py
@@ -161,8 +161,20 @@ def add_incineration_line(db, test_supplier_user) -> dict[str, Sensor]:
         db, test_supplier_user.data_source[0], temperature_sensor
     )
 
+    empty_temperature_sensor = Sensor(
+        name="empty temperature sensor",
+        unit="°C",
+        event_resolution=timedelta(0),
+        generic_asset=incineration_asset,
+    )
+    db.session.add(empty_temperature_sensor)
+
     db.session.flush()  # assign sensor ids
-    return {gas_sensor.name: gas_sensor, temperature_sensor.name: temperature_sensor}
+    return {
+        gas_sensor.name: gas_sensor,
+        temperature_sensor.name: temperature_sensor,
+        empty_temperature_sensor.name: empty_temperature_sensor,
+    }
 
 
 def add_gas_measurements(db, source: Source, sensor: Sensor):

--- a/flexmeasures/api/v3_0/tests/test_sensor_data.py
+++ b/flexmeasures/api/v3_0/tests/test_sensor_data.py
@@ -235,8 +235,8 @@ def test_post_sensor_data_twice(client, setup_api_test_data, requesting_user, db
         (1, 200, "Request has been processed.", 1),
         (
             2,
-            500,
-            "Cannot save multiple instantaneous values that overlap. That is, two values spanning the same moment (a zero duration). Try sending a single value or defininin a non-zero duration.",
+            422,
+            "Cannot save multiple instantaneous values that overlap. That is, two values spanning the same moment (a zero duration). Try sending a single value or definining a non-zero duration.",
             0,
         ),
     ],
@@ -269,5 +269,9 @@ def test_post_sensor_instantaneous_data(
     )
 
     assert response.status_code == status_code
-    assert response.json["message"] == message
+    if status_code == 422:
+        assert response.json["message"]["json"]["_schema"][0] == message
+    else:
+        assert response.json["message"] == message
+
     assert len(sensor.search_beliefs()) - rows == saved_rows

--- a/flexmeasures/api/v3_0/tests/test_sensor_data.py
+++ b/flexmeasures/api/v3_0/tests/test_sensor_data.py
@@ -233,13 +233,13 @@ def test_post_sensor_data_twice(client, setup_api_test_data, requesting_user, db
     "num_values, status_code, message, saved_rows",
     [
         (1, 200, "Request has been processed.", 1),
-        (2, 500, "Cannot save multiple instantenous values simultaneously.", 0),
+        (2, 500, "Cannot save multiple instantaneous values simultaneously.", 0),
     ],
 )
 @pytest.mark.parametrize(
     "requesting_user", ["test_supplier_user_4@seita.nl"], indirect=True
 )
-def test_post_sensor_instantenous_data(
+def test_post_sensor_instantaneous_data(
     client,
     setup_api_test_data,
     num_values,

--- a/flexmeasures/api/v3_0/tests/test_sensor_data.py
+++ b/flexmeasures/api/v3_0/tests/test_sensor_data.py
@@ -233,7 +233,12 @@ def test_post_sensor_data_twice(client, setup_api_test_data, requesting_user, db
     "num_values, status_code, message, saved_rows",
     [
         (1, 200, "Request has been processed.", 1),
-        (2, 500, "Cannot save multiple instantaneous values simultaneously.", 0),
+        (
+            2,
+            500,
+            "Cannot save multiple instantaneous values that overlap. That is, two values spanning the same moment (a zero duration). Try sending a single value or defininin a non-zero duration.",
+            0,
+        ),
     ],
 )
 @pytest.mark.parametrize(

--- a/flexmeasures/api/v3_0/tests/test_sensor_data.py
+++ b/flexmeasures/api/v3_0/tests/test_sensor_data.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from datetime import timedelta
 from flask import url_for
 import pytest
-
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
 
 from flexmeasures import Sensor, Source, User
 from flexmeasures.api.v3_0.tests.utils import make_sensor_data_request_for_gas_sensor
@@ -184,8 +185,18 @@ def test_post_invalid_sensor_data(
 @pytest.mark.parametrize(
     "requesting_user", ["test_supplier_user_4@seita.nl"], indirect=True
 )
-def test_post_sensor_data_twice(client, setup_api_test_data, requesting_user):
+def test_post_sensor_data_twice(client, setup_api_test_data, requesting_user, db):
     post_data = make_sensor_data_request_for_gas_sensor()
+
+    @event.listens_for(Engine, "handle_error")
+    def receive_handle_error(exception_context):
+        """
+        Check that the error that we are getting is of type IntegrityError.
+        """
+        error_info = exception_context.sqlalchemy_exception
+
+        # If the assert failed, we would get a 500 status code
+        assert error_info.__class__.__name__ == "IntegrityError"
 
     # Check that 1st time posting the data succeeds
     response = client.post(
@@ -213,3 +224,45 @@ def test_post_sensor_data_twice(client, setup_api_test_data, requesting_user):
     print(response.json)
     assert response.status_code == 403
     assert "data represents a replacement" in response.json["message"]
+
+    # at this point, the transaction has failed and needs to be rolled back.
+    db.session.rollback()
+
+
+@pytest.mark.parametrize(
+    "num_values, status_code, message, saved_rows",
+    [
+        (1, 200, "Request has been processed.", 1),
+        (2, 500, "Cannot save multiple instantenous values simultaneously.", 0),
+    ],
+)
+@pytest.mark.parametrize(
+    "requesting_user", ["test_supplier_user_4@seita.nl"], indirect=True
+)
+def test_post_sensor_instantenous_data(
+    client,
+    setup_api_test_data,
+    num_values,
+    status_code,
+    message,
+    saved_rows,
+    requesting_user,
+):
+    post_data = make_sensor_data_request_for_gas_sensor(
+        sensor_name="empty temperature sensor",
+        num_values=num_values,
+        unit="°C",
+        duration="PT0H",
+    )
+    sensor = setup_api_test_data["empty temperature sensor"]
+    rows = len(sensor.search_beliefs())
+
+    # Check that 1st time posting the data succeeds
+    response = client.post(
+        url_for("SensorAPI:post_data"),
+        json=post_data,
+    )
+
+    assert response.status_code == status_code
+    assert response.json["message"] == message
+    assert len(sensor.search_beliefs()) - rows == saved_rows

--- a/flexmeasures/api/v3_0/tests/utils.py
+++ b/flexmeasures/api/v3_0/tests/utils.py
@@ -9,12 +9,13 @@ def make_sensor_data_request_for_gas_sensor(
     duration: str = "PT1H",
     unit: str = "m³",
     include_a_null: bool = False,
+    sensor_name: str = "some gas sensor",
 ) -> dict:
     """Creates request to post sensor data for a gas sensor.
     This particular gas sensor measures units of m³/h with a 10-minute resolution.
     """
     sensor = db.session.execute(
-        select(Sensor).filter_by(name="some gas sensor")
+        select(Sensor).filter_by(name=sensor_name)
     ).scalar_one_or_none()
     values = num_values * [-11.28]
     if include_a_null:


### PR DESCRIPTION
## Description

While trying to store instantaneous measurements via the API I encountered that it wasn't possible to send them using the list format.

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
