### PR TITLE
fix: use of unit and resolution of the output sensor

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -35,6 +35,14 @@ Bugfixes
 * Fix issue with displaying ``deactivate user`` and ``reset password`` buttons for non admin users [see `PR #1220 <https://github.com/FlexMeasures/flexmeasures/pull/1220>`_]
 
 
+v0.23.1 | November 12, 2024
+============================
+
+Bugfixes
+-----------
+* Correct unit conversion of reporter output to output sensor [see `PR #1238 <https://github.com/FlexMeasures/flexmeasures/pull/1238>`_]
+
+
 v0.23.0 | September 18, 2024
 ============================
 

--- a/flexmeasures/data/models/reporting/pandas_reporter.py
+++ b/flexmeasures/data/models/reporting/pandas_reporter.py
@@ -181,8 +181,8 @@ class PandasReporter(Reporter):
                 output_data *= convert_units(
                     1,
                     from_unit=output_unit,
-                    to_unit=output_data.sensor.unit,
-                    event_resolution=output_data.sensor.event_resolution,
+                    to_unit=output_description["sensor"].unit,
+                    event_resolution=output_description["sensor"].event_resolution,
                 )
 
             result["data"] = output_data


### PR DESCRIPTION
## Description

The `PandasReporter` used the wrong units and event resolution for the conversion of the results. 

--

- [X] I agree to contribute to the project under Apache 2 License. 
- [X] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
