### PR TITLE
Search sensors in API by asset

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -19,6 +19,7 @@ New features
 * Speed up loading the accounts page,by making the pagination backend-based and adding support for that in the API [see `PR #1196 <https://github.com/FlexMeasures/flexmeasures/pull/1196>`_]
 * Speed up loading the account detail page by by switching to server-side pagination for assets, replacing client-side pagination [see `PR #1202 <https://github.com/FlexMeasures/flexmeasures/pull/1202>`_]
 * Simplify and Globalize toasts in the flexmeasures project [see `PR #1207 <https://github.com/FlexMeasures/flexmeasures/pull/1207>_`]
+* Enhanced API for listing sensors: Added option to filter by asset ID [see `PR #1219 <https://github.com/FlexMeasures/flexmeasures/pull/1219>_`] 
 
 Infrastructure / Support
 ----------------------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -15,11 +15,10 @@ New features
 * The data chart on the asset page splits up its color-coded sensor legend when showing more than 7 sensors, becoming a legend per subplot [see `PR #1176 <https://github.com/FlexMeasures/flexmeasures/pull/1176>`_ and `PR #1193 <https://github.com/FlexMeasures/flexmeasures/pull/1193>`_]
 * Speed up loading the users page, by making the pagination backend-based and adding support for that in the API [see `PR #1160 <https://github.com/FlexMeasures/flexmeasures/pull/1160>`_]
 * X-axis labels in CLI plots show datetime values in a readable and informative format [see `PR #1172 <https://github.com/FlexMeasures/flexmeasures/pull/1172>`_]
-* Enhanced API for listing sensors: Added filtering and pagination on sensor index endpoint and created new endpoint to get all sensors under an asset [see `PR #1191 <https://github.com/FlexMeasures/flexmeasures/pull/1191>`_ ]
+* Enhanced API for listing sensors: Added filtering and pagination on sensor index endpoint and created new endpoint to get all sensors under an asset [see `PR #1191 <https://github.com/FlexMeasures/flexmeasures/pull/1191>`_ and `PR #1219 <https://github.com/FlexMeasures/flexmeasures/pull/1219>`_]
 * Speed up loading the accounts page,by making the pagination backend-based and adding support for that in the API [see `PR #1196 <https://github.com/FlexMeasures/flexmeasures/pull/1196>`_]
 * Speed up loading the account detail page by by switching to server-side pagination for assets, replacing client-side pagination [see `PR #1202 <https://github.com/FlexMeasures/flexmeasures/pull/1202>`_]
 * Simplify and Globalize toasts in the flexmeasures project [see `PR #1207 <https://github.com/FlexMeasures/flexmeasures/pull/1207>_`]
-* Enhanced API for listing sensors: Added option to filter by asset ID [see `PR #1219 <https://github.com/FlexMeasures/flexmeasures/pull/1219>_`] 
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -205,6 +205,8 @@ class SensorAPI(FlaskView):
                     account_ids.extend([acc.id for acc in consultancy_accounts])
 
             filter_statement = GenericAsset.account_id.in_(account_ids)
