### PR TITLE
Fix assets to display on /assets/owned_by/<account ID> page

### DIFF
--- a/flexmeasures/ui/crud/assets/views.py
+++ b/flexmeasures/ui/crud/assets/views.py
@@ -60,6 +60,7 @@ class AssetCrudUI(FlaskView):
             "crud/assets.html",
             asset_icon_map=ICON_MAPPING,
             message=msg,
+            account=None,
             user_can_create_assets=user_can_create_assets(),
         )
 

--- a/flexmeasures/ui/templates/crud/assets.html
+++ b/flexmeasures/ui/templates/crud/assets.html
@@ -63,7 +63,7 @@
           Math.floor(data["start"] / data["length"]) + 1
         }&per_page=${data["length"]}`;
 
-        if ("{{ account }}" != "") {
+        if ("{{ account }}" != "None") {
           url = `${url}&account_id={{ account.id }}`;
         } else {
           url = `${url}&all_accessible=true`;

--- a/flexmeasures/ui/templates/crud/assets.html
+++ b/flexmeasures/ui/templates/crud/assets.html
@@ -63,11 +63,11 @@
           Math.floor(data["start"] / data["length"]) + 1
         }&per_page=${data["length"]}`;
 
-        if ("{{ account }}" != "None") {
-          url = `${url}&account_id={{ account.id }}`;
-        } else {
-          url = `${url}&all_accessible=true`;
-        }
+        {% if account %}
+          url += "&account_id={{ account.id }}";
+        {% else %}
+          url += "&all_accessible=true";
+        {% endif %}
 
         if (filter.length > 0) {
           url = `${url}&filter=${filter}`;

--- a/flexmeasures/ui/templates/crud/assets.html
+++ b/flexmeasures/ui/templates/crud/assets.html
@@ -61,7 +61,13 @@
         
         let url = `${basePath}/api/v3_0/assets?page=${
           Math.floor(data["start"] / data["length"]) + 1
-        }&per_page=${data["length"]}&all_accessible=true`;
+        }&per_page=${data["length"]}`;
+
+        if ("{{ account }}" != "") {
+          url = `${url}&account_id={{ account.id }}`;
+        } else {
+          url = `${url}&all_accessible=true`;
+        }
 
         if (filter.length > 0) {
           url = `${url}&filter=${filter}`;


### PR DESCRIPTION
## Description

This PR fixes a current bug on the `assets/owned_by`. The page should show all assets owned by a particular account but it's currently showing all assets.

## Look & Feel

![Screenshot from 2024-11-26 13-15-52](https://github.com/user-attachments/assets/aeba0c9a-cf15-4a55-a8ab-0901a864bdcd)

## How to test the /assets/owned_by/<account ID>  page and see if only the specified account assets is what is displayed

Visit the 

## Further Improvements

none

## Related Items

This PR closes the issue #1243 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
