### PR TITLE
fix: remove duplicate x-axis title in histogram

### DIFF
--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -63,6 +63,7 @@ def create_bar_chart_or_histogram_specs(
     if sensor.event_resolution == timedelta(0) and sensor.has_attribute("interpolate"):
         mark_type = "area"
         mark_interpolate = sensor.get_attribute("interpolate")
+    replay_ruler = REPLAY_RULER.copy()
     if chart_type == "histogram":
         description = "A histogram showing the distribution of sensor data."
         x = {
@@ -72,6 +73,13 @@ def create_bar_chart_or_histogram_specs(
         y = {
             "aggregate": "count",
             "title": "Count",
+        }
+        replay_ruler["encoding"] = {
+            "detail": {
+                "field": "belief_time",
+                "type": "temporal",
+                "title": None,
+            },
         }
     else:
         description = (f"A simple {mark_type} chart showing sensor data.",)
@@ -117,7 +125,7 @@ def create_bar_chart_or_histogram_specs(
                     "scroll": {"type": "interval", "bind": "scales", "encodings": ["x"]}
                 },
             },
-            REPLAY_RULER,
+            replay_ruler,
         ],
     }
     for k, v in override_chart_specs.items():


### PR DESCRIPTION
- [x] Remove duplicate x-axis title in histogram (fix outstanding issue in #1143).
- [x] Retain replay functionality.

Explanation: I inspected the `belief_time` axis label in the browser UI to discover that the specs defined two x-axes in the histogram chart type. The second x-axis was coming from the replay ruler specs, which shouldn't apply to the histogram chart. I removed it visually, but kept the functionality to update the histogram as you replay through a certain period. To test that, just use the replay button on a couple of days of data.
