### PR TITLE
fix account audit log browser tab title

### DIFF
--- a/flexmeasures/ui/templates/crud/account_audit_log.html
+++ b/flexmeasures/ui/templates/crud/account_audit_log.html
@@ -2,7 +2,7 @@
 
 {% set active_page = "accounts" %}
 
-{% block title %} Account <a href="/accounts/{{ account.id }}">{{ account.name }}</a> actions history {% endblock %}
+{% block title %} Account {{ account.name }} actions history {% endblock %}
 
 {% block divs %}
 


### PR DESCRIPTION
## Description

- Remove HTML tags from the browser tab title in the account audit log page
- Update the account_audit_log.html template to display a clean, text-only tab title

## Look & Feel

before:

![Screenshot from 2024-09-20 16-14-33](https://github.com/user-attachments/assets/93de6f0d-1b06-47fb-b70d-4f00d6bb2452)

After: 

![Screenshot from 2024-09-20 17-27-56](https://github.com/user-attachments/assets/179295b8-dd1d-4831-8ae2-da84f748a85c)

## How to test

Steps to test it or name of the tests functions.

1. Navigate to an account's audit log page
2. Verify that the browser tab title displays correctly without HTML tags


## Related Items

closes #1188 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
