### PR TITLE
chore: install HiGHs solver on macOS for developers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,10 @@ install-for-dev:
 	make ensure-deps-folder
 	pip-sync requirements/${PYV}/app.txt requirements/${PYV}/dev.txt requirements/${PYV}/test.txt
 	make install-flexmeasures
+# Locally install HiGS on macOS
+	if [ "$(shell uname)" = "Darwin" ]; then \
+		make install-highs-macos; \
+	fi
 
 install-for-test:
 	make install-pip-tools

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,6 +13,8 @@ New features
 Infrastructure / Support
 ----------------------
 
+* For MacOS developers, install HiGHS solver automatically [see `PR #1187 <https://github.com/FlexMeasures/flexmeasures/pull/1187>`_]
+
 Bugfixes
 -----------
 


### PR DESCRIPTION
## Description

We installed it when they ran `make install-for-test`, but missed it with `make install-for-dev`

## Look & Feel

Running `make install-for-dev` on macOS should install HiGHS
