### PR TITLE
Docs/macOS port

### DIFF
--- a/documentation/dev/setup-and-guidelines.rst
+++ b/documentation/dev/setup-and-guidelines.rst
@@ -12,6 +12,7 @@ Furthermore, we discuss several guidelines and best practices.
     :local:
     :depth: 1
 
+|
 .. note:: Are you implementing code based on FlexMeasures, you're probably interested in :ref:`datamodel`.
 
 

--- a/documentation/dev/setup-and-guidelines.rst
+++ b/documentation/dev/setup-and-guidelines.rst
@@ -150,6 +150,17 @@ Otherwise, you need to add some other user first. Here is how we add an admin:
 (The `account` you need in the 2nd command is printed by the 1st)
 
 
+.. note:: For newer versions of macOS, port 5000 is in use by default by Control Center.
+          You can turn this off by going to System Preferences > Sharing and untick the "Airplay Receiver" box.
+          If you don't want to do this for some reason, you can change the port for locally running FlexMeasures by setting the ``FLASK_RUN_PORT`` environment variable.
+          For example, to set it to port 5001:
+
+          .. code-block:: bash
+
+              $ export FLASK_RUN_PORT=5001  # You can also add this to your local .env
+
+          If you do this, remember that you will have to go to http://localhost:5001 in your browser when you want to inspect the FlexMeasures UI.
+
 .. note::
 
     If you are on Windows, then running & developing FlexMeasures will not work 100%. For instance, the queueing only works if you install rq-win (https://github.com/michaelbrooks/rq-win) manually and the make tooling is difficult to get to work as well.

--- a/documentation/dev/setup-and-guidelines.rst
+++ b/documentation/dev/setup-and-guidelines.rst
@@ -150,16 +150,7 @@ Otherwise, you need to add some other user first. Here is how we add an admin:
 (The `account` you need in the 2nd command is printed by the 1st)
 
 
-.. note:: For newer versions of macOS, port 5000 is in use by default by Control Center.
-          You can turn this off by going to System Preferences > Sharing and untick the "Airplay Receiver" box.
-          If you don't want to do this for some reason, you can change the port for locally running FlexMeasures by setting the ``FLASK_RUN_PORT`` environment variable.
-          For example, to set it to port 5001:
-
-          .. code-block:: bash
-
-              $ export FLASK_RUN_PORT=5001  # You can also add this to your local .env
-
-          If you do this, remember that you will have to go to http://localhost:5001 in your browser when you want to inspect the FlexMeasures UI.
+.. include:: ../notes/macOS-port-note.rst
 
 .. note::
 

--- a/documentation/host/docker.rst
+++ b/documentation/host/docker.rst
@@ -48,8 +48,7 @@ The two minimal environment variables to run the container successfully are ``SQ
 In this example, we connect to a postgres database running on our local computer, so we use the host network. In the docker-compose section below, we use a Docker container for the database, as well.
 
 Browsing ``http://localhost:5000`` should work now and ask you to log in.
-
-Of course, you might not have created a user. You can use ``docker exec -it <flexmeasures-container-name> bash`` to go inside the container and use the :ref:`cli` to create everything you need. 
+Of course, you might not have created a user. You can use ``docker exec -it <flexmeasures-container-name> bash`` to go inside the container and use the :ref:`cli` to create everything you need.
 
 
 .. _docker_configuration:

--- a/documentation/host/docker.rst
+++ b/documentation/host/docker.rst
@@ -37,9 +37,11 @@ Running the image (as a container) might work like this (remember to get the ima
 
 .. code-block:: bash
 
-    $ docker run --env SQLALCHEMY_DATABASE_URI=postgresql://user:pass@localhost:5432/dbname --env SECRET_KEY=blabla --env FLEXMEASURES_ENV=development -d --net=host lfenergy/flexmeasures
+    $ docker run --env SQLALCHEMY_DATABASE_URI=postgresql://user:pass@localhost:5432/dbname --env SECRET_KEY=blabla --env FLEXMEASURES_ENV=development -p 5000:5000 -d --net=host lfenergy/flexmeasures
 
 .. note:: Don't know what your image is called (its "tag")? We used ``lfenergy/flexmeasures`` here, as that should be the name when pulling it from Docker Hub. You can run ``docker images`` to see which images you have.
+
+.. include:: ../notes/macOS-docker-port-note.rst
 
 The two minimal environment variables to run the container successfully are ``SQLALCHEMY_DATABASE_URI`` and the ``SECRET_KEY``, see :ref:`configuration`. ``FLEXMEASURES_ENV=development`` is needed if you do not have an SSL certificate set up (the default mode is ``production``, and in that mode FlexMeasures requires https for security reasons). If you see too much output, you can also set ``LOGGING_LEVEL=INFO``.
 

--- a/documentation/notes/macOS-docker-port-note.rst
+++ b/documentation/notes/macOS-docker-port-note.rst
@@ -1,0 +1,4 @@
+.. note:: For newer versions of macOS, port 5000 is in use by default by Control Center. You can turn this off by going to System Preferences > Sharing and untick the "Airplay Receiver" box.
+          If you don't want to do this for some reason, you can change the host port in the ``docker run`` command to some other port.
+          For example, to set it to port 5001, change ``-p 5000:5000`` in the command to ``-p 5001:5000``.
+          If you do this, remember that you will have to go to http://localhost:5001 in your browser when you want to inspect the FlexMeasures UI.

--- a/documentation/notes/macOS-port-note.rst
+++ b/documentation/notes/macOS-port-note.rst
@@ -1,0 +1,10 @@
+.. note:: For newer versions of macOS, port 5000 is in use by default by Control Center.
+          You can turn this off by going to System Preferences > Sharing and untick the "Airplay Receiver" box.
+          If you don't want to do this for some reason, you can change the port for locally running FlexMeasures by setting the ``FLASK_RUN_PORT`` environment variable.
+          For example, to set it to port 5001:
+
+          .. code-block:: bash
+
+              $ export FLASK_RUN_PORT=5001  # You can also add this to your local .env
+
+          If you do this, remember that you will have to go to http://localhost:5001 in your browser when you want to inspect the FlexMeasures UI.

--- a/documentation/tut/toy-example-setup.rst
+++ b/documentation/tut/toy-example-setup.rst
@@ -84,10 +84,7 @@ Install Flexmeasures and the database
 
         When started, the FlexMeasures UI should be available at http://localhost:5000 in your browser.
 
-        .. note:: For newer versions of macOS, port 5000 is in use by default by Control Center. You can turn this off by going to System Preferences > Sharing and untick the "Airplay Receiver" box.
-                  If you don't want to do this for some reason, you can change the host port in the ``docker run`` command to some other port, for example port 5001.
-                  To do this, change ``-p 5000:5000`` in the command to ``-p 5001:5000``.
-                  If you do this, remember that you will have to go to http://localhost:5001 in your browser when you want to inspect the FlexMeasures UI.
+        .. include:: ../notes/macOS-docker-port-note.rst
 
         .. note:: Got docker-compose? You could run this tutorial with 5 containers :) ― Go to :ref:`docker-compose-tutorial`.
 

--- a/documentation/tut/toy-example-setup.rst
+++ b/documentation/tut/toy-example-setup.rst
@@ -45,6 +45,9 @@ Install Flexmeasures and the database
             $ docker pull postgres
             $ docker network create flexmeasures_network
 
+        .. note:: A tip on Linux/macOS ― You might have the ``docker`` command, but need `sudo` rights to execute it.
+                  ``alias docker='sudo docker'`` enables you to still run this tutorial.
+
         After running these commands, we can start the Postgres database and the FlexMeasures app with the following commands:
 
         .. code-block:: bash
@@ -52,13 +55,15 @@ Install Flexmeasures and the database
             $ docker run --rm --name flexmeasures-tutorial-db -e POSTGRES_PASSWORD=fm-db-passwd -e POSTGRES_DB=flexmeasures-db -d --network=flexmeasures_network postgres:latest
             $ docker run --rm --name flexmeasures-tutorial-fm --env SQLALCHEMY_DATABASE_URI=postgresql://postgres:fm-db-passwd@flexmeasures-tutorial-db:5432/flexmeasures-db --env SECRET_KEY=notsecret --env FLEXMEASURES_ENV=development --env LOGGING_LEVEL=INFO -d --network=flexmeasures_network -p 5000:5000 lfenergy/flexmeasures
 
+        When the app has started, the FlexMeasures UI should be available at http://localhost:5000 in your browser.
+
+        .. include:: ../notes/macOS-docker-port-note.rst
+
         To establish the FlexMeasures database structure, execute:
 
         .. code-block:: bash
 
             $ docker exec flexmeasures-tutorial-fm bash -c "flexmeasures db upgrade"
-
-        .. note:: A tip on Linux/macOS ― You might have the ``docker`` command, but need `sudo` rights to execute it. ``alias docker='sudo docker'`` enables you to still run this tutorial.
 
         Now - what's *very important* to remember is this: The rest of this tutorial will happen *inside* the ``flexmeasures-tutorial-fm`` container! This is how you hop inside the container and run a terminal there:
 
@@ -81,10 +86,6 @@ Install Flexmeasures and the database
 
             $ docker start flexmeasures-tutorial-db
             $ docker start flexmeasures-tutorial-fm
-
-        When started, the FlexMeasures UI should be available at http://localhost:5000 in your browser.
-
-        .. include:: ../notes/macOS-docker-port-note.rst
 
         .. note:: Got docker-compose? You could run this tutorial with 5 containers :) ― Go to :ref:`docker-compose-tutorial`.
 