+        else:
+            filter_statement = None
 
         if include_public_assets:
             filter_statement = or_(

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -154,18 +154,8 @@ class SensorAPI(FlaskView):
         :status 403: INVALID_SENDER
         :status 422: UNPROCESSABLE_ENTITY
         """
-        if isinstance(account, list):
-            accounts = account
-        else:
-            accounts: list = [account] if account else []
-
-        accounts = [
-            account for account in accounts if check_access(account, "read") is None
-        ]
-        account_ids: list = [acc.id for acc in accounts]
-
-        if asset and asset.account_id not in account_ids:
-            return {"message": "Asset does not belong to the account"}, 422
+        account_ids: list = [account.id]
+        accounts: list = [account]
 
         if asset is not None:
             child_assets = (
@@ -184,6 +174,9 @@ class SensorAPI(FlaskView):
                 acc.consultancy_account_id for acc in accounts
             ]
             account_ids.extend(consultancy_account_ids)
+
+        if asset and asset.account_id not in account_ids:
+            return {"message": "Asset does not belong to the account"}, 422
 
         if include_public_assets or all_accessible:
 
@@ -206,6 +199,7 @@ class SensorAPI(FlaskView):
                         or_(
                             Sensor.name.ilike(f"%{term}%"),
                             Account.name.ilike(f"%{term}%"),
+                            GenericAsset.name.ilike(f"%{term}%"),
                         )
                         for term in filter
                     )

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -67,30 +67,27 @@ class SensorAPI(FlaskView):
     @route("", methods=["GET"])
     @use_kwargs(
         {
-            "account": AccountIdField(
-                data_key="account_id", load_default=AccountIdField.load_current
-            ),
+            "account": AccountIdField(data_key="account_id", required=False),
             "asset": AssetIdField(data_key="asset_id", required=False),
             "include_consultancy_clients": fields.Boolean(
                 required=False, load_default=False
             ),
             "include_public_assets": fields.Boolean(required=False, load_default=False),
             "page": fields.Int(
-                required=False, validate=validate.Range(min=1), default=1
+                required=False, validate=validate.Range(min=1), load_default=1
             ),
             "per_page": fields.Int(
-                required=False, validate=validate.Range(min=1), default=10
+                required=False, validate=validate.Range(min=1), load_default=10
             ),
-            "filter": SearchFilterField(required=False, default=None),
-            "unit": UnitField(required=False, default=None),
+            "filter": SearchFilterField(required=False, load_default=None),
+            "unit": UnitField(required=False, load_default=None),
         },
         location="query",
     )
-    @permission_required_for_context("read", ctx_arg_name="account")
     @as_json
     def index(
         self,
-        account: Account,
+        account: Account | None = None,
         asset: GenericAsset | None = None,
         include_consultancy_clients: bool = False,
         include_public_assets: bool = False,
@@ -156,7 +153,11 @@ class SensorAPI(FlaskView):
         :status 403: INVALID_SENDER
         :status 422: UNPROCESSABLE_ENTITY
         """
-        account_ids: list = [account.id]
+        if account and asset is None:
+            account = current_user.account if not current_user.is_anonymous else None
+
+        account = account if check_access(account, "read") is None else None
+        account_ids: list = [account.id] if account else []
 
         if asset is not None:
             asset_tree = (

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -110,7 +110,7 @@ class SensorAPI(FlaskView):
         Alternatively, you can filter by asset hierarchy by providing the `asset` parameter (ID). When this is set, all sensors on the specified
         asset and its sub-assets are retrieved, provided the user has read access to the asset.
 
-        NOTE: You can't set both account and asset at the same time, you can only have one set. The only edge case is if the asset being specified is
+        NOTE: You can't set both account and asset at the same time, you can only have one set. The only exception is if the asset being specified is
         part of the account that was set, then we allow to see sensors under that asset but then ignore the account (account = None).
 
         Finally, you can use the `include_consultancy_clients` parameter to include sensors from accounts for which the current user account is a consultant.

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -57,6 +57,18 @@ post_sensor_schema = PostSensorDataSchema()
 sensors_schema = SensorSchema(many=True)
 sensor_schema = SensorSchema()
 partial_sensor_schema = SensorSchema(partial=True, exclude=["generic_asset_id"])
+asset_fields = [
+    GenericAsset.id,
+    GenericAsset.name,
+    GenericAsset.latitude,
+    GenericAsset.longitude,
+    GenericAsset.sensors_to_show,
+    GenericAsset.parent_asset_id,
+    GenericAsset.generic_asset_type_id,
+    GenericAsset.consumption_price_sensor_id,
+    GenericAsset.production_price_sensor_id,
+    GenericAsset.account_id,
+]  # this intentionally excludes attributes fields
 
 
 class SensorAPI(FlaskView):
@@ -159,11 +171,20 @@ class SensorAPI(FlaskView):
         account_ids: list = [account.id]
 
         if asset is not None:
-            child_assets = (
-                db.session.query(GenericAsset)
-                .filter(GenericAsset.parent_asset_id == asset.id)
-                .all()
+            start_query = (
+                select(*asset_fields)
+                .where(GenericAsset.id == asset.id)
+                .cte(name="asset_tree", recursive=True)
             )
+
+            recursive_query = select(*asset_fields).join(
+                start_query, GenericAsset.parent_asset_id == start_query.c.id
+            )
+
+            asset_tree = start_query.union_all(recursive_query)
+
+            child_assets = db.session.execute(select(asset_tree)).all()
+
             filter_statement = GenericAsset.id.in_(
                 [asset.id] + [a.id for a in child_assets]
             )
@@ -177,8 +198,7 @@ class SensorAPI(FlaskView):
                     .filter(Account.consultancy_account_id == account.id)
                     .all()
                 )
-                consultancy_account_ids: list = [acc.id for acc in consultancy_accounts]
-                account_ids.extend(consultancy_account_ids)
+                account_ids.extend([acc.id for acc in consultancy_accounts])
 
         if asset and asset.account_id not in account_ids:
             return {"message": "Asset does not belong to the account"}, 422

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -74,7 +74,7 @@ class SensorAPI(FlaskView):
             ),
             "include_public_assets": fields.Boolean(required=False, load_default=False),
             "page": fields.Int(
-                required=False, validate=validate.Range(min=1), load_default=1
+                required=False, validate=validate.Range(min=1), load_default=None
             ),
             "per_page": fields.Int(
                 required=False, validate=validate.Range(min=1), load_default=10

--- a/flexmeasures/api/v3_0/tests/test_sensors_api.py
+++ b/flexmeasures/api/v3_0/tests/test_sensors_api.py
@@ -20,7 +20,7 @@ sensor_schema = SensorSchema()
 
 
 @pytest.mark.parametrize(
-    "requesting_user, search_by, search_value, exp_sensor_name, exp_num_results, all_accessible, use_pagination",
+    "requesting_user, search_by, search_value, exp_sensor_name, exp_num_results, all_accessible, use_pagination, asset",
     [
         (
             "test_supplier_user_4@seita.nl",
@@ -30,6 +30,7 @@ sensor_schema = SensorSchema()
             2,
             True,
             False,
+            5,
         ),
         (
             "test_supplier_user_4@seita.nl",
@@ -39,6 +40,7 @@ sensor_schema = SensorSchema()
             1,
             True,
             False,
+            None,
         ),
         (
             "test_supplier_user_4@seita.nl",
@@ -48,6 +50,7 @@ sensor_schema = SensorSchema()
             3,
             True,
             True,
+            None,
         ),
         (
             "test_supplier_user_4@seita.nl",
@@ -57,6 +60,7 @@ sensor_schema = SensorSchema()
             1,
             False,
             False,
+            None,
         ),
     ],
     indirect=["requesting_user"],
@@ -71,6 +75,7 @@ def test_fetch_sensors(
     exp_num_results,
     all_accessible,
     use_pagination,
+    asset,
 ):
     """
     Retrieve all sensors.
@@ -91,6 +96,9 @@ def test_fetch_sensors(
     if all_accessible:
         query["all_accessible"] = True
 
+    if asset:
+        query["asset_id"] = asset
+
     response = client.get(
         url_for("SensorAPI:index"),
         query_string=query,
@@ -109,6 +117,9 @@ def test_fetch_sensors(
         assert is_valid_unit(response.json[0]["unit"])
         assert response.json[0]["name"] == exp_sensor_name
         assert len(response.json) == exp_num_results
+
+        if asset:
+            assert response.json[0]["generic_asset_id"] == asset
 
         if search_by == "unit":
             assert response.json[0]["unit"] == search_value

--- a/flexmeasures/api/v3_0/tests/test_sensors_api.py
+++ b/flexmeasures/api/v3_0/tests/test_sensors_api.py
@@ -52,7 +52,7 @@ sensor_schema = SensorSchema()
             1,
             True,
             False,
-            None,
+            5,
             None,
         ),
         (
@@ -63,7 +63,7 @@ sensor_schema = SensorSchema()
             3,
             True,
             True,
-            None,
+            5,
             None,
         ),
         (
@@ -74,7 +74,7 @@ sensor_schema = SensorSchema()
             1,
             False,
             False,
-            None,
+            5,
             None,
         ),
     ],

--- a/flexmeasures/api/v3_0/tests/test_sensors_api.py
+++ b/flexmeasures/api/v3_0/tests/test_sensors_api.py
@@ -30,7 +30,7 @@ sensor_schema = SensorSchema()
             2,
             True,
             False,
-            False,
+            200,
             None,
             5,
             None,
@@ -43,7 +43,7 @@ sensor_schema = SensorSchema()
             2,
             False,
             False,
-            False,
+            200,
             None,
             7,
             8,  # We test that the endpoint returns the sensor on a battery asset (ID: 8) while we filter for the building asset (ID: 7) that includes it
@@ -56,7 +56,7 @@ sensor_schema = SensorSchema()
             1,
             True,
             False,
-            False,
+            200,
             None,
             5,
             None,
@@ -69,7 +69,7 @@ sensor_schema = SensorSchema()
             None,
             None,
             None,
-            True,  # Error expected due to both asset_id and account_id being provided
+            422,  # Error expected due to both asset_id and account_id being provided
             1,
             5,
             None,
@@ -82,7 +82,7 @@ sensor_schema = SensorSchema()
             None,
             None,
             None,
-            True,  # Error expected as the user lacks access to the specified asset
+            403,  # Error expected as the user lacks access to the specified asset
             None,
             5,
             None,
@@ -95,7 +95,7 @@ sensor_schema = SensorSchema()
             None,
             None,
             None,
-            True,  # Error expected as the user lacks access to the specified account
+            403,  # Error expected as the user lacks access to the specified account
             1,
             None,
             None,
@@ -108,7 +108,7 @@ sensor_schema = SensorSchema()
             3,
             True,
             True,
-            False,
+            200,
             None,
             5,
             None,
@@ -121,7 +121,7 @@ sensor_schema = SensorSchema()
             1,
             False,
             False,
-            False,
+            200,
             None,
             5,
             None,
@@ -187,10 +187,10 @@ def test_fetch_sensors(
 
     print("Server responded with:\n%s" % response.json)
 
-    if expected_status_code:
-        assert response.status_code > 400
+    if expected_status_code > 400:
+        assert response.status_code == expected_status_code
     else:
-        assert response.status_code == 200
+        assert response.status_code == expected_status_code
 
         if use_pagination:
             assert isinstance(response.json["data"][0], dict)

--- a/flexmeasures/api/v3_0/tests/test_sensors_api.py
+++ b/flexmeasures/api/v3_0/tests/test_sensors_api.py
@@ -20,7 +20,7 @@ sensor_schema = SensorSchema()
 
 
 @pytest.mark.parametrize(
-    "requesting_user, search_by, search_value, exp_sensor_name, exp_num_results, all_accessible, use_pagination, asset",
+    "requesting_user, search_by, search_value, exp_sensor_name, exp_num_results, include_consultancy_clients, use_pagination, asset, parent_asset_id",
     [
         (
             "test_supplier_user_4@seita.nl",
@@ -31,6 +31,18 @@ sensor_schema = SensorSchema()
             True,
             False,
             5,
+            None,
+        ),
+        (
+            "test_prosumer_user@seita.nl",
+            None,
+            None,
+            "power",
+            2,
+            False,
+            False,
+            7,
+            8,
         ),
         (
             "test_supplier_user_4@seita.nl",
@@ -40,6 +52,7 @@ sensor_schema = SensorSchema()
             1,
             True,
             False,
+            None,
             None,
         ),
         (
@@ -51,6 +64,7 @@ sensor_schema = SensorSchema()
             True,
             True,
             None,
+            None,
         ),
         (
             "test_supplier_user_4@seita.nl",
@@ -61,6 +75,7 @@ sensor_schema = SensorSchema()
             False,
             False,
             None,
+            None,
         ),
     ],
     indirect=["requesting_user"],
@@ -68,14 +83,16 @@ sensor_schema = SensorSchema()
 def test_fetch_sensors(
     client,
     setup_api_test_data,
+    add_battery_assets,
     requesting_user,
     search_by,
     search_value,
     exp_sensor_name,
     exp_num_results,
-    all_accessible,
+    include_consultancy_clients,
     use_pagination,
     asset,
+    parent_asset_id,
 ):
     """
     Retrieve all sensors.
@@ -93,8 +110,8 @@ def test_fetch_sensors(
     elif search_by == "filter":
         query["filter"] = search_value
 
-    if all_accessible:
-        query["all_accessible"] = True
+    if include_consultancy_clients:
+        query["include_consultancy_clients"] = True
 
     if asset:
         query["asset_id"] = asset
@@ -118,7 +135,9 @@ def test_fetch_sensors(
         assert response.json[0]["name"] == exp_sensor_name
         assert len(response.json) == exp_num_results
 
-        if asset:
+        if asset and parent_asset_id:
+            assert response.json[0]["generic_asset_id"] == parent_asset_id
+        elif asset:
             assert response.json[0]["generic_asset_id"] == asset
 
         if search_by == "unit":

--- a/flexmeasures/api/v3_0/tests/test_sensors_api.py
+++ b/flexmeasures/api/v3_0/tests/test_sensors_api.py
@@ -20,7 +20,7 @@ sensor_schema = SensorSchema()
 
 
 @pytest.mark.parametrize(
-    "requesting_user, search_by, search_value, exp_sensor_name, exp_num_results, include_consultancy_clients, use_pagination, test_errors, filter_account_id, filter_asset_id, asset_id_of_of_first_sensor_result",
+    "requesting_user, search_by, search_value, exp_sensor_name, exp_num_results, include_consultancy_clients, use_pagination, expected_status_code, filter_account_id, filter_asset_id, asset_id_of_of_first_sensor_result",
     [
         (
             "test_supplier_user_4@seita.nl",
@@ -69,7 +69,7 @@ sensor_schema = SensorSchema()
             None,
             None,
             None,
-            True,
+            True,  # Error expected due to both asset_id and account_id being provided
             1,
             5,
             None,
@@ -82,9 +82,22 @@ sensor_schema = SensorSchema()
             None,
             None,
             None,
-            True,
+            True,  # Error expected as the user lacks access to the specified asset
             None,
             5,
+            None,
+        ),
+        (
+            "test_supplier_user_4@seita.nl",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            True,  # Error expected as the user lacks access to the specified account
+            1,
+            None,
             None,
         ),
         (
@@ -127,7 +140,7 @@ def test_fetch_sensors(
     exp_num_results,
     include_consultancy_clients,
     use_pagination,
-    test_errors,
+    expected_status_code,
     filter_account_id,
     filter_asset_id,
     asset_id_of_of_first_sensor_result,
@@ -174,7 +187,7 @@ def test_fetch_sensors(
 
     print("Server responded with:\n%s" % response.json)
 
-    if test_errors:
+    if expected_status_code:
         assert response.status_code > 400
     else:
         assert response.status_code == 200

--- a/flexmeasures/api/v3_0/tests/test_sensors_api.py
+++ b/flexmeasures/api/v3_0/tests/test_sensors_api.py
@@ -187,11 +187,8 @@ def test_fetch_sensors(
 
     print("Server responded with:\n%s" % response.json)
 
-    if expected_status_code > 400:
-        assert response.status_code == expected_status_code
-    else:
-        assert response.status_code == expected_status_code
-
+    assert response.status_code == expected_status_code
+    if expected_status_code == 200:
         if use_pagination:
             assert isinstance(response.json["data"][0], dict)
             assert is_valid_unit(response.json["data"][0]["unit"])

--- a/flexmeasures/api/v3_0/tests/test_sensors_api.py
+++ b/flexmeasures/api/v3_0/tests/test_sensors_api.py
@@ -215,6 +215,7 @@ def test_post_a_sensor(client, setup_api_test_data, requesting_user, db):
     assert response.status_code == 201
     assert response.json["name"] == "power"
     assert response.json["event_resolution"] == "PT1H"
+    assert response.json["generic_asset_id"] == post_data["generic_asset_id"]
 
     sensor: Sensor = db.session.execute(
         select(Sensor).filter_by(name="power", unit="kWh")

--- a/flexmeasures/api/v3_0/tests/test_sensors_api.py
+++ b/flexmeasures/api/v3_0/tests/test_sensors_api.py
@@ -217,8 +217,9 @@ def test_post_a_sensor(client, setup_api_test_data, requesting_user, db):
     assert response.json["event_resolution"] == "PT1H"
 
     sensor: Sensor = db.session.execute(
-        select(Sensor).filter_by(name="power")
+        select(Sensor).filter_by(name="power", unit="kWh")
     ).scalar_one_or_none()
+
     assert sensor is not None
     assert sensor.unit == "kWh"
     assert sensor.attributes["capacity_in_mw"] == 0.0074

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -487,7 +487,6 @@
       });
     });
   </script>
-  
 
 {% block paginate_tables_script %} {{ super() }} {% endblock %} 
 {% endblock %}

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -487,6 +487,7 @@
       });
     });
   </script>
+  
 
 {% block paginate_tables_script %} {{ super() }} {% endblock %} 
 {% endblock %}


### PR DESCRIPTION
## Description

Search sensors by asset ID

## Look & Feel
![Screenshot from 2024-10-22 15-20-35](https://github.com/user-attachments/assets/cfdd4cde-b5b2-47a5-9fad-1cade619f4ac)


## How to test

Apply the `asset_id` query param to the sensors API  `http://localhost:5000/api/v3_0/sensors?page=1&per_page=10&asset_id=2`

Simply put in the ID of any valid asset

## Further Improvements

None

## Related Items

This PR closes: #1209 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
