### PR TITLE
Feature/rq dashboard sort order

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -15,6 +15,7 @@ New features
 * Support zoom-in action on the asset and sensor charts [see `PR #1130 <https://github.com/FlexMeasures/flexmeasures/pull/1130>`_]
 * Added Primary and Secondary colors to account for white-labelled UI themes [see `PR #1137 <https://github.com/FlexMeasures/flexmeasures/pull/1137>`_]
 * Added Logo URL to account for white-labelled UI themes [see `PR #1145 <https://github.com/FlexMeasures/flexmeasures/pull/1145>`_]
+* When listing past jobs on the `Tasks` page, show the most recent jobs first [see `PR #1163 <https://github.com/FlexMeasures/flexmeasures/pull/1163>`_]
 * Introduce the ``VariableQuantityField`` to allow three ways of passing a variable quantity in most of the ``flex-model`` and ``flex-context`` fields [see `PR #1127 <https://github.com/FlexMeasures/flexmeasures/pull/1127>`_ and `PR #1138 <https://github.com/FlexMeasures/flexmeasures/pull/1138>`_]
 * Support directly passing a fixed price in the ``flex-context`` using the new fields ``consumption-price`` and ``production-price``, which are meant to replace the ``consumption-price-sensor`` and ``production-price-sensor`` fields, respectively [see `PR #1028 <https://github.com/FlexMeasures/flexmeasures/pull/1028>`_]
 

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -122,7 +122,7 @@
                     <ul class="dropdown-menu" aria-labelledby="tasksDropdown">
                     {% for queue in queue_names %}
                         <li {% if current_user.has_role('anonymous') %} class="disabled" {% endif %}>
-                        <a class="dropdown-item" {% if not current_user.has_role('anonymous') %} href="/tasks/0/view/jobs/{{ queue }}/started/10/1" {% endif %}>
+                        <a class="dropdown-item" {% if not current_user.has_role('anonymous') %} href="/tasks/0/view/jobs/{{ queue }}/started/10/asc/1" {% endif %}>
                             {{ queue | capitalize }}
                         </a>
                         </li>

--- a/flexmeasures/ui/templates/rq_dashboard/base.html
+++ b/flexmeasures/ui/templates/rq_dashboard/base.html
@@ -73,34 +73,7 @@
 <script type="text/javascript">
     {% include "rq_dashboard/inline_js.html" %}
     {% block content_scripts %}{% endblock %}
-
-    {#- Override sort order to prefer looking at the most recent past first, workaround for https://github.com/Parallels/rq-dashboard/issues/123 -#}
-    function updateLinks() {
-        document.querySelectorAll('td.failed a, td.narrow a').forEach(link => {
-            const href = link.getAttribute('href');
-            if (href.includes('/canceled/') || href.includes('/failed/') || href.includes('/finished/')) {
-                const newHref = href.replace('/asc/', '/dsc/');
-                link.setAttribute('href', newHref);
-            }
-        });
-    }
-
-    // Function to check if the table is done loading
-    function checkTableAndUpdate(mutationsList, observer) {
-        const loadingRow = document.querySelector('tbody tr');
-        if (loadingRow && loadingRow.textContent.trim() !== 'Loading...') {
-            updateLinks();
-            observer.disconnect();  // Stop observing once the table is updated
-        }
-    }
-
-    // Monitor the tbody for changes
-    const observer = new MutationObserver(checkTableAndUpdate);
-
-    // Start observing the tbody element for child list changes
-    const tbody = document.querySelector('tbody');
-    observer.observe(tbody, { childList: true, subtree: true });
-
+    {% include "rq_dashboard/update_links.js" %}
 </script>
 
 {% endblock scripts %}

--- a/flexmeasures/ui/templates/rq_dashboard/base.html
+++ b/flexmeasures/ui/templates/rq_dashboard/base.html
@@ -86,20 +86,20 @@
     }
 
     // Function to check if the table is done loading
