### PR TITLE
Fix audit log and jobs queue table sorting with datetime

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -59,8 +59,7 @@ Bugfixes
 * Fix missing value on spring :abbr:`DST (Daylight Saving Time)` transition for ``PandasReporter`` using daily sensor as input [see `PR #1122 <https://github.com/FlexMeasures/flexmeasures/pull/1122>`_]
 * Fix date range persistence on session across different pages [see `PR #1165 <https://github.com/FlexMeasures/flexmeasures/pull/1165>`_]
 * Fix issue with account creation failing when the --logo-url flag is omitted. [see related PRs `PR #1167 <https://github.com/FlexMeasures/flexmeasures/pull/1167>`_ and `PR #1145 <https://github.com/FlexMeasures/flexmeasures/pull/1145>`_]
-* Fix ordering of audit logs and job list on status page [see PR `PR #1179 <https://github.com/FlexMeasures/flexmeasures/pull/1179>_`]
-
+* Fix ordering of audit logs (asset, account) and job list on status page [see PR `PR #1179 <https://github.com/FlexMeasures/flexmeasures/pull/1179>_` and `PR #1183 <https://github.com/FlexMeasures/flexmeasures/pull/1183>`_]
 
 v0.22.0 | June 29, 2024
 ============================

--- a/flexmeasures/ui/templates/crud/account_audit_log.html
+++ b/flexmeasures/ui/templates/crud/account_audit_log.html
@@ -14,6 +14,7 @@
             <table id="account_audit_log" class="table table-striped table-responsive paginate nav-on-click" title="View data">
                 <thead>
                     <tr>
+                        <th style="display:none;">Event Timestamp</th><!-- Hidden UTC Timestamp column for sorting, Keep at position zero -->
                         <th>Event Name</th>
                         <th>Event Datetime</th>
                         <th>Active user id</th>
@@ -22,6 +23,9 @@
                 <tbody>
                     {% for audit_log in audit_logs: %}
                     <tr>
+                        <td style="display:none;">
+                            {{ audit_log.event_datetime | to_utc_timestamp }} <!-- Hidden UTC Timestamp column for sorting, Keep at position zero -->
+                        </td>
                         <td>
                             {{ audit_log.event }}
                         </td>
@@ -42,8 +46,16 @@
 
 <script>
     $(document).ready(function() {
-        $('#account_audit_log').DataTable({"order": [[ 1, "desc" ]]});
+        $('#account_audit_log').DataTable({
+            "order": [[ 1, "desc" ]], //Default sort by "Event Name" column
+            "columnDefs": [
+            { 
+                "targets": 2,  // Target the visible "Event Datetime" column
+                "orderData": 0  // Use data from the first column (UTC Timestamp) for sorting
+            }
+        ]
     });
+});
 </script>
 
 {% endblock %}

--- a/flexmeasures/ui/templates/crud/account_audit_log.html
+++ b/flexmeasures/ui/templates/crud/account_audit_log.html
@@ -15,8 +15,8 @@
                 <thead>
                     <tr>
                         <th style="display:none;">Event Timestamp</th><!-- Hidden UTC Timestamp column for sorting, Keep at position zero -->
-                        <th>Event Name</th>
                         <th>Event Datetime</th>
+                        <th>Event Name</th>
                         <th>Active user id</th>
                     </tr>
                 </thead>
@@ -27,10 +27,10 @@
                             {{ audit_log.event_datetime | to_utc_timestamp }} <!-- Hidden UTC Timestamp column for sorting, Keep at position zero -->
                         </td>
                         <td>
-                            {{ audit_log.event }}
+                            {{ audit_log.event_datetime }}
                         </td>
                         <td>
-                            {{ audit_log.event_datetime }}
+                            {{ audit_log.event }}
                         </td>
                         <td>
                             {{ audit_log.active_user_id }}
