### PR TITLE
Restrict Audit Log Button Visibility

### DIFF
--- a/flexmeasures/ui/crud/accounts.py
+++ b/flexmeasures/ui/crud/accounts.py
@@ -63,11 +63,12 @@ class AccountCrudUI(FlaskView):
     @login_required
     def auditlog(self, account_id: str):
         """/accounts/auditlog/<account_id>"""
-        account = get_account(account_id)
+        account = db.session.execute(select(Account).filter_by(id=account_id)).scalar()
         audit_log_response = InternalApi().get(
             url_for("AccountAPI:auditlog", id=account_id)
         )
         audit_logs_response = audit_log_response.json()
+
         return render_flexmeasures_template(
             "crud/account_audit_log.html",
             audit_logs=audit_logs_response,

--- a/flexmeasures/ui/templates/admin/logged_in_user.html
+++ b/flexmeasures/ui/templates/admin/logged_in_user.html
@@ -76,14 +76,18 @@
       </div>
     </div>
     <div class="col-md-2">
+      {% if can_view_account_auditlog %}
       <form action="/accounts/auditlog/{{ logged_in_user.account.id }}" method="get" class="bt-md-0 mb-3 mt-3">
         <button class="btn btn-sm btn-responsive btn-info" type="submit"
          title="View history of account actions.">Account audit log</button>
       </form>
+      {% endif %}
+      {% if can_view_user_auditlog %}
       <form action="/users/auditlog/{{ logged_in_user.id }}" method="get" class="mb-md-0 mb-3 mt-3">
           <button class="btn btn-sm btn-responsive btn-info" type="submit"
           title="View history of user actions.">User audit log</button>
       </form>
+      {% endif %}
     </div>
     
   </div>

--- a/flexmeasures/ui/views/logged_in_user.py
+++ b/flexmeasures/ui/views/logged_in_user.py
@@ -1,6 +1,13 @@
+from sqlalchemy import select
+from werkzeug.exceptions import Forbidden
 from flask_security.core import current_user
 from flask_security import login_required
 
+from flexmeasures.auth.policy import check_access
+
+from flexmeasures.data import db
+from flexmeasures.data.models.audit_log import AuditLog
+from flexmeasures.data.models.user import Account
 from flexmeasures.ui.views import flexmeasures_ui
 from flexmeasures.data.services.accounts import (
     get_number_of_assets_in_account,
@@ -18,6 +25,27 @@ def logged_in_user_view():
     """
     account_roles = get_account_roles(current_user.account_id)
     account_role_names = [account_role.name for account_role in account_roles]
+    account = db.session.execute(
+        select(Account).filter_by(id=current_user.account_id)
+    ).scalar()
+
+    try:
+        user_view_account_auditlog = bool(
+            check_access(AuditLog.account_table_acl(account), "read")
+        )
+    except Forbidden:
+        user_view_account_auditlog = False
+
+    try:
+        user_view_user_auditlog = bool(
+            check_access(AuditLog.user_table_acl(current_user), "read")
+        )
+    except Forbidden as e:
+        print("Forbidden: ", e)
+        user_view_user_auditlog = False
+
+    print("==================account: ", user_view_account_auditlog)
+    print("==================user: ", user_view_user_auditlog)
 
     return render_flexmeasures_template(
         "admin/logged_in_user.html",
@@ -25,4 +53,6 @@ def logged_in_user_view():
         roles=",".join([role.name for role in current_user.roles]),
         num_assets=get_number_of_assets_in_account(current_user.account_id),
         account_role_names=account_role_names,
+        can_view_account_auditlog=user_view_account_auditlog,
+        can_view_user_auditlog=user_view_user_auditlog,
     )


### PR DESCRIPTION
## Description

Conditionally display audit log buttons based on user permissions

This PR is still being worked on

## Look & Feel

This section can contain example pictures for UI, Input/Output for CLI, Request / Response for API endpoint, etc.

## How to test

Steps to test it or name of the tests functions.

The library [flexmeasures-client](https://github.com/FlexMeasures/flexmeasures-client/) can be useful to showcase new features. For example,
it can be used to set some example data to be used in a new UI feature.

## Further Improvements

None

## Related Items

This PR closes: #1222

---

- [ ] I agree to contribute to the project under Apache 2 License. 
- [ ] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
