### PR TITLE
Add histogram option on the sensor page

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -9,6 +9,7 @@ v0.23.0 | August XX, 2024
 
 New features
 -------------
+* New chart type on sensor page: histogram [see `PR #1143 <https://github.com/FlexMeasures/flexmeasures/pull/1143>`_]
 * Add basic sensor info to sensor page [see `PR #1115 <https://github.com/FlexMeasures/flexmeasures/pull/1115>`_]
 * Support zoom-in action on the asset and sensor charts [see `PR #1130 <https://github.com/FlexMeasures/flexmeasures/pull/1130>`_]
 * Added Primary and Secondary colors to account for white-labelled UI themes [see `PR #1137 <https://github.com/FlexMeasures/flexmeasures/pull/1137>`_]

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -67,7 +67,7 @@ def create_bar_chart_or_histogram_specs(
         description = "A histogram showing the distribution of sensor data."
         x = {
             **event_value_field_definition,
-            "bin": {"step": 2},
+            "bin": True,
         }
         y = {
             "aggregate": "count",

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -7,7 +7,6 @@ from flexmeasures.utils.flexmeasures_inflection import (
     capitalize,
     join_words_into_a_list,
 )
-from flexmeasures.data.models.time_series import Sensor
 from flexmeasures.utils.coding_utils import flatten_unique
 from flexmeasures.utils.unit_utils import (
     is_power_unit,

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -15,7 +15,7 @@ from flexmeasures.utils.unit_utils import (
 )
 
 
-def create_bar_chart_or_histgram_specs(
+def create_bar_chart_or_histogram_specs(
     sensor: "Sensor",  # noqa F821
     event_starts_after: datetime | None = None,
     event_ends_before: datetime | None = None,
@@ -116,8 +116,45 @@ def histogram(
     event_ends_before: datetime | None = None,
     **override_chart_specs: dict,
 ):
+    """
+    Generates a histogram chart specification for sensor data.
+
+    Parameters:
+    -----------
+    sensor : Sensor
+        An instance of the Sensor class containing sensor data and metadata.
+    event_starts_after : datetime, optional
+        A datetime object specifying the start time filter for the events. Only events occurring after this time will be included in the histogram.
+    event_ends_before : datetime, optional
+        A datetime object specifying the end time filter for the events. Only events occurring before this time will be included in the histogram.
+    **override_chart_specs : dict
+        Additional chart specifications to override the default settings. These can include any valid Vega-Lite chart specification parameters.
+
+    Returns:
+    --------
+    dict
+        A dictionary containing the Vega-Lite chart specifications for the histogram.
+
+    Notes:
+    ------
+    - The function utilizes the `create_bar_chart_or_histogram_specs` helper function to generate the chart specifications.
+    - Axis names and headers are removed from the chart for a cleaner appearance.
+    - If `event_starts_after` and `event_ends_before` are provided, the x-axis domain is set to the specified time range.
+    - The `bin_size` parameter is configurable through the `override_chart_specs`.
+
+    Example:
+    --------
+    To create a histogram with custom bin size and event time filters:
+
+    >>> histogram(
+    ...     sensor,
+    ...     event_starts_after=datetime(2023, 1, 1),
+    ...     event_ends_before=datetime(2023, 12, 31),
+    ...     **override_chart_specs,
+    ... )
+    """
     chart_type = "histogram"
-    chart_specs = create_bar_chart_or_histgram_specs(
+    chart_specs = create_bar_chart_or_histogram_specs(
         sensor,
         event_starts_after,
         event_ends_before,
@@ -133,7 +170,7 @@ def bar_chart(
     event_ends_before: datetime | None = None,
     **override_chart_specs: dict,
 ):
-    chart_specs = create_bar_chart_or_histgram_specs(
+    chart_specs = create_bar_chart_or_histogram_specs(
         sensor,
         event_starts_after,
         event_ends_before,

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -22,6 +22,18 @@ def create_bar_chart_or_histogram_specs(
     chart_type: str = "bar_chart",
     **override_chart_specs: dict,
 ):
+    """
+    This function generates the specifications required to visualize sensor data either as a bar chart or a histogram.
+    The chart type can be specified, and various field definitions are set up based on the sensor attributes and
+    event time range. The resulting specifications can be customized further through additional keyword arguments.
+
+    The function handles the following:
+    - Determines unit and formats for the sensor data.
+    - Configures event value and event start field definitions.
+    - Sets the appropriate mark type and interpolation based on sensor attributes.
+    - Defines chart specifications for both bar charts and histograms, including titles, axis configurations, and tooltips.
+    - Merges any additional specifications provided through keyword arguments into the final chart specifications.
+    """
     unit = sensor.unit if sensor.unit else "a.u."
     event_value_field_definition = dict(
         title=f"{capitalize(sensor.sensor_type)} ({unit})",
@@ -117,42 +129,10 @@ def histogram(
     **override_chart_specs: dict,
 ):
     """
-    Generates a histogram chart specification for sensor data.
-
-    Parameters:
-    -----------
-    sensor : Sensor
-        An instance of the Sensor class containing sensor data and metadata.
-    event_starts_after : datetime, optional
-        A datetime object specifying the start time filter for the events. Only events occurring after this time will be included in the histogram.
-    event_ends_before : datetime, optional
-        A datetime object specifying the end time filter for the events. Only events occurring before this time will be included in the histogram.
-    **override_chart_specs : dict
-        Additional chart specifications to override the default settings. These can include any valid Vega-Lite chart specification parameters.
-
-    Returns:
-    --------
-    dict
-        A dictionary containing the Vega-Lite chart specifications for the histogram.
-
-    Notes:
-    ------
-    - The function utilizes the `create_bar_chart_or_histogram_specs` helper function to generate the chart specifications.
-    - Axis names and headers are removed from the chart for a cleaner appearance.
-    - If `event_starts_after` and `event_ends_before` are provided, the x-axis domain is set to the specified time range.
-    - The `bin_size` parameter is configurable through the `override_chart_specs`.
-
-    Example:
-    --------
-    To create a histogram with custom bin size and event time filters:
-
-    >>> histogram(
-    ...     sensor,
-    ...     event_starts_after=datetime(2023, 1, 1),
-    ...     event_ends_before=datetime(2023, 12, 31),
-    ...     **override_chart_specs,
-    ... )
+    Generates specifications for a histogram chart using sensor data. This function leverages
+    the `create_bar_chart_or_histogram_specs` helper function, specifying `chart_type` as 'histogram'.
     """
+
     chart_type = "histogram"
     chart_specs = create_bar_chart_or_histogram_specs(
         sensor,
@@ -170,6 +150,11 @@ def bar_chart(
     event_ends_before: datetime | None = None,
     **override_chart_specs: dict,
 ):
+    """
+    Generates specifications for a bar chart using sensor data. This function leverages
+    the `create_bar_chart_or_histogram_specs` helper function to create the specifications.
+    """
+
     chart_specs = create_bar_chart_or_histogram_specs(
         sensor,
         event_starts_after,

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -59,7 +59,7 @@ def create_bar_chart_or_histogram_specs(
         }
         y = {
             "aggregate": "count",
-            "title": "Frequency",
+            "title": "Count",
         }
     else:
         description = (f"A simple {mark_type} chart showing sensor data.",)

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -7,6 +7,7 @@ from flexmeasures.utils.flexmeasures_inflection import (
     capitalize,
     join_words_into_a_list,
 )
+from flexmeasures.data.models.time_series import Sensor
 from flexmeasures.utils.coding_utils import flatten_unique
 from flexmeasures.utils.unit_utils import (
     is_power_unit,
@@ -15,10 +16,11 @@ from flexmeasures.utils.unit_utils import (
 )
 
 
-def bar_chart(
+def create_bar_chart_or_histgram_specs(
     sensor: "Sensor",  # noqa F821
     event_starts_after: datetime | None = None,
     event_ends_before: datetime | None = None,
+    chart_type: str = "bar_chart",
     **override_chart_specs: dict,
 ):
     unit = sensor.unit if sensor.unit else "a.u."
@@ -50,9 +52,23 @@ def bar_chart(
     if sensor.event_resolution == timedelta(0) and sensor.has_attribute("interpolate"):
         mark_type = "area"
         mark_interpolate = sensor.get_attribute("interpolate")
+    if chart_type == "histogram":
+        description = "A histogram showing the distribution of sensor data."
+        x = {
+            **event_value_field_definition,
+            "bin": {"step": 2},
+        }
+        y = {
+            "aggregate": "count",
+            "title": "Frequency",
+        }
+    else:
+        description = (f"A simple {mark_type} chart showing sensor data.",)
+        x = event_start_field_definition
+        y = event_value_field_definition
+
     chart_specs = {
-        "description": f"A simple {mark_type} chart showing sensor data.",
-        # the sensor type is already shown as the y-axis title (avoid redundant info)
+        "description": description,
         "title": capitalize(sensor.name) if sensor.name != sensor.sensor_type else None,
         "layer": [
             {
@@ -63,13 +79,15 @@ def bar_chart(
                     "width": {"band": 0.999},
                 },
                 "encoding": {
-                    "x": event_start_field_definition,
-                    "y": event_value_field_definition,
+                    "x": x,
+                    "y": y,
                     "color": FIELD_DEFINITIONS["source_name"],
                     "detail": FIELD_DEFINITIONS["source"],
                     "opacity": {"value": 0.7},
                     "tooltip": [
-                        FIELD_DEFINITIONS["full_date"],
+                        FIELD_DEFINITIONS["full_date"]
+                        if chart_type != "histogram"
+                        else None,
                         {
                             **event_value_field_definition,
                             **dict(title=f"{capitalize(sensor.sensor_type)}"),
@@ -90,6 +108,38 @@ def bar_chart(
     }
     for k, v in override_chart_specs.items():
         chart_specs[k] = v
+    return chart_specs
+
+
+def histogram(
+    sensor: "Sensor",  # noqa F821
+    event_starts_after: datetime | None = None,
+    event_ends_before: datetime | None = None,
+    **override_chart_specs: dict,
+):
+    chart_type = "histogram"
+    chart_specs = create_bar_chart_or_histgram_specs(
+        sensor,
+        event_starts_after,
+        event_ends_before,
+        chart_type,
+        **override_chart_specs,
+    )
+    return chart_specs
+
+
+def bar_chart(
+    sensor: "Sensor",  # noqa F821
+    event_starts_after: datetime | None = None,
+    event_ends_before: datetime | None = None,
+    **override_chart_specs: dict,
+):
+    chart_specs = create_bar_chart_or_histgram_specs(
+        sensor,
+        event_starts_after,
+        event_ends_before,
+        **override_chart_specs,
+    )
     return chart_specs
 
 

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -24,7 +24,7 @@ def create_bar_chart_or_histogram_specs(
 ):
     """
     This function generates the specifications required to visualize sensor data either as a bar chart or a histogram.
-    The chart type can be specified, and various field definitions are set up based on the sensor attributes and
+    The chart type (bar_chart or histogram) can be specified, and various field definitions are set up based on the sensor attributes and
     event time range. The resulting specifications can be customized further through additional keyword arguments.
 
     The function handles the following:

--- a/flexmeasures/ui/templates/views/sensors.html
+++ b/flexmeasures/ui/templates/views/sensors.html
@@ -72,6 +72,7 @@
                               </button>
                               <ul class="dropdown-menu center-aligned" aria-labelledby="chartTypeDropdown">
                                   <li><a class="dropdown-item" href="#" data-chart-type="bar_chart">Bar chart</a></li>
+                                  <li><a class="dropdown-item" href="#" data-chart-type="histogram">Histogram</a></li>
                                   <li><a class="dropdown-item" href="#" data-chart-type="daily_heatmap">Daily heatmap</a></li>
                                   <li><a class="dropdown-item" href="#" data-chart-type="weekly_heatmap">Weekly heatmap</a></li>
                               </ul>


### PR DESCRIPTION
## Description

I have add a histogram option on the sensor page, and also refactored the code. 

## Look & Feel

![image](https://github.com/user-attachments/assets/a5efbf58-efe7-4094-8413-54889d7e44fc)

## How to test

- Check out this branch and load any sensor. Then select `Histogram` from the `Select Chart` dropdown and see the chart. 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
