### PR TITLE
feat: globalize and simplify toasts

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -9,11 +9,11 @@ v0.24.0 | October XX, 2024
 
 New features
 -------------
-* The data chart on the asset page splits up its color-coded sensor legend when showing more than 7 sensors, becoming a legend per subplot [see `PR #1176 <https://github.com/FlexMeasures/flexmeasures/pull/1176>`_ and `PR #1193 <https://github.com/FlexMeasures/flexmeasures/pull/1193>`_
+* The data chart on the asset page splits up its color-coded sensor legend when showing more than 7 sensors, becoming a legend per subplot [see `PR #1176 <https://github.com/FlexMeasures/flexmeasures/pull/1176>`_ and `PR #1193 <https://github.com/FlexMeasures/flexmeasures/pull/1193>`_]
 * Speed up loading the users page, by making the pagination backend-based and adding support for that in the API [see `PR #1160 <https://github.com/FlexMeasures/flexmeasures/pull/1160>`]
 * X-axis labels in CLI plots show datetime values in a readable and informative format [see `PR #1172 <https://github.com/FlexMeasures/flexmeasures/pull/1172>`_]
 * Speed up loading the accounts page,by making the pagination backend-based and adding support for that in the API [see `PR #1196 <https://github.com/FlexMeasures/flexmeasures/pull/1196>`_]
-* Simplify and Globalize toasts in the flexmeasures project [See `PR #1207 <https://github.com/FlexMeasures/flexmeasures/pull/1207>_`]
+* Simplify and Globalize toasts in the flexmeasures project [see `PR #1207 <https://github.com/FlexMeasures/flexmeasures/pull/1207>_`]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,6 +13,7 @@ New features
 * Speed up loading the users page, by making the pagination backend-based and adding support for that in the API [see `PR #1160 <https://github.com/FlexMeasures/flexmeasures/pull/1160>`]
 * X-axis labels in CLI plots show datetime values in a readable and informative format [see `PR #1172 <https://github.com/FlexMeasures/flexmeasures/pull/1172>`_]
 * Speed up loading the accounts page,by making the pagination backend-based and adding support for that in the API [see `PR #1196 <https://github.com/FlexMeasures/flexmeasures/pull/1196>`_]
+* Simplify and Globalize toasts in the flexmeasures project [See `PR #1207 <https://github.com/FlexMeasures/flexmeasures/pull/1207>_`]
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -156,10 +156,18 @@
           </div>
         </div>
     </nav>
-      
-      
-
     {% endblock nav %}
+
+    <div
+        class="position-fixed bottom-0 end-0 p-3"
+        id="toast-container"
+        role="alert"
+        aria-live="assertive"
+        aria-atomic="true"
+        style="z-index: 11"
+    >
+        <button id="close-all-toasts" class="btn">Close All</button>
+    </div>
 
     {% if message and message != "" %}
     <div class="col-md-12 alert alert-info">{{ message}} </div>
@@ -728,6 +736,14 @@
 
     <!-- JS to enable toast -->
     <script defer>
+        const toastStack = document.getElementById("toast-container");
+        const closeToastBtn = document.getElementById("close-all-toasts");
+        
+        // written like this since this script(order) is ontop of the main script
+        document.addEventListener("DOMContentLoaded", function () {
+            initiateToastCloseBtn(closeToastBtn);
+        });
+
         function initiateToastCloseBtn(closeToastBtn){
             // hide button
             closeToastBtn.style.display = "none";
@@ -755,7 +771,7 @@
             });
         }
 
-        function showToast(message, type, toastStack, closeToastBtn) {
+        function showToast(message, type) {
             let colorClass;
             let colorStyle = "";
             let title;

--- a/flexmeasures/ui/templates/crud/account.html
+++ b/flexmeasures/ui/templates/crud/account.html
@@ -173,17 +173,6 @@ Account overview {% endblock %} {% block divs %}
       </div>
     </div>
     <div class="col-md-8">
-      <div
-        class="position-fixed bottom-0 end-0 p-3"
-        id="toast-container"
-        role="alert"
-        aria-live="assertive"
-        aria-atomic="true"
-        style="z-index: 11"
-      >
-        <button id="close-all-toasts" class="btn">Close All</button>
-      </div>
-
       <div class="card">
         <h3>Account</h3>
         <small>Account: {{ account.name }}</small>
@@ -345,15 +334,8 @@ Account overview {% endblock %} {% block divs %}
   const usersApiUrl = basePath + "/api/v3_0/users";
 
   const form = document.getElementById("editaccount");
-  const toastStack = document.getElementById("toast-container");
-  const closeToastBtn = document.getElementById("close-all-toasts");
   const tableBody = document.getElementById("users-table-body");
   const paginationControls = document.getElementById("pagination-controls");
-
-  // written like this since this script(order) is ontop of the main script
-  document.addEventListener("DOMContentLoaded", function () {
-    initiateToastCloseBtn(closeToastBtn);
-  });
 
   form.addEventListener("submit", function (event) {
     event.preventDefault(); // Prevent the default form submission
@@ -382,12 +364,7 @@ Account overview {% endblock %} {% block divs %}
       .then((response) => response.json())
       .then((data) => {
         if (data.status == 200) {
-          showToast(
-            "Account updated successfully!",
-            "success",
-            toastStack,
-            closeToastBtn
-          );
+          showToast("Account updated successfully!", "success");
         } else {
           if (data.message && typeof data.message === "string") {
             showToast(data.message, "error", toastStack, closeToastBtn);
@@ -395,12 +372,7 @@ Account overview {% endblock %} {% block divs %}
             const errors = data.message.json;
 
             for (const key in errors) {
-              showToast(
-                `${key}: ${errors[key]}`,
-                "error",
-                toastStack,
-                closeToastBtn
-              );
+              showToast(`${key}: ${errors[key]}`, "error");
             }
           }
         }


### PR DESCRIPTION
## Description

- Simplify toast interaction(now only requires two parameters)
- Globnablize toast use project-wide

## Look & Feel

![Screenshot from 2024-10-07 14-32-29](https://github.com/user-attachments/assets/8d01ba5f-aaa1-4888-b596-ec000bd87d55)

## How to test

1. Visit the accounts page
2. open an account
3. Edit and save changes. The toast will pop up at the bottom right of the screen.

You can test this functionality on other pages using the script below. The delay is introduced to ensure that the HTML has been fully rendered before the toast notification is displayed, as the toast logic requires access to the DOM. A brief pause (in this case, 3 seconds) ensures everything is ready for the toast to work correctly.

```
    setTimeout(function () {
        showToast("Message from taost!", "success");
    }, 3000);
```

## Further Improvements

None

## Related Items

None

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
