### PR TITLE
Fix Sorting bug on users table

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -28,7 +28,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
-* Fix table sorting on the assets page (regression from `PR #988 <https://github.com/FlexMeasures/flexmeasures/pull/988>`_) [see `PR #1239 <https://github.com/FlexMeasures/flexmeasures/pull/1239>`_]
+* Fix table sorting on the assets and users page (regression from `PR #988 <https://github.com/FlexMeasures/flexmeasures/pull/988>`_) [see `PR #1239 <https://github.com/FlexMeasures/flexmeasures/pull/1239>`_ and `PR #1242 <https://github.com/FlexMeasures/flexmeasures/pull/1242>`_ ]
 * The UI footer now stays at the bottom even on pages with little content [see `PR #1204 <https://github.com/FlexMeasures/flexmeasures/pull/1204>`_]
 * Correct stroke dash (based on source type) for forecasts made by forecasters included in FlexMeasures [see `PR #1211 <https://www.github.com/FlexMeasures/flexmeasures/pull/1211>`_]
 * Show the correct UTC offset for the data's time span as shown under sensor stats in the UI [see `PR #1213 <https://github.com/FlexMeasures/flexmeasures/pull/1213>`_]

--- a/flexmeasures/api/v3_0/tests/test_api_v3_0_users.py
+++ b/flexmeasures/api/v3_0/tests/test_api_v3_0_users.py
@@ -30,16 +30,47 @@ def test_get_users_bad_auth(requesting_user, client, setup_api_test_data):
         assert get_users_response.status_code == 401
 
 
-@pytest.mark.parametrize("include_inactive", [False, True])
 @pytest.mark.parametrize(
-    "requesting_user", ["test_prosumer_user_2@seita.nl"], indirect=True
+    "requesting_user, include_inactive, sort_by, sort_dir, expected_name_of_first_user",
+    [
+        ("test_prosumer_user_2@seita.nl", False, None, None, None),
+        (
+            "test_prosumer_user_2@seita.nl",
+            True,
+            "username",
+            "asc",
+            "inactive test admin",
+        ),
+        (
+            "test_prosumer_user_2@seita.nl",
+            True,
+            "username",
+            "desc",
+            "Test Prosumer User 2",
+        ),
+    ],
+    indirect=["requesting_user"],
 )
