### PR TITLE
fix: Link to shown user's audit log, not current user

### DIFF
--- a/flexmeasures/ui/templates/crud/user.html
+++ b/flexmeasures/ui/templates/crud/user.html
@@ -109,7 +109,7 @@
     </div>
     <div class="col-md-2">
       {% if can_view_user_auditlog %}
-      <form action="/users/auditlog/{{ logged_in_user.id }}" method="get" class="mb-md-0 mb-3 mt-3">
+      <form action="/users/auditlog/{{ user.id }}" method="get" class="mb-md-0 mb-3 mt-3">
           <button class="btn btn-sm btn-responsive btn-info" type="submit"
           title="View history of user actions.">User audit log</button>
       </form>


### PR DESCRIPTION
## Description

The user page was using the wrong user ID for the user audit log button.

## Look & Feel / Test

Go to /users list (as admin user), select a user and check if now the audit log button shows their audit log, not yours.

