### PR TITLE
Paginate assets auditlog table and API

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -30,7 +30,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
-* Fix table sorting on the assets, accounts and users page (regression from `PR #988 <https://github.com/FlexMeasures/flexmeasures/pull/988>`_) [see `PR #1239 <https://github.com/FlexMeasures/flexmeasures/pull/1239>`_ and `PR #1242 <https://github.com/FlexMeasures/flexmeasures/pull/1242>`_ and `PR #1248 <https://github.com/FlexMeasures/flexmeasures/pull/1248>`_ and `PR #1247 <https://github.com/FlexMeasures/flexmeasures/pull/1247>`_ ]
+* Fix table sorting on the assets, accounts and users page (regression from `PR #988 <https://github.com/FlexMeasures/flexmeasures/pull/988>`_) [see `PR #1239 <https://github.com/FlexMeasures/flexmeasures/pull/1239>`_ and `PR #1242 <https://github.com/FlexMeasures/flexmeasures/pull/1242>`_ and `PR #1248 <https://github.com/FlexMeasures/flexmeasures/pull/1248>`_ and `PR #1247 <https://github.com/FlexMeasures/flexmeasures/pull/1247>`_ and `PR #1272 <https://github.com/FlexMeasures/flexmeasures/pull/1272>`_]
 * Fix asset count on the user page, which showed 0 assets after (de)activating a user or resetting their password [see `PR #1251 <https://github.com/FlexMeasures/flexmeasures/pull/1251>`_]
 * The UI footer now stays at the bottom even on pages with little content [see `PR #1204 <https://github.com/FlexMeasures/flexmeasures/pull/1204>`_]
 * Correct stroke dash (based on source type) for forecasts made by forecasters included in FlexMeasures [see `PR #1211 <https://www.github.com/FlexMeasures/flexmeasures/pull/1211>`_]

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -32,7 +32,7 @@ from flexmeasures.auth.policy import check_access
 from werkzeug.exceptions import Forbidden, Unauthorized
 from flexmeasures.data.schemas.sensors import SensorSchema
 from flexmeasures.data.models.time_series import Sensor
-
+from flexmeasures.utils.time_utils import naturalized_datetime_str
 
 asset_schema = AssetSchema()
 assets_schema = AssetSchema(many=True)
@@ -611,19 +611,63 @@ class AssetAPI(FlaskView):
         location="path",
     )
     @permission_required_for_context("read", ctx_arg_name="asset")
+    @use_kwargs(
+        {
+            "page": fields.Int(
+                required=False, validate=validate.Range(min=1), load_default=1
+            ),
+            "per_page": fields.Int(
+                required=False, validate=validate.Range(min=1), load_default=10
+            ),
+            "filter": SearchFilterField(required=False, load_default=None),
+            "sort_by": fields.Str(
+                required=False,
+                load_default=None,
+                validate=validate.OneOf(["event_datetime"]),
+            ),
+            "sort_dir": fields.Str(
+                required=False,
+                load_default=None,
+                validate=validate.OneOf(["asc", "desc"]),
+            ),
+        },
+        location="query",
+    )
     @as_json
-    def auditlog(self, id: int, asset: GenericAsset):
+    def auditlog(
+        self,
+        id: int,
+        asset: GenericAsset,
+        page: int | None = None,
+        per_page: int | None = None,
+        filter: list[str] | None = None,
+        sort_by: str | None = None,
+        sort_dir: str | None = None,
+    ):
         """API endpoint to get history of asset related actions.
+
+        The endpoint is paginated and supports search filters.
+
+            - If the `page` parameter is not provided, all audit logs are returned paginated by `per_page` (default is 10).
+            - If a `page` parameter is provided, the response will be paginated, showing a specific number of assets per page as defined by `per_page` (default is 10).
+            - If a search 'filter' is provided, the response will filter out audit logs where each search term is either present in the event or active user name.
+              The response schema for pagination is inspired by https://datatables.net/manual/server-side
+
+
         **Example response**
 
         .. sourcecode:: json
-            [
-                {
-                    'event': 'Asset test asset deleted',
-                    'event_datetime': '2021-01-01T00:00:00',
-                    'active_user_name': 'Test user',
-                }
-            ]
+            {
+                "data" : [
+                    {
+                        'event': 'Asset test asset deleted',
+                        'event_datetime': '2021-01-01T00:00:00',
+                        'active_user_name': 'Test user',
+                    }
+                ],
+                "num-records" : 1,
+                "filtered-records" : 1
+            }
 
         :reqheader Authorization: The authentication token
         :reqheader Content-Type: application/json
@@ -634,19 +678,52 @@ class AssetAPI(FlaskView):
         :status 403: INVALID_SENDER
         :status 422: UNPROCESSABLE_ENTITY
         """
