### PR TITLE
Fix build pipeline by excluding sphinx==7.4.*

### DIFF
--- a/requirements/3.10/docs.txt
+++ b/requirements/3.10/docs.txt
@@ -55,7 +55,7 @@ six==1.16.0
     #   sphinxcontrib-httpdomain
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==7.4.7
+sphinx==7.3.7
     # via
     #   -r requirements/docs.in
     #   sphinx-copybutton
@@ -87,8 +87,6 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
-    # via sphinx
-tomli==2.0.1
     # via sphinx
 urllib3==2.2.3
     # via

--- a/requirements/3.11/docs.txt
+++ b/requirements/3.11/docs.txt
@@ -55,7 +55,7 @@ six==1.16.0
     #   sphinxcontrib-httpdomain
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==7.4.7
+sphinx==7.3.7
     # via
     #   -r requirements/docs.in
     #   sphinx-copybutton

--- a/requirements/3.9/docs.txt
+++ b/requirements/3.9/docs.txt
@@ -92,8 +92,6 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-tomli==2.0.1
-    # via sphinx
 urllib3==2.2.3
     # via
     #   -c requirements/3.9/app.txt

--- a/requirements/3.9/docs.txt
+++ b/requirements/3.9/docs.txt
@@ -59,7 +59,7 @@ six==1.16.0
     #   sphinxcontrib-httpdomain
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==7.4.7
+sphinx==7.3.7
     # via
     #   -r requirements/docs.in
     #   sphinx-copybutton

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -1,4 +1,4 @@
-sphinx
+sphinx!=7.4.*
 sphinx-rtd-theme >= 1.2
 sphinxcontrib.httpdomain
 sphinx_fontawesome


### PR DESCRIPTION
This PR fixed the docs build pipeline as shown here: https://readthedocs.org/projects/flexmeasures/builds/26081978/