### PR TITLE
Fix: reduce repition on lastseen monitoring

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -20,6 +20,7 @@ New features
 * Simplify and globalize UI messages, using Toast [see `PR #1207 <https://github.com/FlexMeasures/flexmeasures/pull/1207>`_]
 * Power sensors created through the CLI no longer require a capacity attribute to be set [see `PR #1234 <https://github.com/FlexMeasures/flexmeasures/pull/1234>`_]
 * The breadcrumbs on asset and sensor pages can now be customized [see `PR #1257 <https://github.com/FlexMeasures/flexmeasures/pull/1257>`_]
+* The monitoring command to check for users who have been absent to long now can be used to keep data volume low and be more effective [see `PR #1268 <https://github.com/FlexMeasures/flexmeasures/pull/1268>`_]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/cli/commands.rst
+++ b/documentation/cli/commands.rst
@@ -92,6 +92,15 @@ of which some are referred to in this documentation.
 ================================================= =======================================
 
 
+``monitor`` - Monitoring
+--------------
+
+================================================= =======================================
+``flexmeasures monitor latest-run``               Check if the given task's last successful execution happened less than the allowed time ago.
+``flexmeasures monitor last-seen``                Check if given users last contact (via a request) happened less than the allowed time ago.
+================================================= =======================================
+
+
 ``jobs`` - Job queueing
 --------------
 

--- a/flexmeasures/cli/monitor.py
+++ b/flexmeasures/cli/monitor.py
@@ -211,7 +211,7 @@ def send_lastseen_monitoring_alert(
     "--only-newly-absent-users/--all-absent-users",
     type=bool,
     default=True,
-    help="If False, a user is only included in this alert once after they were absent for too long. Defaults to False, so as to keep regular emails to low volume with newsworthy alerts.",
+    help="If True, a user is only included in this alert once after they were absent for too long. Defaults to True, so as to keep regular emails to low volume with newsworthy alerts.",
 )
 @click.option(
     "--task-name",

--- a/flexmeasures/cli/monitor.py
+++ b/flexmeasures/cli/monitor.py
@@ -63,35 +63,6 @@ def send_task_monitoring_alert(
     app.logger.error(f"{msg} {latest_run_txt} NOTE: {custom_msg}")
 
 
-@fm_monitor.command("tasks")  # TODO: deprecate, this is the old name
-@with_appcontext
-@click.option(
-    "--task",
-    type=(str, int),
-    multiple=True,
-    required=True,
-    help="The name of the task and the maximal allowed minutes between successful runs. Use multiple times if needed.",
-)
-@click.option(
-    "--custom-message",
-    type=str,
-    default="",
-    help="Add this message to the monitoring alert (if one is sent).",
-)
-@click.pass_context
-def monitor_task(ctx, task, custom_message):
-    """
-    DEPRECATED, use `latest-run`.
-    Check if the given task's last successful execution happened less than the allowed time ago.
-    If not, alert someone, via email or sentry.
-    """
-    click.secho(
-        "This function has been renamed (and is now deprecated). Please use flexmeasures monitor latest-run.",
-        **MsgStyle.ERROR,
-    )
-    ctx.forward(monitor_latest_run)
-
-
 @fm_monitor.command("latest-run")
 @with_appcontext
 @click.option(


### PR DESCRIPTION
## Description

The monitoring for users who have not connected in some time (usually used for automations, like sending data) can be more useful.

- Only announce users who have not already been included in previous alerts
- Format the email better (increase readability)

## Look & Feel

Test the CLI command `flexmeasures monitor last-seen` to see its output and also check the sent email.

## How to test

Update last-seen-at field of a user, and/or also the last time the CLI command has been noted to have run: `update latest_task_run set datetime = '2024-11-30T19:00:00' where name = 'monitor-last-seen-users';`
