### PR TITLE
docs/fix/stop building of PDF docs, as that stopped working on RTD.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,8 +8,8 @@ sphinx:
   configuration: documentation/conf.py
 
 # Optionally build your docs in additional formats such as PDF
-formats:
-  - pdf
+#formats:
+#  - pdf  # stopped working (e.g. https://readthedocs.org/projects/flexmeasures/builds/26604114/, also not required)
 
 build:
   os: ubuntu-20.04


### PR DESCRIPTION
 Also, they are not beautiful anyways.

## Description

Summary of the changes introduced in this PR. Try to use bullet points as much as possible.

- [x] Removed config for building PDF in ReadTheDocs yaml.

## Look & Feel

Now on flexmeasures.readthedocs.io a link to the PDF docs would not be shown anymore. I doubt anyone used it, ever.

## How to test

It seemed to go fine locally, so testing this is on RTD, where we can tell it to build this branch.