### PR TITLE
Added highspy to the tutorials documentation

### DIFF
--- a/documentation/tut/toy-example-setup.rst
+++ b/documentation/tut/toy-example-setup.rst
@@ -107,6 +107,7 @@ Install Flexmeasures and the database
         .. code-block:: bash
 
             $ pip install flexmeasures
+            $ pip install highspy
             $ export SQLALCHEMY_DATABASE_URI="postgresql://flexmeasures-user:fm-db-passwd@localhost:5432/flexmeasures-db" SECRET_KEY=notsecret LOGGING_LEVEL="INFO" DEBUG=0
             $ export FLEXMEASURES_ENV="development"
             $ flexmeasures db upgrade


### PR DESCRIPTION
## Description

Added `highspy` installation command for the tutorial.

## How to test

Nothing much to test. It is just an additional command that is added to install `highspy` python package.

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
