### PR TITLE
Show chart type dropdown on the left side panel

### DIFF
--- a/flexmeasures/ui/static/css/flexmeasures.css
+++ b/flexmeasures/ui/static/css/flexmeasures.css
@@ -981,6 +981,20 @@ body .dataTables_wrapper .dataTables_paginate .paginate_button.current:hover {
     margin-left: 20px !important;
 }
 
+.side-dropdown{
+    margin-left: -90px !important;
+    color: var(--nav-default-color);
+    background: var(--nav-default-background-color);
+    width: calc(var(--litepicker-day-width) * 6);
+    padding: 13px 15px;
+    min-height: 40px;  // line-height + padding-top + padding-bottom
+    border-top-left-radius: 0px;
+    border-bottom-left-radius: 0px;
+    border-top-right-radius: 15px;
+    border-bottom-right-radius: 15px;
+    text-align: right;
+    position: absolute;
+}
 
 /* --- End Tables ---- */
 

--- a/flexmeasures/ui/templates/views/sensors.html
+++ b/flexmeasures/ui/templates/views/sensors.html
@@ -66,7 +66,10 @@
                       <div class="left-sidepanel-label">Select dates</div>
                       <div class="sidepanel left-sidepanel">
                           <div id="datepicker"></div>
-                          <div id="chart-type-picker" class="dropdown header-action-button">
+                      </div>
+                  </div>
+                  <div class="sidepanel-container">
+                          <div id="chart-type-picker" class="side-dropdown">
                               <button class="btn dropdown-toggle" type="button" id="chartTypeDropdown" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                   Select chart
                               </button>
@@ -76,7 +79,6 @@
                                   <li><a class="dropdown-item" href="#" data-chart-type="weekly_heatmap">Weekly heatmap</a></li>
                               </ul>
                           </div>
-                      </div>
                   </div>
               </div>
               <div class="col-sm-8">


### PR DESCRIPTION
## Description
Create a left side panel, where user can easily change the chart type.

## Look & Feel
![image](https://github.com/user-attachments/assets/3ae2217f-e0f9-4be0-bc23-ed3c16c93f98)

## How to test
Check out this `show-sensor-chart-type` branch and then load a sensor page. You will see a `Select chart` dropdown just below the `date-picker` dev. 
