### PR TITLE
feat: sort asset table

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -28,6 +28,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
+* Fix table sorting on the assets page (regression from `PR #988 <https://github.com/FlexMeasures/flexmeasures/pull/988>`_) [see `PR #1239 <https://github.com/FlexMeasures/flexmeasures/pull/1239>`_]
 * The UI footer now stays at the bottom even on pages with little content [see `PR #1204 <https://github.com/FlexMeasures/flexmeasures/pull/1204>`_]
 * Correct stroke dash (based on source type) for forecasts made by forecasters included in FlexMeasures [see `PR #1211 <https://www.github.com/FlexMeasures/flexmeasures/pull/1211>`_]
 * Show the correct UTC offset for the data's time span as shown under sensor stats in the UI [see `PR #1213 <https://github.com/FlexMeasures/flexmeasures/pull/1213>`_]

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -79,6 +79,14 @@ class AssetAPI(FlaskView):
                 required=False, validate=validate.Range(min=1), load_default=10
             ),
             "filter": SearchFilterField(required=False, load_default=None),
+            "sort_by": fields.Str(
+                required=False,
+                load_default=None,
+            ),
+            "sort_dir": fields.Str(
+                required=False,
+                load_default=None,
+            ),
         },
         location="query",
     )
@@ -91,6 +99,8 @@ class AssetAPI(FlaskView):
         page: int | None = None,
         per_page: int | None = None,
         filter: list[str] | None = None,
+        sort_by: str | None = None,
+        sort_dir: str | None = None,
     ):
         """List all assets owned  by user's accounts, or a certain account or all accessible accounts.
 
@@ -161,6 +171,22 @@ class AssetAPI(FlaskView):
         query = query_assets_by_search_terms(
             search_terms=filter, filter_statement=filter_statement
         )
+
+        if sort_by is not None:
+            valid_sort_columns = {
+                "name": GenericAsset.name,
+                "owner": GenericAsset.account_id,
+            }
+
+            if sort_by not in valid_sort_columns:
+                return {"error": f"Invalid sort column: {sort_by}"}, 400
+
+            query = query.order_by(
+                valid_sort_columns[sort_by].asc()
+                if sort_dir == "asc"
+                else valid_sort_columns[sort_by].desc()
+            )
+
         if page is None:
             response = asset_schema.dump(db.session.scalars(query).all(), many=True)
         else:

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -82,10 +82,12 @@ class AssetAPI(FlaskView):
             "sort_by": fields.Str(
                 required=False,
                 load_default=None,
+                validate=validate.OneOf(["name", "owner"]),
             ),
             "sort_dir": fields.Str(
                 required=False,
                 load_default=None,
+                validate=validate.OneOf(["asc", "desc"]),
             ),
         },
         location="query",
@@ -172,14 +174,11 @@ class AssetAPI(FlaskView):
             search_terms=filter, filter_statement=filter_statement
         )
 
-        if sort_by is not None:
+        if sort_by is not None and sort_dir is not None:
             valid_sort_columns = {
                 "name": GenericAsset.name,
                 "owner": GenericAsset.account_id,
             }
-
-            if sort_by not in valid_sort_columns:
-                return {"error": f"Invalid sort column: {sort_by}"}, 400
 
             query = query.order_by(
                 valid_sort_columns[sort_by].asc()

--- a/flexmeasures/api/v3_0/tests/test_assets_api.py
+++ b/flexmeasures/api/v3_0/tests/test_assets_api.py
@@ -67,7 +67,7 @@ def test_get_asset_nonaccount_access(client, setup_api_test_data, requesting_use
 
 
 @pytest.mark.parametrize(
-    "requesting_user, account_name, num_assets, use_pagination, sort_by, sort_dir, expected_asset_name",
+    "requesting_user, account_name, num_assets, use_pagination, sort_by, sort_dir, expected_name_of_first_asset",
     [
         ("test_admin_user@seita.nl", "Prosumer", 1, False, None, None, None),
         ("test_admin_user@seita.nl", "Supplier", 2, False, None, None, None),
@@ -103,7 +103,7 @@ def test_get_assets(
     use_pagination,
     sort_by,
     sort_dir,
-    expected_asset_name,
+    expected_name_of_first_asset,
     requesting_user,
 ):
     """