-        audit_logs = (
-            db.session.query(AssetAuditLog).filter_by(affected_asset_id=asset.id).all()
-        )
-        audit_logs = [
-            {
-                k: getattr(log, k)
-                for k in (
-                    "event",
-                    "event_datetime",
-                    "active_user_name",
-                    "active_user_id",
+        query_statement = AssetAuditLog.affected_asset_id == asset.id
+        query = select(AssetAuditLog).filter(query_statement)
+
+        if filter:
+            search_terms = filter[0].split(" ")
+            query = query.filter(
+                or_(
+                    *[AssetAuditLog.event.ilike(f"%{term}%") for term in search_terms],
+                    *[
+                        AssetAuditLog.active_user_name.ilike(f"%{term}%")
+                        for term in search_terms
+                    ],
                 )
+            )
+
+        if sort_by is not None and sort_dir is not None:
+            valid_sort_columns = {"event_datetime": AssetAuditLog.event_datetime}
+
+            query = query.order_by(
+                valid_sort_columns[sort_by].asc()
+                if sort_dir == "asc"
+                else valid_sort_columns[sort_by].desc()
+            )
+
+        select_pagination: SelectPagination = db.paginate(
+            query, per_page=per_page, page=page
+        )
+
+        num_records = db.session.scalar(
+            select(func.count(AssetAuditLog.id)).where(query_statement)
+        )
+
+        audit_logs_response: list = [
+            {
+                "event": audit_log.event,
+                "event_datetime": naturalized_datetime_str(audit_log.event_datetime),
+                "active_user_name": audit_log.active_user_name,
+                "active_user_id": audit_log.active_user_id,
             }
-            for log in audit_logs
+            for audit_log in select_pagination.items
         ]
-        return audit_logs, 200
+
+        response = {
+            "data": audit_logs_response,
+            "num-records": num_records,
+            "filtered-records": select_pagination.total,
+        }
+
+        return response, 200

--- a/flexmeasures/ui/crud/assets/views.py
+++ b/flexmeasures/ui/crud/assets/views.py
@@ -302,10 +302,7 @@ class AssetCrudUI(FlaskView):
         asset_dict = get_asset_response.json()
         asset = process_internal_api_response(asset_dict, int(id), make_obj=True)
 
-        audit_log_response = InternalApi().get(url_for("AssetAPI:auditlog", id=id))
-        audit_logs_response = audit_log_response.json()
         return render_flexmeasures_template(
             "crud/asset_audit_log.html",
-            audit_logs=audit_logs_response,
             asset=asset,
         )

--- a/flexmeasures/ui/templates/crud/asset_audit_log.html
+++ b/flexmeasures/ui/templates/crud/asset_audit_log.html
@@ -10,48 +10,59 @@
     <div class="row">
         <div class="asset auditlog card">
             <h3>History of actions for asset <a href="/assets/{{ asset.id }}">{{ asset.name }}</a></h3>
-            <table id="asset_audit_log" class="table table-striped paginate nav-on-click" title="View data">
-                <thead>
-                    <tr>
-                        <th style="display:none;">Event Timestamp</th><!-- Hidden UTC Timestamp column for sorting, Keep at position zero -->
-                        <th>Event Datetime</th>
-                        <th>Event Name</th>
-                        <th>Acting user</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for audit_log in audit_logs: %}
-                    <tr>
-                        <td style="display:none;">
-                            {{ audit_log.event_datetime | to_utc_timestamp }} <!-- Hidden UTC Timestamp column for sorting, Keep at position zero -->
-                        </td>
-                        <td title="{{  audit_log.event_datetime }}">
-                            {{ audit_log.event_datetime | naturalized_datetime }}
-                        </td>
-                        <td>
-                            {{ audit_log.event }}
-                        </td>
-                        <td>
-                            {{ audit_log.active_user_name }} (Id: {{ audit_log.active_user_id }})
-                        </td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
+            <table id="assetAuditLog" class="table table-striped paginate nav-on-click" title="View data">
             </table>
         </div>
     </div>
 </div>
 
 <script>
+    function AuditLog(event_datetime, event, acting_user_name) {
+        this.event_datetime = event_datetime;
+        this.event = event;
+        this.acting_user_name = acting_user_name;
+    }
+
     $(document).ready(function() {
-    $('#asset_audit_log').DataTable({
+    $('#assetAuditLog').DataTable({
         "order": [[ 0, "desc" ]],  // Default sort by the hidden UTC Timestamp column
-        "columnDefs": [
-            { 
-                "targets": 1,  // Target the visible "Event Datetime" column
-                "orderData": 0  // Use data from the first column (UTC Timestamp) for sorting
+        serverSide: true,
+        columns: [
+            { data: "event_datetime", title: "Event Datetime", orderable: true },
+            { data: "event", title: "Event Name", orderable: false, width: "80%" },
+            { data: "acting_user_name", title: "Actiing User", orderable: false },
+        ],
+
+        ajax: function (data, callback, settings) {
+            const basePath = window.location.origin;
+            let filter = data["search"]["value"];
+            let orderColumnIndex = data["order"][0]["column"]
+            let orderDirection = data["order"][0]["dir"];
+            let orderColumnName = data["columns"][orderColumnIndex]["data"];
+            let url = `${basePath}/api/v3_0/assets/{{ asset.id }}/auditlog?page=${Math.floor(data["start"] / data["length"]) + 1}&per_page=${data["length"]}`;
+            if (filter.length > 0) {
+                url = `${url}&filter=${filter}`;
             }
-        ]
+    
+            if (orderColumnName){
+                url = `${url}&sort_by=${orderColumnName}&sort_dir=${orderDirection}`;
+            }
+
+            $.ajax({
+                type: "get",
+                url: url,
+                success: function(response, text) {
+                    let clean_response = [];
+                    response["data"].forEach( (element) => clean_response.push(
+                        new AuditLog(element["event_datetime"], element["event"], `${element["active_user_name"]} (Id: ${element["active_user_id"]})`)
+                    ));
+                    callback({"data": clean_response, "recordsTotal": response["num-records"], "recordsFiltered": response["filtered-records"]});
+                },
+                error: function (request, status, error) {
+                    console.log("Error: ", error)
+                }
+            });
+        }
     });
 });
 </script>

--- a/flexmeasures/ui/templates/crud/asset_audit_log.html
+++ b/flexmeasures/ui/templates/crud/asset_audit_log.html
@@ -36,7 +36,7 @@
         ajax: function (data, callback, settings) {
             const basePath = window.location.origin;
             let filter = data["search"]["value"];
-            let orderColumnIndex = data["order"][0]["column"]
+            let orderColumnIndex = data["order"][0]["column"];
             let orderDirection = data["order"][0]["dir"];
             let orderColumnName = data["columns"][orderColumnIndex]["data"];
             let url = `${basePath}/api/v3_0/assets/{{ asset.id }}/auditlog?page=${Math.floor(data["start"] / data["length"]) + 1}&per_page=${data["length"]}`;


### PR DESCRIPTION
## Description

This PR paginates the assets audit log table and also applies pagination to the API as well

## Look & Feel
![Screenshot from 2024-12-03 12-32-55](https://github.com/user-attachments/assets/ce26297a-717b-4802-b048-e711d3c73c01)


## How to test

1. Visit the assets [page](http://localhost:5000/assets)
2. Then click on audit log to view the assets audit logs
3. Try out the sorting/search as well to get a feel of how it works

## Further Improvements

None

## Related Items

This PR closes #1190 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
