### PR TITLE
Refactor/simplify audit log messages

### DIFF
--- a/flexmeasures/api/v3_0/accounts.py
+++ b/flexmeasures/api/v3_0/accounts.py
@@ -211,7 +211,7 @@ class AccountAPI(FlaskView):
         for k, v in account_data.items():
             setattr(account, k, v)
 
-        event_message = f"Account {account.name} has been updated. Modified fields: {modified_fields_str}"
+        event_message = f"Account Updated, Field: {modified_fields_str}"
 
         # Add Audit log
         account_audit_log = AuditLog(

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -354,17 +354,16 @@ class AssetAPI(FlaskView):
                 for attr_key, attr_value in v.items():
                     if current_attributes.get(attr_key) != attr_value:
                         audit_log_data.append(
-                            f"Attr: {attr_key}, From: {current_attributes.get(attr_key)}, To: {attr_value}"
+                            f"Updated Attr: {attr_key}, From: {current_attributes.get(attr_key)}, To: {attr_value}"
                         )
                 continue
-            audit_log_data.append(f"Field: {k}, From: {getattr(db_asset, k)}, To: {v}")
+            audit_log_data.append(
+                f"Updated Field: {k}, From: {getattr(db_asset, k)}, To: {v}"
+            )
 
         # Iterate over each field or attribute updates and create a separate audit log entry for each.
         for event in audit_log_data:
-            audit_log_event = (
-                f"Updated asset '{db_asset.name}': {db_asset.id}; fields: {event}"
-            )
-            AssetAuditLog.add_record(db_asset, audit_log_event)
+            AssetAuditLog.add_record(db_asset, event)
 
         for k, v in asset_data.items():
             setattr(db_asset, k, v)

--- a/flexmeasures/api/v3_0/tests/test_assets_api.py
+++ b/flexmeasures/api/v3_0/tests/test_assets_api.py
@@ -203,7 +203,7 @@ def test_alter_an_asset(
     print(f"Editing Response: {asset_edit_response.json}")
     assert asset_edit_response.status_code == 200
 
-    audit_log_event = f"Updated asset '{prosumer_asset.name}': {prosumer_asset.id}; fields: Field: name, From: {name}, To: other"
+    audit_log_event = f"Updated Field: name, From: {name}, To: other"
     assert db.session.execute(
         select(AssetAuditLog).filter_by(
             event=audit_log_event,
@@ -213,7 +213,7 @@ def test_alter_an_asset(
         )
     ).scalar_one_or_none()
 
-    audit_log_event = f"Updated asset '{prosumer_asset.name}': {prosumer_asset.id}; fields: Field: latitude, From: {latitude}, To: 11.1"
+    audit_log_event = f"Updated Field: latitude, From: {latitude}, To: 11.1"
     assert db.session.execute(
         select(AssetAuditLog).filter_by(
             event=audit_log_event,


### PR DESCRIPTION
## Description

This PR simplifies the messages written in both the asset and account audit logs. Because The logs are already linked to the asset or account, so including the asset name and ID is unnecessary. The following changes have been made:

- Removed redundant asset name and ID from the asset audit log messages.

  - Instead of: `Asset '<ASSETNAME>': <ID>; fields: Updated Field: name, From: X, To: Y`
  - Now: `Updated Field: name, From: X, To: Y`
- Shortened the account audit log messages.

  - Instead of: `Account NAME has been updated`
  - Now: `Account updated`
## Look & Feel

- Asset AuditLog:
  - Before:
![Screenshot from 2024-09-20 18-47-24](https://github.com/user-attachments/assets/056533e9-263c-4aca-9190-e41de3ddcf34)

  - After 
![Screenshot from 2024-09-20 18-47-13](https://github.com/user-attachments/assets/9ff3028c-d911-48bd-a897-8b8495d380dc)

- Account AuditLog:
  - Before:
![Screenshot from 2024-09-20 18-46-31](https://github.com/user-attachments/assets/846343e2-95c8-4671-a5c6-7adc468842ed)

  - After : 
  ![Screenshot from 2024-09-20 18-45-49](https://github.com/user-attachments/assets/ef717479-fa48-4fc3-b72b-b21410add602)
 
## How to test

1. Make some updates to an asset (name, attributes) or to the account (name, primary or secondary colors)
2. Navigate to the audit logs page for assets or account audit log page .
3. Confirm that the logs entries are in the intended format.



---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
