### PR TITLE
chore: tz-explicit utcnow

### DIFF
--- a/flexmeasures/api/common/implementations.py
+++ b/flexmeasures/api/common/implementations.py
@@ -1,7 +1,6 @@
-from datetime import datetime
+from datetime import datetime, timezone
 import time
 
-import pytz
 from flask import request, current_app
 from flask_json import as_json
 from sqlalchemy import exc as sqla_exc, select
@@ -91,7 +90,7 @@ def post_task_run():
     task_name = request.form.get("name", "")
     if task_name == "":
         return {"status": "ERROR", "reason": "No task name given."}, 400
-    date_time = request.form.get("datetime", datetime.utcnow().replace(tzinfo=pytz.utc))
+    date_time = request.form.get("datetime", datetime.now(timezone.utc))
     status = request.form.get("status", "True") == "True"
     try:
         task_run = db.session.execute(

--- a/flexmeasures/api/tests/conftest.py
+++ b/flexmeasures/api/tests/conftest.py
@@ -1,5 +1,4 @@
-from datetime import datetime, timedelta
-import pytz
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -40,7 +39,7 @@ def setup_api_test_data(db, setup_accounts, setup_roles_users):
     older_task = LatestTaskRun(
         name="task-A",
         status=True,
-        datetime=datetime.utcnow().replace(tzinfo=pytz.utc) - timedelta(days=1),
+        datetime=datetime.now(timezone.utc) - timedelta(days=1),
     )
     recent_task = LatestTaskRun(name="task-B", status=False)
     db.session.add(older_task)

--- a/flexmeasures/api/tests/test_task_runs.py
+++ b/flexmeasures/api/tests/test_task_runs.py
@@ -1,9 +1,8 @@
 import pytest
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from flask import url_for
-import pytz
 import isodate
 
 from flexmeasures.api.tests.utils import get_auth_token, get_task_run, post_task_run
@@ -73,7 +72,7 @@ def test_api_task_run_get_recent_entry(client):
     assert task_run.json["process"] == "FlexMeasures"
     assert task_run.json["server"] == "test"
     task_time = isodate.parse_datetime(task_run.json.get("lastrun"))
-    utcnow = datetime.utcnow().replace(tzinfo=pytz.utc)
+    utcnow = datetime.now(timezone.utc)
     assert task_time <= utcnow
     assert task_time >= utcnow - timedelta(minutes=2)
     assert task_run.json.get("status") == "ERROR"
@@ -84,7 +83,7 @@ def test_api_task_run_get_older_entry_then_update(client, requesting_user):
     task_run = get_task_run(client, "task-A")
     assert task_run.status_code == 200
     task_time = isodate.parse_datetime(task_run.json.get("lastrun"))
-    utcnow = datetime.utcnow().replace(tzinfo=pytz.utc)
+    utcnow = datetime.now(timezone.utc)
     assert task_time <= utcnow - timedelta(days=1)
     assert task_time >= utcnow - timedelta(days=1, minutes=1)
     assert task_run.json.get("status") == "OK"
@@ -93,7 +92,7 @@ def test_api_task_run_get_older_entry_then_update(client, requesting_user):
     assert task_update.status_code == 200
     task_run = get_task_run(client, "task-A")
     task_time = isodate.parse_datetime(task_run.json.get("lastrun"))
-    utcnow = datetime.utcnow().replace(tzinfo=pytz.utc)
+    utcnow = datetime.now(timezone.utc)
     assert task_time <= utcnow
     assert task_time >= utcnow - timedelta(minutes=1)
     assert task_run.json.get("status") == "ERROR"

--- a/flexmeasures/cli/monitor.py
+++ b/flexmeasures/cli/monitor.py
@@ -4,7 +4,7 @@ CLI commands for monitoring functionality.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import click
 from flask import current_app as app
@@ -250,7 +250,9 @@ def monitor_last_seen(
 
     # find users we haven't seen in the given time window
     users: list[User] = db.session.scalars(
-        select(User).filter(User.last_seen_at < datetime.utcnow() - last_seen_delta)
+        select(User).filter(
+            User.last_seen_at < datetime.now(timezone.utc) - last_seen_delta
+        )
     ).all()
     # role filters
     if account_role is not None:

--- a/flexmeasures/data/models/task_runs.py
+++ b/flexmeasures/data/models/task_runs.py
@@ -1,5 +1,4 @@
-from datetime import datetime
-import pytz
+from datetime import datetime, timezone
 
 from sqlalchemy import select
 
@@ -14,9 +13,7 @@ class LatestTaskRun(db.Model):
     """
 
     name = db.Column(db.String(80), primary_key=True)
-    datetime = db.Column(
-        db.DateTime(timezone=True), default=datetime.utcnow().replace(tzinfo=pytz.utc)
-    )
+    datetime = db.Column(db.DateTime(timezone=True), default=datetime.now(timezone.utc))
     status = db.Column(db.Boolean, default=True)
 
     def __repr__(self):
@@ -39,5 +36,5 @@ class LatestTaskRun(db.Model):
         if task_run is None:
             task_run = LatestTaskRun(name=task_name)
             db.session.add(task_run)
-        task_run.datetime = datetime.utcnow().replace(tzinfo=pytz.utc)
+        task_run.datetime = datetime.now(timezone.utc)
         task_run.status = status

--- a/flexmeasures/data/models/user.py
+++ b/flexmeasures/data/models/user.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from datetime import datetime
+from datetime import datetime, timezone
 
 from flask_security import UserMixin, RoleMixin
 import pandas as pd
@@ -307,7 +307,7 @@ class User(db.Model, UserMixin, AuthModelMixin):
 
 def remember_login(the_app, user):
     """We do not use the tracking feature of flask_security, but this basic meta data are quite handy to know"""
-    user.last_login_at = datetime.utcnow()
+    user.last_login_at = datetime.now(timezone.utc)
     if user.login_count is None:
         user.login_count = 0
     user.login_count = user.login_count + 1
@@ -316,7 +316,7 @@ def remember_login(the_app, user):
 def remember_last_seen(user):
     """Update the last_seen field"""
     if user is not None and user.is_authenticated:
-        user.last_seen_at = datetime.utcnow()
+        user.last_seen_at = datetime.now(timezone.utc)
         db.session.add(user)
         db.session.commit()
 

--- a/flexmeasures/utils/config_utils.py
+++ b/flexmeasures/utils/config_utils.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import os
 import sys
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from logging.config import dictConfig as loggingDictConfig
 from pathlib import Path
 
@@ -133,7 +133,7 @@ def read_config(app: Flask, custom_path_to_config: str | None):
     app.logger.setLevel(app.config.get("LOGGING_LEVEL", "INFO"))
     # print("Logging level is %s" % logging.getLevelName(app.logger.level))
 
-    app.config["START_TIME"] = datetime.utcnow()
+    app.config["START_TIME"] = datetime.now(timezone.utc)
 
 
 def read_custom_config(

--- a/flexmeasures/utils/tests/test_time_utils.py
+++ b/flexmeasures/utils/tests/test_time_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from isodate import duration_isoformat as original_duration_isoformat
 import pandas as pd
@@ -55,7 +55,14 @@ def test_original_duration_isoformat(td: timedelta, iso: str):
     [
         (None, pd.Timestamp.utcnow(), "UTC", 3, "3 hours ago"),
         (None, pd.Timestamp.utcnow().tz_convert("Asia/Seoul"), "UTC", 3, "3 hours ago"),
-        (None, datetime.utcnow(), "UTC", 3, "3 hours ago"),
+        (None, datetime.now(timezone.utc), "UTC", 3, "3 hours ago"),
+        (
+            None,
+            datetime.now(timezone.utc).replace(tzinfo=None),
+            "UTC",
+            3,
+            "3 hours ago",
+        ),
         (
             None,
             datetime(2021, 5, 17, 3),

--- a/flexmeasures/utils/time_utils.py
+++ b/flexmeasures/utils/time_utils.py
@@ -5,7 +5,7 @@ Utils for dealing with time
 from __future__ import annotations
 
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from flask import current_app
 from flask_security.core import current_user
@@ -18,7 +18,7 @@ from dateutil import tz
 
 def server_now() -> datetime:
     """The current time (timezone aware), converted to the timezone of the FlexMeasures platform."""
-    return get_timezone().fromutc(datetime.utcnow())
+    return datetime.now(get_timezone())
 
 
 def ensure_local_timezone(
@@ -114,7 +114,7 @@ def naturalized_datetime_str(
     if isinstance(dt, str):
         dt = datetime.strptime(dt, "%a, %d %b %Y %H:%M:%S %Z")
     if now is None:
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
     naive_utc_now = naive_utc_from(now)
 
     # Convert or localize to utc


### PR DESCRIPTION
## Description

utcnow() is deprecated and needs to be made tz-explicit. See [this blog post](https://blog.miguelgrinberg.com/post/it-s-time-for-a-change-datetime-utcnow-is-now-deprecated) for explanation and options.

## Look & Feel

We got a lot of these deprecation warnings:

```
datetime.datetime’s utcnow() and utcfromtimestamp() are deprecated and will be removed in a future version.
```

I have mostly replaced `utcnow()` with `datetime.now(timezone.utc)`.
In many cases, we had already made the datetime object tz-aware by setting the UTC timezone on the (naive) object.
I believe in the other cases, it is preferable to have a tz-aware object. 
In one test case, I decided to simply test both.

## How to test

All tests should pass.
