### PR TITLE
Belief chart: legends possible per plot

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -9,6 +9,8 @@ v0.24.0 | October XX, 2024
 
 New features
 -------------
+* The asset beliefs chart can now be configured to not combine legends, but show them per plot [see `PR #1176 <https://github.com/FlexMeasures/flexmeasures/pull/1176>`_]
+
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -412,6 +412,7 @@ class AssetAPI(FlaskView):
             "beliefs_after": AwareDateTimeField(format="iso", required=False),
             "beliefs_before": AwareDateTimeField(format="iso", required=False),
             "include_data": fields.Boolean(required=False),
+            "combine_legend": fields.Boolean(required=False, load_default=True),
             "dataset_name": fields.Str(required=False),
             "height": fields.Str(required=False),
             "width": fields.Str(required=False),

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -624,8 +624,6 @@ def chart_for_multiple_sensors(
                 "as": "source_name_and_id",
             },
         ],
-        spacing=100,
-        bounds="flush",
     )
     chart_specs["config"] = {
         "view": {"continuousWidth": 800, "continuousHeight": 150},

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -480,6 +480,7 @@ def chart_for_multiple_sensors(
     sensors_to_show: list["Sensor", list["Sensor"]],  # noqa F821
     event_starts_after: datetime | None = None,
     event_ends_before: datetime | None = None,
+    combined_legend: bool = True,
     **override_chart_specs: dict,
 ):
     # Determine the shared data resolution
@@ -639,7 +640,10 @@ def chart_for_multiple_sensors(
         "view": {"continuousWidth": 800, "continuousHeight": 150},
         "autosize": {"type": "fit-x", "contains": "padding"},
     }
-    chart_specs["resolve"] = {"scale": {"x": "shared"}}
+    if combined_legend is True:
+        chart_specs["resolve"] = {"scale": {"x": "shared"}}
+    else:
+        chart_specs["resolve"] = {"scale": {"color": "independent"}}
     for k, v in override_chart_specs.items():
         chart_specs[k] = v
     return chart_specs

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -506,12 +506,6 @@ def chart_for_multiple_sensors(
             ]
         }
 
-    # Set up field definition for sensor descriptions
-    sensor_field_definition = FIELD_DEFINITIONS["sensor_description"].copy()
-    sensor_field_definition["scale"] = dict(
-        domain=[sensor.to_dict()["description"] for sensor in all_shown_sensors]
-    )
-
     sensors_specs = []
     for s in sensors_to_show:
         # List the sensors that go into one row
