### PR TITLE
Chore/pandas freqstr deprecation of t and h

### DIFF
--- a/flexmeasures/conftest.py
+++ b/flexmeasures/conftest.py
@@ -537,7 +537,7 @@ def create_assets(
 
         # one day of test data (one complete sine curve)
         time_slots = pd.date_range(
-            datetime(2015, 1, 1), datetime(2015, 1, 1, 23, 45), freq="15T"
+            datetime(2015, 1, 1), datetime(2015, 1, 1, 23, 45), freq="15min"
         ).tz_localize("UTC")
         seed(42)  # ensure same results over different test runs
         add_beliefs(
@@ -1251,7 +1251,7 @@ def capacity_sensors(db, add_battery_assets, setup_sources):
     db.session.flush()
 
     time_slots = pd.date_range(
-        datetime(2015, 1, 2), datetime(2015, 1, 2, 7, 45), freq="15T"
+        datetime(2015, 1, 2), datetime(2015, 1, 2, 7, 45), freq="15min"
     ).tz_localize("Europe/Amsterdam")
 
     add_beliefs(
@@ -1289,7 +1289,7 @@ def capacity_sensors(db, add_battery_assets, setup_sources):
     db.session.commit()
 
     time_slots = pd.date_range(
-        datetime(2016, 1, 2), datetime(2016, 1, 2, 7, 45), freq="15T"
+        datetime(2016, 1, 2), datetime(2016, 1, 2, 7, 45), freq="15min"
     ).tz_localize("Europe/Amsterdam")
     values = [250] * 4 * 4 + [150] * 4 * 4
     beliefs = [
@@ -1346,7 +1346,7 @@ def soc_sensors(db, add_battery_assets, setup_sources) -> tuple:
     db.session.flush()
 
     time_slots = pd.date_range(
-        datetime(2015, 1, 1, 2), datetime(2015, 1, 2), freq="15T"
+        datetime(2015, 1, 1, 2), datetime(2015, 1, 2), freq="15min"
     ).tz_localize("Europe/Amsterdam")
 
     values = np.arange(len(time_slots)) / (len(time_slots) - 1)

--- a/flexmeasures/data/models/__init__.py
+++ b/flexmeasures/data/models/__init__.py
@@ -3,7 +3,7 @@ Data models for FlexMeasures
 """
 
 # Time resolutions
-resolutions = ["15T", "1h", "1d", "1w"]
+resolutions = ["15min", "1h", "1d", "1w"]
 
 # The confidence interval for forecasting
 confidence_interval_width = 0.9

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -728,7 +728,7 @@ def build_device_soc_values(
     2010-01-01 05:30:00    2.0
     2010-01-01 05:45:00    2.5
     2010-01-01 06:00:00    3.0
-    Freq: 15T, dtype: float64
+    Freq: 15min, dtype: float64
 
     TODO: this function could become the deserialization method of a new TimedEventSchema (targets, plural), which wraps TimedEventSchema.
 

--- a/flexmeasures/data/models/planning/tests/conftest.py
+++ b/flexmeasures/data/models/planning/tests/conftest.py
@@ -181,7 +181,7 @@ def add_inflexible_device_forecasts(
     time_slots = initialize_index(
         start=pd.Timestamp("2015-01-01").tz_localize("Europe/Amsterdam"),
         end=pd.Timestamp("2015-01-03").tz_localize("Europe/Amsterdam"),
-        resolution="15T",
+        resolution="15min",
     )
 
     # PV (8 hours at zero capacity, 8 hours at 90% capacity, and again 8 hours at zero capacity)

--- a/flexmeasures/data/tests/conftest.py
+++ b/flexmeasures/data/tests/conftest.py
@@ -74,7 +74,7 @@ def add_test_weather_sensor_and_forecasts(db: SQLAlchemy, setup_generic_asset_ty
         sensor = Sensor(name=sensor_name, generic_asset=weather_station, unit=unit)
         db.session.add(sensor)
         time_slots = pd.date_range(
-            datetime(2015, 1, 1), datetime(2015, 1, 2, 23, 45), freq="15T"
+            datetime(2015, 1, 1), datetime(2015, 1, 2, 23, 45), freq="15min"
         )
         values = [random() * (1 + np.sin(x / 15)) for x in range(len(time_slots))]
         if sensor_name == "temperature":

--- a/flexmeasures/data/tests/test_time_series_services.py
+++ b/flexmeasures/data/tests/test_time_series_services.py
@@ -27,7 +27,7 @@ def test_drop_unchanged_beliefs(setup_beliefs, db):
 
     # See what happens when storing all beliefs with their belief time updated
     bdf = tb_utils.replace_multi_index_level(
-        bdf, "belief_time", bdf.belief_times + pd.Timedelta("1H")
+        bdf, "belief_time", bdf.belief_times + pd.Timedelta("1h")
     )
     save_to_db(bdf)
 
@@ -86,7 +86,7 @@ def test_do_not_drop_changed_probabilistic_belief(setup_beliefs, db):
         old_belief, "cumulative_probability", pd.Index([0.3, 0.5])
     )
     new_belief = tb_utils.replace_multi_index_level(
-        new_belief, "belief_time", new_belief.belief_times + pd.Timedelta("1H")
+        new_belief, "belief_time", new_belief.belief_times + pd.Timedelta("1h")
     )
     save_to_db(new_belief)
 

--- a/flexmeasures/ui/utils/view_utils.py
+++ b/flexmeasures/ui/utils/view_utils.py
@@ -46,12 +46,6 @@ def render_flexmeasures_template(html_filename: str, **variables):
     variables["page"] = html_filename.split("/")[-1].replace(".html", "")
 
     variables["resolution"] = session.get("resolution", "")
-    variables["resolution_human"] = time_utils.freq_label_to_human_readable_label(
-        session.get("resolution", "")
-    )
-    variables["horizon_human"] = time_utils.freq_label_to_human_readable_label(
-        session.get("forecast_horizon", "")
-    )
 
     variables["flexmeasures_version"] = flexmeasures_version
 

--- a/flexmeasures/utils/time_utils.py
+++ b/flexmeasures/utils/time_utils.py
@@ -140,7 +140,7 @@ def resolution_to_hour_factor(resolution: str | timedelta) -> float:
     """Return the factor with which a value needs to be multiplied in order to get the value per hour,
     e.g. 10 MW at a resolution of 15min are 2.5 MWh per time step.
 
-    :param resolution: timedelta or pandas offset such as "15T" or "1H"
+    :param resolution: timedelta or pandas offset such as "15min" or "h"
     """
     if isinstance(resolution, timedelta):
         return resolution / timedelta(hours=1)
@@ -153,7 +153,7 @@ def decide_resolution(start: datetime | None, end: datetime | None) -> str:
     Useful for querying or plotting.
     """
     if start is None or end is None:
-        return "15T"  # default if we cannot tell period
+        return "15min"  # default if we cannot tell period
     period_length = end - start
     if period_length > timedelta(weeks=16):
         resolution = "168h"  # So upon switching from days to weeks, you get at least 16 data points
@@ -162,9 +162,9 @@ def decide_resolution(start: datetime | None, end: datetime | None) -> str:
     elif period_length > timedelta(hours=48):
         resolution = "1h"  # So upon switching from 15min to hours, you get at least 48 data points
     elif period_length > timedelta(hours=8):
-        resolution = "15T"
+        resolution = "15min"
     else:
-        resolution = "5T"  # we are (currently) not going lower than 5 minutes
+        resolution = "5min"  # we are (currently) not going lower than 5 minutes
     return resolution
 
 
@@ -277,9 +277,9 @@ def forecast_horizons_for(resolution: str | timedelta) -> list[str] | list[timed
     else:
         resolution_str = resolution
     horizons = []
-    if resolution_str in ("5T", "10T"):
+    if resolution_str in ("5T", "5min", "10T", "10min"):
         horizons = ["1h", "6h", "24h"]
-    elif resolution_str in ("15T", "1h", "H"):
+    elif resolution_str in ("15T", "15min", "1h", "H"):
         horizons = ["1h", "6h", "24h", "48h"]
     elif resolution_str in ("24h", "D"):
         horizons = ["24h", "48h"]
@@ -405,7 +405,7 @@ def apply_offset_chain(
             if offset.strip().lower() == "db":  # db = day begin
                 _dt = _dt.floor("D")
             elif offset.strip().lower() == "hb":  # hb = hour begin
-                _dt = _dt.floor("H")
+                _dt = _dt.floor("h")
 
     # Return output in the same type as the input
     if isinstance(dt, datetime):

--- a/flexmeasures/utils/time_utils.py
+++ b/flexmeasures/utils/time_utils.py
@@ -257,18 +257,6 @@ def get_first_day_of_next_month() -> datetime:
     return (datetime.now().replace(day=1) + timedelta(days=32)).replace(day=1)
 
 
-def freq_label_to_human_readable_label(freq_label: str) -> str:
-    """Translate pandas frequency labels to human-readable labels."""
-    f2h_map = {
-        "5T": "5 minutes",
-        "15T": "15 minutes",
-        "1h": "1 hour",
-        "24h": "1 day",
-        "168h": "1 week",
-    }
-    return f2h_map.get(freq_label, freq_label)
-
-
 def forecast_horizons_for(resolution: str | timedelta) -> list[str] | list[timedelta]:
     """Return a list of horizons that are supported per resolution.
     Return values or of the same type as the input."""


### PR DESCRIPTION
## Description

Get rid of:

- `FutureWarning: 'H' is deprecated and will be removed in a future version, please use 'h' instead.`
- `FutureWarning: 'T' is deprecated and will be removed in a future version, please use 'min' instead.`
- Obsolete view utils

