### PR TITLE
Assets UI pagination

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,6 +13,7 @@ New features
 * Speed up loading the users page, by making the pagination backend-based and adding support for that in the API [see `PR #1160 <https://github.com/FlexMeasures/flexmeasures/pull/1160>`]
 * X-axis labels in CLI plots show datetime values in a readable and informative format [see `PR #1172 <https://github.com/FlexMeasures/flexmeasures/pull/1172>`_]
 * Speed up loading the accounts page,by making the pagination backend-based and adding support for that in the API [see `PR #1196 <https://github.com/FlexMeasures/flexmeasures/pull/1196>`_]
+* Speed up loading the account detail page by by switching to server-side pagination for assets, replacing client-side pagination [see `PR #1202 <https://github.com/FlexMeasures/flexmeasures/pull/1202>`_]
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/api/v3_0/accounts.py
+++ b/flexmeasures/api/v3_0/accounts.py
@@ -45,12 +45,12 @@ class AccountAPI(FlaskView):
     @use_kwargs(
         {
             "page": fields.Int(
-                required=False, validate=validate.Range(min=1), default=1
+                required=False, validate=validate.Range(min=1), load_default=None
             ),
             "per_page": fields.Int(
-                required=False, validate=validate.Range(min=1), default=10
+                required=False, validate=validate.Range(min=1), load_default=10
             ),
-            "filter": SearchFilterField(required=False, default=None),
+            "filter": SearchFilterField(required=False, load_default=None),
         },
         location="query",
     )

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -96,6 +96,7 @@ class AssetAPI(FlaskView):
         This endpoint returns all accessible assets by accounts.
         The `account_id` query parameter can be used to list assets from any account (if the user is allowed to read them). Per default, the user's account is used.
         Alternatively, the `all_accessible` query parameter can be used to list assets from all accounts the current_user has read-access to, plus all public assets. Defaults to `false`.
+        The `include_public` query parameter can be used to include public assets in the response. Defaults to `false`.
 
         The endpoint supports pagination of the asset list using the `page` and `per_page` query parameters.
 

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -63,19 +63,12 @@ class AssetAPI(FlaskView):
     @use_kwargs(
         {
             "account": AccountIdField(data_key="account_id", load_default=None),
-        },
-        location="query",
-    )
-    @use_kwargs(
-        {
             "all_accessible": fields.Bool(
                 data_key="all_accessible", load_default=False
             ),
-        },
-        location="query",
-    )
-    @use_kwargs(
-        {
+            "include_public": fields.Bool(
+                data_key="include_public", load_default=False
+            ),
             "page": fields.Int(
                 required=False, validate=validate.Range(min=1), load_default=1
             ),
@@ -91,6 +84,7 @@ class AssetAPI(FlaskView):
         self,
         account: Account | None,
         all_accessible: bool,
+        include_public: bool,
         page: int | None = None,
         per_page: int | None = None,
         filter: list[str] | None = None,
@@ -157,7 +151,7 @@ class AssetAPI(FlaskView):
         filter_statement = GenericAsset.account_id.in_([a.id for a in accounts])
 
         # add public assets if the request asks for all the accessible assets
-        if all_accessible:
+        if all_accessible or include_public:
             filter_statement = filter_statement | GenericAsset.account_id.is_(None)
 
         num_records = db.session.scalar(

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -70,7 +70,7 @@ class AssetAPI(FlaskView):
                 data_key="include_public", load_default=False
             ),
             "page": fields.Int(
-                required=False, validate=validate.Range(min=1), load_default=1
+                required=False, validate=validate.Range(min=1), load_default=None
             ),
             "per_page": fields.Int(
                 required=False, validate=validate.Range(min=1), load_default=10

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -77,12 +77,12 @@ class AssetAPI(FlaskView):
     @use_kwargs(
         {
             "page": fields.Int(
-                required=False, validate=validate.Range(min=1), default=1
+                required=False, validate=validate.Range(min=1), load_default=1
             ),
             "per_page": fields.Int(
-                required=False, validate=validate.Range(min=1), default=10
+                required=False, validate=validate.Range(min=1), load_default=10
             ),
-            "filter": SearchFilterField(required=False, default=None),
+            "filter": SearchFilterField(required=False, load_default=None),
         },
         location="query",
     )

--- a/flexmeasures/api/v3_0/users.py
+++ b/flexmeasures/api/v3_0/users.py
@@ -53,12 +53,12 @@ class UserAPI(FlaskView):
             "account": AccountIdField(data_key="account_id", load_default=None),
             "include_inactive": fields.Bool(load_default=False),
             "page": fields.Int(
-                required=False, validate=validate.Range(min=1), default=1
+                required=False, validate=validate.Range(min=1), load_default=None
             ),
             "per_page": fields.Int(
-                required=False, validate=validate.Range(min=1), default=1
+                required=False, validate=validate.Range(min=1), load_default=1
             ),
-            "filter": SearchFilterField(required=False, default=None),
+            "filter": SearchFilterField(required=False, load_default=None),
         },
         location="query",
     )

--- a/flexmeasures/ui/crud/accounts.py
+++ b/flexmeasures/ui/crud/accounts.py
@@ -10,7 +10,6 @@ from flexmeasures.auth.policy import user_has_admin_access
 
 from flexmeasures.ui.crud.api_wrapper import InternalApi
 from flexmeasures.ui.utils.view_utils import render_flexmeasures_template
-from flexmeasures.ui.crud.assets import get_assets_by_account
 from flexmeasures.data.models.user import Account
 from flexmeasures.data import db
 
@@ -53,14 +52,11 @@ class AccountCrudUI(FlaskView):
             ).scalar_one_or_none()
             if consultancy_account:
                 account["consultancy_account_name"] = consultancy_account.name
