### PR TITLE
feat: show certain buttons to only authorised users

### DIFF
--- a/flexmeasures/ui/crud/accounts.py
+++ b/flexmeasures/ui/crud/accounts.py
@@ -62,11 +62,18 @@ class AccountCrudUI(FlaskView):
         except (Forbidden, Unauthorized):
             user_can_view_account_auditlog = False
 
+        user_can_update_account = True
+        try:
+            check_access(account, "update")
+        except (Forbidden, Unauthorized):
+            user_can_update_account = False
+
         return render_flexmeasures_template(
             "crud/account.html",
             account=account,
             accounts=accounts,
             include_inactive=include_inactive,
+            user_can_update_account=user_can_update_account,
             can_view_account_auditlog=user_can_view_account_auditlog,
         )
 

--- a/flexmeasures/ui/crud/assets/__init__.py
+++ b/flexmeasures/ui/crud/assets/__init__.py
@@ -5,6 +5,7 @@ from flexmeasures.ui.crud.assets.utils import (
     process_internal_api_response,
     user_can_create_assets,
     user_can_delete,
+    user_can_update,
     get_assets_by_account,
 )
 from flexmeasures.ui.crud.assets.views import AssetCrudUI

--- a/flexmeasures/ui/crud/assets/utils.py
+++ b/flexmeasures/ui/crud/assets/utils.py
@@ -174,6 +174,14 @@ def user_can_delete(asset) -> bool:
     return True
 
 
+def user_can_update(asset) -> bool:
+    try:
+        check_access(asset, "update")
+    except Exception:
+        return False
+    return True
+
+
 def get_assets_by_account(account_id: int | str | None) -> list[GenericAsset]:
     if account_id is not None:
         get_assets_response = InternalApi().get(

--- a/flexmeasures/ui/crud/assets/views.py
+++ b/flexmeasures/ui/crud/assets/views.py
@@ -22,6 +22,7 @@ from flexmeasures.ui.crud.assets.utils import (
     process_internal_api_response,
     user_can_create_assets,
     user_can_delete,
+    user_can_update,
 )
 from flexmeasures.data.services.sensors import (
     build_sensor_status_data,
@@ -132,6 +133,7 @@ class AssetCrudUI(FlaskView):
             mapboxAccessToken=current_app.config.get("MAPBOX_ACCESS_TOKEN", ""),
             user_can_create_assets=user_can_create_assets(),
             user_can_delete_asset=user_can_delete(asset),
+            user_can_update_asset=user_can_update(asset),
             event_starts_after=request.args.get("start_time"),
             event_ends_before=request.args.get("end_time"),
         )

--- a/flexmeasures/ui/templates/crud/account.html
+++ b/flexmeasures/ui/templates/crud/account.html
@@ -17,6 +17,7 @@ Account overview {% endblock %} {% block divs %}
 <div class="container-fluid">
   <div class="row">
     <div class="col-md-2">
+      {% if user_can_update_account %}  
       <div class="sidepanel-container">
         <div
           class="left-sidepanel-label"
@@ -173,6 +174,7 @@ Account overview {% endblock %} {% block divs %}
           </form>
         </div>
       </div>
+      {% endif %}
     </div>
     <div class="col-md-8">
       <div class="card">

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -62,6 +62,7 @@
                     <div id="datepicker"></div>
                 </div>
             </div>
+            {% if user_can_update_asset %}
             <div class="sidepanel-container">
                 <div class="left-sidepanel-label">Edit asset</div>
                 <div class="sidepanel left-sidepanel">
@@ -180,6 +181,7 @@
                     </form>
                 </div>
             </div>
+            {% endif %}
         </div>
         <div class="col-md-8">
             <div id="spinner" hidden="hidden">


### PR DESCRIPTION
## Description

This PR is used to dynamically show certain sensitive buttons only to authorized users

## Look & Feel
For authorized users
![Screenshot from 2024-12-03 03-35-22](https://github.com/user-attachments/assets/163ba7e4-e3a7-434c-852a-58a05a844b62)

For non-authorized users
![Screenshot from 2024-12-03 03-36-06](https://github.com/user-attachments/assets/06dd7bed-49b4-475f-b23b-579b90664914)

## How to test
To test this PR visit any of the following pages as an authorised user and take note if the sensitive buttons are still displayed.

Pages: assets, asset, accounts and user page

## Further Improvements

None

## Related Items

This PR closes #1198 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
