### PR TITLE
Add link to account on logged-in-user page

### DIFF
--- a/flexmeasures/ui/templates/admin/logged_in_user.html
+++ b/flexmeasures/ui/templates/admin/logged_in_user.html
@@ -32,7 +32,7 @@
             </tr>
             <tr>
               <td>Account</td>
-              <td>{{ logged_in_user.account.name }}</td>
+              <td><a href="/accounts/{{ logged_in_user.account.id }}">{{ logged_in_user.account.name }}</a></td>
             </tr>
             {% if account_roles %}
             <tr>


### PR DESCRIPTION
## Description

The logged-in user pages display the account name but doesn't link to it.

## Look & Feel

It should link now

## How to test

Open the page and check.

