### PR TITLE
Allow numeric values for dimensionless fields

### DIFF
--- a/flexmeasures/api/v3_0/tests/test_sensor_schedules_fresh_db.py
+++ b/flexmeasures/api/v3_0/tests/test_sensor_schedules_fresh_db.py
@@ -500,9 +500,11 @@ def test_multiple_contracts(
     roundtrip_efficiency = (
         float(message["flex-model"]["roundtrip-efficiency"].replace("%", "")) / 100.0
     )
-    storage_efficiency = (
-        float(message["flex-model"]["storage-efficiency"].replace("%", "")) / 100.0
-    )
+    storage_efficiency_field = message["flex-model"]["storage-efficiency"]
+    if isinstance(storage_efficiency_field, str):
+        storage_efficiency = float(storage_efficiency_field.replace("%", "")) / 100.0
+    else:
+        storage_efficiency = storage_efficiency_field
     soc_targets = message["flex-model"].get("soc-targets")
 
     soc_schedule = integrate_time_series(

--- a/flexmeasures/api/v3_0/tests/utils.py
+++ b/flexmeasures/api/v3_0/tests/utils.py
@@ -80,7 +80,7 @@ def message_for_trigger_schedule(
         "soc-max": 40,  # in kWh, according to soc-unit
         "soc-unit": "kWh",
         "roundtrip-efficiency": "98%" if not use_perfect_efficiencies else "100%",
-        "storage-efficiency": "99.99%" if not use_perfect_efficiencies else "100%",
+        "storage-efficiency": "99.99%" if not use_perfect_efficiencies else 1,
         "power-capacity": "2 MW",  # same as capacity_in_mw attribute of test battery and test charging station
     }
     if with_targets:

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -261,6 +261,8 @@ class VariableQuantityField(MarshmallowClickMixin, fields.Field):
                                       a quantity of 1 EUR/kWh with to_unit='/MWh' is deserialized to 1000 EUR/MWh.
         :param default_src_unit:    What unit to use in case of getting a numeric value.
                                     Does not apply to time series or sensors.
+                                    In case to_unit is dimensionless, default_src_unit defaults to dimensionless;
+                                    as a result, numeric values are accepted.
         :param return_magnitude:    In case of getting a time series, whether the result should include
                                     the magnitude of each quantity, or each Quantity object itself.
         :param timezone:            Only used in case a time series is specified and one of the *timed events*
@@ -278,6 +280,10 @@ class VariableQuantityField(MarshmallowClickMixin, fields.Field):
                 f"Variable `to_unit='{to_unit}'` must define a denominator."
             )
         self.to_unit = to_unit
+        if default_src_unit is None and units_are_convertible(
+            self.to_unit, "dimensionless"
+        ):
+            default_src_unit = "dimensionless"
         self.default_src_unit = default_src_unit
         self.return_magnitude = return_magnitude
 

--- a/flexmeasures/data/schemas/tests/test_sensor.py
+++ b/flexmeasures/data/schemas/tests/test_sensor.py
@@ -20,6 +20,8 @@ from marshmallow import ValidationError
         ({"sensor": 2}, "EUR/kWh", False, None),
         ({"sensor": 2}, "EUR", True, None),
         # deserialize a quantity
+        (1, "%", False, "100.0 %"),
+        (5, "%", False, "500.0 %"),
         ("1MWh", "MWh", False, "1 MWh"),
         ("1 MWh", "kWh", False, "1000.0 kWh"),
         ("1 MWh", "kW", True, None),
@@ -78,7 +80,7 @@ def test_quantity_or_sensor_deserialize(
 
     try:
         dst_quantity = schema.deserialize(src_quantity)
-        if isinstance(src_quantity, ur.Quantity):
+        if isinstance(src_quantity, (ur.Quantity, int, float)):
             assert dst_quantity == ur.Quantity(exp_dst_quantity)
             assert str(dst_quantity) == exp_dst_quantity
         elif isinstance(src_quantity, list):


### PR DESCRIPTION
## Description

Small improvement of our `VariableQuantityField` allowing numeric values to be passed to fields set up for a dimensionless quantity. (The `storage-efficiency` field already supported this.)

## Look & Feel

For example:
- `"charging-efficiency": 4` can be used for a COP (coefficient of performance), and
- `"charging-efficiency": 0.4` can be used to set an efficiency of 40%.

Before, these needed to be passed as strings: e.g. `"4"` or `"400%"`.

## How to test

New test cases are included.