### PR TITLE
fix: issue with sorting on accounts table

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -29,7 +29,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
-* Fix table sorting on the assets and users page (regression from `PR #988 <https://github.com/FlexMeasures/flexmeasures/pull/988>`_) [see `PR #1239 <https://github.com/FlexMeasures/flexmeasures/pull/1239>`_ and `PR #1242 <https://github.com/FlexMeasures/flexmeasures/pull/1242>`_ ]
+* Fix table sorting on the assets, accounts and users page (regression from `PR #988 <https://github.com/FlexMeasures/flexmeasures/pull/988>`_) [see `PR #1239 <https://github.com/FlexMeasures/flexmeasures/pull/1239>`_ and `PR #1242 <https://github.com/FlexMeasures/flexmeasures/pull/1242>`_ and `PR #1248 <https://github.com/FlexMeasures/flexmeasures/pull/1248>`_ ]
 * The UI footer now stays at the bottom even on pages with little content [see `PR #1204 <https://github.com/FlexMeasures/flexmeasures/pull/1204>`_]
 * Correct stroke dash (based on source type) for forecasts made by forecasters included in FlexMeasures [see `PR #1211 <https://www.github.com/FlexMeasures/flexmeasures/pull/1211>`_]
 * Show the correct :abbr:`UTC (Coordinated Universal Time)` offset for the data's time span as shown under sensor stats in the UI [see `PR #1213 <https://github.com/FlexMeasures/flexmeasures/pull/1213>`_]

