### PR TITLE
Fix/get default inside function

### DIFF
--- a/flexmeasures/cli/utils.py
+++ b/flexmeasures/cli/utils.py
@@ -154,7 +154,7 @@ def get_timerange_from_flag(
     last_7_days: bool = False,
     last_month: bool = False,
     last_year: bool = False,
-    timezone: pytz.BaseTzInfo = get_timezone(),
+    timezone: pytz.BaseTzInfo | None = None,
 ) -> tuple[datetime, datetime]:
     """This function returns a time range [start,end] of the last-X period.
     See input parameters for more details.
@@ -167,6 +167,9 @@ def get_timerange_from_flag(
     :param timezone: timezone object to represent
     :returns: start:datetime, end:datetime
     """
+
+    if timezone is None:
+        timezone = get_timezone()
 
     current_hour = get_most_recent_hour().astimezone(timezone)
 


### PR DESCRIPTION
## Description

The function `get_timerange_from_flag` calls the `get_timezone` to get the the default timezone from the .flexmeasures.cfg. The function `get_timezone` requires an app context to work and, as it's, called when the module is imported, it crashes if no app context has been started.

For me, this turn out a problem when running tests for a plugin.

---

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
