### PR TITLE
Improve 'Add titles to asset page graphs' implementation

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -9,10 +9,10 @@ v0.23.0 | August XX, 2024
 
 New features
 -------------
-* Added support for adding custom titles the graphs on the asset page. This works via an extension to the sensors_to_show format. [see `PR #1125 <https://github.com/FlexMeasures/flexmeasures/pull/1125>`_ and `PR #1177 <https://github.com/FlexMeasures/flexmeasures/pull/1177>`_]
 * New chart type on sensor page: histogram [see `PR #1143 <https://github.com/FlexMeasures/flexmeasures/pull/1143>`_]
 * Add basic sensor info to sensor page [see `PR #1115 <https://github.com/FlexMeasures/flexmeasures/pull/1115>`_]
 * Add `Statistics` table on the sensor page and also add `api/v3_0/sensors/<id>/stats` endpoint to get sensor statistics [see `PR #1116 <https://github.com/FlexMeasures/flexmeasures/pull/1116>`_]
+* Added support for adding custom titles to the graphs on the asset page. This works via an extension to the sensors_to_show format. [see `PR #1125 <https://github.com/FlexMeasures/flexmeasures/pull/1125>`_ and `PR #1177 <https://github.com/FlexMeasures/flexmeasures/pull/1177>`_]
 * Support zoom-in action on the asset and sensor charts [see `PR #1130 <https://github.com/FlexMeasures/flexmeasures/pull/1130>`_]
 * Speed up loading the assets page, by making the pagination backend-based and adding support for that in the API, and by enabling to query all accounts one can see in a single call (for admins and consultants) [see `PR #988 <https://github.com/FlexMeasures/flexmeasures/pull/988>`_]
 * Added Primary and Secondary colors to account for white-labelled UI themes [see `PR #1137 <https://github.com/FlexMeasures/flexmeasures/pull/1137>`_]

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -9,7 +9,7 @@ v0.23.0 | August XX, 2024
 
 New features
 -------------
-* Added support for adding custom titles the graphs on the asset page. This works via an extension to the sensors_to_show format. [see `PR #1125 <https://github.com/FlexMeasures/flexmeasures/pull/1125>`_]
+* Added support for adding custom titles the graphs on the asset page. This works via an extension to the sensors_to_show format. [see `PR #1125 <https://github.com/FlexMeasures/flexmeasures/pull/1125>`_ and `PR #1177 <https://github.com/FlexMeasures/flexmeasures/pull/1177>`_]
 * New chart type on sensor page: histogram [see `PR #1143 <https://github.com/FlexMeasures/flexmeasures/pull/1143>`_]
 * Add basic sensor info to sensor page [see `PR #1115 <https://github.com/FlexMeasures/flexmeasures/pull/1115>`_]
 * Add `Statistics` table on the sensor page and also add `api/v3_0/sensors/<id>/stats` endpoint to get sensor statistics [see `PR #1116 <https://github.com/FlexMeasures/flexmeasures/pull/1116>`_]

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -662,11 +662,16 @@ class GenericAsset(db.Model, AuthModelMixin):
         # Import the schema for validation
         from flexmeasures.data.schemas.generic_assets import SensorsToShowSchema
 
+        sensors_to_show_schema = SensorsToShowSchema()
+
         # Deserialize the sensor_ids_to_show using SensorsToShowSchema
-        standardized_sensors_to_show = SensorsToShowSchema().deserialize(
+        standardized_sensors_to_show = sensors_to_show_schema.deserialize(
             sensor_ids_to_show
         )
-        sensor_id_allowlist = flatten_unique(standardized_sensors_to_show)
+
+        sensor_id_allowlist = sensors_to_show_schema.flatten(
+            standardized_sensors_to_show
+        )
 
         # Only allow showing sensors from assets owned by the user's organization,
         # except in play mode, where any sensor may be shown

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -669,9 +669,7 @@ class GenericAsset(db.Model, AuthModelMixin):
             sensor_ids_to_show
         )
 