-    function checkTableLoaded() {
+    function checkTableAndUpdate(mutationsList, observer) {
         const loadingRow = document.querySelector('tbody tr');
         if (loadingRow && loadingRow.textContent.trim() !== 'Loading...') {
             updateLinks();
-            clearInterval(intervalId);  // Stop the interval after updating links
+            observer.disconnect();  // Stop observing once the table is updated
         }
     }
 
-    // Check every 500ms if the table has finished loading
-    const intervalId = setInterval(checkTableLoaded, 500);
+    // Monitor the tbody for changes
+    const observer = new MutationObserver(checkTableAndUpdate);
 
-
-
-
+    // Start observing the tbody element for child list changes
+    const tbody = document.querySelector('tbody');
+    observer.observe(tbody, { childList: true, subtree: true });
 
 </script>
 

--- a/flexmeasures/ui/templates/rq_dashboard/base.html
+++ b/flexmeasures/ui/templates/rq_dashboard/base.html
@@ -73,6 +73,34 @@
 <script type="text/javascript">
     {% include "rq_dashboard/inline_js.html" %}
     {% block content_scripts %}{% endblock %}
+
+    {#- Override sort order to prefer looking at the most recent past first, workaround for https://github.com/Parallels/rq-dashboard/issues/123 -#}
+    function updateLinks() {
+        document.querySelectorAll('td.failed a, td.narrow a').forEach(link => {
+            const href = link.getAttribute('href');
+            if (href.includes('/canceled/') || href.includes('/failed/') || href.includes('/finished/')) {
+                const newHref = href.replace('/asc/', '/dsc/');
+                link.setAttribute('href', newHref);
+            }
+        });
+    }
+
+    // Function to check if the table is done loading
+    function checkTableLoaded() {
+        const loadingRow = document.querySelector('tbody tr');
+        if (loadingRow && loadingRow.textContent.trim() !== 'Loading...') {
+            updateLinks();
+            clearInterval(intervalId);  // Stop the interval after updating links
+        }
+    }
+
+    // Check every 500ms if the table has finished loading
+    const intervalId = setInterval(checkTableLoaded, 500);
+
+
+
+
+
 </script>
 
 {% endblock scripts %}

--- a/flexmeasures/ui/templates/rq_dashboard/base.html
+++ b/flexmeasures/ui/templates/rq_dashboard/base.html
@@ -73,6 +73,11 @@
 <script type="text/javascript">
     {% include "rq_dashboard/inline_js.html" %}
     {% block content_scripts %}{% endblock %}
+
+    {#- Override sort order to prefer looking at the most recent past first, workaround for https://github.com/Parallels/rq-dashboard/issues/123 -#}
+    if (['canceled', 'failed', 'finished'].indexOf($('#select-registry').val()) >= 0) {
+        $('#select-sort-order').val('dsc');
+    }
 </script>
 
 {% endblock scripts %}

--- a/flexmeasures/ui/templates/rq_dashboard/base.html
+++ b/flexmeasures/ui/templates/rq_dashboard/base.html
@@ -73,11 +73,6 @@
 <script type="text/javascript">
     {% include "rq_dashboard/inline_js.html" %}
     {% block content_scripts %}{% endblock %}
-
-    {#- Override sort order to prefer looking at the most recent past first, workaround for https://github.com/Parallels/rq-dashboard/issues/123 -#}
-    if (['canceled', 'failed', 'finished'].indexOf($('#select-registry').val()) >= 0) {
-        $('#select-sort-order').val('dsc');
-    }
 </script>
 
 {% endblock scripts %}

--- a/flexmeasures/ui/templates/rq_dashboard/update_links.js
+++ b/flexmeasures/ui/templates/rq_dashboard/update_links.js
@@ -1,4 +1,4 @@
-
+{#- Override sort order to prefer looking at the most recent past first, workaround for https://github.com/Parallels/rq-dashboard/issues/123 -#}
 function updateLinks() {
     document.querySelectorAll('td.failed a, td.narrow a').forEach(link => {
         const href = link.getAttribute('href');

--- a/flexmeasures/ui/templates/rq_dashboard/update_links.js
+++ b/flexmeasures/ui/templates/rq_dashboard/update_links.js
@@ -1,0 +1,26 @@
+
+function updateLinks() {
+    document.querySelectorAll('td.failed a, td.narrow a').forEach(link => {
+        const href = link.getAttribute('href');
+        if (href.includes('/canceled/') || href.includes('/failed/') || href.includes('/finished/')) {
+            const newHref = href.replace('/asc/', '/dsc/');
+            link.setAttribute('href', newHref);
+        }
+    });
+}
+
+// Function to check if the table is done loading
+function checkTableAndUpdate(mutationsList, observer) {
+    const loadingRow = document.querySelector('tbody tr');
+    if (loadingRow && loadingRow.textContent.trim() !== 'Loading...') {
+        updateLinks();
+        observer.disconnect();  // Stop observing once the table is updated
+    }
+}
+
+// Monitor the tbody for changes
+const observer = new MutationObserver(checkTableAndUpdate);
+
+// Start observing the tbody element for child list changes
+const tbody = document.querySelector('tbody');
+observer.observe(tbody, { childList: true, subtree: true });

--- a/requirements/3.10/app.txt
+++ b/requirements/3.10/app.txt
@@ -284,7 +284,7 @@ rq==1.16.1
     # via
     #   -r requirements/app.in
     #   rq-dashboard
-rq-dashboard==0.6.7.2
+rq-dashboard==0.8.0.2
     # via -r requirements/app.in
 scikit-base==0.7.5
     # via sktime

--- a/requirements/3.11/app.txt
+++ b/requirements/3.11/app.txt
@@ -282,7 +282,7 @@ rq==1.16.1
     # via
     #   -r requirements/app.in
     #   rq-dashboard
-rq-dashboard==0.6.7.2
+rq-dashboard==0.8.0.2
     # via -r requirements/app.in
 scikit-base==0.7.5
     # via sktime

--- a/requirements/3.8/app.txt
+++ b/requirements/3.8/app.txt
@@ -297,7 +297,7 @@ rq==1.16.1
     # via
     #   -r requirements/app.in
     #   rq-dashboard
-rq-dashboard==0.6.7.2
+rq-dashboard==0.8.0.2
     # via -r requirements/app.in
 scikit-base==0.7.5
     # via sktime

--- a/requirements/3.9/app.txt
+++ b/requirements/3.9/app.txt
@@ -287,7 +287,7 @@ rq==1.16.1
     # via
     #   -r requirements/app.in
     #   rq-dashboard
-rq-dashboard==0.6.7.2
+rq-dashboard==0.8.0.2
     # via -r requirements/app.in
 scikit-base==0.7.5
     # via sktime

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -25,7 +25,8 @@ click
 click-default-group
 email_validator
 rq
-rq-dashboard
+# sort order
+rq-dashboard>=0.8.0.2
 # the following uses environment markers (see PEP 496)
 rq-win; os_name == 'nt' or os_name == 'win'
 # This limit resolves a conflict with test.in. The culprit is fakeredis (check their pyproject.toml)


### PR DESCRIPTION
## Description

- [x] Update rq-dashboard to v0.8.0 to get the Sort Order button.
- [x] Override the default ascending Sort Order to descending, for URLs to registries showing jobs of the past (canceled, failed and finished).
