### PR TITLE
Uses load_default for all APIs

### DIFF
--- a/flexmeasures/api/v3_0/accounts.py
+++ b/flexmeasures/api/v3_0/accounts.py
@@ -45,12 +45,12 @@ class AccountAPI(FlaskView):
     @use_kwargs(
         {
             "page": fields.Int(
-                required=False, validate=validate.Range(min=1), default=1
+                required=False, validate=validate.Range(min=1), load_default=None
             ),
             "per_page": fields.Int(
-                required=False, validate=validate.Range(min=1), default=10
+                required=False, validate=validate.Range(min=1), load_default=10
             ),
-            "filter": SearchFilterField(required=False, default=None),
+            "filter": SearchFilterField(required=False, load_default=None),
         },
         location="query",
     )

--- a/flexmeasures/api/v3_0/users.py
+++ b/flexmeasures/api/v3_0/users.py
@@ -53,12 +53,12 @@ class UserAPI(FlaskView):
             "account": AccountIdField(data_key="account_id", load_default=None),
             "include_inactive": fields.Bool(load_default=False),
             "page": fields.Int(
-                required=False, validate=validate.Range(min=1), default=1
+                required=False, validate=validate.Range(min=1), load_default=None
             ),
             "per_page": fields.Int(
-                required=False, validate=validate.Range(min=1), default=1
+                required=False, validate=validate.Range(min=1), load_default=1
             ),
-            "filter": SearchFilterField(required=False, default=None),
+            "filter": SearchFilterField(required=False, load_default=None),
         },
         location="query",
     )


### PR DESCRIPTION
## Description

Replace the use of the depreciated `default` on our APIs and now using `load_default`

## Look & Feel
None - Backend Change

## How to test

Hit any of our paginated API without the `page` query. For example the accounts API:

`http://localhost:5000/api/v3_0/accounts?per_page=2`
![Screenshot from 2024-10-04 13-06-58](https://github.com/user-attachments/assets/6d952749-380c-48c6-8ac4-7aeef3d743f5)

Note in the above image there are no pagination related keys, just the array containing the data

This should have the below response without the pagination keys like `data`, `filtered-records` and `num-records`

## Further Improvements

None

## Related Items

Follow up from #1202 PR

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
