### PR TITLE
Display deactivate btn only as admin/account-admin

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -30,7 +30,7 @@ Bugfixes
 * The UI footer now stays at the bottom even on pages with little content [see `PR #1204 <https://github.com/FlexMeasures/flexmeasures/pull/1204>`_]
 * Correct stroke dash (based on source type) for forecasts made by forecasters included in FlexMeasures [see `PR #1211 <https://www.github.com/FlexMeasures/flexmeasures/pull/1211>`_]
 * Show the correct UTC offset for the data's time span as shown under sensor stats in the UI [see `PR #1213 <https://github.com/FlexMeasures/flexmeasures/pull/1213>`_]
-* Fix issue with displaying 'deactivate user' and 'reset password' buttons for non admin users [see `PR #1220 <https://github.com/FlexMeasures/flexmeasures/pull/1220>`_]
+* Fix issue with displaying ``deactivate user`` and ``reset password`` buttons for non admin users [see `PR #1220 <https://github.com/FlexMeasures/flexmeasures/pull/1220>`_]
 
 
 v0.23.0 | September 18, 2024

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -30,6 +30,7 @@ Bugfixes
 * The UI footer now stays at the bottom even on pages with little content [see `PR #1204 <https://github.com/FlexMeasures/flexmeasures/pull/1204>`_]
 * Correct stroke dash (based on source type) for forecasts made by forecasters included in FlexMeasures [see `PR #1211 <https://www.github.com/FlexMeasures/flexmeasures/pull/1211>`_]
 * Show the correct UTC offset for the data's time span as shown under sensor stats in the UI [see `PR #1213 <https://github.com/FlexMeasures/flexmeasures/pull/1213>`_]
+* Fix issue with displaying 'deactivate user' and 'reset password' buttons for non admin users [see `PR #1220 <https://github.com/FlexMeasures/flexmeasures/pull/1220>`_]
 
 
 v0.23.0 | September 18, 2024

--- a/flexmeasures/ui/templates/crud/user.html
+++ b/flexmeasures/ui/templates/crud/user.html
@@ -12,6 +12,7 @@
   <div class="row">
     <div class="col-md-2 on-top-md">
       <div class="header-action-button">
+        {% if current_user.has_role('admin') or current_user.has_role('account-admin')  %}
         <div class="">
           <form action="/users/toggle_active/{{ user.id }}" method="get">
             <button class="btn btn-sm btn-responsive {% if user.active %} btn-warning  {% else %} btn-success {% endif %} delete-button mb-3" type="submit" title="Toggle activation status of this user.">
@@ -19,6 +20,7 @@
             </button>
           </form>
         </div>
+        {% endif %}
         <div>
           <form action="/users/reset_password_for/{{ user.id }}" method="get">
             <button class="btn btn-sm btn-responsive btn-info delete-button" type="submit"

--- a/flexmeasures/ui/templates/crud/user.html
+++ b/flexmeasures/ui/templates/crud/user.html
@@ -20,13 +20,13 @@
             </button>
           </form>
         </div>
-        {% endif %}
         <div>
           <form action="/users/reset_password_for/{{ user.id }}" method="get">
             <button class="btn btn-sm btn-responsive btn-info delete-button" type="submit"
               title="Reset the password and send instructions how to choose a new one.">Reset password</button>
           </form>
         </div>
+        {% endif %}
       </div>
     </div>
     <div class="col-md-8">


### PR DESCRIPTION
## Description

Added condition to display the deactivate button on user detail page only if current logged in user is admin or account-admin

## Look & Feel

**Admin**
![Screenshot from 2024-10-24 12-49-40](https://github.com/user-attachments/assets/07bcbd21-9be6-4fa2-8a20-fc7fd970f2bc)
**Admin Reader**
![Screenshot from 2024-10-24 12-50-54](https://github.com/user-attachments/assets/962726c0-1fc1-4ebf-b370-0ea450030c40)


## How to test

1. Log in as an admin reader
2. visit the [user's page](http://localhost:5000/users)
3. click on a user
4. you  should see only one button at the top left of the screen, which should be the _reset password_ button

## Further Improvements

None

## Related Items

This PR closes: #1185 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
