### PR TITLE
feat: paginate user auditlog table and API

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -17,6 +17,7 @@ New features
 * Enhanced API for listing sensors: Added filtering and pagination on sensor index endpoint and created new endpoint to get all sensors under an asset [see `PR #1191 <https://github.com/FlexMeasures/flexmeasures/pull/1191>`_ and `PR #1219 <https://github.com/FlexMeasures/flexmeasures/pull/1219>`_]
 * Speed up loading the accounts page by making the pagination backend-based and adding support for that in the API [see `PR #1196 <https://github.com/FlexMeasures/flexmeasures/pull/1196>`_]
 * Speed up loading the account detail page by by switching to server-side pagination for assets, replacing client-side pagination [see `PR #1202 <https://github.com/FlexMeasures/flexmeasures/pull/1202>`_]
+* Speed up loading on audit log tables page by switching to server-side pagination, replacing client-side pagination [see `PR #1274 <https://github.com/FlexMeasures/flexmeasures/pull/1274>`_ and `PR #1272 <https://github.com/FlexMeasures/flexmeasures/pull/1272>`_]
 * Simplify and globalize UI messages, using Toast [see `PR #1207 <https://github.com/FlexMeasures/flexmeasures/pull/1207>`_]
 * Power sensors created through the CLI no longer require a capacity attribute to be set [see `PR #1234 <https://github.com/FlexMeasures/flexmeasures/pull/1234>`_]
 * The breadcrumbs on asset and sensor pages can now be customized [see `PR #1257 <https://github.com/FlexMeasures/flexmeasures/pull/1257>`_]

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -32,7 +32,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
-* Fix table sorting on the assets, accounts and users page (regression from `PR #988 <https://github.com/FlexMeasures/flexmeasures/pull/988>`_) [see `PR #1239 <https://github.com/FlexMeasures/flexmeasures/pull/1239>`_ and `PR #1242 <https://github.com/FlexMeasures/flexmeasures/pull/1242>`_ and `PR #1248 <https://github.com/FlexMeasures/flexmeasures/pull/1248>`_ and `PR #1247 <https://github.com/FlexMeasures/flexmeasures/pull/1247>`_ ]
+* Fix table sorting on the assets, accounts and users page (regression from `PR #988 <https://github.com/FlexMeasures/flexmeasures/pull/988>`_) [see `PR #1239 <https://github.com/FlexMeasures/flexmeasures/pull/1239>`_ and `PR #1242 <https://github.com/FlexMeasures/flexmeasures/pull/1242>`_ and `PR #1248 <https://github.com/FlexMeasures/flexmeasures/pull/1248>`_]
 * Fix asset count on the user page, which showed 0 assets after (de)activating a user or resetting their password [see `PR #1251 <https://github.com/FlexMeasures/flexmeasures/pull/1251>`_]
 * The UI footer now stays at the bottom even on pages with little content [see `PR #1204 <https://github.com/FlexMeasures/flexmeasures/pull/1204>`_]
 * Correct stroke dash (based on source type) for forecasts made by forecasters included in FlexMeasures [see `PR #1211 <https://www.github.com/FlexMeasures/flexmeasures/pull/1211>`_]

--- a/flexmeasures/api/v3_0/users.py
+++ b/flexmeasures/api/v3_0/users.py
@@ -3,7 +3,7 @@ from flask_classful import FlaskView, route
 from marshmallow import fields
 import marshmallow.validate as validate
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy import and_, select, func
+from sqlalchemy import and_, select, func, or_
 from flask_sqlalchemy.pagination import SelectPagination
 from webargs.flaskparser import use_kwargs
 from flask_security import current_user, auth_required
@@ -23,7 +23,6 @@ from flexmeasures.data.schemas.users import UserSchema
 from flexmeasures.data.services.users import (
     set_random_password,
     remove_cookie_and_token_access,
-    get_audit_log_records,
 )
 from flexmeasures.auth.decorators import permission_required_for_context
 from flexmeasures.data import db
@@ -365,19 +364,61 @@ class UserAPI(FlaskView):
         pass_ctx_to_loader=True,
         ctx_loader=AuditLog.user_table_acl,
     )
+    @use_kwargs(
+        {
+            "page": fields.Int(
+                required=False, validate=validate.Range(min=1), load_default=1
+            ),
+            "per_page": fields.Int(
+                required=False, validate=validate.Range(min=1), load_default=10
+            ),
+            "filter": SearchFilterField(required=False, load_default=None),
+            "sort_by": fields.Str(
+                required=False,
+                load_default=None,
+                validate=validate.OneOf(["event_datetime"]),
+            ),
+            "sort_dir": fields.Str(
+                required=False,
+                load_default=None,
+                validate=validate.OneOf(["asc", "desc"]),
+            ),
+        },
+        location="query",
+    )
     @as_json
