### PR TITLE
fix: logo url validation

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -35,7 +35,7 @@ Bugfixes
 * Fix posting a single instantaneous belief [see `PR #1129 <https://github.com/FlexMeasures/flexmeasures/pull/1129>`_]
 * Allow reassigning a public asset to private ownership using the ``flexmeasures edit transfer-ownership`` CLI command [see `PR #1123 <https://github.com/FlexMeasures/flexmeasures/pull/1123>`_]
 * Fix missing value on spring :abbr:`DST (Daylight Saving Time)` transition for ``PandasReporter`` using daily sensor as input [see `PR #1122 <https://github.com/FlexMeasures/flexmeasures/pull/1122>`_]
-
+* Fix issue with account creation failing when the --logo-url flag is omitted. [see related PRs `PR #1167 <https://github.com/FlexMeasures/flexmeasures/pull/1167>`_ and `PR #1145 <https://github.com/FlexMeasures/flexmeasures/pull/1145>`_]
 
 v0.22.0 | June 29, 2024
 ============================

--- a/flexmeasures/cli/utils.py
+++ b/flexmeasures/cli/utils.py
@@ -306,6 +306,8 @@ def get_sensor_aliases(
 
 def validate_color_hex(ctx, param, value):
     """
+    Optional parameter validation
+
     Validates that a given value is a valid hex color code.
 
     Parameters:
@@ -314,7 +316,9 @@ def validate_color_hex(ctx, param, value):
     """
     if value is None:
         return value
+
     hex_pattern = re.compile(r"^#?([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$")
+
     if re.match(hex_pattern, value):
         return value
     else:
@@ -323,6 +327,8 @@ def validate_color_hex(ctx, param, value):
 
 def validate_url(ctx, param, value):
     """
+    Optional parameter valdiation
+
     Validates that a given value is a valid URL format using regex.
 
     Parameters:
@@ -330,6 +336,9 @@ def validate_url(ctx, param, value):
     :param param:   Click parameter. URL value.
     :param value:   The URL to validate.
     """
+    if value is None:
+        return value
+
     url_regex = re.compile(
         r"^(https?|ftp)://"  # Protocol: http, https, or ftp
         r"((([A-Za-z0-9-]+\.)+[A-Za-z]{2,6})|"  # Domain name
@@ -338,9 +347,6 @@ def validate_url(ctx, param, value):
         r"(/([A-Za-z0-9$_.+!*\'(),;?&=-]|%[0-9A-Fa-f]{2})*)*"  # Path
         r"(\?([A-Za-z0-9$_.+!*\'(),;?&=-]|%[0-9A-Fa-f]{2})*)?"  # Query string
     )
-
-    if value is None:
-        return value
 
     if not url_regex.match(value):
         raise click.BadParameter(f"'{value}' is not a valid URL.")

--- a/flexmeasures/cli/utils.py
+++ b/flexmeasures/cli/utils.py
@@ -339,6 +339,9 @@ def validate_url(ctx, param, value):
         r"(\?([A-Za-z0-9$_.+!*\'(),;?&=-]|%[0-9A-Fa-f]{2})*)?"  # Query string
     )
 
+    if value is None:
+        return value
+
     if not url_regex.match(value):
         raise click.BadParameter(f"'{value}' is not a valid URL.")
 


### PR DESCRIPTION
## Description

Logo URL validation previously didn't allow for a null value, this has been fixed to now allow a null value

## Look & Feel
![Screenshot from 2024-09-06 17-51-10](https://github.com/user-attachments/assets/f2326de8-fca6-4249-a8b9-4c0dc7738a7e)

## How to test

- Attempt to create an account using the command without the `--logo-url `flag.
- Observe the failure due to the non-nullable `logo_url` field.

## Further Improvements

None

## Related Items

This PR fixes the issue: #1166 

---

- [✅] I agree to contribute to the project under Apache 2 License. 
- [✅] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