@@ -519,6 +513,12 @@ def chart_for_multiple_sensors(
             row_sensors: list["Sensor"] = s  # noqa F821
         else:
             row_sensors: list["Sensor"] = [s]  # noqa F821
+
+        # Set up field definition for sensor descriptions
+        sensor_field_definition = FIELD_DEFINITIONS["sensor_description"].copy()
+        sensor_field_definition["scale"] = dict(
+            domain=[sensor.to_dict()["description"] for sensor in row_sensors]
+        )
 
         # Derive the unit that should be shown
         unit = determine_shared_unit(row_sensors)

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -103,9 +103,11 @@ def create_bar_chart_or_histogram_specs(
                     "detail": FIELD_DEFINITIONS["source"],
                     "opacity": {"value": 0.7},
                     "tooltip": [
-                        FIELD_DEFINITIONS["full_date"]
-                        if chart_type != "histogram"
-                        else None,
+                        (
+                            FIELD_DEFINITIONS["full_date"]
+                            if chart_type != "histogram"
+                            else None
+                        ),
                         {
                             **event_value_field_definition,
                             **dict(title=f"{capitalize(sensor.sensor_type)}"),
@@ -682,22 +684,26 @@ def create_line_layer(
     line_layer = {
         "mark": {
             "type": "line",
-            "interpolate": "step-after"
-            if event_resolution != timedelta(0)
-            else "linear",
+            "interpolate": (
+                "step-after" if event_resolution != timedelta(0) else "linear"
+            ),
             "clip": True,
         },
         "encoding": {
             "x": event_start_field_definition,
             "y": event_value_field_definition,
-            "color": sensor_field_definition if combine_legend else {
-                **sensor_field_definition,
-                "legend": {
-                    "orient": "right",
-                    "columns": 1,
-                    "direction": "vertical",
-                },
-            },
+            "color": (
+                sensor_field_definition
+                if combine_legend
+                else {
+                    **sensor_field_definition,
+                    "legend": {
+                        "orient": "right",
+                        "columns": 1,
+                        "direction": "vertical",
+                    },
+                }
+            ),
             "strokeDash": {
                 "scale": {
                     # Distinguish forecasters and schedulers by line stroke

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -571,6 +571,7 @@ def chart_for_multiple_sensors(
                 event_start_field_definition,
                 event_value_field_definition,
                 sensor_field_definition,
+                combine_legend=combine_legend,
             )
         ]
 
@@ -671,6 +672,7 @@ def create_line_layer(
     event_start_field_definition: dict,
     event_value_field_definition: dict,
     sensor_field_definition: dict,
+    combine_legend: bool,
 ):
     event_resolutions = list(set([sensor.event_resolution for sensor in sensors]))
     assert all(res == timedelta(0) for res in event_resolutions) or all(
@@ -688,7 +690,7 @@ def create_line_layer(
         "encoding": {
             "x": event_start_field_definition,
             "y": event_value_field_definition,
-            "color": {
+            "color": sensor_field_definition if combine_legend else {
                 **sensor_field_definition,
                 "legend": {
                     "orient": "right",

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -479,7 +479,7 @@ def chart_for_multiple_sensors(
     sensors_to_show: list["Sensor" | list["Sensor"] | dict[str, "Sensor"]],  # noqa F821
     event_starts_after: datetime | None = None,
     event_ends_before: datetime | None = None,
-    combined_legend: bool = True,
+    combine_legend: bool = True,
     **override_chart_specs: dict,
 ):
     # Determine the shared data resolution
@@ -631,7 +631,7 @@ def chart_for_multiple_sensors(
         "view": {"continuousWidth": 800, "continuousHeight": 150},
         "autosize": {"type": "fit-x", "contains": "padding"},
     }
-    if combined_legend is True:
+    if combine_legend is True:
         chart_specs["resolve"] = {"scale": {"x": "shared"}}
     else:
         chart_specs["resolve"] = {"scale": {"color": "independent"}}

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -688,7 +688,14 @@ def create_line_layer(
         "encoding": {
             "x": event_start_field_definition,
             "y": event_value_field_definition,
-            "color": sensor_field_definition,
+            "color": {
+                **sensor_field_definition,
+                "legend": {
+                    "orient": "right",
+                    "columns": 1,
+                    "direction": "vertical",
+                },
+            },
             "strokeDash": {
                 "scale": {
                     # Distinguish forecasters and schedulers by line stroke

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -435,6 +435,7 @@ class GenericAsset(db.Model, AuthModelMixin):
         event_ends_before: datetime | None = None,
         beliefs_after: datetime | None = None,
         beliefs_before: datetime | None = None,
+        combined_legend: bool = True,
         source: DataSource
         | list[DataSource]
         | int
@@ -454,6 +455,7 @@ class GenericAsset(db.Model, AuthModelMixin):
         :param event_ends_before: only return beliefs about events that end before this datetime (inclusive)
         :param beliefs_after: only return beliefs formed after this datetime (inclusive)
         :param beliefs_before: only return beliefs formed before this datetime (inclusive)
+        :param combined_legend: show a combined legend of all plots below the chart
         :param source: search only beliefs by this source (pass the DataSource, or its name or id) or list of sources
         :param include_data: if True, include data in the chart, or if False, exclude data
         :param dataset_name: optionally name the dataset used in the chart (the default name is sensor_<id>)
@@ -475,6 +477,7 @@ class GenericAsset(db.Model, AuthModelMixin):
             chart_type,
             sensors_to_show=self.sensors_to_show,
             dataset_name=dataset_name,
+            combined_legend=False,
             **kwargs,
         )
 

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -477,7 +477,7 @@ class GenericAsset(db.Model, AuthModelMixin):
             chart_type,
             sensors_to_show=self.sensors_to_show,
             dataset_name=dataset_name,
-            combined_legend=False,
+            combined_legend=combined_legend,
             **kwargs,
         )
 

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -435,7 +435,7 @@ class GenericAsset(db.Model, AuthModelMixin):
         event_ends_before: datetime | None = None,
         beliefs_after: datetime | None = None,
         beliefs_before: datetime | None = None,
-        combined_legend: bool = True,
+        combine_legend: bool = True,
         source: DataSource
         | list[DataSource]
         | int
@@ -455,7 +455,7 @@ class GenericAsset(db.Model, AuthModelMixin):
         :param event_ends_before: only return beliefs about events that end before this datetime (inclusive)
         :param beliefs_after: only return beliefs formed after this datetime (inclusive)
         :param beliefs_before: only return beliefs formed before this datetime (inclusive)
-        :param combined_legend: show a combined legend of all plots below the chart
+        :param combine_legend: show a combined legend of all plots below the chart
         :param source: search only beliefs by this source (pass the DataSource, or its name or id) or list of sources
         :param include_data: if True, include data in the chart, or if False, exclude data
         :param dataset_name: optionally name the dataset used in the chart (the default name is sensor_<id>)
@@ -477,7 +477,7 @@ class GenericAsset(db.Model, AuthModelMixin):
             chart_type,
             sensors_to_show=self.sensors_to_show,
             dataset_name=dataset_name,
-            combined_legend=combined_legend,
+            combine_legend=combine_legend,
             **kwargs,
         )
 

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -319,8 +319,9 @@
     }
 
     async function embedAndLoad(chartSpecsPath, elementId, datasetName, previousResult, startDate, endDate) {
+        var combineLegend = 'true';
 
-        await vegaEmbed('#'+elementId, chartSpecsPath + 'dataset_name=' + datasetName + '&width=container&include_sensor_annotations=false&include_asset_annotations=false&chart_type=' + chartType, {{ chart_options | safe }})
+        await vegaEmbed('#'+elementId, chartSpecsPath + 'dataset_name=' + datasetName + '&combine_legend='+ combineLegend + '&width=container&include_sensor_annotations=false&include_asset_annotations=false&chart_type=' + chartType, {{ chart_options | safe }})
         .then(function (result) {
 
             // Create a custom menu item for exporting to CSV


### PR DESCRIPTION
## Description

Right now, the default on the asset charts is that multiple plots have one combined legend at the bottom. Some users (the ones exporting graphs for external purposes, but maybe also those whose charts legends are getting too crowded) want that one legend exists per plot (next to it).

## Look & Feel

![asset-7058-Location 1 (4)](https://github.com/user-attachments/assets/9008c2a1-b317-49e8-a91c-6f6114df997d)


## How to test

Set the new `combine_legend` parameter to `False` in `GenericAsset.chart()` - in `models/generic_assets.py` line 480
Or  set `combineLegend` = 'false';` in base.html (currently set to 'true').

## TODO

- [x] add `combined_legend` parameter
- [x] stop including all sensors in each sensor spec
- [x] move legends to the side
- [x] non-repeating colors -> moved to https://github.com/FlexMeasures/flexmeasures/pull/1182
- [x] `combined_legend` also as parameter to `GET /assets/<id>/chart`?

## Related Items

- https://vega.github.io/vega-lite/docs/resolve.html
- https://vega.github.io/vega-lite/docs/concat.html

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