--- a/documentation/tut/toy-example-setup.rst
+++ b/documentation/tut/toy-example-setup.rst
@@ -82,7 +82,10 @@ Install Flexmeasures and the database
             $ docker start flexmeasures-tutorial-db
             $ docker start flexmeasures-tutorial-fm
 
-        .. note:: For newer versions of macOS, port 5000 is in use by default by Control Center. You can turn this off by going to System Preferences > Sharing and untick the "Airplay Receiver" box. If you don't want to do this for some reason, you can change the host port in the ``docker run`` command to some other port, for example 5001. To do this, change ``-p 5000:5000`` in the command to ``-p 5001:5000``. If you do this, remember that you will have to go to ``localhost:5001`` in your browser when you want to inspect the FlexMeasures UI.
+        .. note:: For newer versions of macOS, port 5000 is in use by default by Control Center. You can turn this off by going to System Preferences > Sharing and untick the "Airplay Receiver" box.
+                  If you don't want to do this for some reason, you can change the host port in the ``docker run`` command to some other port, for example port 5001.
+                  To do this, change ``-p 5000:5000`` in the command to ``-p 5001:5000``.
+                  If you do this, remember that you will have to go to http://localhost:5001 in your browser when you want to inspect the FlexMeasures UI.
 
         .. note:: Got docker-compose? You could run this tutorial with 5 containers :) ― Go to :ref:`docker-compose-tutorial`.
 