-def test_get_users_inactive(
-    requesting_user, client, setup_api_test_data, setup_inactive_user, include_inactive
+def test_get_users_inatest_get_users_inactivective(
+    requesting_user,
+    client,
+    setup_api_test_data,
+    setup_inactive_user,
+    include_inactive,
+    sort_by,
+    sort_dir,
+    expected_name_of_first_user,
 ):
     query = {}
     if include_inactive in (True, False):
         query["include_inactive"] = include_inactive
+
+    if sort_by:
+        query["sort_by"] = sort_by
+
+    if sort_dir:
+        query["sort_dir"] = sort_dir
+
     get_users_response = client.get(
         url_for("UserAPI:index"),
         query_string=query,
@@ -50,7 +81,11 @@ def test_get_users_inactive(
     if include_inactive is False:
         assert len(get_users_response.json) == 3
     else:
-        assert len(get_users_response.json) == 5
+        users = get_users_response.json
+        assert len(users) == 5
+
+        if sort_by:
+            assert users[0]["username"] == expected_name_of_first_user
 
 
 @pytest.mark.parametrize(

--- a/flexmeasures/api/v3_0/users.py
+++ b/flexmeasures/api/v3_0/users.py
@@ -62,7 +62,7 @@ class UserAPI(FlaskView):
             "sort_by": fields.Str(
                 required=False,
                 load_default=None,
-                validate=validate.OneOf(["username", "email"]),
+                validate=validate.OneOf(["username", "email", "lastLogin", "lastSeen"]),
             ),
             "sort_dir": fields.Str(
                 required=False,
@@ -143,6 +143,8 @@ class UserAPI(FlaskView):
             valid_sort_columns = {
                 "username": UserModel.username,
                 "email": UserModel.email,
+                "lastLogin": UserModel.last_login_at,
+                "lastSeen": UserModel.last_seen_at,
             }
 
             query = query.order_by(

--- a/flexmeasures/data/queries/users.py
+++ b/flexmeasures/data/queries/users.py
@@ -21,7 +21,6 @@ def query_users_by_search_terms(
                 for term in search_terms
             )
         )
-        query = select_statement.where(filter_statement).order_by(UserModel.id)
-    else:
-        query = select_statement.where(filter_statement).order_by(UserModel.id)
+
+    query = select_statement.where(filter_statement)
     return query

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -826,112 +826,120 @@
     </script>
 
     <script>
-        function User(
-          id,
-          username,
-          email,
-          roles,
-          account,
-          timezone,
-          lastLogin,
-          lastSeen,
-          active
-        ) {
-          this.id = id;
-          this.username = `<span>${username}</span>`;
-          this.email = `<a href="mailto:${email}" title="Mail this user">${email}</a>`;
-          this.roles = roles.map((role) => role).join(", ");
-          this.url = `/users/${id}`;
-      
-          if (account == null) this.account = "PUBLIC";
-          else
+    function User(
+        id,
+        username,
+        email,
+        roles,
+        account,
+        timezone,
+        lastLogin,
+        lastSeen,
+        active
+    ) {
+        this.id = id;
+        this.username = `<span>${username}</span>`;
+        this.email = `<a href="mailto:${email}" title="Mail this user">${email}</a>`;
+        this.roles = roles.map((role) => role).join(", ");
+        this.url = `/users/${id}`;
+
+        if (account == null) this.account = "PUBLIC";
+        else
             this.account = `
                 <a href="/accounts/${account["id"]}" title="View this account">${account["name"]}</a>
               `;
-          this.timezone = timezone;
-          this.lastLogin = lastLogin;
-          this.lastSeen = lastSeen;
-          this.active = active;
-        }
-      
-        $(document).ready(function () {
-          let includeInactive = false;
-          const tableTitle = $("#usersTableTitle");
-          // Initialize the DataTable
-          const table = $("#usersTable").dataTable({
-            order: [[3, "desc"]],
+        this.timezone = timezone;
+        this.lastLogin = lastLogin;
+        this.lastSeen = lastSeen;
+        this.active = active;
+    }
+
+    $(document).ready(function() {
+        let includeInactive = false;
+        const tableTitle = $("#usersTableTitle");
+        // Initialize the DataTable
+        const table = $("#usersTable").dataTable({
+            order: [[0, "asc"]],
             serverSide: true,
             // make the table row vertically aligned with header
             columns: [
-              { data: "username", title: "Username" },
-              { data: "email", title: "Email" },
-              { data: "roles", title: "Roles" },
-              { data: "account", title: "Account" },
-              { data: "timezone", title: "Timezone" },
-              { data: "lastLogin", title: "Last login" },
-              { data: "lastSeen", title: "Last seen" },
-              { data: "active", title: "Active" },
+              { data: "username", title: "Username", orderable: true },
+              { data: "email", title: "Email", orderable: true },
+              { data: "roles", title: "Roles", orderable: false },
+              { data: "account", title: "Account", orderable: false },
+              { data: "timezone", title: "Timezone", orderable: false },
+              { data: "lastLogin", title: "Last login", orderable: false },
+              { data: "lastSeen", title: "Last seen", orderable: false },
+              { data: "active", title: "Active", orderable: false },
               { data: "url", title: "URL", className: "d-none" },
             ],
-      
-            ajax: function (data, callback, settings) {
-              const basePath = window.location.origin;
-              let filter = data["search"]["value"];
-              let url = `${basePath}/api/v3_0/users?page=${
-                data["start"] / data["length"] + 1
-              }&per_page=${data["length"]}&include_inactive=${includeInactive}`;
-      
-              if (filter.length > 0) {
-                url = `${url}&filter=${filter}`;
-              }
-      
-              $.ajax({
-                type: "get",
-                url: url,
-                success: function (response, text) {
-                  let clean_response = [];
-                  response["data"].forEach((element) =>
-                    clean_response.push(
-                      new User(
-                        element["id"],
-                        element["username"],
-                        element["email"],
-                        element["flexmeasures_roles"],
-                        element["account"],
-                        element["timezone"],
-                        element["last_login_at"],
-                        element["last_seen_at"],
-                        element["active"]
-                      )
-                    )
-                  );
-      
-                  callback({
-                    data: clean_response,
-                    recordsTotal: response["num-records"],
-                    recordsFiltered: response["filtered-records"],
-                  });
-                },
-                error: function (request, status, error) {
-                  console.log("Error: ", error);
-                },
-              });
+
+            ajax: function(data, callback, settings) {
+
+                const basePath = window.location.origin;
+                let filter = data["search"]["value"];
+                let orderColumnIndex = data["order"][0]["column"]
+                let orderDirection = data["order"][0]["dir"];
+                let orderColumnName = data["columns"][orderColumnIndex]["data"];
+
+                let url = `${basePath}/api/v3_0/users?page=${data["start"] / data["length"] + 1}&per_page=${data["length"]}&include_inactive=${includeInactive}`;
+
+                if (filter.length > 0) {
+                    url = `${url}&filter=${filter}`;
+                }
+
+                if (orderColumnName){
+                    console.log(orderColumnName);
+                    url = `${url}&sort_by=${orderColumnName}&sort_dir=${orderDirection}`;
+                  }
+
+                $.ajax({
+                    type: "get",
+                    url: url,
+                    success: function(response, text) {
+                        let clean_response = [];
+                        response["data"].forEach((element) =>
+                            clean_response.push(
+                                new User(
+                                    element["id"],
+                                    element["username"],
+                                    element["email"],
+                                    element["flexmeasures_roles"],
+                                    element["account"],
+                                    element["timezone"],
+                                    element["last_login_at"],
+                                    element["last_seen_at"],
+                                    element["active"]
+                                )
+                            )
+                        );
+
+                        callback({
+                            data: clean_response,
+                            recordsTotal: response["num-records"],
+                            recordsFiltered: response["filtered-records"],
+                        });
+                    },
+                    error: function(request, status, error) {
+                        console.log("Error: ", error);
+                    },
+                });
             },
-          });
-      
-      
-          // Event listener for the checkbox to toggle includeInactive state
-          $("#inactiveUsersCheckbox").change(function () {
+        });
+
+
+        // Event listener for the checkbox to toggle includeInactive state
+        $("#inactiveUsersCheckbox").change(function() {
             includeInactive = this.checked;
             table.api().ajax.reload();
             if (!includeInactive) {
-              tableTitle.text("All users");
+                tableTitle.text("All users");
             } else {
-              tableTitle.text("All active users");
+                tableTitle.text("All active users");
             }
-          });
         });
-      </script>
+    }); 
+</script>
 
 
     <!-- External scripts -->

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -868,8 +868,8 @@
               { data: "roles", title: "Roles", orderable: false },
               { data: "account", title: "Account", orderable: false },
               { data: "timezone", title: "Timezone", orderable: false },
-              { data: "lastLogin", title: "Last login", orderable: false },
-              { data: "lastSeen", title: "Last seen", orderable: false },
+              { data: "lastLogin", title: "Last login", orderable: true },
+              { data: "lastSeen", title: "Last seen", orderable: true },
               { data: "active", title: "Active", orderable: false },
               { data: "url", title: "URL", className: "d-none" },
             ],
@@ -889,9 +889,8 @@
                 }
 
                 if (orderColumnName){
-                    console.log(orderColumnName);
                     url = `${url}&sort_by=${orderColumnName}&sort_dir=${orderDirection}`;
-                  }
+                }
 
                 $.ajax({
                     type: "get",


### PR DESCRIPTION
## Description

This gives the users table the ability to sort users based on their `username` or `email`

## Look & Feel

Below is an image of sorting the assets by asset name in descending order
![Screenshot from 2024-11-15 15-50-11](https://github.com/user-attachments/assets/4ada3a19-f8c1-4178-bf1c-4a8a6175f7af)

## How to test

1. Vist the users page [assets](http://localhost:5000/users)
2. Click on the sorting arrows on either the Username or Emil column as these are the two sortable columns

## Further Improvements

None

## Related Items

This PR checks the users box in the issue: #1197 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