@@ -47,10 +47,10 @@
 <script>
     $(document).ready(function() {
         $('#account_audit_log').DataTable({
-            "order": [[ 1, "desc" ]], //Default sort by "Event Name" column
+            "order": [[ 0, "desc" ]], //Default sort by "Event Datetime" column
             "columnDefs": [
             { 
-                "targets": 2,  // Target the visible "Event Datetime" column
+                "targets": 1,  // Target the visible "Event Datetime" column
                 "orderData": 0  // Use data from the first column (UTC Timestamp) for sorting
             }
         ]

--- a/flexmeasures/ui/templates/crud/asset_audit_log.html
+++ b/flexmeasures/ui/templates/crud/asset_audit_log.html
@@ -44,10 +44,16 @@
 
 <script>
     $(document).ready(function() {
-        $('#asset_audit_log').DataTable({
-            "order": [[ 0, "desc" ]]  // Sort by the hidden UTC Timestamp column
-        });
+    $('#asset_audit_log').DataTable({
+        "order": [[ 0, "desc" ]],  // Default sort by the hidden UTC Timestamp column
+        "columnDefs": [
+            { 
+                "targets": 1,  // Target the visible "Event Datetime" column
+                "orderData": 0  // Use data from the first column (UTC Timestamp) for sorting
+            }
+        ]
     });
+});
 </script>
 
 {% endblock %}

--- a/flexmeasures/ui/templates/crud/user_audit_log.html
+++ b/flexmeasures/ui/templates/crud/user_audit_log.html
@@ -46,8 +46,16 @@
 
 <script>
     $(document).ready(function() {
-        $('#user_audit_log').DataTable({"order": [[ 0, "desc" ]]}); // Sort by the hidden UTC Timestamp column
+        $('#user_audit_log').DataTable({
+        "order": [[ 0, "desc" ]],  // Default sort by the hidden UTC Timestamp column
+        "columnDefs": [
+            { 
+                "targets": 2,  // Target the visible "Event Datetime" column
+                "orderData": 0  // Use data from the first column (UTC Timestamp) for sorting
+            }
+        ]
     });
+});
 </script>
 
 {% endblock %}

--- a/flexmeasures/ui/templates/views/status.html
+++ b/flexmeasures/ui/templates/views/status.html
@@ -140,7 +140,15 @@
 <!-- sort scheduling and forecasting jobs by hidden 'Created at Timestamp' column -->
 <script>
     $(document).ready(function() {
-        $('#scheduling_forecasting_jobs').DataTable({"order": [[ 0, "desc" ]]}); // Sort by the hidden UTC Timestamp column
+        $('#scheduling_forecasting_jobs').DataTable({
+        "order": [[ 0, "desc" ]],  // Default sort by the hidden UTC Timestamp column
+        "columnDefs": [
+            { 
+                "targets": 1,  // Target the visible "Created at" column
+                "orderData": 0  // Use data from the first column (UTC Timestamp) for sorting
+            }
+        ]
     });
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Description:
This PR addresses an issue where the audit logs (for assets, users, and jobs queue on the status page) were being sorted incorrectly when users clicked the `Event Datetime` column. Previously, sorting was done using the human-friendly datetime, which resulted in inaccurate ordering. This was resolved by introducing hidden UTC timestamp column and using that for default sorting [ See [PR #1178](https://github.com/FlexMeasures/flexmeasures/pull/1179)].
 In this pr we introduce using the hidden TimeStamp column for sorting when  `Event Datetime`  is clicked.

## Changes include:

Allow the `Event Datetime` column to be clickable, but route sorting through the hidden UTC column for correct ordering.
The new sorting logic ensures that even when users click the `Event Datetime` column, sorting happens using the hidden UTC Timestamp column, providing the correct order.

## How to Test:

1. Navigate to the Assets, Users, or Status page.
2. Click on the `Event Datetime` column to trigger sorting.
3. Verify that the log entries are now sorted by the correct UTC Timestamp (hidden) instead of the human-friendly datetime.

## Related Items:

This is a follow-up for PR #1178 