### PR TITLE
fix: asset search fails when paired with sorting

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -29,7 +29,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
-* Fix table sorting on the assets, accounts and users page (regression from `PR #988 <https://github.com/FlexMeasures/flexmeasures/pull/988>`_) [see `PR #1239 <https://github.com/FlexMeasures/flexmeasures/pull/1239>`_ and `PR #1242 <https://github.com/FlexMeasures/flexmeasures/pull/1242>`_ and `PR #1248 <https://github.com/FlexMeasures/flexmeasures/pull/1248>`_ ]
+* Fix table sorting on the assets, accounts and users page (regression from `PR #988 <https://github.com/FlexMeasures/flexmeasures/pull/988>`_) [see `PR #1239 <https://github.com/FlexMeasures/flexmeasures/pull/1239>`_ and `PR #1242 <https://github.com/FlexMeasures/flexmeasures/pull/1242>`_ and `PR #1248 <https://github.com/FlexMeasures/flexmeasures/pull/1248>`_ and `PR #1247 <https://github.com/FlexMeasures/flexmeasures/pull/1247>`_ ]
 * The UI footer now stays at the bottom even on pages with little content [see `PR #1204 <https://github.com/FlexMeasures/flexmeasures/pull/1204>`_]
 * Correct stroke dash (based on source type) for forecasts made by forecasters included in FlexMeasures [see `PR #1211 <https://www.github.com/FlexMeasures/flexmeasures/pull/1211>`_]
 * Show the correct :abbr:`UTC (Coordinated Universal Time)` offset for the data's time span as shown under sensor stats in the UI [see `PR #1213 <https://github.com/FlexMeasures/flexmeasures/pull/1213>`_]

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -82,7 +82,7 @@ class AssetAPI(FlaskView):
             "sort_by": fields.Str(
                 required=False,
                 load_default=None,
-                validate=validate.OneOf(["name", "owner"]),
+                validate=validate.OneOf(["id", "name", "owner"]),
             ),
             "sort_dir": fields.Str(
                 required=False,

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -171,20 +171,11 @@ class AssetAPI(FlaskView):
             filter_statement = filter_statement | GenericAsset.account_id.is_(None)
 
         query = query_assets_by_search_terms(
-            search_terms=filter, filter_statement=filter_statement
+            search_terms=filter,
+            filter_statement=filter_statement,
+            sort_by=sort_by,
+            sort_dir=sort_dir,
         )
-
-        if sort_by is not None and sort_dir is not None:
-            valid_sort_columns = {
-                "name": GenericAsset.name,
-                "owner": GenericAsset.account_id,
-            }
-
-            query = query.order_by(
-                valid_sort_columns[sort_by].asc()
-                if sort_dir == "asc"
-                else valid_sort_columns[sort_by].desc()
-            )
 
         if page is None:
             response = asset_schema.dump(db.session.scalars(query).all(), many=True)

--- a/flexmeasures/data/queries/generic_assets.py
+++ b/flexmeasures/data/queries/generic_assets.py
@@ -160,6 +160,7 @@ def query_assets_by_search_terms(
     select_statement = select(GenericAsset)
 
     valid_sort_columns = {
+        "id": GenericAsset.id,
         "name": GenericAsset.name,
         "owner": GenericAsset.account_id,
     }

--- a/flexmeasures/ui/templates/crud/account.html
+++ b/flexmeasures/ui/templates/crud/account.html
@@ -13,7 +13,6 @@ Account overview {% endblock %} {% block divs %}
     </button>
   </form>
   {% endif %}
-
 </div>
 <div class="container-fluid">
   <div class="row">
@@ -311,26 +310,38 @@ Account overview {% endblock %} {% block divs %}
 
   $(document).ready(function () {
     $("#assetTable").dataTable({
+      order: [[1, "asc"]],
       serverSide: true,
       columns: [
         { data: "id", title: "Asset ID" },
-        { data: "name", title: "Name" },
-        { data: "owner", title: "Account" },
-        { data: "location", title: "Location" },
-        { data: "num_sensors", title: "Sensors" },
-        { data: "status", title: "Status" },
+        {data: "name", title: "Name", orderable: true},
+        {data: "owner", title: "Account", orderable: true},
+        {data: "location", title: "Location", orderable: false},
+        {data: "num_sensors", title: "Sensors", orderable: false},
+        {data: "status", title: "Status", orderable: false},
         { data: "url", title: "URL", className: "d-none" },
       ],
       ajax: function (data, callback, settings) {
+        const basePath = window.location.origin;
         let filter = data["search"]["value"];
-        let url = `{{url_for("AssetAPI:index")}}?page=${
+        let orderColumnIndex = data["order"][0]["column"]
+        let orderDirection = data["order"][0]["dir"];
+        let orderColumnName = data["columns"][orderColumnIndex]["data"];
+
+        let url = `${basePath}/api/v3_0/assets?page=${
           Math.floor(data["start"] / data["length"]) + 1
         }&per_page=${data["length"]}&include_public=true&account_id=${
           {{ account.id }}
         }`;
+
         if (filter.length > 0) {
           url = `${url}&filter=${filter}`;
         }
+
+        if (orderColumnName){
+          url = `${url}&sort_by=${orderColumnName}&sort_dir=${orderDirection}`;
+        }
+
         $.ajax({
           type: "get",
           url: url,

--- a/flexmeasures/ui/templates/crud/assets.html
+++ b/flexmeasures/ui/templates/crud/assets.html
@@ -61,7 +61,7 @@
         
         let url = `${basePath}/api/v3_0/assets?page=${
           Math.floor(data["start"] / data["length"]) + 1
-        }&per_page=${data["length"]}&include_public=true`;
+        }&per_page=${data["length"]}&all_accessible=true`;
 
         if (filter.length > 0) {
           url = `${url}&filter=${filter}`;

--- a/flexmeasures/ui/templates/crud/assets.html
+++ b/flexmeasures/ui/templates/crud/assets.html
@@ -41,10 +41,11 @@
 
   $(document).ready(function() {  
     $("#assetTable").dataTable({
+      order: [[1, "asc"]],
       serverSide: true,
       columns: [
+        {data: "id", title: "ID", orderable: false},
         {data: "name", title: "Name", orderable: true},
-        {data: "id", title: "Asset ID", orderable: false},
         {data: "owner", title: "Account", orderable: true},
         {data: "location", title: "Location", orderable: false},
         {data: "num_sensors", title: "Sensors", orderable: false},
@@ -52,12 +53,16 @@
         {data: "url", title: "URL", className: "d-none"},
       ],
       ajax: function (data, callback, settings) {
+        const basePath = window.location.origin;
         let filter = data["search"]["value"];
         let orderColumnIndex = data["order"][0]["column"]
         let orderDirection = data["order"][0]["dir"];
         let orderColumnName = data["columns"][orderColumnIndex]["data"];
         
-        let url = `{{url_for("AssetAPI:index")}}?page=${Math.floor((data["start"])/data["length"] ) + 1 }&per_page=${data["length"]}&all_accessible=true`;
+        let url = `${basePath}/api/v3_0/assets?page=${
+          Math.floor(data["start"] / data["length"]) + 1
+        }&per_page=${data["length"]}&include_public=true`;
+
         if (filter.length > 0) {
           url = `${url}&filter=${filter}`;
         }

--- a/flexmeasures/ui/templates/crud/assets.html
+++ b/flexmeasures/ui/templates/crud/assets.html
@@ -41,10 +41,10 @@
 
   $(document).ready(function() {  
     $("#assetTable").dataTable({
-      order: [[1, "asc"]],
+      order: [[0, "asc"]],
       serverSide: true,
       columns: [
-        {data: "id", title: "ID", orderable: false},
+        {data: "id", title: "ID", orderable: true},
         {data: "name", title: "Name", orderable: true},
         {data: "owner", title: "Account", orderable: true},
         {data: "location", title: "Location", orderable: false},


### PR DESCRIPTION
## Description

This PR fixes a newly introduced bug on the addition of sorting on the asset table

## Look & Feel

![Screenshot from 2024-11-19 14-58-49](https://github.com/user-attachments/assets/28aa3475-011f-434d-b89d-58853e962bf7)

## How to test

1. Visit the assets page: [assets](http://localhost:5000/assets)
2. Search for a sensor(you can optionally sort at the same time)
3. This action should now work fine online previously where the search just didn't work

## Further Improvements

None

## Related Items

This PR closes the issue: #1246 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