-        assets = get_assets_by_account(account_id)
-        assets += get_assets_by_account(account_id=None)
         accounts = get_accounts() if user_has_admin_access(current_user, "read") else []
         return render_flexmeasures_template(
             "crud/account.html",
             account=account,
             accounts=accounts,
-            assets=assets,
             include_inactive=include_inactive,
         )
 

--- a/flexmeasures/ui/templates/crud/account.html
+++ b/flexmeasures/ui/templates/crud/account.html
@@ -333,7 +333,9 @@ Account overview {% endblock %} {% block divs %}
         let filter = data["search"]["value"];
         let url = `{{url_for("AssetAPI:index")}}?page=${
           Math.floor(data["start"] / data["length"]) + 1
-        }&per_page=${data["length"]}&all_accessible=true`;
+        }&per_page=${data["length"]}&all_accessible=true&account_id=${
+          {{ account.id }}
+        }`;
         if (filter.length > 0) {
           url = `${url}&filter=${filter}`;
         }

--- a/flexmeasures/ui/templates/crud/account.html
+++ b/flexmeasures/ui/templates/crud/account.html
@@ -319,6 +319,7 @@ Account overview {% endblock %} {% block divs %}
     $("#assetTable").dataTable({
       serverSide: true,
       columns: [
+        { data: "id", title: "Asset ID" },
         { data: "name", title: "Name" },
         { data: "owner", title: "Account" },
         { data: "location", title: "Location" },

--- a/flexmeasures/ui/templates/crud/account.html
+++ b/flexmeasures/ui/templates/crud/account.html
@@ -292,7 +292,9 @@ Account overview {% endblock %} {% block divs %}
     let icon = asset_icon_map[asset_type.toLowerCase()];
     if (icon === undefined) icon = `icon-${asset_type}`;
 
-    this.name = name;
+    this.name = `
+    <i class="${icon} left-icon">${name}</i>
+  `;
 
     this.id = id;
     this.location = "";

--- a/flexmeasures/ui/templates/crud/account.html
+++ b/flexmeasures/ui/templates/crud/account.html
@@ -333,7 +333,7 @@ Account overview {% endblock %} {% block divs %}
         let filter = data["search"]["value"];
         let url = `{{url_for("AssetAPI:index")}}?page=${
           Math.floor(data["start"] / data["length"]) + 1
-        }&per_page=${data["length"]}&all_accessible=true&account_id=${
+        }&per_page=${data["length"]}&include_public=false&account_id=${
           {{ account.id }}
         }`;
         if (filter.length > 0) {

--- a/flexmeasures/ui/templates/crud/account.html
+++ b/flexmeasures/ui/templates/crud/account.html
@@ -265,7 +265,7 @@ Account overview {% endblock %} {% block divs %}
         <div class="table-responsive">
           <table
             class="table table-striped paginate nav-on-click"
-            title="View this asset"
+            title="View this user"
             id="usersTable"
           ></table>
         </div>
@@ -276,69 +276,97 @@ Account overview {% endblock %} {% block divs %}
           <table
             class="table table-striped paginate nav-on-click"
             title="View this asset"
-          >
-            <thead>
-              <tr>
-                <th><i class="left-icon">Name</i></th>
-                <th>Location</th>
-                <th>Asset ID</th>
-                <th>Account</th>
-
-                <th>Sensors</th>
-                <th class="no-sort">Status</th>
-                <th class="text-right no-sort">
-                  {% if user_can_create_assets %}
-                  <form action="/assets/new" method="get">
-                    <button
-                      class="btn btn-sm btn-responsive btn-success create-button"
-                      type="submit"
-                    >
-                      Create new asset
-                    </button>
-                  </form>
-                  {% endif %}
-                </th>
-                <th class="d-none">URL</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for asset in assets %}
-              <tr>
-                <td>
-                  <i
-                    class="{{ asset.generic_asset_type.name | asset_icon }} left-icon"
-                    >{{ asset.name }}</i
-                  >
-                </td>
-                <td>
-                  {% if asset.latitude and asset.longitude %} LAT: {{
-                  "{:,.4f}".format( asset.latitude ) }} LONG: {{
-                  "{:,.4f}".format( asset.longitude ) }} {% endif %}
-                </td>
-                <td>{{ asset.id }}</td>
-                <td>
-                  {% if asset.owner %} {{ asset.owner.name }} {% else %} PUBLIC
-                  {% endif %}
-                </td>
-                <td>{{ asset.sensors | length }}</td>
-                <td>
-                  <a href="/assets/{{ asset.id }}/status">
-                    <button type="button" class="btn">Status</button>
-                  </a>
-                </td>
-                <td class="text-right"></td>
-                <td class="d-none">/assets/{{ asset.id }}</td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
+            id="assetTable"
+          ></table>
         </div>
       </div>
     </div>
     <div class="col-md-2"></div>
   </div>
 </div>
-{% block paginate_tables_script %} {{ super() }} {% endblock %}
+
+<script>
+  const asset_icon_map = JSON.parse("{{ asset_icon_map | tojson | safe }}");
+
+  function Asset(id, name, account, latitude, longitude, sensors, asset_type) {
+    let icon = asset_icon_map[asset_type.toLowerCase()];
+    if (icon === undefined) icon = `icon-${asset_type}`;
+
+    this.name = name;
+
+    this.id = id;
+    this.location = "";
+    this.url = `/assets/${id}`;
+    this.status = `
+        <a href="/assets/${id}/status">
+          <button type="button" class="btn btn-primary">Status</button>
+        </a>
+      `;
+
+    if (account == null) this.owner = "PUBLIC";
+    else
+      this.owner = `
+          <a href="/accounts/${account["id"]}" title="View this account">${account["name"]}</a>
+        `;
+
+    this.num_sensors = sensors.length;
+
+    if (latitude != null && longitude != null)
+      this.location = `LAT: ${latitude}, LONG: ${longitude}`;
+  }
+
+  $(document).ready(function () {
+    $("#assetTable").dataTable({
+      serverSide: true,
+      columns: [
+        { data: "name", title: "Name" },
+        { data: "owner", title: "Account" },
+        { data: "location", title: "Location" },
+        { data: "num_sensors", title: "Sensors" },
+        { data: "status", title: "Status" },
+        { data: "url", title: "URL", className: "d-none" },
+      ],
+      ajax: function (data, callback, settings) {
+        let filter = data["search"]["value"];
+        let url = `{{url_for("AssetAPI:index")}}?page=${
+          Math.floor(data["start"] / data["length"]) + 1
+        }&per_page=${data["length"]}&all_accessible=true`;
+        if (filter.length > 0) {
+          url = `${url}&filter=${filter}`;
+        }
+        $.ajax({
+          type: "get",
+          url: url,
+          success: function (response, text) {
+            let clean_response = [];
+            response["data"].forEach((element) =>
+              clean_response.push(
+                new Asset(
+                  element["id"],
+                  element["name"],
+                  element["owner"],
+                  element["latitude"],
+                  element["longitude"],
+                  element["sensors"],
+                  element["generic_asset_type"]["name"]
+                )
+              )
+            );
+            callback({
+              data: clean_response,
+              recordsTotal: response["num-records"],
+              recordsFiltered: response["filtered-records"],
+            });
+          },
+          error: function (request, status, error) {
+            console.log("Error: ", error);
+          },
+        });
+      },
+    });
+  });
+</script>
+
 <script defer>
   let currentPage = 1;
   const basePath = window.location.origin;
@@ -407,4 +435,4 @@ Account overview {% endblock %} {% block divs %}
       });
   });
 </script>
-{% endblock %}
+{% block paginate_tables_script %} {{ super() }} {% endblock %} {% endblock %}

--- a/flexmeasures/ui/templates/crud/account.html
+++ b/flexmeasures/ui/templates/crud/account.html
@@ -333,7 +333,7 @@ Account overview {% endblock %} {% block divs %}
         let filter = data["search"]["value"];
         let url = `{{url_for("AssetAPI:index")}}?page=${
           Math.floor(data["start"] / data["length"]) + 1
-        }&per_page=${data["length"]}&include_public=false&account_id=${
+        }&per_page=${data["length"]}&include_public=true&account_id=${
           {{ account.id }}
         }`;
         if (filter.length > 0) {

--- a/flexmeasures/ui/templates/crud/assets.html
+++ b/flexmeasures/ui/templates/crud/assets.html
@@ -8,78 +8,72 @@
 
 <script>
 
-const asset_icon_map = JSON.parse('{{ asset_icon_map | tojson | safe }}');
+  const asset_icon_map = JSON.parse('{{ asset_icon_map | tojson | safe }}');
 
-function Asset ( id, name, asset_type, sensors, account, latitude, longitude) {
-    let icon = asset_icon_map[asset_type.toLowerCase()];
-    if (icon === undefined)
-      icon = `icon-${asset_type}`
+  function Asset ( id, name, asset_type, sensors, account, latitude, longitude) {
+      let icon = asset_icon_map[asset_type.toLowerCase()];
+      if (icon === undefined)
+        icon = `icon-${asset_type}`
 
-    this.name = `
-      <i class="${ icon } left-icon">${ name }</i>
-    `;
+      this.name = `
+        <i class="${ icon } left-icon">${ name }</i>
+      `;
 
-    this.id = id;
-    this.location = "";
-    this.url = `/assets/${id}`
-    this.status = `
-      <a href="/assets/${id}/status">
-        <button type="button" class="btn btn-primary">Status</button>
-      </a>
-    `;
+      this.id = id;
+      this.location = "";
+      this.url = `/assets/${id}`
+      this.status = `
+        <a href="/assets/${id}/status">
+          <button type="button" class="btn btn-primary">Status</button>
+        </a>
+      `;
 
-    if (account == null) this.owner = "PUBLIC";
-    else
-      this.owner = `
-        <a href="/accounts/${ account['id'] }" title="View this account">${ account["name"] }</a>
-      `
+      if (account == null) this.owner = "PUBLIC";
+      else
+        this.owner = `
+          <a href="/accounts/${ account['id'] }" title="View this account">${ account["name"] }</a>
+        `
 
-    this.num_sensors = sensors.length;
+      this.num_sensors = sensors.length;
 
-    if (latitude !=  null && longitude != null) this.location = `LAT: ${latitude}, LONG: ${longitude}`;
-};
+      if (latitude !=  null && longitude != null) this.location = `LAT: ${latitude}, LONG: ${longitude}`;
+  };
 
-$(document).ready(function() {  
-
-  /*
-  Initialize a DataTable on an HTML element with the ID #assetTable, enabling server-side processing. 
-  The table is configured to display columns for the asset's name, ID, account owner, location, number of sensors, status, and a hidden URL field. 
-  The data for the table is fetched from a server using AJAX.
-  */
-  $("#assetTable").dataTable({
-    serverSide: true,
-    columns: [
-      {data: "name", title: "Name"},
-      {data: "id", title: "Asset ID"},
-      {data: "owner", title: "Account"},
-      {data: "location", title: "Location"},
-      {data: "num_sensors", title: "Sensors"},
-      {data: "status", title: "Status"},
-      {data: "url", title: "URL", className: "d-none"},
-    ],
-    ajax: function (data, callback, settings) {
-      let filter = data["search"]["value"];
-      let url = `{{url_for("AssetAPI:index")}}?page=${Math.floor((data["start"])/data["length"] ) + 1 }&per_page=${data["length"]}&all_accessible=true`;
-      if (filter.length > 0) {
-        url = `${url}&filter=${filter}`;
-      }
-      $.ajax({
-        type: "get",
-        url: url,
-        success: function(response, text) {
-          let clean_response = [];
-          response["data"].forEach( (element) => clean_response.push(
-            new Asset(element["id"], element["name"], element["generic_asset_type"]["name"], element["sensors"], element["owner"], element["latitude"], element["longitude"])
-          )) 
-          callback({"data": clean_response, "recordsTotal": response["num-records"], "recordsFiltered": response["filtered-records"]});
-        },
-        error: function (request, status, error) {
-          console.log("Error: ", error)
+  $(document).ready(function() {  
+    $("#assetTable").dataTable({
+      serverSide: true,
+      columns: [
+        {data: "name", title: "Name"},
+        {data: "id", title: "Asset ID"},
+        {data: "owner", title: "Account"},
+        {data: "location", title: "Location"},
+        {data: "num_sensors", title: "Sensors"},
+        {data: "status", title: "Status"},
+        {data: "url", title: "URL", className: "d-none"},
+      ],
+      ajax: function (data, callback, settings) {
+        let filter = data["search"]["value"];
+        let url = `{{url_for("AssetAPI:index")}}?page=${Math.floor((data["start"])/data["length"] ) + 1 }&per_page=${data["length"]}&all_accessible=true`;
+        if (filter.length > 0) {
+          url = `${url}&filter=${filter}`;
         }
-      });
-    }
-  });
-})
+        $.ajax({
+          type: "get",
+          url: url,
+          success: function(response, text) {
+            let clean_response = [];
+            response["data"].forEach( (element) => clean_response.push(
+              new Asset(element["id"], element["name"], element["generic_asset_type"]["name"], element["sensors"], element["owner"], element["latitude"], element["longitude"])
+            )) 
+            callback({"data": clean_response, "recordsTotal": response["num-records"], "recordsFiltered": response["filtered-records"]});
+          },
+          error: function (request, status, error) {
+            console.log("Error: ", error)
+          }
+        });
+      }
+    });
+  })
 
 </script>
 


### PR DESCRIPTION
## Description

Added pagination to the asset table under the account detail page

## Look & Feel
![Screenshot from 2024-10-03 10-09-16](https://github.com/user-attachments/assets/2ee85f52-c12f-482f-bd8f-5d4c99f7e7ce)

## How to test

1. Vist the accounts page: [Link](http://localhost:5000/accounts)
2. Click on an accounts with assets 

## Further Improvements

Bug with icons not displaying for assets in all assets tables

## Related Items
This PR resolves the issue #1201

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