-    def auditlog(self, id: int, user: UserModel):
+    def auditlog(
+        self,
+        id: int,
+        user: UserModel,
+        page: int | None = None,
+        per_page: int | None = None,
+        filter: list[str] | None = None,
+        sort_by: str | None = None,
+        sort_dir: str | None = None,
+    ):
         """API endpoint to get history of user actions.
+
+        The endpoint is paginated and supports search filters.
+            - If the `page` parameter is not provided, all audit logs are returned paginated by `per_page` (default is 10).
+            - If a `page` parameter is provided, the response will be paginated, showing a specific number of audit logs per page as defined by `per_page` (default is 10).
+            - If a search 'filter' is provided, the response will filter out audit logs where each search term is either present in the event or active user name.
+              The response schema for pagination is inspired by https://datatables.net/manual/server-side
+
         **Example response**
 
         .. sourcecode:: json
-            [
-                {
-                    'event': 'User test user deleted',
-                    'event_datetime': '2021-01-01T00:00:00',
-                    'active_user_name': 'Test user',
-                }
-            ]
+            {
+                "data" : [
+                    {
+                        'event': 'User test user deleted',
+                        'event_datetime': '2021-01-01T00:00:00',
+                        'active_user_name': 'Test user',
+                    }
+                ],
+                "num-records" : 1,
+                "filtered-records" : 1
+            }
 
         :reqheader Authorization: The authentication token
         :reqheader Content-Type: application/json
@@ -388,17 +429,52 @@ class UserAPI(FlaskView):
         :status 403: INVALID_SENDER
         :status 422: UNPROCESSABLE_ENTITY
         """
