### PR TITLE
Fix/faster asset count in user view

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -27,6 +27,7 @@ Infrastructure / Support
 * The breadcrumbs on asset and sensor pages can now be customized [see `PR #1257 <https://github.com/FlexMeasures/flexmeasures/pull/1257>`_]
 * The monitoring command to check for users who have been absent too long now can be used to keep data volume low and be more effective [see `PR #1268 <https://github.com/FlexMeasures/flexmeasures/pull/1268>`_]
 * Speed up status page by choosing for a faster query (only latest belief needed) [see `PR #1142 <https://github.com/FlexMeasures/flexmeasures/pull/1142>`_]
+* Speed up user page (for users with many assets) [see `PR #1286 <https://github.com/FlexMeasures/flexmeasures/pull/1286>`_]
 * For MacOS developers, install HiGHS solver automatically [see `PR #1187 <https://github.com/FlexMeasures/flexmeasures/pull/1187>`_]
 * Migrate data for the ``sensors_to_show`` asset attribute to a dedicated column in the database table for assets [see `PR #1200 <https://github.com/FlexMeasures/flexmeasures/pull/1200>`_ and `PR #1282 <https://github.com/FlexMeasures/flexmeasures/pull/1282>`_]
 * Add support for installing FlexMeasures under Python 3.12 [see `PR #1233 <https://github.com/FlexMeasures/flexmeasures/pull/1233>`_]

--- a/flexmeasures/ui/crud/users.py
+++ b/flexmeasures/ui/crud/users.py
@@ -129,7 +129,7 @@ class UserCrudUI(FlaskView):
         )
         asset_count = get_asset_count(user)
         return render_user(
-            user,
+            patched_user,
             asset_count=asset_count,
             msg="User %s's new activation status is now %s."
             % (patched_user.username, patched_user.active),

--- a/flexmeasures/ui/crud/users.py
+++ b/flexmeasures/ui/crud/users.py
@@ -6,9 +6,6 @@ from flask import request, url_for
 from flask_classful import FlaskView
 from flask_security.core import current_user
 from flask_security import login_required
-from flask_wtf import FlaskForm
-from wtforms import StringField, FloatField, DateTimeField, BooleanField
-from wtforms.validators import DataRequired
 from werkzeug.exceptions import Forbidden, Unauthorized
 from sqlalchemy import select
 
@@ -29,15 +26,6 @@ User Crud views for admins.
 """
 
 
-class UserForm(FlaskForm):
-    email = StringField("Email", validators=[DataRequired()])
-    username = StringField("Username", validators=[DataRequired()])
-    roles = FloatField("Roles", validators=[DataRequired()])
-    timezone = StringField("Timezone", validators=[DataRequired()])
-    last_login_at = DateTimeField("Last Login was at", validators=[DataRequired()])
-    active = BooleanField("Activation Status", validators=[DataRequired()])
-
-
 def get_asset_count(user: User):
     """Returns the asset count for a user."""
     asset_count = 0
@@ -50,8 +38,6 @@ def get_asset_count(user: User):
 
 
 def render_user(user: User | None, asset_count: int = 0, msg: str | None = None):
-    user_form = UserForm()
-    user_form.process(obj=user)
 
     user_view_user_auditlog = True
     try:
@@ -64,7 +50,6 @@ def render_user(user: User | None, asset_count: int = 0, msg: str | None = None)
         can_view_user_auditlog=user_view_user_auditlog,
         logged_in_user=current_user,
         user=user,
-        user_form=user_form,
         asset_count=asset_count,
         msg=msg,
     )

--- a/flexmeasures/ui/crud/users.py
+++ b/flexmeasures/ui/crud/users.py
@@ -26,18 +26,7 @@ User Crud views for admins.
 """
 
 
-def get_asset_count(user: User):
-    """Returns the asset count for a user."""
-    asset_count = 0
-    if user:
-        get_users_assets_response = InternalApi().get(
-            url_for("AssetAPI:index", account_id=user.account_id)
-        )
-        asset_count = len(get_users_assets_response.json())
-    return asset_count
-
-
-def render_user(user: User | None, asset_count: int = 0, msg: str | None = None):
+def render_user(user: User | None, msg: str | None = None):
 
     user_view_user_auditlog = True
     try:
@@ -48,9 +37,8 @@ def render_user(user: User | None, asset_count: int = 0, msg: str | None = None)
     return render_flexmeasures_template(
         "crud/user.html",
         can_view_user_auditlog=user_view_user_auditlog,
-        logged_in_user=current_user,
         user=user,
-        asset_count=asset_count,
+        asset_count=user.account.number_of_assets,
         msg=msg,
     )
 
@@ -113,8 +101,7 @@ class UserCrudUI(FlaskView):
         user: User = process_internal_api_response(
             get_user_response.json(), make_obj=True
         )
-        asset_count = get_asset_count(user)
-        return render_user(user, asset_count=asset_count)
+        return render_user(user)
 
     @roles_required(ADMIN_ROLE)
     def toggle_active(self, id: str):
@@ -127,10 +114,8 @@ class UserCrudUI(FlaskView):
         patched_user: User = process_internal_api_response(
             user_response.json(), make_obj=True
         )
-        asset_count = get_asset_count(user)
         return render_user(
             patched_user,
-            asset_count=asset_count,
             msg="User %s's new activation status is now %s."
             % (patched_user.username, patched_user.active),
         )
@@ -144,10 +129,8 @@ class UserCrudUI(FlaskView):
         InternalApi().patch(
             url_for("UserAPI:reset_user_password", id=id),
         )
-        asset_count = get_asset_count(user)
         return render_user(
             user,
-            asset_count=asset_count,
             msg="The user's password has been changed to a random password"
             " and password reset instructions have been sent to the user."
             " Cookies and the API access token have also been invalidated.",

--- a/flexmeasures/ui/tests/utils.py
+++ b/flexmeasures/ui/tests/utils.py
@@ -64,6 +64,7 @@ def mock_user_response(
         password="secret",
         flexmeasures_roles=[1],
         last_login_at="2021-05-14T20:00:00+02:00",
+        account_id=1,
     )
     if as_list:
         user_list = [user]


### PR DESCRIPTION
## Description

Replace slow calls to count assets in a user's account with fast ones.

Closes #1285

## Look & Feel

Clicking on a user in an account with many assets can lead to long loading times. After this it should be faster.

## How to test

I used the profiler, and confirmed for an account with 28 assets a ten-fold improvement. In production, an account with >1200 assets already took 14 seconds or so to show this page.

## Further Improvements

This PR also includes a small bugfix for (de)activating a user and removes unused code.