### PR TITLE
Sensorstoshow input

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -17,6 +17,7 @@ New features
 * X-axis labels in CLI plots show datetime values in a readable and informative format [see `PR #1172 <https://github.com/FlexMeasures/flexmeasures/pull/1172>`_]
 * Speed up loading the accounts page,by making the pagination backend-based and adding support for that in the API [see `PR #1196 <https://github.com/FlexMeasures/flexmeasures/pull/1196>`_]
 * Simplify and Globalize toasts in the flexmeasures project [see `PR #1207 <https://github.com/FlexMeasures/flexmeasures/pull/1207>_`]
+* Added an input field to edit the raw JSON data of the sensors_to_show model field [see `PR #1208 <https://github.com/FlexMeasures/flexmeasures/pull/1208>_`]
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/ui/crud/assets/forms.py
+++ b/flexmeasures/ui/crud/assets/forms.py
@@ -44,6 +44,7 @@ class AssetForm(FlaskForm):
         render_kw={"placeholder": "--Click the map or enter a longitude--"},
     )
     attributes = StringField("Other attributes (JSON)", default="{}")
+    sensors_to_show = StringField("Sensors to show (JSON)", default="[]")
     production_price_sensor_id = SelectField(
         "Production price sensor", coerce=int, validate_choice=False
     )

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -184,6 +184,15 @@
                                         {% endfor %}
                                     </div>
                                 </div>
+                                <div class="form-group">
+                                    {{ asset_form.sensors_to_show.label(class="col-sm-3 control-label") }}
+                                    <div class="col-md-3">
+                                        {{ asset_form.sensors_to_show(class_="form-control") }}
+                                        {% for error in asset_form.errors.sensors_to_show %}
+                                        <span style="color: red;">[{{error}}]</span>
+                                        {% endfor %}
+                                    </div>
+                                </div>
                                 <label class="control-label">Location</label>
                                 <small>(Click map to edit latitude and longitude in form)</small>
                                 <div id="mapid"></div>


### PR DESCRIPTION
## Description

Added sensors_to_show input field in the asset update form on the asset page.

## Look & Feel
![Screenshot from 2024-10-09 11-15-52](https://github.com/user-attachments/assets/0ad4d023-f4db-4be9-b3a7-e007e86a02af)

## How to test

1. Visit the assets page: [link](http://localhost:5000/assets)
2. Click on an asset with sensors
3. Navigate to the edit form and edit the sensors_to_show field
4. Save and check if the changes have been saved.

## Further Improvements

Enhancement to be more user friendly

## Related Items

Follow up for user friendly sensors_to_show edit form

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