-        sensor_id_allowlist = sensors_to_show_schema.flatten(
-            standardized_sensors_to_show
-        )
+        sensor_id_allowlist = SensorsToShowSchema.flatten(standardized_sensors_to_show)
 
         # Only allow showing sensors from assets owned by the user's organization,
         # except in play mode, where any sensor may be shown

--- a/flexmeasures/data/schemas/generic_assets.py
+++ b/flexmeasures/data/schemas/generic_assets.py
@@ -115,7 +115,7 @@ class SensorsToShowSchema(fields.Field):
             )
 
     @classmethod
-    def flatten(nested_list) -> list[int]:
+    def flatten(cls, nested_list) -> list[int]:
         """
         Flatten a nested list of sensors or sensor dictionaries into a unique list of sensor IDs.
 
@@ -245,7 +245,7 @@ class GenericAssetSchema(ma.SQLAlchemySchema):
             sensors_to_show_schema = SensorsToShowSchema()
 
             standardized_sensors = sensors_to_show_schema.deserialize(sensors_to_show)
-            unique_sensor_ids = sensors_to_show_schema.flatten(standardized_sensors)
+            unique_sensor_ids = SensorsToShowSchema.flatten(standardized_sensors)
 
             # Check whether IDs represent accessible sensors
             from flexmeasures.data.schemas import SensorIdField

--- a/flexmeasures/data/schemas/generic_assets.py
+++ b/flexmeasures/data/schemas/generic_assets.py
@@ -114,11 +114,12 @@ class SensorsToShowSchema(fields.Field):
                 "Invalid item type in 'sensors_to_show'. Expected int, list, or dict."
             )
 
-    def flatten(self, nested_list) -> list:
+    @classmethod
+    def flatten(nested_list) -> list[int]:
         """
         Flatten a nested list of sensors or sensor dictionaries into a unique list of sensor IDs.
 
-        This method processes the following formats:
+        This method processes the following formats, for each of the entries of the nested list:
         - A list of sensor IDs: `[1, 2, 3]`
         - A list of dictionaries where each dictionary contains a `sensors` list or a `sensor` key:
         `[{"title": "Temperature", "sensors": [1, 2]}, {"title": "Pressure", "sensor": 3}]`
@@ -245,17 +246,11 @@ class GenericAssetSchema(ma.SQLAlchemySchema):
 
             standardized_sensors = sensors_to_show_schema.deserialize(sensors_to_show)
             unique_sensor_ids = sensors_to_show_schema.flatten(standardized_sensors)
+
             # Check whether IDs represent accessible sensors
             from flexmeasures.data.schemas import SensorIdField
 
             for sensor_id in unique_sensor_ids:
-                SensorIdField().deserialize(sensor_id)
-
-            # Check whether IDs represent accessible sensors
-            from flexmeasures.data.schemas import SensorIdField
-
-            sensor_ids = unique_sensor_ids
-            for sensor_id in sensor_ids:
                 SensorIdField().deserialize(sensor_id)
 
 

--- a/flexmeasures/data/tests/test_SensorsToShowSchema.py
+++ b/flexmeasures/data/tests/test_SensorsToShowSchema.py
@@ -37,8 +37,11 @@ def test_dict_with_title_and_multiple_sensors():
 
 def test_invalid_sensor_string_input():
     schema = SensorsToShowSchema()
-    with pytest.raises(ValidationError, match="Invalid JSON string."):
-        schema.deserialize("invalid_string")
+    with pytest.raises(
+        ValidationError,
+        match="Invalid item type in 'sensors_to_show'. Expected int, list, or dict.",
+    ):
+        schema.deserialize(["invalid_string"])
 
 
 def test_invalid_sensor_in_list():
@@ -85,3 +88,38 @@ def test_string_json_input():
         {"title": "Test2", "sensors": [3]},
     ]
     assert schema.deserialize(input_value) == expected_output
