### PR TITLE
Fixed sorting on asset sensors table

### DIFF
--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -215,6 +215,16 @@ class AssetAPI(FlaskView):
             "per_page": fields.Int(
                 required=False, validate=validate.Range(min=1), dump_default=10
             ),
+            "sort_by": fields.Str(
+                required=False,
+                load_default=None,
+                validate=validate.OneOf(["id", "name", "resolution"]),
+            ),
+            "sort_dir": fields.Str(
+                required=False,
+                load_default=None,
+                validate=validate.OneOf(["asc", "desc"]),
+            ),
         },
         location="query",
     )
@@ -225,6 +235,8 @@ class AssetAPI(FlaskView):
         asset: GenericAsset | None,
         page: int | None = None,
         per_page: int | None = None,
+        sort_by: str | None = None,
+        sort_dir: str | None = None,
     ):
         """
         List all sensors under an asset.
@@ -276,6 +288,19 @@ class AssetAPI(FlaskView):
         query_statement = Sensor.generic_asset_id == asset.id
 
         query = select(Sensor).filter(query_statement)
+
+        if sort_by is not None and sort_dir is not None:
+            valid_sort_columns = {
+                "id": Sensor.id,
+                "name": Sensor.name,
+                "resolution": Sensor.event_resolution,
+            }
+
+            query = query.order_by(
+                valid_sort_columns[sort_by].asc()
+                if sort_dir == "asc"
+                else valid_sort_columns[sort_by].desc()
+            )
 
         select_pagination: SelectPagination = db.paginate(
             query, per_page=per_page, page=page

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -423,59 +423,71 @@
       let unit = "";
       // Initialize the DataTable
       const table = $("#sensorsTable").dataTable({
+        order: [[0, "asc"]],
         serverSide: true,
         // make the table row vertically aligned with header
         columns: [
-          { data: "id", title: "ID" },
-          { data: "name", title: "Name" },
-          { data: "unit", title: "Unit" },
-          { data: "resolution", title: "Resolution" },
-          { data: "entity_address", title: "Entity address" },
+          { data: "id", title: "ID", orderable: true },
+          { data: "name", title: "Name", orderable: true },
+          { data: "unit", title: "Unit", orderable: false },
+          { data: "resolution", title: "Resolution", orderable: true },
+          { data: "entity_address", title: "Entity address", orderable: false },
           { data: "url", title: "URL", className: "d-none" },
         ],
   
         ajax: function (data, callback, settings) {
-          const basePath = window.location.origin;
-          let filter = data["search"]["value"];
-          let url = `${basePath}/api/v3_0/assets/{{asset.id}}/sensors?page=${
-            data["start"] / data["length"] + 1
-          }&per_page=4`;
+            const basePath = window.location.origin;
+            let filter = data["search"]["value"];
+            let orderColumnIndex = data["order"][0]["column"]
+            let orderDirection = data["order"][0]["dir"];
+            let orderColumnName = data["columns"][orderColumnIndex]["data"];
+
+            let url = `${basePath}/api/v3_0/assets/{{asset.id}}/sensors?page=${
+                data["start"] / data["length"] + 1
+            }&per_page=4`;
+    
+            if (orderColumnName){
+                url = `${url}&sort_by=${orderColumnName}&sort_dir=${orderDirection}`;
+            }
+            
+            if (filter.length > 0) {
+                url = `${url}&filter=${filter}`;
+            }
+
+            if (unit !== "") {
+                url = `${url}&unit=${unit}`;
+            }
+
+            
   
-          if (filter.length > 0) {
-            url = `${url}&filter=${filter}`;
-          }
-          if (unit !== "") {
-            url = `${url}&unit=${unit}`;
-          }
-  
-          $.ajax({
-            type: "get",
-            url: url,
-            success: function (response, text) {
-              let clean_response = [];
-              response["data"].forEach((element) =>
-                clean_response.push(
-                  new Sensor(
-                    element["id"],
-                    element["name"],
-                    element["unit"],
-                    element["event_resolution"],
-                    element["entity_address"],
-                    element["active"]
-                  )
-                )
-              );
-  
-              callback({
-                data: clean_response,
-                recordsTotal: response["num-records"],
-                recordsFiltered: response["filtered-records"],
-              });
-            },
-            error: function (request, status, error) {
-              console.log("Error: ", error);
-            },
-          });
+            $.ajax({
+                type: "get",
+                url: url,
+                success: function (response, text) {
+                let clean_response = [];
+                response["data"].forEach((element) =>
+                    clean_response.push(
+                    new Sensor(
+                        element["id"],
+                        element["name"],
+                        element["unit"],
+                        element["event_resolution"],
+                        element["entity_address"],
+                        element["active"]
+                    )
+                    )
+                );
+    
+                callback({
+                    data: clean_response,
+                    recordsTotal: response["num-records"],
+                    recordsFiltered: response["filtered-records"],
+                });
+                },
+                error: function (request, status, error) {
+                console.log("Error: ", error);
+                },
+            });
         },
       });
   


### PR DESCRIPTION
## Description

This PR fixes the sorting issue on the asset sensor table

## Look & Feel
![Screenshot from 2024-11-25 22-23-55](https://github.com/user-attachments/assets/0a0e9545-735c-444e-8dbe-f89ceba3b787)


## How to test

1. Go to the assets page
2. Click on an asset with sensors
3. scroll down to the sensors table
4. Test out the sorting on either of the following columns (ID, name and resolution)

## Further Improvements

None

## Related Items

This PR checks the asset/sensors box in the issue #1197 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
