### PR TITLE
Asset search filter applies to both asset names and account names

### DIFF
--- a/documentation/api/change_log.rst
+++ b/documentation/api/change_log.rst
@@ -8,7 +8,7 @@ API change log
 v3.0-20 | 2024-09-XX
 """"""""""""""""""""
 
--  Introduce (optional) pagination to the endpoint `/assets` (GET), also add `all_accessible` option to allow querying all accounts one can access in one go.
+-  Introduce (optional) pagination to the endpoint `/assets` (GET), also adding the `all_accessible` option to allow querying all accessible accounts in one go.
 
 
 v3.0-19 | 2024-08-13

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,7 +13,7 @@ New features
 * Add basic sensor info to sensor page [see `PR #1115 <https://github.com/FlexMeasures/flexmeasures/pull/1115>`_]
 * Add `Statistics` table on the sensor page and also add `api/v3_0/sensors/<id>/stats` endpoint to get sensor statistics [see `PR #1116 <https://github.com/FlexMeasures/flexmeasures/pull/1116>`_]
 * Support zoom-in action on the asset and sensor charts [see `PR #1130 <https://github.com/FlexMeasures/flexmeasures/pull/1130>`_]
-* Speed up /assets page load, by making the pagination backend-based (supported in API) and enabling to query all accounts one can see at once (for admins and consultants) [see `PR #988 <https://github.com/FlexMeasures/flexmeasures/pull/988>`_]
+* Speed up loading the assets page, by making the pagination backend-based and adding support for that in the API, and by enabling to query all accounts one can see in a single call (for admins and consultants) [see `PR #988 <https://github.com/FlexMeasures/flexmeasures/pull/988>`_]
 * Added Primary and Secondary colors to account for white-labelled UI themes [see `PR #1137 <https://github.com/FlexMeasures/flexmeasures/pull/1137>`_]
 * Added Logo URL to account for white-labelled UI themes [see `PR #1145 <https://github.com/FlexMeasures/flexmeasures/pull/1145>`_]
 * Introduce the ``VariableQuantityField`` to allow three ways of passing a variable quantity in most of the ``flex-model`` and ``flex-context`` fields [see `PR #1127 <https://github.com/FlexMeasures/flexmeasures/pull/1127>`_ and `PR #1138 <https://github.com/FlexMeasures/flexmeasures/pull/1138>`_]

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from shlex import split
 import json
 
 from flask import current_app
@@ -104,7 +105,7 @@ class AssetAPI(FlaskView):
 
             - If the `page` parameter is not provided, all assets are returned, without pagination information. The result will be a list of assets.
             - If a `page` parameter is provided, the response will be paginated, showing a specific number of assets per page as defined by `per_page` (default is 10).
-            - If a 'filter' sentence such as 'solar ACME' is provided, the response will filter out assets where each word is either present in their name or account name.
+            - If a 'filter' sentence such as 'solar "ACME corp"' is provided, the response will filter out assets where each word is either present in their name or account name.
               The response schema for pagination is inspired by https://datatables.net/manual/server-side#Returned-data
 
 
@@ -170,14 +171,14 @@ class AssetAPI(FlaskView):
             select_statement = select_statement.join(
                 Account, Account.id == GenericAsset.account_id
             )
-            words = filter.split(" ")
+            terms = split(filter)
             filter_statement = filter_statement & and_(
                 *(
                     or_(
-                        GenericAsset.name.ilike(f"%{word}%"),
-                        Account.name.ilike(f"%{word}%"),
+                        GenericAsset.name.ilike(f"%{term}%"),
+                        Account.name.ilike(f"%{term}%"),
                     )
-                    for word in words
+                    for term in terms
                 )
             )
 

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -171,14 +171,13 @@ class AssetAPI(FlaskView):
             select_statement = select_statement.join(
                 Account, Account.id == GenericAsset.account_id
             )
-            terms = split(filter)
             filter_statement = filter_statement & and_(
                 *(
                     or_(
                         GenericAsset.name.ilike(f"%{term}%"),
                         Account.name.ilike(f"%{term}%"),
                     )
-                    for term in terms
+                    for term in split(filter)
                 )
             )
 

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -105,7 +105,7 @@ class AssetAPI(FlaskView):
 
             - If the `page` parameter is not provided, all assets are returned, without pagination information. The result will be a list of assets.
             - If a `page` parameter is provided, the response will be paginated, showing a specific number of assets per page as defined by `per_page` (default is 10).
-            - If a 'filter' sentence such as 'solar "ACME corp"' is provided, the response will filter out assets where each word is either present in their name or account name.
+            - If a search 'filter' such as 'solar "ACME corp"' is provided, the response will filter out assets where each search term is either present in their name or account name.
               The response schema for pagination is inspired by https://datatables.net/manual/server-side#Returned-data
 
 
@@ -167,7 +167,7 @@ class AssetAPI(FlaskView):
 
         select_statement = select(GenericAsset)
         if filter is not None:
-            # Words in the filter should either come back in the asset name or account name
+            # Search terms in the search filter should either come back in the asset name or account name
             select_statement = select_statement.join(
                 Account, Account.id == GenericAsset.account_id
             )

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -13,7 +13,7 @@ from marshmallow import fields
 import marshmallow.validate as validate
 
 from webargs.flaskparser import use_kwargs, use_args
-from sqlalchemy import select, delete, func
+from sqlalchemy import select, delete, func, or_, and_
 
 from flexmeasures.auth.decorators import permission_required_for_context
 from flexmeasures.data import db
@@ -104,6 +104,7 @@ class AssetAPI(FlaskView):
 
             - If the `page` parameter is not provided, all assets are returned, without pagination information. The result will be a list of assets.
             - If a `page` parameter is provided, the response will be paginated, showing a specific number of assets per page as defined by `per_page` (default is 10).
+            - If a 'filter' sentence such as 'solar ACME' is provided, the response will filter out assets where each word is either present in their name or account name.
               The response schema for pagination is inspired by https://datatables.net/manual/server-side#Returned-data
 
 
@@ -163,10 +164,24 @@ class AssetAPI(FlaskView):
             select(func.count(GenericAsset.id)).where(filter_statement)
         )
 
+        select_statement = select(GenericAsset)
         if filter is not None:
-            filter_statement = filter_statement & GenericAsset.name.ilike(f"%{filter}%")
+            # Words in the filter should either come back in the asset name or account name
+            select_statement = select_statement.join(
+                Account, Account.id == GenericAsset.account_id
+            )
+            words = filter.split(" ")
+            filter_statement = filter_statement & and_(
+                *(
+                    or_(
+                        GenericAsset.name.ilike(f"%{word}%"),
+                        Account.name.ilike(f"%{word}%"),
+                    )
+                    for word in words
+                )
+            )
 
-        query = select(GenericAsset).where(filter_statement)
+        query = select_statement.where(filter_statement)
 
         if page is None:
             response = asset_schema.dump(db.session.scalars(query).all(), many=True)


### PR DESCRIPTION
From reviewing #988. This enables UX much closer to how we used the search filter originally.