### PR TITLE
Fix 1199 audit log cursor issue

### DIFF
--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -48,6 +48,15 @@
             --create-color: var(--green);
             --delete-color: var(--red);
         }
+        #asset_audit_log.nav-on-click tr {
+            cursor: default;
+        }
+        #account_audit_log.nav-on-click tr {
+            cursor: default; 
+        }
+        #user_audit_log.nav-on-click tr {
+            cursor: default; 
+        }
     </style>
     <!-- Leaflet -->
     <link href="https://cdn.jsdelivr.net/npm/leaflet@1.7.1/dist/leaflet.css" rel="stylesheet" />

--- a/flexmeasures/ui/templates/crud/account_audit_log.html
+++ b/flexmeasures/ui/templates/crud/account_audit_log.html
@@ -11,7 +11,7 @@
         <div class="sensors-asset card">
             <h3>History of actions for account <a href="/accounts/{{ account.id }}">{{ account.name }}</a></h3>
             <div class="table-responsive">
-            <table id="account_audit_log" class="table table-striped paginate nav-on-click" title="View data">
+            <table id="account_audit_log" class="table table-striped paginate nav-on-click">
                 <thead>
                     <tr>
                         <th style="display:none;">Event Timestamp</th><!-- Hidden UTC Timestamp column for sorting, Keep at position zero -->

--- a/flexmeasures/ui/templates/crud/asset_audit_log.html
+++ b/flexmeasures/ui/templates/crud/asset_audit_log.html
@@ -10,7 +10,7 @@
     <div class="row">
         <div class="asset auditlog card">
             <h3>History of actions for asset <a href="/assets/{{ asset.id }}">{{ asset.name }}</a></h3>
-            <table id="asset_audit_log" class="table table-striped paginate nav-on-click" title="View data">
+            <table id="asset_audit_log" class="table table-striped paginate nav-on-click">
                 <thead>
                     <tr>
                         <th style="display:none;">Event Timestamp</th><!-- Hidden UTC Timestamp column for sorting, Keep at position zero -->

--- a/flexmeasures/ui/templates/crud/user_audit_log.html
+++ b/flexmeasures/ui/templates/crud/user_audit_log.html
@@ -11,7 +11,7 @@
         <div class="sensors-asset card">
             <h3>History of actions for user <a href="/users/{{ user.id }}">{{ user.username }}</a></h3>
             <div class="table-responsive">
-                <table id="user_audit_log" class="table table-striped paginate nav-on-click" title="View data">
+                <table id="user_audit_log" class="table table-striped paginate nav-on-click">
                     <thead>
                         <tr>
                             <th style="display:none;">Event Timestamp</th> <!-- Hidden UTC Timestamp column for sorting, Keep at position zero -->


### PR DESCRIPTION
## Description

**Problem:**
Audit log tables appeared clickable due to cursor behavior and displayed an unnecessary tooltip ("View Data").

**Solution:**
- Removed the `title="View data"` attribute from the `<table>` element in `asset_audit_log.html`.
- Ensured the cursor no longer changes to the link-hand style by overriding `pointer-events` in CSS if needed.

## Look & Feel

- when opening an audit log table for (assets, account, user) page hovering the cursor on the audit log table will result in cursor transformation and tooltip suggestion ("View data"). which is useless because audit log table rows aren't meant to be clickable.

**Before:**
![Screenshot from 2024-12-03 22-16-14](https://github.com/user-attachments/assets/0e2e2603-57bd-47b7-bc9b-e9a8606cdea1)

**After:**
![Screenshot from 2024-12-03 22-14-55](https://github.com/user-attachments/assets/f56cfe15-d0cc-4c97-80d6-c44d65981a2a)


## How to test

open an account, asset or user audit log table and hover the cursor over the rows the cursor shouldn't appear to be clickable or open a tooltip suggestion called ("View data").



## Related Items

closes #1199 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
