### PR TITLE
feat: zoom-in asset and sensor chart

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -10,6 +10,8 @@ v0.23.0 | August XX, 2024
 New features
 -------------
 * Add basic sensor info to sensor page [see `PR #1115 <https://github.com/FlexMeasures/flexmeasures/pull/1115>`_]
+* Support zoom-in action on the asset and sensor charts [see `PR #1130 <https://github.com/FlexMeasures/flexmeasures/pull/1130>`_]
+ 
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -84,6 +84,9 @@ def bar_chart(
                         "as": "source_name_and_id",
                     },
                 ],
+                "selection": {
+                    "scroll": {"type": "interval", "bind": "scales", "encodings": ["x"]}
+                },
             },
             REPLAY_RULER,
         ],
@@ -627,6 +630,9 @@ def create_line_layer(
                 },
             },
             "detail": [FIELD_DEFINITIONS["source"]],
+        },
+        "selection": {
+            "scroll": {"type": "interval", "bind": "scales", "encodings": ["x"]}
         },
     }
     return line_layer


### PR DESCRIPTION
## Description

The current charts work really nice for hourly data and even for resolution that go down to 15min. Nonetheless, for finer grained data (e.g. high frequency instantaneous events), it's hard to inspect the values.

This PR introduces the capability to zoom-in the time axis both on the sensor and asset charts. This allow us to inspect data that comes in high frequency.

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