--- a/documentation/tut/toy-example-setup.rst
+++ b/documentation/tut/toy-example-setup.rst
@@ -82,7 +82,7 @@ Install Flexmeasures and the database
             $ docker start flexmeasures-tutorial-db
             $ docker start flexmeasures-tutorial-fm
 
-        .. note:: For newer versions of MacOS, port 5000 is in use by default by Control Center. You can turn this off by going to System Preferences > Sharing and untick the "Airplay Receiver" box. If you don't want to do this for some reason, you can change the host port in the ``docker run`` command to some other port, for example 5001. To do this, change ``-p 5000:5000`` in the command to ``-p 5001:5000``. If you do this, remember that you will have to go to ``localhost:5001`` in your browser when you want to inspect the FlexMeasures UI.
+        .. note:: For newer versions of macOS, port 5000 is in use by default by Control Center. You can turn this off by going to System Preferences > Sharing and untick the "Airplay Receiver" box. If you don't want to do this for some reason, you can change the host port in the ``docker run`` command to some other port, for example 5001. To do this, change ``-p 5000:5000`` in the command to ``-p 5001:5000``. If you do this, remember that you will have to go to ``localhost:5001`` in your browser when you want to inspect the FlexMeasures UI.
 
         .. note:: Got docker-compose? You could run this tutorial with 5 containers :) ― Go to :ref:`docker-compose-tutorial`.
 

