### PR TITLE
Fix/makefile print statements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ install-for-dev:
 	make ensure-deps-folder
 	pip-sync requirements/${PYV}/app.txt requirements/${PYV}/dev.txt requirements/${PYV}/test.txt
 	make install-flexmeasures
-# Locally install HiGS on macOS
+# Locally install HiGHS on macOS
 	if [ "$(shell uname)" = "Darwin" ]; then \
 		make install-highs-macos; \
 	fi
@@ -57,7 +57,7 @@ else
 	pip install --upgrade -r requirements/app.in -r requirements/test.in
 endif
 	make install-flexmeasures
-# Locally install HiGS on macOS
+# Locally install HiGHS on macOS
 	if [ "$(shell uname)" = "Darwin" ]; then \
 		make install-highs-macos; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ install-for-dev:
 	pip-sync requirements/${PYV}/app.txt requirements/${PYV}/dev.txt requirements/${PYV}/test.txt
 	make install-flexmeasures
 # Locally install HiGHS on macOS
-	if [ "$(shell uname)" = "Darwin" ]; then \
+	@if [ "$(shell uname)" = "Darwin" ]; then \
 		make install-highs-macos; \
 	fi
 
@@ -58,12 +58,12 @@ else
 endif
 	make install-flexmeasures
 # Locally install HiGHS on macOS
-	if [ "$(shell uname)" = "Darwin" ]; then \
+	@if [ "$(shell uname)" = "Darwin" ]; then \
 		make install-highs-macos; \
 	fi
 
 $(HIGHS_DIR):
-	if [ ! -d $(HIGHS_DIR) ]; then \
+	@if [ ! -d $(HIGHS_DIR) ]; then \
 		git clone https://github.com/ERGO-Code/HiGHS.git $(HIGHS_DIR); \
 	fi
 	brew install cmake;


### PR DESCRIPTION
## Description

Running `make install-for-dev` was echoing an if-statement, which was confusing me.

```
if [ "$(shell uname)" = "Darwin" ]; then \
	make install-highs-macos; \
fi
```

This PR suppresses that echo by using `@if`.


## How to test

Run `make install-for-dev` or `make-install-for-test`. The last statements that either command prints should no longer be the above.


## Related Items

@VladIftime you mentioned HiGHS wasn't installed correctly with macOS. This PR doesn't fix your issue, but I hope it helps you with understanding the log statements in your terminal. Feel free to make a FlexMeasures Issue about your problem. Did you already try running `make install-highs-macos` as a standalone command? If that works, there might be an issue with the if-statement.