### PR TITLE
Added commit to the add_record

### DIFF
--- a/flexmeasures/data/models/audit_log.py
+++ b/flexmeasures/data/models/audit_log.py
@@ -183,6 +183,7 @@ class AssetAuditLog(db.Model, AuthModelMixin):
             affected_asset_id=asset.id,
         )
         db.session.add(audit_log)
+        db.session.commit()
 
 
 def truncate_string(value: str, max_length: int) -> str:


### PR DESCRIPTION
## Description

The `add_record` method in `AssetAuditLog` was missing `db.session.commit()` which is needed to push the record to the database.

## How to test

Create a simulation and see if the record for the audit logs is added to the `AssetAuditLog`.

## Related Items

This PR is part of this [Smart Buildings PR](https://github.com/SeitaBV/smart-buildings/pull/524)

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
