### PR TITLE
fix: add missing API changelog entry for soc-minima and soc-maxima

### DIFF
--- a/documentation/api/change_log.rst
+++ b/documentation/api/change_log.rst
@@ -55,7 +55,12 @@ v3.0-11 | 2023-08-02
 v3.0-10 | 2023-06-12
 """"""""""""""""""""
 
-- Introduced the ``storage-efficiency`` field to the ``flex-model``field for `/sensors/<id>/schedules/trigger` (POST).
+- Introduced new ``flex-model`` fields for `/sensors/<id>/schedules/trigger` (POST):
+
+  - ``storage-efficiency``
+  - ``soc-minima``
+  - ``soc-maxima``
+
 - Introduced the ``database_redis`` optional field to the response of the endpoint `/health/ready` (GET).
 
 v3.0-9 | 2023-04-26


### PR DESCRIPTION
fix: add missing API changelog entry for new flex-model fields soc-minima and soc-maxima (introduced in #680)