### PR TITLE
Clean up sensortoshow key from attribute field on assets

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -28,8 +28,7 @@ Infrastructure / Support
 ----------------------
 * Speed up status page by choosing for a faster query (only latest belief needed) [see `PR #1142 <https://github.com/FlexMeasures/flexmeasures/pull/1142>`_]
 * For MacOS developers, install HiGHS solver automatically [see `PR #1187 <https://github.com/FlexMeasures/flexmeasures/pull/1187>`_]
-* Add dedicated ``sensors_to_show`` field to asset model and logic to migrate data from parent source(attributes field) [see `PR #1200 <https://github.com/FlexMeasures/flexmeasures/pull/1200>`_]
-* Clean up ``sensors_to_show`` data from the ``attributes`` field of the asset model [see `PR #1282 <https://github.com/FlexMeasures/flexmeasures/pull/1282>`_] 
+* Migrate data for the ``sensors_to_show`` asset attribute to a dedicated column in the database table for assets [see `PR #1200 <https://github.com/FlexMeasures/flexmeasures/pull/1200>`_ and `PR #1282 <https://github.com/FlexMeasures/flexmeasures/pull/1282>`_]
 * Add support for installing FlexMeasures under Python 3.12 [see `PR #1233 <https://github.com/FlexMeasures/flexmeasures/pull/1233>`_]
 
 Bugfixes

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -29,6 +29,7 @@ Infrastructure / Support
 * Speed up status page by choosing for a faster query (only latest belief needed) [see `PR #1142 <https://github.com/FlexMeasures/flexmeasures/pull/1142>`_]
 * For MacOS developers, install HiGHS solver automatically [see `PR #1187 <https://github.com/FlexMeasures/flexmeasures/pull/1187>`_]
 * Add dedicated ``sensors_to_show`` field to asset model and logic to migrate data from parent source(attributes field) [see `PR #1200 <https://github.com/FlexMeasures/flexmeasures/pull/1200>`_]
+* Clean up ``sensors_to_show`` data from the ``attributes`` field of the asset model [see `PR #1282 <https://github.com/FlexMeasures/flexmeasures/pull/1282>`_] 
 * Add support for installing FlexMeasures under Python 3.12 [see `PR #1233 <https://github.com/FlexMeasures/flexmeasures/pull/1233>`_]
 
 Bugfixes

--- a/flexmeasures/data/migrations/versions/a42b5124cc46_clean_sensors_to_show_from_asset_.py
+++ b/flexmeasures/data/migrations/versions/a42b5124cc46_clean_sensors_to_show_from_asset_.py
@@ -1,0 +1,40 @@
+"""Remove sensors_to_show key from attributes column
+
+Revision ID: 2ba59c7c954e
+Revises: 950e23e3aa54
+Create Date: 2024-12-10 09:31:06.603743
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "2ba59c7c954e"
+down_revision = "950e23e3aa54"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Fetch all rows in the generic_assets table, update 'attributes' column by removing the 'sensors_to_show' key
+    connection = op.get_bind()
+    table_name = "generic_asset"
+    attribute_key_to_remove = "sensors_to_show"
+
+    # Use raw SQL to fetch and update rows
+    connection.execute(
+        sa.text(
+            f"""
+        UPDATE {table_name}
+        SET attributes = attributes::jsonb - '{attribute_key_to_remove}'
+        WHERE attributes IS NOT NULL;
+        """
+        )
+    )
+
+
+def downgrade():
+    # This downgrade should be done together with the downgrade of the 950e23e3aa54 revision, which restores the sensors_to_show attribute.
+    pass


### PR DESCRIPTION
## Description

This PR adds a migration to cleanup the `sensor_to_show` key from the asset attribute fields.

## Look & Feel

None

## How to test

Run the command `flexmeasures db upgrade`

## Further Improvements

None

## Related Items

Closes issue #1281 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