--- a/flexmeasures/api/v3_0/accounts.py
+++ b/flexmeasures/api/v3_0/accounts.py
@@ -54,7 +54,7 @@ class AccountAPI(FlaskView):
             "sort_by": fields.Str(
                 required=False,
                 load_default=None,
-                validate=validate.OneOf(["name", "assets", "users"]),
+                validate=validate.OneOf(["id", "name", "assets", "users"]),
             ),
             "sort_dir": fields.Str(
                 required=False,
@@ -142,6 +142,7 @@ class AccountAPI(FlaskView):
 
         if sort_by is not None and sort_dir is not None:
             valid_sort_columns = {
+                "id": Account.id,
                 "name": Account.name,
                 "assets": func.count(GenericAsset.id),
                 "users": func.count(User.id),

--- a/flexmeasures/api/v3_0/tests/test_accounts_api.py
+++ b/flexmeasures/api/v3_0/tests/test_accounts_api.py
@@ -24,16 +24,32 @@ def test_get_accounts_missing_auth(client, requesting_user, status_code):
 
 
 @pytest.mark.parametrize(
-    "requesting_user, num_accounts",
+    "requesting_user, num_accounts, sort_by, sort_dir, expected_name_of_first_account",
     [
-        ("test_admin_user@seita.nl", 7),
-        ("test_prosumer_user@seita.nl", 1),
-        ("test_consultant@seita.nl", 2),
-        ("test_consultancy_user_without_consultant_access@seita.nl", 1),
+        ("test_admin_user@seita.nl", 7, None, None, None),
+        ("test_prosumer_user@seita.nl", 1, None, None, None),
+        ("test_consultant@seita.nl", 2, None, None, None),
+        (
+            "test_consultancy_user_without_consultant_access@seita.nl",
+            1,
+            None,
+            None,
+            None,
+        ),
+        ("test_admin_user@seita.nl", 7, "name", "asc", "Multi Role Account"),
+        ("test_admin_user@seita.nl", 7, "name", "desc", "Test Supplier Account"),
     ],
     indirect=["requesting_user"],
 )
-def test_get_accounts(client, setup_api_test_data, requesting_user, num_accounts):
+def test_get_accounts(
+    client,
+    setup_api_test_data,
+    requesting_user,
+    num_accounts,
+    sort_by,
+    sort_dir,
+    expected_name_of_first_account,
+):
     """
     Get accounts for:
     - A normal user.
@@ -41,13 +57,28 @@ def test_get_accounts(client, setup_api_test_data, requesting_user, num_accounts
     - A user with a consultant role, belonging to a consultancy account with a linked consultancy client account.
     - A user without a consultant role, belonging to a consultancy account with a linked consultancy client account.
     """
+    query = {}
+
+    if sort_by:
+        query["sort_by"] = sort_by
+
+    if sort_dir:
+        query["sort_dir"] = sort_dir
+
     get_accounts_response = client.get(
         url_for("AccountAPI:index"),
+        query_string=query,
     )
-    print("Server responded with:\n%s" % get_accounts_response.data)
-    assert len(get_accounts_response.json) == num_accounts
-    account_names = [a["name"] for a in get_accounts_response.json]
+
+    print("Server responded with:\n%s" % get_accounts_response.json)
+
+    accounts = get_accounts_response.json
+    assert len(accounts) == num_accounts
+    account_names = [a["name"] for a in accounts]
     assert requesting_user.account.name in account_names
+
+    if sort_by:
+        assert accounts[0]["name"] == expected_name_of_first_account
 
 
 @pytest.mark.parametrize(

--- a/flexmeasures/ui/templates/crud/accounts.html
+++ b/flexmeasures/ui/templates/crud/accounts.html
@@ -41,11 +41,11 @@
       let unit = "";
       // Initialize the DataTable
       const table = $("#accountsTable").dataTable({
-        order: [[1, "asc"]],
+        order: [[0, "asc"]],
         serverSide: true,
         // make the table row vertically aligned with header
         columns: [
-          { data: "id", title: "ID", orderable: false},
+          { data: "id", title: "ID", orderable: true},
           { data: "name", title: "Name", orderable: true},
           { data: "assets", title: "Assets", orderable: true},
           { data: "users", title: "Users", orderable: true},

--- a/flexmeasures/ui/templates/crud/accounts.html
+++ b/flexmeasures/ui/templates/crud/accounts.html
@@ -41,26 +41,35 @@
       let unit = "";
       // Initialize the DataTable
       const table = $("#accountsTable").dataTable({
+        order: [[1, "asc"]],
         serverSide: true,
         // make the table row vertically aligned with header
         columns: [
-          { data: "id", title: "ID" },
-          { data: "name", title: "Name" },
-          { data: "assets", title: "Assets" },
-          { data: "users", title: "Users" },
-          { data: "roles", title: "Roles" },
+          { data: "id", title: "ID", orderable: false},
+          { data: "name", title: "Name", orderable: true},
+          { data: "assets", title: "Assets", orderable: true},
+          { data: "users", title: "Users", orderable: true},
+          { data: "roles", title: "Roles", orderable: false},
           { data: "url", title: "URL", className: "d-none" },
         ],
 
         ajax: function (data, callback, settings) {
           const basePath = window.location.origin;
           let filter = data["search"]["value"];
+          let orderColumnIndex = data["order"][0]["column"]
+          let orderDirection = data["order"][0]["dir"];
+          let orderColumnName = data["columns"][orderColumnIndex]["data"];
+
           let url = `${basePath}/api/v3_0/accounts?page=${
             data["start"] / data["length"] + 1
           }&per_page=${data["length"]}`; 
 
           if (filter.length > 0) {
             url = `${url}&filter=${filter}`;
+          }
+
+          if (orderColumnName){
+            url = `${url}&sort_by=${orderColumnName}&sort_dir=${orderDirection}`;
           }
 
           $.ajax({


### PR DESCRIPTION
## Description

This PR fixes the sort issue on the accounts table.

## Look & Feel
![Screenshot from 2024-11-19 21-53-03](https://github.com/user-attachments/assets/950f9269-3633-41a1-ab87-f4da6feebe24)

## How to test

1. Visit the accounts page [accounts](http://localhost:5000/accounts)
2. Click on the directional arrows on any of the allowed columns for sorting

## Further Improvements

None

## Related Items

This PR checks the accounts box in the issue: #1197 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
