### PR TITLE
fix: footer stays at the bottom (not sticky!)

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -22,7 +22,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
-
+* The UI footer now stays at the bottom even on pages with little content [see `PR #1204 <https://github.com/FlexMeasures/flexmeasures/pull/1204>`_]
 
 
 v0.23.0 | September 18, 2024

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -78,7 +78,7 @@
     {% endblock %}
 </head>
 
-<body>
+<body class="d-flex flex-column min-vh-100">
 
     {% block body %}
 
@@ -943,7 +943,7 @@
         src="https://cdn.datatables.net/plug-ins/1.10.22/features/conditionalPaging/dataTables.conditionalPaging.js"></script>
     {% endblock paginate_tables_script %}
 
-    <footer class="page-footer font-small pt-4 mt-4">
+    <footer class="page-footer font-small pt-4 mt-auto">
         <div class="footer text-center">
             <div class="container-fluid">
                 {% block copyright_notice %}


### PR DESCRIPTION
If there is little content on a page, the footer tends to 'float up'. We want it to stay at the bottom. However, we do not want it to be 'sticky'. That is, if there is lots of page content, the footer should still 'sink down' out of view.

Before:

![image](https://github.com/user-attachments/assets/2d22736b-a859-4815-8d87-100a81a5c8fa)

After:

![image](https://github.com/user-attachments/assets/ae271b83-7c38-492b-a3a5-e7d35664a09a)
