### PR TITLE
fix: docs should build again

### DIFF
--- a/flexmeasures/ui/__init__.py
+++ b/flexmeasures/ui/__init__.py
@@ -118,10 +118,11 @@ def register_rq_dashboard(app):
         return
 
     # Logged-in users can view queues on the demo server, but only admins can view them on other servers
-    if app.config.get("FLEXMEASURES_MODE", "") == "demo":
-        rq_dashboard.blueprint.before_request(basic_auth)
-    else:
-        rq_dashboard.blueprint.before_request(basic_admin_auth)
+    if app.config.get("FLEXMEASURES_ENV") != "documentation":
+        if app.config.get("FLEXMEASURES_MODE", "") == "demo":
+            rq_dashboard.blueprint.before_request(basic_auth)
+        else:
+            rq_dashboard.blueprint.before_request(basic_admin_auth)
 
     # To set template variables, use set_global_template_variables in app.py
     app.register_blueprint(rq_dashboard.blueprint, url_prefix="/tasks")


### PR DESCRIPTION
## Description

This PR attempts to fix the currently failing pipeline for readthedocs. At least locally, this change resolves the failing of `make update-docs`.

## Look & Feel

Before:

```
Exception occurred:
  File "/flexmeasures/venv/lib/python3.11/site-packages/flask/sansio/blueprints.py", line 215, in _check_setup_finished
    raise AssertionError(
AssertionError: The setup method 'before_request' can no longer be called on the blueprint 'rq_dashboard'. It has already been registered at least once, any changes will not be applied consistently.
Make sure all imports, decorators, functions, etc. needed to set up the blueprint are done before registering it.
```

## How to test

I aim to test the RTD build for this branch.
