### PR TITLE
docs: recategorize some 0.24 PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@ it can be used to set some example data to be used in a new UI feature.
 
 ## Further Improvements
 
-Potential improvements to be done in the same PR or follow up Issues/Discussions/PRs.
+Potential improvements to be done in the same PR or follow-up Issues/Discussions/PRs.
 
 ## Related Items
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,12 @@ Summary of the changes introduced in this PR. Try to use bullet points as much a
 - [ ] ...
 - [ ] Added changelog item in `documentation/changelog.rst`
 
+<!--
+Note regarding our changelog:
+- The 'New features' section targets API / CLI / UI users.
+- The 'Infrastructure / Support' section targets plugin developers and hosts.
+-->
+
 ## Look & Feel
 
 This section can contain example pictures for UI, Input/Output for CLI, Request / Response for API endpoint, etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,9 @@
 
 Summary of the changes introduced in this PR. Try to use bullet points as much as possible.
 
+- [ ] ...
+- [ ] Added changelog item in `documentation/changelog.rst`
+
 ## Look & Feel
 
 This section can contain example pictures for UI, Input/Output for CLI, Request / Response for API endpoint, etc.

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -25,7 +25,7 @@ New features
 Infrastructure / Support
 ----------------------
 * The breadcrumbs on asset and sensor pages can now be customized [see `PR #1257 <https://github.com/FlexMeasures/flexmeasures/pull/1257>`_]
-* The monitoring command to check for users who have been absent to long now can be used to keep data volume low and be more effective [see `PR #1268 <https://github.com/FlexMeasures/flexmeasures/pull/1268>`_]
+* The monitoring command to check for users who have been absent too long now can be used to keep data volume low and be more effective [see `PR #1268 <https://github.com/FlexMeasures/flexmeasures/pull/1268>`_]
 * Speed up status page by choosing for a faster query (only latest belief needed) [see `PR #1142 <https://github.com/FlexMeasures/flexmeasures/pull/1142>`_]
 * For MacOS developers, install HiGHS solver automatically [see `PR #1187 <https://github.com/FlexMeasures/flexmeasures/pull/1187>`_]
 * Migrate data for the ``sensors_to_show`` asset attribute to a dedicated column in the database table for assets [see `PR #1200 <https://github.com/FlexMeasures/flexmeasures/pull/1200>`_ and `PR #1282 <https://github.com/FlexMeasures/flexmeasures/pull/1282>`_]

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -21,11 +21,11 @@ New features
 * Speed up loading on audit log tables page by switching to server-side pagination, replacing client-side pagination [see `PR #1274 <https://github.com/FlexMeasures/flexmeasures/pull/1274>`_ and `PR #1272 <https://github.com/FlexMeasures/flexmeasures/pull/1272>`_]
 * Simplify and globalize UI messages, using Toast [see `PR #1207 <https://github.com/FlexMeasures/flexmeasures/pull/1207>`_]
 * Power sensors created through the CLI no longer require a capacity attribute to be set [see `PR #1234 <https://github.com/FlexMeasures/flexmeasures/pull/1234>`_]
-* The breadcrumbs on asset and sensor pages can now be customized [see `PR #1257 <https://github.com/FlexMeasures/flexmeasures/pull/1257>`_]
-* The monitoring command to check for users who have been absent to long now can be used to keep data volume low and be more effective [see `PR #1268 <https://github.com/FlexMeasures/flexmeasures/pull/1268>`_]
 
 Infrastructure / Support
 ----------------------
+* The breadcrumbs on asset and sensor pages can now be customized [see `PR #1257 <https://github.com/FlexMeasures/flexmeasures/pull/1257>`_]
+* The monitoring command to check for users who have been absent to long now can be used to keep data volume low and be more effective [see `PR #1268 <https://github.com/FlexMeasures/flexmeasures/pull/1268>`_]
 * Speed up status page by choosing for a faster query (only latest belief needed) [see `PR #1142 <https://github.com/FlexMeasures/flexmeasures/pull/1142>`_]
 * For MacOS developers, install HiGHS solver automatically [see `PR #1187 <https://github.com/FlexMeasures/flexmeasures/pull/1187>`_]
 * Migrate data for the ``sensors_to_show`` asset attribute to a dedicated column in the database table for assets [see `PR #1200 <https://github.com/FlexMeasures/flexmeasures/pull/1200>`_ and `PR #1282 <https://github.com/FlexMeasures/flexmeasures/pull/1282>`_]


### PR DESCRIPTION
## Description

- I think these two items should be under **Support** as they represent features for plugin developer / hosts rather than CLI / API / UI users. At least, that's how I think we historically used our changelog categories.
- I amended out PR template for consistency.