-        audit_logs = get_audit_log_records(user)
-        audit_logs = [
-            {
-                k: getattr(log, k)
-                for k in (
-                    "event",
-                    "event_datetime",
-                    "active_user_name",
-                    "active_user_id",
+        query_statement = AuditLog.affected_user_id == user.id
+        query = select(AuditLog).filter(query_statement)
+
+        if filter:
+            search_terms = filter[0].split(" ")
+            query = query.filter(
+                or_(
+                    *[AuditLog.event.ilike(f"%{term}%") for term in search_terms],
+                    *[
+                        AuditLog.active_user_name.ilike(f"%{term}%")
+                        for term in search_terms
+                    ],
                 )
+            )
+
+        if sort_by is not None and sort_dir is not None:
+            valid_sort_columns = {"event_datetime": AuditLog.event_datetime}
+
+            query = query.order_by(
+                valid_sort_columns[sort_by].asc()
+                if sort_dir == "asc"
+                else valid_sort_columns[sort_by].desc()
+            )
+
+        select_pagination: SelectPagination = db.paginate(
+            query, per_page=per_page, page=page
+        )
+
+        num_records = db.session.scalar(
+            select(func.count(AuditLog.id)).where(query_statement)
+        )
+
+        audit_logs_response = [
+            {
+                "event": audit_log.event,
+                "event_datetime": naturalized_datetime_str(audit_log.event_datetime),
+                "active_user_name": audit_log.active_user_name,
+                "active_user_id": audit_log.active_user_id,
             }
-            for log in audit_logs
+            for audit_log in select_pagination.items
         ]
-        return audit_logs, 200
+
+        response = {
+            "data": audit_logs_response,
+            "num-records": num_records,
+            "filtered-records": select_pagination.total,
+        }
+
+        return response, 200

--- a/flexmeasures/data/services/users.py
+++ b/flexmeasures/data/services/users.py
@@ -235,13 +235,3 @@ def delete_user(user: User):
         affected_account_id=user.account_id,
     )
     db.session.add(user_audit_log)
-
-
-def get_audit_log_records(user: User):
-    """
-    Get history of user actions
-    """
-    audit_log_records = (
-        db.session.query(AuditLog).filter_by(affected_user_id=user.id).all()
-    )
-    return audit_log_records

--- a/flexmeasures/ui/crud/users.py
+++ b/flexmeasures/ui/crud/users.py
@@ -174,10 +174,7 @@ class UserCrudUI(FlaskView):
         View all user actions.
         """
         user: User = get_user(id)
-        audit_log_response = InternalApi().get(url_for("UserAPI:auditlog", id=id))
-        audit_logs_response = audit_log_response.json()
         return render_flexmeasures_template(
             "crud/user_audit_log.html",
             user=user,
-            audit_logs=audit_logs_response,
         )

--- a/flexmeasures/ui/templates/crud/user_audit_log.html
+++ b/flexmeasures/ui/templates/crud/user_audit_log.html
@@ -11,33 +11,7 @@
         <div class="sensors-asset card">
             <h3>History of actions for user <a href="/users/{{ user.id }}">{{ user.username }}</a></h3>
             <div class="table-responsive">
-                <table id="user_audit_log" class="table table-striped paginate nav-on-click" title="View data">
-                    <thead>
-                        <tr>
-                            <th style="display:none;">Event Timestamp</th> <!-- Hidden UTC Timestamp column for sorting, Keep at position zero -->
-                            <th>Event Name</th>
-                            <th>Event Datetime</th>
-                            <th>Acting user</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for audit_log in audit_logs: %}
-                        <tr>
-                            <td style="display:none;">
-                                {{ audit_log.event_datetime | to_utc_timestamp }} <!-- Hidden UTC Timestamp column for sorting, Keep at position zero -->
-                            </td>
-                            <td>
-                                {{ audit_log.event }}
-                            </td>
-                            <td title="{{  audit_log.event_datetime }}">
-                                {{ audit_log.event_datetime | naturalized_datetime }}
-                            </td>
-                            <td>
-                                {{ audit_log.active_user_name }} (Id: {{ audit_log.active_user_id }})
-                            </td>
-                        </tr>
-                        {% endfor %}
-                    </tbody>
+                <table id="userAuditLog" class="table table-striped paginate nav-on-click" title="View data">
                 </table>
             </div>
         </div>
@@ -45,15 +19,52 @@
 </div>
 
 <script>
-    $(document).ready(function() {
-        $('#user_audit_log').DataTable({
+function AuditLog(event_datetime, event, acting_user_name) {
+    this.event_datetime = event_datetime;
+    this.event = event;
+    this.acting_user_name = acting_user_name;
+}
+
+$(document).ready(function() {
+    $('#userAuditLog').DataTable({
         "order": [[ 0, "desc" ]],  // Default sort by the hidden UTC Timestamp column
-        "columnDefs": [
-            { 
-                "targets": 2,  // Target the visible "Event Datetime" column
-                "orderData": 0  // Use data from the first column (UTC Timestamp) for sorting
+        serverSide: true,
+        columns: [
+            { data: "event_datetime", title: "Event Datetime", orderable: true },
+            { data: "event", title: "Event Name", orderable: false, width: "80%" },
+            { data: "acting_user_name", title: "Acting User", orderable: false },
+        ],
+
+        ajax: function (data, callback, settings) {
+            const basePath = window.location.origin;
+            let filter = data["search"]["value"];
+            let orderColumnIndex = data["order"][0]["column"];
+            let orderDirection = data["order"][0]["dir"];
+            let orderColumnName = data["columns"][orderColumnIndex]["data"];
+            let url = `${basePath}/api/v3_0/users/{{ user.id }}/auditlog?page=${Math.floor(data["start"] / data["length"]) + 1}&per_page=${data["length"]}`;
+            if (filter.length > 0) {
+                url = `${url}&filter=${filter}`;
             }
-        ]
+
+            if (orderColumnName){
+                url = `${url}&sort_by=${orderColumnName}&sort_dir=${orderDirection}`;
+            }
+
+            $.ajax({
+                type: "get",
+                url: url,
+                success: function(response, text) {
+                    let clean_response = [];
+                    response["data"].forEach( (element) => clean_response.push(
+                        new AuditLog(element["event_datetime"], element["event"], `${element["active_user_name"]} (Id: ${element["active_user_id"]})`)
+                    ));
+                    callback({"data": clean_response, "recordsTotal": response["num-records"], "recordsFiltered": response["filtered-records"]});
+                },
+                error: function (request, status, error) {
+                    console.log("Error: ", error)
+                }
+            });
+        }
     });
 });
 </script>


### PR DESCRIPTION
## Description

This PR paginates the user audit log table and also applies pagination to the API as well

## Look & Feel

![Screenshot from 2024-12-04 12-15-04](https://github.com/user-attachments/assets/93f8a56c-72af-46b3-86b4-152ebdb5fd4f)

## How to test

1. Visit the users [page](http://localhost:5000/users)
2. Then click on audit log to view the user audit logs
3. Try out the sorting/search as well to get a feel of how it works

## Further Improvements

None

## Related Items

This PR closes #1190 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