--- a/documentation/tut/toy-example-setup.rst
+++ b/documentation/tut/toy-example-setup.rst
@@ -121,6 +121,26 @@ Install Flexmeasures and the database
 
             $ make clean-db db_name=flexmeasures-db [db_user=flexmeasures]
 
+        To start the web application, you can run:
+
+        .. code-block:: bash
+
+            $ flexmeasures run
+
+        When started, the FlexMeasures UI should be available at http://localhost:5000 in your browser.
+
+        .. note:: For newer versions of macOS, port 5000 is in use by default by Control Center.
+          You can turn this off by going to System Preferences > Sharing and untick the "Airplay Receiver" box.
+          If you don't want to do this for some reason, you can change the port for locally running FlexMeasures by setting the ``FLASK_RUN_PORT`` environment variable.
+          For example, to set it to port 5001:
+
+          .. code-block:: bash
+
+              $ export FLASK_RUN_PORT=5001  # You can also add this to your local .env
+
+          If you do this, remember that you will have to go to http://localhost:5001 in your browser when you want to inspect the FlexMeasures UI.
+
+
 Add some structural data
 ---------------------------------------
 

--- a/documentation/tut/toy-example-setup.rst
+++ b/documentation/tut/toy-example-setup.rst
@@ -129,16 +129,7 @@ Install Flexmeasures and the database
 
         When started, the FlexMeasures UI should be available at http://localhost:5000 in your browser.
 
-        .. note:: For newer versions of macOS, port 5000 is in use by default by Control Center.
-          You can turn this off by going to System Preferences > Sharing and untick the "Airplay Receiver" box.
-          If you don't want to do this for some reason, you can change the port for locally running FlexMeasures by setting the ``FLASK_RUN_PORT`` environment variable.
-          For example, to set it to port 5001:
-
-          .. code-block:: bash
-
-              $ export FLASK_RUN_PORT=5001  # You can also add this to your local .env
-
-          If you do this, remember that you will have to go to http://localhost:5001 in your browser when you want to inspect the FlexMeasures UI.
+        .. include:: ../notes/macOS-port-note.rst
 
 
 Add some structural data

--- a/documentation/tut/toy-example-setup.rst
+++ b/documentation/tut/toy-example-setup.rst
@@ -82,6 +82,8 @@ Install Flexmeasures and the database
             $ docker start flexmeasures-tutorial-db
             $ docker start flexmeasures-tutorial-fm
 
+        When started, the FlexMeasures UI should be available at http://localhost:5000 in your browser.
+
         .. note:: For newer versions of macOS, port 5000 is in use by default by Control Center. You can turn this off by going to System Preferences > Sharing and untick the "Airplay Receiver" box.
                   If you don't want to do this for some reason, you can change the host port in the ``docker run`` command to some other port, for example port 5001.
                   To do this, change ``-p 5000:5000`` in the command to ``-p 5001:5000``.


### PR DESCRIPTION
## Description

Documentation-only changes suggested in https://github.com/FlexMeasures/flexmeasures/issues/594#issuecomment-1521552756. Specifically, I added notes (to use `FLASK_RUN_PORT` or to change the docker host port) here:

- The [from-scratch tutorial](https://flexmeasures.readthedocs.io/en/v0.22.0/tut/toy-example-setup.html#install-flexmeasures-and-the-database) in the "On your PC" part.
- The tutorial for hosters to run FlexMeasures [on Docker](https://flexmeasures.readthedocs.io/en/v0.22.0/host/docker.html).
- For developers [who run locally](https://flexmeasures.readthedocs.io/en/v0.22.0/dev/setup-and-guidelines.html#run-locally).
            
## Further Improvements

I plan to follow-up with a PR to deal with the docker-compose tutorial (this requires a few code changes).

## Related Items

Addresses documentation-only changes suggested in #594.