+
+
+# New test cases for misspelled or missing title and mixed sensor/sensors formats
+
+
+def test_dict_missing_title_key():
+    schema = SensorsToShowSchema()
+    input_value = [{"sensor": 42}]
+    with pytest.raises(ValidationError, match="Dictionary must contain a 'title' key."):
+        schema.deserialize(input_value)
+
+
+def test_dict_misspelled_title_key():
+    schema = SensorsToShowSchema()
+    input_value = [{"titel": "Temperature", "sensor": 42}]  # Misspelled 'title'
+    with pytest.raises(ValidationError, match="Dictionary must contain a 'title' key."):
+        schema.deserialize(input_value)
+
+
+def test_dict_with_sensor_as_list():
+    schema = SensorsToShowSchema()
+    input_value = [{"title": "Temperature", "sensor": [42]}]
+    with pytest.raises(ValidationError, match="'sensor' value must be an integer."):
+        schema.deserialize(input_value)
+
+
+def test_dict_with_sensors_as_int():
+    schema = SensorsToShowSchema()
+    input_value = [
+        {"title": "Temperature", "sensors": 42}
+    ]  # 'sensors' should be a list, not an int
+    with pytest.raises(
+        ValidationError, match="'sensors' value must be a list of integers."
+    ):
+        schema.deserialize(input_value)

--- a/flexmeasures/utils/coding_utils.py
+++ b/flexmeasures/utils/coding_utils.py
@@ -83,7 +83,10 @@ def flatten_unique(nested_list_of_objects: list) -> list:
         if isinstance(s, list):
             all_objects.extend(s)
         elif isinstance(s, dict):
-            all_objects.extend(s["sensors"])
+            if "sensors" in s:
+                all_objects.extend(s["sensors"])
+            if "sensor" in s:
+                all_objects.append(s["sensor"])
         else:
             all_objects.append(s)
     return list(dict.fromkeys(all_objects).keys())

--- a/flexmeasures/utils/coding_utils.py
+++ b/flexmeasures/utils/coding_utils.py
@@ -69,24 +69,29 @@ def sort_dict(unsorted_dict: dict) -> dict:
     return sorted_dict
 
 
+# This function is used for sensors_to_show in follow-up PR it will be moved and renamed to flatten_sensors_to_show
 def flatten_unique(nested_list_of_objects: list) -> list:
-    """Returns unique objects in a possibly nested (one level) list of objects.
+    """
+    Get unique sensor IDs from a list of `sensors_to_show`.
 
-    Preserves the original order in which unique objects first occurred.
+    Handles:
+    - Lists of sensor IDs
+    - Dictionaries with a `sensors` key
+    - Nested lists (one level)
 
-    For example:
-    >>> flatten_unique([1, [2, 20, 6], 10, [6, 2]])
-    <<< [1, 2, 20, 6, 10]
+    Example:
+        Input:
+        [1, [2, 20, 6], 10, [6, 2], {"title":None,"sensors": [10, 15]}, 15]
+
+        Output:
+        [1, 2, 20, 6, 10, 15]
     """
     all_objects = []
     for s in nested_list_of_objects:
         if isinstance(s, list):
             all_objects.extend(s)
         elif isinstance(s, dict):
-            if "sensors" in s:
-                all_objects.extend(s["sensors"])
-            if "sensor" in s:
-                all_objects.append(s["sensor"])
+            all_objects.extend(s["sensors"])
         else:
             all_objects.append(s)
     return list(dict.fromkeys(all_objects).keys())


### PR DESCRIPTION
## Description

This PR introduces improvements for code introduced in 'Add support for adding titles to asset page graphs'  [PR #1125](https://github.com/FlexMeasures/flexmeasures/pull/1125#event-14236047165):

- Add `flatten` method to `SensorsToShowSchema` to get sensors id's from validated `sensors_to_show`
- Add validation case for missing `title` key from dict input and input validation
- Update doc-string for `flatten_unique` which is a util function used exclusivity for`sensors_to_show` and will in follow-up PR be moved to models/GenericAsset and renamed.
- Add more test cases in `test_SensorsToShowSchema.py`

## Improvements introduced
-  Handle `sensor` input in dict entry in `sensors_to_show` e.g. {"title": "Title 1", "sensor": 1}
- Better Error for missing `Title` key in `sensors_to_show`
- Improve docstring of `flatten_unique`

#Follow up work
Create a follow-up PR to rename and move `flatten_unique`, which is used exclusivity for `sensors_to_show`


---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