@@ -136,7 +136,7 @@ def test_get_assets(
         assets = get_assets_response.json
 
         if sort_by:
-            assert assets[0]["name"] == expected_asset_name
+            assert assets[0]["name"] == expected_name_of_first_asset
 
     assert len(assets) == num_assets
 

--- a/flexmeasures/api/v3_0/tests/test_assets_api.py
+++ b/flexmeasures/api/v3_0/tests/test_assets_api.py
@@ -67,12 +67,30 @@ def test_get_asset_nonaccount_access(client, setup_api_test_data, requesting_use
 
 
 @pytest.mark.parametrize(
-    "requesting_user, account_name, num_assets, use_pagination",
+    "requesting_user, account_name, num_assets, use_pagination, sort_by, sort_dir, expected_asset_name",
     [
-        ("test_admin_user@seita.nl", "Prosumer", 1, False),
-        ("test_admin_user@seita.nl", "Supplier", 2, False),
-        ("test_consultant@seita.nl", "ConsultancyClient", 1, False),
-        ("test_admin_user@seita.nl", "Prosumer", 1, True),
+        ("test_admin_user@seita.nl", "Prosumer", 1, False, None, None, None),
+        ("test_admin_user@seita.nl", "Supplier", 2, False, None, None, None),
+        (
+            "test_admin_user@seita.nl",
+            "Supplier",
+            2,
+            False,
+            "name",
+            "asc",
+            "incineration line",
+        ),
+        (
+            "test_admin_user@seita.nl",
+            "Supplier",
+            2,
+            False,
+            "name",
+            "desc",
+            "Test wind turbine",
+        ),
+        ("test_consultant@seita.nl", "ConsultancyClient", 1, False, None, None, None),
+        ("test_admin_user@seita.nl", "Prosumer", 1, True, None, None, None),
     ],
     indirect=["requesting_user"],
 )
@@ -83,6 +101,9 @@ def test_get_assets(
     account_name,
     num_assets,
     use_pagination,
+    sort_by,
+    sort_dir,
+    expected_asset_name,
     requesting_user,
 ):
     """
@@ -93,6 +114,12 @@ def test_get_assets(
     query = {"account_id": setup_accounts[account_name].id}
     if use_pagination:
         query["page"] = 1
+
+    if sort_by:
+        query["sort_by"] = sort_by
+
+    if sort_dir:
+        query["sort_dir"] = sort_dir
 
     get_assets_response = client.get(
         url_for("AssetAPI:index"),
@@ -107,6 +134,9 @@ def test_get_assets(
         assert get_assets_response.json["filtered-records"] == num_assets
     else:
         assets = get_assets_response.json
+
+        if sort_by:
+            assert assets[0]["name"] == expected_asset_name
 
     assert len(assets) == num_assets
 

--- a/flexmeasures/ui/templates/crud/assets.html
+++ b/flexmeasures/ui/templates/crud/assets.html
@@ -43,12 +43,12 @@
     $("#assetTable").dataTable({
       serverSide: true,
       columns: [
-        {data: "name", title: "Name"},
-        {data: "id", title: "Asset ID"},
-        {data: "owner", title: "Account"},
-        {data: "location", title: "Location"},
-        {data: "num_sensors", title: "Sensors"},
-        {data: "status", title: "Status"},
+        {data: "name", title: "Name", orderable: true},
+        {data: "id", title: "Asset ID", orderable: false},
+        {data: "owner", title: "Account", orderable: true},
+        {data: "location", title: "Location", orderable: false},
+        {data: "num_sensors", title: "Sensors", orderable: false},
+        {data: "status", title: "Status", orderable: false},
         {data: "url", title: "URL", className: "d-none"},
       ],
       ajax: function (data, callback, settings) {

--- a/flexmeasures/ui/templates/crud/assets.html
+++ b/flexmeasures/ui/templates/crud/assets.html
@@ -53,10 +53,19 @@
       ],
       ajax: function (data, callback, settings) {
         let filter = data["search"]["value"];
+        let orderColumnIndex = data["order"][0]["column"]
+        let orderDirection = data["order"][0]["dir"];
+        let orderColumnName = data["columns"][orderColumnIndex]["data"];
+        
         let url = `{{url_for("AssetAPI:index")}}?page=${Math.floor((data["start"])/data["length"] ) + 1 }&per_page=${data["length"]}&all_accessible=true`;
         if (filter.length > 0) {
           url = `${url}&filter=${filter}`;
         }
+
+        if (orderColumnName){
+          url = `${url}&sort_by=${orderColumnName}&sort_dir=${orderDirection}`;
+        }
+
         $.ajax({
           type: "get",
           url: url,


### PR DESCRIPTION
## Description

This PR actually fixes a bug rather than introducing a new feature, as the sorting feature was lost after the implementation of a direct API connection.

## Look & Feel

Below is an image of sorting the assets by asset name in descending order
![Screenshot from 2024-11-13 13-55-16](https://github.com/user-attachments/assets/0c5dbf5b-222d-48a5-858a-d8544ad8d290)

Below is the same sorting but by ascending order
![Screenshot from 2024-11-13 13-55-50](https://github.com/user-attachments/assets/548d4c62-a6f7-4b0a-aa85-015b591072cb)

## How to test
1. Vist your assets page [assets](http://localhost:5000/assets)
2. Click on the sorting arrows on either the Name or Account column as these are the two sortable columns


## Further Improvements

None

## Related Items

This PR checks the asset box in the issue: #1197 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
