### PR TITLE
Feature/stock commitments

### DIFF
--- a/documentation/api/change_log.rst
+++ b/documentation/api/change_log.rst
@@ -5,6 +5,14 @@ API change log
 
 .. note:: The FlexMeasures API follows its own versioning scheme. This is also reflected in the URL (e.g. `/api/v3_0`), allowing developers to upgrade at their own pace.
 
+v3.0-22 | 2025-03-17
+""""""""""""""""""""
+
+- Introduce new price fields in the ``flex-context`` in order to relax SoC constraints in the ``device-model``:
+
+  - ``soc-minima-breach-price``: if set, the ``soc-minima`` are used as a soft constraint, and not meeting the minima is penalized according to this per-kWh price. The price is applied to each breach that occurs given the resolution of the scheduled power sensor.
+  - ``soc-maxima-breach-price``: if set, the ``soc-maxima`` are used as a soft constraint, and not meeting the maxima is penalized according to this per-kWh price. The price is applied to each breach that occurs given the resolution of the scheduled power sensor.
+
 v3.0-22 | 2024-12-27
 """"""""""""""""""""
 

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -11,6 +11,7 @@ v0.25.0 | February XX, 2025
 
 New features
 -------------
+* Allow relaxing SoC minima and maxima, by setting penalties for not meeting these constraints, using two new ``flex-context`` fields [see `PR #1300 <https://github.com/FlexMeasures/flexmeasures/pull/1300>`_]
 * Added form modal to edit an asset's ``flex_context`` [see `PR #1320 <https://github.com/FlexMeasures/flexmeasures/pull/1320>`_]
 * Better y-axis titles for charts that show multiple sensors with a shared unit [see `PR #1346 <https://github.com/FlexMeasures/flexmeasures/pull/1346>`_]
 * Add CLI command ``flexmeasures jobs save-last-failed`` for saving the last failed jobs [see `PR #1342 <https://www.github.com/FlexMeasures/flexmeasures/pull/1342>`_ and `PR #1359 <https://github.com/FlexMeasures/flexmeasures/pull/1359>`_]

--- a/documentation/features/scheduling.rst
+++ b/documentation/features/scheduling.rst
@@ -43,7 +43,7 @@ The full list of flex-context fields follows below.
 For more details on the possible formats for field values, see :ref:`variable_quantities`.
 
 Where should you set these fields?
-Within requests to the API or the data model.
+Within requests to the API or by editing the relevant asset in the UI.
 If they are not sent in via the API (the endpoint triggering schedule computation), the scheduler will look them up on the `flex-context` field of the asset.
 For consumption price, production price and inflexible devices, the scheduler will also search if parent assets have set them (it should probably do the same for other flex context fields ― work in progress).
 Finally, some of these values will default to attributes, for legacy reasons.

--- a/documentation/features/scheduling.rst
+++ b/documentation/features/scheduling.rst
@@ -212,7 +212,10 @@ For more details on the possible formats for field values, see :ref:`variable_qu
      - This can encode losses over time, so each time step the energy is held longer leads to higher losses (defaults to 100%). Also read [#storage_efficiency]_ about applying this value per time step across longer time spans.
    * - ``prefer-charging-sooner``
      - ``True``
-     - Tie-breaking policy to apply if conditions are stable (defaults to True, which also signals a preference to discharge later). Boolean option only.
+     - Tie-breaking policy to apply if conditions are stable, which signals a preference to charge sooner rather than later (defaults to True). It also signals a preference to discharge later. Boolean option only.
+   * - ``prefer-curtailing-later``
+     - ``True``
+     - Tie-breaking policy to apply if conditions are stable, which signals a preference to curtail both consumption and production later, whichever is applicable (defaults to True). Boolean option only.
    * - ``power-capacity``
      - ``"50kW"``
      - Device-level power constraint. How much power can be applied to this asset (defaults to the Sensor attribute ``capacity_in_mw``). [#minimum_overlap]_

--- a/documentation/features/scheduling.rst
+++ b/documentation/features/scheduling.rst
@@ -42,7 +42,11 @@ Fields can have fixed values, but some fields can also point to sensors, so they
 The full list of flex-context fields follows below.
 For more details on the possible formats for field values, see :ref:`variable_quantities`.
 
-Where should you set these fields? Within requests to the API or the data model. If they are not sent in via the API (the endpoint triggering schedule computation), the scheduler will look them up on the `flex-context` field of the asset. For consumption price, production price and inflexible devices, the scheduler will also search if parent assets have set them (it should probably do the same for other flex context fields ― work in progress). Finally, some of these values will default to attributes, for legacy reasons.
+Where should you set these fields?
+Within requests to the API or the data model.
+If they are not sent in via the API (the endpoint triggering schedule computation), the scheduler will look them up on the `flex-context` field of the asset.
+For consumption price, production price and inflexible devices, the scheduler will also search if parent assets have set them (it should probably do the same for other flex context fields ― work in progress).
+Finally, some of these values will default to attributes, for legacy reasons.
 
 
 

--- a/documentation/features/scheduling.rst
+++ b/documentation/features/scheduling.rst
@@ -46,7 +46,6 @@ Where should you set these fields?
 Within requests to the API or by editing the relevant asset in the UI.
 If they are not sent in via the API (the endpoint triggering schedule computation), the scheduler will look them up on the `flex-context` field of the asset.
 For consumption price, production price and inflexible devices, the scheduler will also search if parent assets have set them (it should probably do the same for other flex context fields ― work in progress).
-Finally, some of these values will default to attributes, for legacy reasons.
 
 
 

--- a/documentation/features/scheduling.rst
+++ b/documentation/features/scheduling.rst
@@ -112,10 +112,10 @@ And if the asset belongs to a larger system (a hierarchy of assets), the schedul
      - ``"260 EUR/MWh"``
      - Production peaks above the ``site-peak-production`` are penalized against this per-kW price. [#penalty_field]_
    * - ``soc-minima-breach-price``
-     - ``"6 EUR/kWh"``
+     - ``"2 EUR/kWh/min"``
      - Penalty for not meeting ``soc-minima`` defined in the flex-model. [#penalty_field]_ [#soc_breach_prices]_
    * - ``soc-maxima-breach-price``
-     - ``"6 EUR/kWh"``
+     - ``"2 EUR/kWh/min"``
      - Penalty for not meeting ``soc-maxima`` defined in the flex-model. [#penalty_field]_ [#soc_breach_prices]_
 
 .. [#old_sensor_field] The old field only accepted an integer (sensor ID).
@@ -130,7 +130,7 @@ And if the asset belongs to a larger system (a hierarchy of assets), the schedul
 
 .. [#production] Example: with a connection capacity (``site-power-capacity``) of 1 MVA (apparent power) and a production capacity (``site-production-capacity``) of 400 kW (active power), the scheduler will make sure that the grid inflow doesn't exceed 400 kW.
 
-.. [#soc_breach_prices] The SoC breach prices (e.g. 6 EUR/kWh) to use for the schedule are applied over each time step equal to the sensor resolution. For example, a SoC breach price of 6 EUR/kWh per hour, for scheduling a 5-minute resolution sensor, should be passed as a SoC breach price of :math:`6*5/60 = 0.50` EUR/kWh.
+.. [#soc_breach_prices] The SoC breach prices (e.g. 2 EUR/kWh/min) to use for the schedule are applied over each time step equal to the sensor resolution. For example, a SoC breach price of 2 EUR/kWh/min, for scheduling a 5-minute resolution sensor, will be applied as a SoC breach price of 10 EUR/kWh for breaches measured every 5 minutes.
 
 .. note:: If no (symmetric, consumption and production) site capacity is defined (also not as defaults), the scheduler will not enforce any bound on the site power.
           The flexible device can still have its own power limit defined in its flex-model.

--- a/documentation/features/scheduling.rst
+++ b/documentation/features/scheduling.rst
@@ -148,7 +148,9 @@ The storage scheduler is suitable for batteries and :abbr:`EV (electric vehicle)
 The process scheduler is suitable for shiftable, breakable and inflexible loads, and is automatically selected for asset types ``"process"`` and ``"load"``.
 
 
-We describe the respective flex models below. At the moment, they have to be sent through the API (the endpoint to trigger schedule computation, or using the FlexMeasures client) or the CLI (the command to add schedules). We will soon work on the possibility to store (a subset of) these fields on the data model and edit them in the UI.
+We describe the respective flex models below.
+At the moment, they have to be sent through the API (the endpoint to trigger schedule computation, or using the FlexMeasures client) or through the CLI (the command to add schedules).
+We will soon work on the possibility to store (a subset of) these fields on the data model and edit them in the UI.
 
 
 Storage

--- a/documentation/views/asset-data.rst
+++ b/documentation/views/asset-data.rst
@@ -26,7 +26,7 @@ The asset page as data dashboard
 The data charts are maybe the most interesting feature - they form your own data dashboard. When the most interesting sensors are shown, the replay button on the right creates a very meaningful dynamic insight!
 
 
-Sensors to show on Graph
+Sensors to show on a graph
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Use the "Add Graph" button to create graphs. For each graph, you can select one or more sensors, from all available sensors associated with the asset, including public sensors, and add them to your plot.  
@@ -42,7 +42,7 @@ Finally, it is possible to set custom titles for any sensor graph by clicking on
 Internally, the asset has a `sensors_to_show`` field, which controls which sensor data appears in the plot. This can also be set by a script. Accepted formats are simple lists of sensor IDs (e.g. `[2, [5,6]]` or a more expressive format (e.g. `[{"title": "Power", "sensor": 2}, {"title": "Costs", "sensors": [5,6] }`). 
 
 
-Editing Asset FlexContext 
+Editing an asset's flex-context
 =========================
 
 |
@@ -59,14 +59,14 @@ Overview
 * **Left Panel:** Displays a list of currently configured fields.
 * **Right Panel:** Shows details of the selected field and provides a form to modify its value.
 
-Adding a Field
+Adding a field
 --------------
 
 1.  **Select Field:** Choose the desired field from the dropdown menu in the top right corner of the modal.
 2.  **Add Field:** Click the "Add Field" button next to the dropdown.
 3.  The field will be added to the list in the left panel.
 
-Setting a Field Value
+Setting a field value
 ----------------------
 
 1.  **Select Field(if it is not selected yet):** Click on the field in the left panel.

--- a/documentation/views/asset-data.rst
+++ b/documentation/views/asset-data.rst
@@ -69,7 +69,7 @@ Adding a field
 Setting a field value
 ----------------------
 
-1.  **Select Field(if it is not selected yet):** Click on the field in the left panel.
+1.  **Select Field (if it is not selected yet):** Click on the field in the left panel.
 2.  **Set Value:** In the right panel, use the provided form to set the field's value.
 
     * Some fields may only accept a sensor value.

--- a/flexmeasures/conftest.py
+++ b/flexmeasures/conftest.py
@@ -1424,7 +1424,9 @@ def soc_sensors(db, add_battery_assets, setup_sources) -> tuple:
         source=setup_sources["Seita"],
     )
 
-    yield soc_maxima, soc_minima, soc_targets, values
+    soc_schedule = pd.Series(data=values, index=time_slots)
+
+    yield soc_maxima, soc_minima, soc_targets, soc_schedule
 
 
 @pytest.fixture(scope="module")

--- a/flexmeasures/data/models/planning/__init__.py
+++ b/flexmeasures/data/models/planning/__init__.py
@@ -308,10 +308,14 @@ class Commitment:
 
 
 class FlowCommitment(Commitment):
+    """NB index contains event start, while quantity applies to average flow between event start and end."""
+
     pass
 
 
 class StockCommitment(Commitment):
+    """NB index contains event start, while quantity applies to stock at event end."""
+
     pass
 
 

--- a/flexmeasures/data/models/planning/__init__.py
+++ b/flexmeasures/data/models/planning/__init__.py
@@ -209,30 +209,23 @@ class Scheduler:
 @dataclass
 class Commitment:
     """Contractual commitment specifying prices for deviating from a given position.
-    ::
-    Parameters
-    ----------
-    name:
-        Name of the commitment.
-    device:
-        Device to which the commitment pertains. If None, the commitment pertains to the EMS.
-    index:
-        Pandas DatetimeIndex defining the time slots to which the commitment applies.
-        The index is shared by the group, quantity, upwards_deviation_price and downwards_deviation_price Pandas Series.
-    _type:
-        'any' or 'each'. Any deviation is penalized via 1 group, whereas each deviation is penalized via n groups.
-    group:
-        Each time slot is assigned to a group. Deviations are determined for each group.
-        The deviation of a group is determined by the time slot with the maximum deviation within that group.
-    quantity:
-        The deviation for each group is determined with respect to this quantity.
-        Can be initialized with a constant value, but always returns a Pandas Series (see also the `index` parameter).
-    upwards_deviation_price:
-        The deviation in the upwards direction is priced against this price. Use a positive price to set a penalty.
-        Can be initialized with a constant value, but always returns a Pandas Series (see also the `index` parameter).
-    downwards_deviation_price:
-        The deviation in the downwards direction is priced against this price. Use a negative price to set a penalty.
-        Can be initialized with a constant value, but always returns a Pandas Series (see also the `index` parameter).
+
+    Attributes:
+        name:       Name of the commitment.
+        device:     Device to which the commitment pertains. If None, the commitment pertains to the EMS.
+        index:      Pandas DatetimeIndex defining the time slots to which the commitment applies.
+                    The index is shared by the group, quantity, upwards_deviation_price and downwards_deviation_price Pandas Series.
+        _type:      'any' or 'each'. Any deviation is penalized via 1 group, whereas each deviation is penalized via n groups.
+        group:      Each time slot is assigned to a group. Deviations are determined for each group.
+                    The deviation of a group is determined by the time slot with the maximum deviation within that group.
+        quantity:   The deviation for each group is determined with respect to this quantity.
+                    Can be initialized with a constant value, but always returns a Pandas Series (see also the `index` parameter).
+        upwards_deviation_price:
+                    The deviation in the upwards direction is priced against this price. Use a positive price to set a penalty.
+                    Can be initialized with a constant value, but always returns a Pandas Series (see also the `index` parameter).
+        downwards_deviation_price:
+                    The deviation in the downwards direction is priced against this price. Use a negative price to set a penalty.
+                    Can be initialized with a constant value, but always returns a Pandas Series (see also the `index` parameter).
     """
 
     name: str

--- a/flexmeasures/data/models/planning/__init__.py
+++ b/flexmeasures/data/models/planning/__init__.py
@@ -303,6 +303,7 @@ class Commitment:
         """Contains all info apart from the name."""
         return pd.concat(
             [
+                self.device,
                 self.quantity,
                 self.upwards_deviation_price,
                 self.downwards_deviation_price,

--- a/flexmeasures/data/models/planning/__init__.py
+++ b/flexmeasures/data/models/planning/__init__.py
@@ -218,7 +218,7 @@ class Commitment:
         Device to which the commitment pertains. If None, the commitment pertains to the EMS.
     index:
         Pandas DatetimeIndex defining the time slots to which the commitment applies.
-        The index is shared by the group, quantity. upwards_deviation_price and downwards_deviation_price Pandas Series.
+        The index is shared by the group, quantity, upwards_deviation_price and downwards_deviation_price Pandas Series.
     _type:
         'any' or 'each'. Any deviation is penalized via 1 group, whereas each deviation is penalized via n groups.
     group:

--- a/flexmeasures/data/models/planning/linear_optimization.py
+++ b/flexmeasures/data/models/planning/linear_optimization.py
@@ -467,8 +467,7 @@ def device_scheduler(  # noqa C901
     def device_stock_commitment_equalities(m, c, j, d):
         """Couple device stocks to each commitment."""
         if (
-            "device"
-            not in commitments[c].columns  # "device" not in commitments[28].columns
+            "device" not in commitments[c].columns
             or (commitments[c]["device"] != d).all()
             or m.commitment_quantity[c] == -infinity
         ):

--- a/flexmeasures/data/models/planning/linear_optimization.py
+++ b/flexmeasures/data/models/planning/linear_optimization.py
@@ -479,20 +479,15 @@ def device_scheduler(  # noqa C901
             return Constraint.Skip
 
         # Determine center part of the lhs <= center part <= rhs constraint
+        center_part = (
+            m.commitment_quantity[c]
+            + m.commitment_downwards_deviation[c]
+            + m.commitment_upwards_deviation[c]
+        )
         if commitments[c]["class"].apply(lambda cl: cl == StockCommitment).all():
-            center_part = (
-                m.commitment_quantity[c]
-                + m.commitment_downwards_deviation[c]
-                + m.commitment_upwards_deviation[c]
-                - _get_stock_change(m, d, j)
-            )
+            center_part -= _get_stock_change(m, d, j)
         elif commitments[c]["class"].apply(lambda cl: cl == FlowCommitment).all():
-            center_part = (
-                m.commitment_quantity[c]
-                + m.commitment_downwards_deviation[c]
-                + m.commitment_upwards_deviation[c]
-                - m.ems_power[d, j]
-            )
+            center_part -= m.ems_power[d, j]
         else:
             raise NotImplementedError("Unknown commitment class")
         return (

--- a/flexmeasures/data/models/planning/linear_optimization.py
+++ b/flexmeasures/data/models/planning/linear_optimization.py
@@ -22,7 +22,11 @@ from pyomo.environ import UnknownSolver  # noqa F401
 from pyomo.environ import value
 from pyomo.opt import SolverFactory, SolverResults
 
-from flexmeasures.data.models.planning import Commitment, FlowCommitment
+from flexmeasures.data.models.planning import (
+    Commitment,
+    FlowCommitment,
+    StockCommitment,
+)
 from flexmeasures.data.models.planning.utils import initialize_series, initialize_df
 from flexmeasures.utils.calculations import apply_stock_changes_and_losses
 
@@ -473,11 +477,7 @@ def device_scheduler(  # noqa C901
         ):
             # Commitment c does not concern device d
             return Constraint.Skip
-        if (
-            not commitments[c]["class"]
-            .apply(lambda cl: cl.__name__ == "StockCommitment")
-            .all()
-        ):
+        if not commitments[c]["class"].apply(lambda cl: cl == StockCommitment).all():
             raise NotImplementedError(
                 "FlowCommitment on a device level has not been implemented. Please file a GitHub ticket explaining your use case."
             )
@@ -517,9 +517,7 @@ def device_scheduler(  # noqa C901
         if (
             "class" in commitments[c].columns
             and not (
-                commitments[c]["class"].apply(
-                    lambda cl: cl.__name__ == "FlowCommitment"
-                )
+                commitments[c]["class"].apply(lambda cl: cl == FlowCommitment)
             ).all()
         ):
             raise NotImplementedError(

--- a/flexmeasures/data/models/planning/linear_optimization.py
+++ b/flexmeasures/data/models/planning/linear_optimization.py
@@ -477,10 +477,25 @@ def device_scheduler(  # noqa C901
         ):
             # Commitment c does not concern device d
             return Constraint.Skip
-        if not commitments[c]["class"].apply(lambda cl: cl == StockCommitment).all():
-            raise NotImplementedError(
-                "FlowCommitment on a device level has not been implemented. Please file a GitHub ticket explaining your use case."
+
+        # Determine center part of the lhs <= center part <= rhs constraint
+        commitment_class = commitments[c]["class"].iloc[j]
+        if commitment_class == StockCommitment:
+            center_part = (
+                m.commitment_quantity[c]
+                + m.commitment_downwards_deviation[c]
+                + m.commitment_upwards_deviation[c]
+                - m.ems_power[d, j]
             )
+        elif commitment_class == FlowCommitment:
+            center_part = (
+                m.commitment_quantity[c]
+                + m.commitment_downwards_deviation[c]
+                + m.commitment_upwards_deviation[c]
+                - _get_stock_change(m, d, j)
+            )
+        else:
+            raise NotImplementedError(f"Unknown commitment class '{commitment_class}'")
         return (
             (
                 0
@@ -489,10 +504,7 @@ def device_scheduler(  # noqa C901
                 else None
             ),
             # 0 if "upwards deviation price" in commitments[c].columns else None,  # todo: possible simplification
-            m.commitment_quantity[c]
-            + m.commitment_downwards_deviation[c]
-            + m.commitment_upwards_deviation[c]
-            - _get_stock_change(m, d, j),
+            center_part,
             (
                 0
                 if len(commitments[c]) == 1

--- a/flexmeasures/data/models/planning/linear_optimization.py
+++ b/flexmeasures/data/models/planning/linear_optimization.py
@@ -479,23 +479,22 @@ def device_scheduler(  # noqa C901
             return Constraint.Skip
 
         # Determine center part of the lhs <= center part <= rhs constraint
-        commitment_class = commitments[c]["class"].iloc[j]
-        if commitment_class == StockCommitment:
-            center_part = (
-                m.commitment_quantity[c]
-                + m.commitment_downwards_deviation[c]
-                + m.commitment_upwards_deviation[c]
-                - m.ems_power[d, j]
-            )
-        elif commitment_class == FlowCommitment:
+        if commitments[c]["class"].apply(lambda cl: cl == StockCommitment).all():
             center_part = (
                 m.commitment_quantity[c]
                 + m.commitment_downwards_deviation[c]
                 + m.commitment_upwards_deviation[c]
                 - _get_stock_change(m, d, j)
             )
+        elif commitments[c]["class"].apply(lambda cl: cl == FlowCommitment).all():
+            center_part = (
+                m.commitment_quantity[c]
+                + m.commitment_downwards_deviation[c]
+                + m.commitment_upwards_deviation[c]
+                - m.ems_power[d, j]
+            )
         else:
-            raise NotImplementedError(f"Unknown commitment class '{commitment_class}'")
+            raise NotImplementedError("Unknown commitment class")
         return (
             (
                 0

--- a/flexmeasures/data/models/planning/linear_optimization.py
+++ b/flexmeasures/data/models/planning/linear_optimization.py
@@ -491,21 +491,9 @@ def device_scheduler(  # noqa C901
         else:
             raise NotImplementedError("Unknown commitment class")
         return (
-            (
-                0
-                if len(commitments[c]) == 1
-                or "upwards deviation price" in commitments[c].columns
-                else None
-            ),
-            # 0 if "upwards deviation price" in commitments[c].columns else None,  # todo: possible simplification
+            0 if "upwards deviation price" in commitments[c].columns else None,
             center_part,
-            (
-                0
-                if len(commitments[c]) == 1
-                or "downwards deviation price" in commitments[c].columns
-                else None
-            ),
-            # 0 if "downwards deviation price" in commitments[c].columns else None,  # todo: possible simplification
+            0 if "downwards deviation price" in commitments[c].columns else None,
         )
 
     def ems_flow_commitment_equalities(m, c, j):

--- a/flexmeasures/data/models/planning/linear_optimization.py
+++ b/flexmeasures/data/models/planning/linear_optimization.py
@@ -473,7 +473,11 @@ def device_scheduler(  # noqa C901
         ):
             # Commitment c does not concern device d
             return Constraint.Skip
-        if not all(cl.__name__ == "StockCommitment" for cl in commitments[c]["class"]):
+        if (
+            not commitments[c]["class"]
+            .apply(lambda cl: cl.__name__ == "StockCommitment")
+            .all()
+        ):
             raise NotImplementedError(
                 "FlowCommitment on a device level has not been implemented. Please file a GitHub ticket explaining your use case."
             )
@@ -510,8 +514,13 @@ def device_scheduler(  # noqa C901
         ) or m.commitment_quantity[c] == -infinity:
             # Commitment c does not concern EMS
             return Constraint.Skip
-        if "class" in commitments[c].columns and not all(
-            cl.__name__ == "FlowCommitment" for cl in commitments[c]["class"]
+        if (
+            "class" in commitments[c].columns
+            and not (
+                commitments[c]["class"].apply(
+                    lambda cl: cl.__name__ == "FlowCommitment"
+                )
+            ).all()
         ):
             raise NotImplementedError(
                 "StockCommitment on an EMS level has not been implemented. Please file a GitHub ticket explaining your use case."

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -529,9 +529,7 @@ class MetaStorageScheduler(Scheduler):
                     resolve_overlaps="max",
                 )
             if self.flex_context.get("soc_minima_breach_price", None) is not None:
-                soc_minima_breach_price = self.flex_context.get(
-                    "soc_minima_breach_price"
-                )
+                soc_minima_breach_price = self.flex_context["soc_minima_breach_price"]
                 soc_minima_breach_price = get_continuous_series_sensor_or_quantity(
                     variable_quantity=soc_minima_breach_price,
                     actuator=asset,
@@ -588,9 +586,7 @@ class MetaStorageScheduler(Scheduler):
                     resolve_overlaps="min",
                 )
             if self.flex_context.get("soc_maxima_breach_price", None) is not None:
-                soc_maxima_breach_price = self.flex_context.get(
-                    "soc_maxima_breach_price"
-                )
+                soc_maxima_breach_price = self.flex_context["soc_maxima_breach_price"]
                 soc_maxima_breach_price = get_continuous_series_sensor_or_quantity(
                     variable_quantity=soc_maxima_breach_price,
                     actuator=asset,

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -158,7 +158,9 @@ class MetaStorageScheduler(Scheduler):
             up_deviation_prices = get_continuous_series_sensor_or_quantity(
                 variable_quantity=consumption_price,
                 actuator=asset,
-                unit=get_unit(consumption_price),
+                unit=FlexContextSchema()
+                .declared_fields["consumption_price"]
+                ._get_unit(consumption_price),
                 query_window=(start, end),
                 resolution=resolution,
                 beliefs_before=belief_time,
@@ -177,7 +179,9 @@ class MetaStorageScheduler(Scheduler):
             down_deviation_prices = get_continuous_series_sensor_or_quantity(
                 variable_quantity=production_price,
                 actuator=asset,
-                unit=get_unit(production_price),
+                unit=FlexContextSchema()
+                .declared_fields["production_price"]
+                ._get_unit(production_price),
                 query_window=(start, end),
                 resolution=resolution,
                 beliefs_before=belief_time,
@@ -288,7 +292,9 @@ class MetaStorageScheduler(Scheduler):
             ems_peak_consumption_price = get_continuous_series_sensor_or_quantity(
                 variable_quantity=ems_peak_consumption_price,
                 actuator=asset,
-                unit=get_unit(ems_peak_consumption_price),
+                unit=FlexContextSchema()
+                .declared_fields["ems_peak_consumption_price"]
+                ._get_unit(ems_peak_consumption_price),
                 query_window=(start, end),
                 resolution=resolution,
                 beliefs_before=belief_time,
@@ -324,7 +330,9 @@ class MetaStorageScheduler(Scheduler):
             ems_peak_production_price = get_continuous_series_sensor_or_quantity(
                 variable_quantity=ems_peak_production_price,
                 actuator=asset,
-                unit=get_unit(ems_peak_production_price),
+                unit=FlexContextSchema()
+                .declared_fields["ems_peak_production_price"]
+                ._get_unit(ems_peak_production_price),
                 query_window=(start, end),
                 resolution=resolution,
                 beliefs_before=belief_time,
@@ -361,7 +369,9 @@ class MetaStorageScheduler(Scheduler):
             ems_consumption_breach_price = get_continuous_series_sensor_or_quantity(
                 variable_quantity=ems_consumption_breach_price,
                 actuator=asset,
-                unit=get_unit(ems_consumption_breach_price),
+                unit=FlexContextSchema()
+                .declared_fields["ems_consumption_breach_price"]
+                ._get_unit(ems_consumption_breach_price),
                 query_window=(start, end),
                 resolution=resolution,
                 beliefs_before=belief_time,
@@ -402,7 +412,9 @@ class MetaStorageScheduler(Scheduler):
             ems_production_breach_price = get_continuous_series_sensor_or_quantity(
                 variable_quantity=ems_production_breach_price,
                 actuator=asset,
-                unit=get_unit(ems_production_breach_price),
+                unit=FlexContextSchema()
+                .declared_fields["ems_production_breach_price"]
+                ._get_unit(ems_production_breach_price),
                 query_window=(start, end),
                 resolution=resolution,
                 beliefs_before=belief_time,
@@ -485,7 +497,9 @@ class MetaStorageScheduler(Scheduler):
                 soc_minima_breach_price = get_continuous_series_sensor_or_quantity(
                     variable_quantity=soc_minima_breach_price,
                     actuator=asset,
-                    unit=get_unit(soc_minima_breach_price),
+                    unit=FlexContextSchema()
+                    .declared_fields["soc_minima_breach_price"]
+                    ._get_unit(soc_minima_breach_price),
                     query_window=(start, end),
                     resolution=resolution,
                     beliefs_before=belief_time,
@@ -534,7 +548,9 @@ class MetaStorageScheduler(Scheduler):
                 soc_maxima_breach_price = get_continuous_series_sensor_or_quantity(
                     variable_quantity=soc_maxima_breach_price,
                     actuator=asset,
-                    unit=get_unit(soc_maxima_breach_price),
+                    unit=FlexContextSchema()
+                    .declared_fields["soc_maxima_breach_price"]
+                    ._get_unit(soc_maxima_breach_price),
                     query_window=(start, end),
                     resolution=resolution,
                     beliefs_before=belief_time,
@@ -1398,7 +1414,9 @@ def validate_storage_constraints(
 
     _constraints["factor_w_wh(t)"] = resolution / timedelta(hours=1)
     _constraints["min(t-1)"] = prepend_series(_constraints["min(t)"], soc_min)
-    _constraints["equals(t-1)"] = prepend_series(_constraints["equals(t)"], soc_at_start)
+    _constraints["equals(t-1)"] = prepend_series(
+        _constraints["equals(t)"], soc_at_start
+    )
     _constraints["max(t-1)"] = prepend_series(_constraints["max(t)"], soc_max)
 
     # 1) equals(t) - equals(t-1) <= derivative_max(t)
@@ -1559,15 +1577,6 @@ def validate_constraint(
         )
 
     return constraint_violations
-
-
-def get_unit(variable_quantity: Sensor | list[dict] | ur.Quantity) -> str:
-    """Obtain the unit from a variable quantity."""
-    if isinstance(variable_quantity, Sensor):
-        return variable_quantity.unit
-    if isinstance(variable_quantity, list):
-        return variable_quantity[0]["value"].units
-    return str(variable_quantity.units)
 
 
 def prepend_series(series: pd.Series, value) -> pd.Series:

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -1166,6 +1166,7 @@ class StorageScheduler(MetaStorageScheduler):
                             commitments, model.commitment_costs.values()
                         )
                     },
+                    "unit": self.flex_context["shared_currency_unit"],
                 },
             ]
         else:

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -1083,7 +1083,7 @@ class StorageFallbackScheduler(MetaStorageScheduler):
 
 
 class StorageScheduler(MetaStorageScheduler):
-    __version__ = "4"
+    __version__ = "5"
     __author__ = "Seita"
 
     fallback_scheduler_class: Type[Scheduler] = StorageFallbackScheduler

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -1178,7 +1178,7 @@ class StorageScheduler(MetaStorageScheduler):
             }
 
         if self.return_multiple:
-            return [
+            storage_schedules = [
                 {
                     "name": "storage_schedule",
                     "sensor": sensor,
@@ -1186,7 +1186,8 @@ class StorageScheduler(MetaStorageScheduler):
                     "unit": sensor.unit,
                 }
                 for sensor in sensors
-            ] + [
+            ]
+            commitment_costs = [
                 {
                     "name": "commitment_costs",
                     "data": {
@@ -1198,7 +1199,7 @@ class StorageScheduler(MetaStorageScheduler):
                     "unit": self.flex_context["shared_currency_unit"],
                 },
             ]
-            +[
+            soc_schedules = [
                 {
                     "name": "state_of_charge",
                     "data": soc,
@@ -1207,6 +1208,7 @@ class StorageScheduler(MetaStorageScheduler):
                 }
                 for sensor, soc in soc_schedule.items()
             ]
+            return storage_schedules + commitment_costs + soc_schedules
         else:
             return storage_schedule[sensors[0]]
 

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -655,6 +655,7 @@ class MetaStorageScheduler(Scheduler):
                 query_window=(start, end),
                 resolution=resolution,
                 beliefs_before=belief_time,
+                min_value=0,  # capacities are positive by definition
                 resolve_overlaps="min",
             )
 
@@ -672,6 +673,7 @@ class MetaStorageScheduler(Scheduler):
                     beliefs_before=belief_time,
                     fallback_attribute="production_capacity",
                     max_value=power_capacity_in_mw[d],
+                    min_value=0,  # capacities are positive by definition
                     resolve_overlaps="min",
                 )
             if sensor_d.get_attribute("is_strictly_non_negative"):
@@ -686,6 +688,7 @@ class MetaStorageScheduler(Scheduler):
                         resolution=resolution,
                         beliefs_before=belief_time,
                         fallback_attribute="consumption_capacity",
+                        min_value=0,  # capacities are positive by definition
                         max_value=power_capacity_in_mw[d],
                         resolve_overlaps="min",
                     )

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -506,7 +506,7 @@ class MetaStorageScheduler(Scheduler):
                 )
                 # todo: check flex-model for soc_minima_breach_price and soc_maxima_breach_price fields; if these are defined, create a StockCommitment using both prices (if only 1 price is given, still create the commitment, but only penalize one direction)
             if isinstance(soc_minima[d], Sensor):
-                soc_minima_d = get_continuous_series_sensor_or_quantity(
+                soc_minima[d] = get_continuous_series_sensor_or_quantity(
                     variable_quantity=soc_minima[d],
                     actuator=sensor_d,
                     unit="MWh",
@@ -531,8 +531,8 @@ class MetaStorageScheduler(Scheduler):
                     fill_sides=True,
                 )
                 # Set up commitments DataFrame
-                # soc_minima_d_temp is a temp variable because add_storage_constraints can't deal with Series yet
-                soc_minima_d_temp = get_continuous_series_sensor_or_quantity(
+                # soc_minima_d is a temp variable because add_storage_constraints can't deal with Series yet
+                soc_minima_d = get_continuous_series_sensor_or_quantity(
                     variable_quantity=soc_minima[d],
                     actuator=sensor_d,
                     unit="MWh",
@@ -544,7 +544,7 @@ class MetaStorageScheduler(Scheduler):
                 )
                 commitment = StockCommitment(
                     name="soc minima",
-                    quantity=soc_minima_d_temp,
+                    quantity=soc_minima_d,
                     # negative price because breaching in the downwards (shortage) direction is penalized
                     downwards_deviation_price=-soc_minima_breach_price,
                     _type="any",
@@ -554,10 +554,10 @@ class MetaStorageScheduler(Scheduler):
                 commitments.append(commitment)
 
                 # soc-minima will become a soft constraint (modelled as stock commitments), so remove hard constraint
-                soc_minima_d = None
+                soc_minima[d] = None
 
             if isinstance(soc_maxima[d], Sensor):
-                soc_maxima_d = get_continuous_series_sensor_or_quantity(
+                soc_maxima[d] = get_continuous_series_sensor_or_quantity(
                     variable_quantity=soc_maxima[d],
                     actuator=sensor_d,
                     unit="MWh",
@@ -582,8 +582,8 @@ class MetaStorageScheduler(Scheduler):
                     fill_sides=True,
                 )
                 # Set up commitments DataFrame
-                # soc_maxima_d_temp is a temp variable because add_storage_constraints can't deal with Series yet
-                soc_maxima_d_temp = get_continuous_series_sensor_or_quantity(
+                # soc_maxima_d is a temp variable because add_storage_constraints can't deal with Series yet
+                soc_maxima_d = get_continuous_series_sensor_or_quantity(
                     variable_quantity=soc_maxima[d],
                     actuator=sensor_d,
                     unit="MWh",
@@ -595,7 +595,7 @@ class MetaStorageScheduler(Scheduler):
                 )
                 commitment = StockCommitment(
                     name="soc maxima",
-                    quantity=soc_maxima_d_temp,
+                    quantity=soc_maxima_d,
                     # positive price because breaching in the upwards (surplus) direction is penalized
                     upwards_deviation_price=soc_maxima_breach_price,
                     _type="any",
@@ -605,7 +605,7 @@ class MetaStorageScheduler(Scheduler):
                 commitments.append(commitment)
 
                 # soc-maxima will become a soft constraint (modelled as stock commitments), so remove hard constraint
-                soc_maxima_d = None
+                soc_maxima[d] = None
 
             if soc_at_start[d] is not None:
                 device_constraints[d] = add_storage_constraints(
@@ -614,8 +614,8 @@ class MetaStorageScheduler(Scheduler):
                     resolution,
                     soc_at_start[d],
                     soc_targets[d],
-                    soc_maxima_d,
-                    soc_minima_d,
+                    soc_maxima[d],
+                    soc_minima[d],
                     soc_max[d],
                     soc_min[d],
                 )

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -471,7 +471,7 @@ class MetaStorageScheduler(Scheduler):
                     variable_quantity=soc_targets[d],
                     actuator=sensor_d,
                     unit="MWh",
-                    query_window=(start, end),
+                    query_window=(start + resolution, end + resolution),
                     resolution=resolution,
                     beliefs_before=belief_time,
                     as_instantaneous_events=True,
@@ -483,7 +483,7 @@ class MetaStorageScheduler(Scheduler):
                     variable_quantity=soc_minima[d],
                     actuator=sensor_d,
                     unit="MWh",
-                    query_window=(start, end),
+                    query_window=(start + resolution, end + resolution),
                     resolution=resolution,
                     beliefs_before=belief_time,
                     as_instantaneous_events=True,
@@ -501,12 +501,12 @@ class MetaStorageScheduler(Scheduler):
                     .declared_fields["soc_minima_breach_price"]
                     ._get_unit(soc_minima_breach_price)
                     + "*h",
-                    query_window=(start, end),
+                    query_window=(start + resolution, end + resolution),
                     resolution=resolution,
                     beliefs_before=belief_time,
                     fallback_attribute="soc-minima-breach-price",
                     fill_sides=True,
-                )
+                ).shift(-1, freq=resolution)
                 # Set up commitments DataFrame
                 # soc_minima_d is a temp variable because add_storage_constraints can't deal with Series yet
                 soc_minima_d = get_continuous_series_sensor_or_quantity(
@@ -544,7 +544,7 @@ class MetaStorageScheduler(Scheduler):
                     variable_quantity=soc_maxima[d],
                     actuator=sensor_d,
                     unit="MWh",
-                    query_window=(start, end),
+                    query_window=(start + resolution, end + resolution),
                     resolution=resolution,
                     beliefs_before=belief_time,
                     as_instantaneous_events=True,
@@ -562,12 +562,12 @@ class MetaStorageScheduler(Scheduler):
                     .declared_fields["soc_maxima_breach_price"]
                     ._get_unit(soc_maxima_breach_price)
                     + "*h",
-                    query_window=(start, end),
+                    query_window=(start + resolution, end + resolution),
                     resolution=resolution,
                     beliefs_before=belief_time,
                     fallback_attribute="soc-maxima-breach-price",
                     fill_sides=True,
-                )
+                ).shift(-1, freq=resolution)
                 # Set up commitments DataFrame
                 # soc_maxima_d is a temp variable because add_storage_constraints can't deal with Series yet
                 soc_maxima_d = get_continuous_series_sensor_or_quantity(

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -541,7 +541,11 @@ class MetaStorageScheduler(Scheduler):
                     beliefs_before=belief_time,
                     as_instantaneous_events=True,
                     resolve_overlaps="max",
-                )
+                ).shift(-1)
+                # shift soc minima by one resolution (they define a state at a certain time,
+                # while the commitment defines what the total stock should be at the end of a time slot,
+                # where the time slot is indexed by its starting time)
+
                 commitment = StockCommitment(
                     name="soc minima",
                     quantity=soc_minima_d - soc_at_start[d],
@@ -591,7 +595,10 @@ class MetaStorageScheduler(Scheduler):
                     beliefs_before=belief_time,
                     as_instantaneous_events=True,
                     resolve_overlaps="min",
-                )
+                ).shift(-1)
+                # shift soc maxima by one resolution (they define a state at a certain time,
+                # while the commitment defines what the total stock should be at the end of a time slot,
+                # where the time slot is indexed by its starting time)
                 commitment = StockCommitment(
                     name="soc maxima",
                     quantity=soc_maxima_d - soc_at_start[d],

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -499,7 +499,8 @@ class MetaStorageScheduler(Scheduler):
                     actuator=asset,
                     unit=FlexContextSchema()
                     .declared_fields["soc_minima_breach_price"]
-                    ._get_unit(soc_minima_breach_price),
+                    ._get_unit(soc_minima_breach_price)
+                    + "*h",
                     query_window=(start, end),
                     resolution=resolution,
                     beliefs_before=belief_time,
@@ -558,7 +559,8 @@ class MetaStorageScheduler(Scheduler):
                     actuator=asset,
                     unit=FlexContextSchema()
                     .declared_fields["soc_maxima_breach_price"]
-                    ._get_unit(soc_maxima_breach_price),
+                    ._get_unit(soc_maxima_breach_price)
+                    + "*h",
                     query_window=(start, end),
                     resolution=resolution,
                     beliefs_before=belief_time,

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -464,12 +464,12 @@ class MetaStorageScheduler(Scheduler):
                 )
                 commitment = FlowCommitment(
                     name=f"prefer curtailing device {d} later",
-                    quantity=0,
                     # Prefer curtailing consumption later by making later consumption more expensive
                     upwards_deviation_price=tiny_price_slope,
                     # Prefer curtailing production later by making later production more expensive
                     downwards_deviation_price=-tiny_price_slope,
                     index=index,
+                    device=d,
                 )
                 commitments.append(commitment)
 

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -506,7 +506,7 @@ class MetaStorageScheduler(Scheduler):
                 )
                 # todo: check flex-model for soc_minima_breach_price and soc_maxima_breach_price fields; if these are defined, create a StockCommitment using both prices (if only 1 price is given, still create the commitment, but only penalize one direction)
             if isinstance(soc_minima[d], Sensor):
-                soc_minima[d] = get_continuous_series_sensor_or_quantity(
+                soc_minima_d = get_continuous_series_sensor_or_quantity(
                     variable_quantity=soc_minima[d],
                     actuator=sensor_d,
                     unit="MWh",
@@ -531,8 +531,8 @@ class MetaStorageScheduler(Scheduler):
                     fill_sides=True,
                 )
                 # Set up commitments DataFrame
-                # soc_minima_d is a temp variable because add_storage_constraints can't deal with Series yet
-                soc_minima_d = get_continuous_series_sensor_or_quantity(
+                # soc_minima_d_temp is a temp variable because add_storage_constraints can't deal with Series yet
+                soc_minima_d_temp = get_continuous_series_sensor_or_quantity(
                     variable_quantity=soc_minima[d],
                     actuator=sensor_d,
                     unit="MWh",
@@ -544,7 +544,7 @@ class MetaStorageScheduler(Scheduler):
                 )
                 commitment = StockCommitment(
                     name="soc minima",
-                    quantity=soc_minima_d,
+                    quantity=soc_minima_d_temp,
                     # negative price because breaching in the downwards (shortage) direction is penalized
                     downwards_deviation_price=-soc_minima_breach_price,
                     _type="any",
@@ -554,10 +554,10 @@ class MetaStorageScheduler(Scheduler):
                 commitments.append(commitment)
 
                 # soc-minima will become a soft constraint (modelled as stock commitments), so remove hard constraint
-                soc_minima[d] = None
+                soc_minima_d = None
 
             if isinstance(soc_maxima[d], Sensor):
-                soc_maxima[d] = get_continuous_series_sensor_or_quantity(
+                soc_maxima_d = get_continuous_series_sensor_or_quantity(
                     variable_quantity=soc_maxima[d],
                     actuator=sensor_d,
                     unit="MWh",
@@ -582,8 +582,8 @@ class MetaStorageScheduler(Scheduler):
                     fill_sides=True,
                 )
                 # Set up commitments DataFrame
-                # soc_maxima_d is a temp variable because add_storage_constraints can't deal with Series yet
-                soc_maxima_d = get_continuous_series_sensor_or_quantity(
+                # soc_maxima_d_temp is a temp variable because add_storage_constraints can't deal with Series yet
+                soc_maxima_d_temp = get_continuous_series_sensor_or_quantity(
                     variable_quantity=soc_maxima[d],
                     actuator=sensor_d,
                     unit="MWh",
@@ -595,7 +595,7 @@ class MetaStorageScheduler(Scheduler):
                 )
                 commitment = StockCommitment(
                     name="soc maxima",
-                    quantity=soc_maxima_d,
+                    quantity=soc_maxima_d_temp,
                     # positive price because breaching in the upwards (surplus) direction is penalized
                     upwards_deviation_price=soc_maxima_breach_price,
                     _type="any",
@@ -605,7 +605,7 @@ class MetaStorageScheduler(Scheduler):
                 commitments.append(commitment)
 
                 # soc-maxima will become a soft constraint (modelled as stock commitments), so remove hard constraint
-                soc_maxima[d] = None
+                soc_maxima_d = None
 
             if soc_at_start[d] is not None:
                 device_constraints[d] = add_storage_constraints(
@@ -614,8 +614,8 @@ class MetaStorageScheduler(Scheduler):
                     resolution,
                     soc_at_start[d],
                     soc_targets[d],
-                    soc_maxima[d],
-                    soc_minima[d],
+                    soc_maxima_d,
+                    soc_minima_d,
                     soc_max[d],
                     soc_min[d],
                 )

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -1132,8 +1132,8 @@ class StorageScheduler(MetaStorageScheduler):
         ) = self._prepare(skip_validation=skip_validation)
 
         ems_schedule, expected_costs, scheduler_results, model = device_scheduler(
-            device_constraints,
-            ems_constraints,
+            device_constraints=device_constraints,
+            ems_constraints=ems_constraints,
             commitments=commitments,
             initial_stock=[
                 (

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -544,7 +544,7 @@ class MetaStorageScheduler(Scheduler):
                 )
                 commitment = StockCommitment(
                     name="soc minima",
-                    quantity=soc_minima_d,
+                    quantity=soc_minima_d - soc_at_start[d],
                     # negative price because breaching in the downwards (shortage) direction is penalized
                     downwards_deviation_price=-soc_minima_breach_price,
                     index=index,
@@ -594,7 +594,7 @@ class MetaStorageScheduler(Scheduler):
                 )
                 commitment = StockCommitment(
                     name="soc maxima",
-                    quantity=soc_maxima_d,
+                    quantity=soc_maxima_d - soc_at_start[d],
                     # positive price because breaching in the upwards (surplus) direction is penalized
                     upwards_deviation_price=soc_maxima_breach_price,
                     index=index,

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -277,7 +277,7 @@ class MetaStorageScheduler(Scheduler):
         commitments.append(commitment)
 
         # Set up peak commitments
-        if self.flex_context.get("ems_peak_consumption_price", None) is not None:
+        if self.flex_context.get("ems_peak_consumption_price") is not None:
             ems_peak_consumption = get_continuous_series_sensor_or_quantity(
                 variable_quantity=self.flex_context.get("ems_peak_consumption_in_mw"),
                 actuator=asset,
@@ -315,7 +315,7 @@ class MetaStorageScheduler(Scheduler):
                 index=index,
             )
             commitments.append(commitment)
-        if self.flex_context.get("ems_peak_production_price", None) is not None:
+        if self.flex_context.get("ems_peak_production_price") is not None:
             ems_peak_production = get_continuous_series_sensor_or_quantity(
                 variable_quantity=self.flex_context.get("ems_peak_production_in_mw"),
                 actuator=asset,
@@ -516,7 +516,7 @@ class MetaStorageScheduler(Scheduler):
                     as_instantaneous_events=True,
                     resolve_overlaps="max",
                 )
-            if self.flex_context.get("soc_minima_breach_price", None) is not None:
+            if self.flex_context.get("soc_minima_breach_price") is not None:
                 soc_minima_breach_price = self.flex_context["soc_minima_breach_price"]
                 soc_minima_breach_price = (
                     get_continuous_series_sensor_or_quantity(
@@ -570,7 +570,7 @@ class MetaStorageScheduler(Scheduler):
                     as_instantaneous_events=True,
                     resolve_overlaps="min",
                 )
-            if self.flex_context.get("soc_maxima_breach_price", None) is not None:
+            if self.flex_context.get("soc_maxima_breach_price") is not None:
                 soc_maxima_breach_price = self.flex_context["soc_maxima_breach_price"]
                 soc_maxima_breach_price = (
                     get_continuous_series_sensor_or_quantity(
@@ -925,8 +925,8 @@ class MetaStorageScheduler(Scheduler):
     def get_min_max_soc_on_sensor(
         self, adjust_unit: bool = False, deserialized_names: bool = True
     ) -> tuple[float | None, float | None]:
-        soc_min_sensor = self.sensor.get_attribute("min_soc_in_mwh", None)
-        soc_max_sensor = self.sensor.get_attribute("max_soc_in_mwh", None)
+        soc_min_sensor: float | None = self.sensor.get_attribute("min_soc_in_mwh")
+        soc_max_sensor: float | None = self.sensor.get_attribute("max_soc_in_mwh")
         soc_unit_label = "soc_unit" if deserialized_names else "soc-unit"
         if adjust_unit:
             if soc_min_sensor and self.flex_model.get(soc_unit_label) == "kWh":

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -513,17 +513,18 @@ class MetaStorageScheduler(Scheduler):
                     variable_quantity=soc_minima[d],
                     actuator=sensor_d,
                     unit="MWh",
-                    query_window=(start, end),
+                    query_window=(start + resolution, end + resolution),
                     resolution=resolution,
                     beliefs_before=belief_time,
                     as_instantaneous_events=True,
                     resolve_overlaps="max",
-                ).shift(-1) * (timedelta(hours=1) / resolution) - soc_at_start[d] * (
-                    timedelta(hours=1) / resolution
                 )
                 # shift soc minima by one resolution (they define a state at a certain time,
                 # while the commitment defines what the total stock should be at the end of a time slot,
                 # where the time slot is indexed by its starting time)
+                soc_minima_d = soc_minima_d.shift(-1, freq=resolution) * (
+                    timedelta(hours=1) / resolution
+                ) - soc_at_start[d] * (timedelta(hours=1) / resolution)
 
                 commitment = StockCommitment(
                     name="soc minima",
@@ -573,17 +574,19 @@ class MetaStorageScheduler(Scheduler):
                     variable_quantity=soc_maxima[d],
                     actuator=sensor_d,
                     unit="MWh",
-                    query_window=(start, end),
+                    query_window=(start + resolution, end + resolution),
                     resolution=resolution,
                     beliefs_before=belief_time,
                     as_instantaneous_events=True,
                     resolve_overlaps="min",
-                ).shift(-1) * (timedelta(hours=1) / resolution) - soc_at_start[d] * (
-                    timedelta(hours=1) / resolution
                 )
                 # shift soc maxima by one resolution (they define a state at a certain time,
                 # while the commitment defines what the total stock should be at the end of a time slot,
                 # where the time slot is indexed by its starting time)
+                soc_maxima_d = soc_maxima_d.shift(-1, freq=resolution) * (
+                    timedelta(hours=1) / resolution
+                ) - soc_at_start[d] * (timedelta(hours=1) / resolution)
+
                 commitment = StockCommitment(
                     name="soc maxima",
                     quantity=soc_maxima_d,

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -516,7 +516,10 @@ class MetaStorageScheduler(Scheduler):
                     as_instantaneous_events=True,
                     resolve_overlaps="max",
                 )
-            if self.flex_context.get("soc_minima_breach_price") is not None:
+            if (
+                self.flex_context.get("soc_minima_breach_price") is not None
+                and soc_minima[d] is not None
+            ):
                 soc_minima_breach_price = self.flex_context["soc_minima_breach_price"]
                 soc_minima_breach_price = get_continuous_series_sensor_or_quantity(
                     variable_quantity=soc_minima_breach_price,
@@ -570,7 +573,10 @@ class MetaStorageScheduler(Scheduler):
                     as_instantaneous_events=True,
                     resolve_overlaps="min",
                 )
-            if self.flex_context.get("soc_maxima_breach_price") is not None:
+            if (
+                self.flex_context.get("soc_maxima_breach_price") is not None
+                and soc_maxima[d] is not None
+            ):
                 soc_maxima_breach_price = self.flex_context["soc_maxima_breach_price"]
                 soc_maxima_breach_price = get_continuous_series_sensor_or_quantity(
                     variable_quantity=soc_maxima_breach_price,

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -875,6 +875,7 @@ class MetaStorageScheduler(Scheduler):
             # Extend schedule period in case a target exceeds its end
             self.possibly_extend_end(soc_targets=self.flex_model.get("soc_targets"))
         elif isinstance(self.flex_model, list):
+            # todo: ensure_soc_min_max in case the device is a storage (see line 847)
             self.flex_model = MultiSensorFlexModelSchema(many=True).load(
                 self.flex_model
             )

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -158,15 +158,7 @@ class MetaStorageScheduler(Scheduler):
             up_deviation_prices = get_continuous_series_sensor_or_quantity(
                 variable_quantity=consumption_price,
                 actuator=asset,
-                unit=(
-                    consumption_price.unit
-                    if isinstance(consumption_price, Sensor)
-                    else (
-                        consumption_price[0]["value"].units
-                        if isinstance(consumption_price, list)
-                        else str(consumption_price.units)
-                    )
-                ),
+                unit=get_unit(consumption_price),
                 query_window=(start, end),
                 resolution=resolution,
                 beliefs_before=belief_time,
@@ -185,15 +177,7 @@ class MetaStorageScheduler(Scheduler):
             down_deviation_prices = get_continuous_series_sensor_or_quantity(
                 variable_quantity=production_price,
                 actuator=asset,
-                unit=(
-                    production_price.unit
-                    if isinstance(production_price, Sensor)
-                    else (
-                        production_price[0]["value"].units
-                        if isinstance(production_price, list)
-                        else str(production_price.units)
-                    )
-                ),
+                unit=get_unit(production_price),
                 query_window=(start, end),
                 resolution=resolution,
                 beliefs_before=belief_time,
@@ -304,15 +288,7 @@ class MetaStorageScheduler(Scheduler):
             ems_peak_consumption_price = get_continuous_series_sensor_or_quantity(
                 variable_quantity=ems_peak_consumption_price,
                 actuator=asset,
-                unit=(
-                    ems_peak_consumption_price.unit
-                    if isinstance(ems_peak_consumption_price, Sensor)
-                    else (
-                        ems_peak_consumption_price[0]["value"].units
-                        if isinstance(ems_peak_consumption_price, list)
-                        else str(ems_peak_consumption_price.units)
-                    )
-                ),
+                unit=get_unit(ems_peak_consumption_price),
                 query_window=(start, end),
                 resolution=resolution,
                 beliefs_before=belief_time,
@@ -348,15 +324,7 @@ class MetaStorageScheduler(Scheduler):
             ems_peak_production_price = get_continuous_series_sensor_or_quantity(
                 variable_quantity=ems_peak_production_price,
                 actuator=asset,
-                unit=(
-                    ems_peak_production_price.unit
-                    if isinstance(ems_peak_production_price, Sensor)
-                    else (
-                        ems_peak_production_price[0]["value"].units
-                        if isinstance(ems_peak_production_price, list)
-                        else str(ems_peak_production_price.units)
-                    )
-                ),
+                unit=get_unit(ems_peak_production_price),
                 query_window=(start, end),
                 resolution=resolution,
                 beliefs_before=belief_time,
@@ -393,15 +361,7 @@ class MetaStorageScheduler(Scheduler):
             ems_consumption_breach_price = get_continuous_series_sensor_or_quantity(
                 variable_quantity=ems_consumption_breach_price,
                 actuator=asset,
-                unit=(
-                    ems_consumption_breach_price.unit
-                    if isinstance(ems_consumption_breach_price, Sensor)
-                    else (
-                        ems_consumption_breach_price[0]["value"].units
-                        if isinstance(ems_consumption_breach_price, list)
-                        else str(ems_consumption_breach_price.units)
-                    )
-                ),
+                unit=get_unit(ems_consumption_breach_price),
                 query_window=(start, end),
                 resolution=resolution,
                 beliefs_before=belief_time,
@@ -442,15 +402,7 @@ class MetaStorageScheduler(Scheduler):
             ems_production_breach_price = get_continuous_series_sensor_or_quantity(
                 variable_quantity=ems_production_breach_price,
                 actuator=asset,
-                unit=(
-                    ems_production_breach_price.unit
-                    if isinstance(ems_production_breach_price, Sensor)
-                    else (
-                        ems_production_breach_price[0]["value"].units
-                        if isinstance(ems_production_breach_price, list)
-                        else str(ems_production_breach_price.units)
-                    )
-                ),
+                unit=get_unit(ems_production_breach_price),
                 query_window=(start, end),
                 resolution=resolution,
                 beliefs_before=belief_time,
@@ -533,15 +485,7 @@ class MetaStorageScheduler(Scheduler):
                 soc_minima_breach_price = get_continuous_series_sensor_or_quantity(
                     variable_quantity=soc_minima_breach_price,
                     actuator=asset,
-                    unit=(
-                        soc_minima_breach_price.unit
-                        if isinstance(soc_minima_breach_price, Sensor)
-                        else (
-                            soc_minima_breach_price[0]["value"].units
-                            if isinstance(soc_minima_breach_price, list)
-                            else str(soc_minima_breach_price.units)
-                        )
-                    ),
+                    unit=get_unit(soc_minima_breach_price),
                     query_window=(start, end),
                     resolution=resolution,
                     beliefs_before=belief_time,
@@ -590,15 +534,7 @@ class MetaStorageScheduler(Scheduler):
                 soc_maxima_breach_price = get_continuous_series_sensor_or_quantity(
                     variable_quantity=soc_maxima_breach_price,
                     actuator=asset,
-                    unit=(
-                        soc_maxima_breach_price.unit
-                        if isinstance(soc_maxima_breach_price, Sensor)
-                        else (
-                            soc_maxima_breach_price[0]["value"].units
-                            if isinstance(soc_maxima_breach_price, list)
-                            else str(soc_maxima_breach_price.units)
-                        )
-                    ),
+                    unit=get_unit(soc_maxima_breach_price),
                     query_window=(start, end),
                     resolution=resolution,
                     beliefs_before=belief_time,
@@ -1623,6 +1559,15 @@ def validate_constraint(
         )
 
     return constraint_violations
+
+
+def get_unit(variable_quantity: Sensor | list[dict] | ur.Quantity) -> str:
+    """Obtain the unit from a variable quantity."""
+    if isinstance(variable_quantity, Sensor):
+        return variable_quantity.unit
+    if isinstance(variable_quantity, list):
+        return variable_quantity[0]["value"].units
+    return str(variable_quantity.units)
 
 
 def prepend_serie(serie: pd.Series, value) -> pd.Series:

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -1397,9 +1397,9 @@ def validate_storage_constraints(
     ##########################################
 
     _constraints["factor_w_wh(t)"] = resolution / timedelta(hours=1)
-    _constraints["min(t-1)"] = prepend_serie(_constraints["min(t)"], soc_min)
-    _constraints["equals(t-1)"] = prepend_serie(_constraints["equals(t)"], soc_at_start)
-    _constraints["max(t-1)"] = prepend_serie(_constraints["max(t)"], soc_max)
+    _constraints["min(t-1)"] = prepend_series(_constraints["min(t)"], soc_min)
+    _constraints["equals(t-1)"] = prepend_series(_constraints["equals(t)"], soc_at_start)
+    _constraints["max(t-1)"] = prepend_series(_constraints["max(t)"], soc_max)
 
     # 1) equals(t) - equals(t-1) <= derivative_max(t)
     constraint_violations += validate_constraint(
@@ -1570,19 +1570,19 @@ def get_unit(variable_quantity: Sensor | list[dict] | ur.Quantity) -> str:
     return str(variable_quantity.units)
 
 
-def prepend_serie(serie: pd.Series, value) -> pd.Series:
-    """Prepend a value to a time series series
+def prepend_series(series: pd.Series, value) -> pd.Series:
+    """Prepend a value to a time series
 
-    :param serie: serie containing the timed values
+    :param series: series containing the timed values
     :param value: value to place in the first position
     """
     # extend max
-    serie = serie.copy()
-    # insert `value` at time `serie.index[0] - resolution` which creates a new entry at the end of the series
-    serie[serie.index[0] - serie.index.freq] = value
+    series = series.copy()
+    # insert `value` at time `series.index[0] - resolution` which creates a new entry at the end of the series
+    series[series.index[0] - series.index.freq] = value
     # sort index to keep the time ordering
-    serie = serie.sort_index()
-    return serie.shift(1)
+    series = series.sort_index()
+    return series.shift(1)
 
 
 #####################

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -544,14 +544,16 @@ class MetaStorageScheduler(Scheduler):
                     beliefs_before=belief_time,
                     as_instantaneous_events=True,
                     resolve_overlaps="max",
-                ).shift(-1)
+                ).shift(-1) * (timedelta(hours=1) / resolution) - soc_at_start[d] * (
+                    timedelta(hours=1) / resolution
+                )
                 # shift soc minima by one resolution (they define a state at a certain time,
                 # while the commitment defines what the total stock should be at the end of a time slot,
                 # where the time slot is indexed by its starting time)
 
                 commitment = StockCommitment(
                     name="soc minima",
-                    quantity=soc_minima_d - soc_at_start[d],
+                    quantity=soc_minima_d,
                     # negative price because breaching in the downwards (shortage) direction is penalized
                     downwards_deviation_price=-soc_minima_breach_price,
                     index=index,
@@ -601,13 +603,15 @@ class MetaStorageScheduler(Scheduler):
                     beliefs_before=belief_time,
                     as_instantaneous_events=True,
                     resolve_overlaps="min",
-                ).shift(-1)
+                ).shift(-1) * (timedelta(hours=1) / resolution) - soc_at_start[d] * (
+                    timedelta(hours=1) / resolution
+                )
                 # shift soc maxima by one resolution (they define a state at a certain time,
                 # while the commitment defines what the total stock should be at the end of a time slot,
                 # where the time slot is indexed by its starting time)
                 commitment = StockCommitment(
                     name="soc maxima",
-                    quantity=soc_maxima_d - soc_at_start[d],
+                    quantity=soc_maxima_d,
                     # positive price because breaching in the upwards (surplus) direction is penalized
                     upwards_deviation_price=soc_maxima_breach_price,
                     index=index,

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -1154,6 +1154,7 @@ class StorageScheduler(MetaStorageScheduler):
                     "name": "storage_schedule",
                     "sensor": sensor,
                     "data": storage_schedule[sensor],
+                    "unit": sensor.unit,
                 }
                 for sensor in sensors
             ] + [

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -547,7 +547,6 @@ class MetaStorageScheduler(Scheduler):
                     quantity=soc_minima_d,
                     # negative price because breaching in the downwards (shortage) direction is penalized
                     downwards_deviation_price=-soc_minima_breach_price,
-                    _type="any",
                     index=index,
                     device=d,
                 )
@@ -598,7 +597,6 @@ class MetaStorageScheduler(Scheduler):
                     quantity=soc_maxima_d,
                     # positive price because breaching in the upwards (surplus) direction is penalized
                     upwards_deviation_price=soc_maxima_breach_price,
-                    _type="any",
                     index=index,
                     device=d,
                 )

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -494,18 +494,21 @@ class MetaStorageScheduler(Scheduler):
                 )
             if self.flex_context.get("soc_minima_breach_price", None) is not None:
                 soc_minima_breach_price = self.flex_context["soc_minima_breach_price"]
-                soc_minima_breach_price = get_continuous_series_sensor_or_quantity(
-                    variable_quantity=soc_minima_breach_price,
-                    actuator=asset,
-                    unit=FlexContextSchema()
-                    .declared_fields["soc_minima_breach_price"]
-                    ._get_unit(soc_minima_breach_price),
-                    query_window=(start, end),
-                    resolution=resolution,
-                    beliefs_before=belief_time,
-                    fallback_attribute="soc-minima-breach-price",
-                    fill_sides=True,
-                )
+                soc_minima_breach_price = (
+                    get_continuous_series_sensor_or_quantity(
+                        variable_quantity=soc_minima_breach_price,
+                        actuator=asset,
+                        unit=FlexContextSchema()
+                        .declared_fields["soc_minima_breach_price"]
+                        ._get_unit(soc_minima_breach_price),
+                        query_window=(start, end),
+                        resolution=resolution,
+                        beliefs_before=belief_time,
+                        fallback_attribute="soc-minima-breach-price",
+                        fill_sides=True,
+                    )
+                    + "*h",
+                )  # e.g. from EUR/(kWh*h) to EUR/kWh
                 # Set up commitments DataFrame
                 # soc_minima_d is a temp variable because add_storage_constraints can't deal with Series yet
                 soc_minima_d = get_continuous_series_sensor_or_quantity(
@@ -545,18 +548,21 @@ class MetaStorageScheduler(Scheduler):
                 )
             if self.flex_context.get("soc_maxima_breach_price", None) is not None:
                 soc_maxima_breach_price = self.flex_context["soc_maxima_breach_price"]
-                soc_maxima_breach_price = get_continuous_series_sensor_or_quantity(
-                    variable_quantity=soc_maxima_breach_price,
-                    actuator=asset,
-                    unit=FlexContextSchema()
-                    .declared_fields["soc_maxima_breach_price"]
-                    ._get_unit(soc_maxima_breach_price),
-                    query_window=(start, end),
-                    resolution=resolution,
-                    beliefs_before=belief_time,
-                    fallback_attribute="soc-maxima-breach-price",
-                    fill_sides=True,
-                )
+                soc_maxima_breach_price = (
+                    get_continuous_series_sensor_or_quantity(
+                        variable_quantity=soc_maxima_breach_price,
+                        actuator=asset,
+                        unit=FlexContextSchema()
+                        .declared_fields["soc_maxima_breach_price"]
+                        ._get_unit(soc_maxima_breach_price),
+                        query_window=(start, end),
+                        resolution=resolution,
+                        beliefs_before=belief_time,
+                        fallback_attribute="soc-maxima-breach-price",
+                        fill_sides=True,
+                    )
+                    + "*h",
+                )  # e.g. from EUR/(kWh*h) to EUR/kWh
                 # Set up commitments DataFrame
                 # soc_maxima_d is a temp variable because add_storage_constraints can't deal with Series yet
                 soc_maxima_d = get_continuous_series_sensor_or_quantity(

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -518,21 +518,18 @@ class MetaStorageScheduler(Scheduler):
                 )
             if self.flex_context.get("soc_minima_breach_price") is not None:
                 soc_minima_breach_price = self.flex_context["soc_minima_breach_price"]
-                soc_minima_breach_price = (
-                    get_continuous_series_sensor_or_quantity(
-                        variable_quantity=soc_minima_breach_price,
-                        actuator=asset,
-                        unit=FlexContextSchema()
-                        .declared_fields["soc_minima_breach_price"]
-                        ._get_unit(soc_minima_breach_price),
-                        query_window=(start, end),
-                        resolution=resolution,
-                        beliefs_before=belief_time,
-                        fallback_attribute="soc-minima-breach-price",
-                        fill_sides=True,
-                    )
-                    + "*h",
-                )  # e.g. from EUR/(kWh*h) to EUR/kWh
+                soc_minima_breach_price = get_continuous_series_sensor_or_quantity(
+                    variable_quantity=soc_minima_breach_price,
+                    actuator=asset,
+                    unit=FlexContextSchema()
+                    .declared_fields["soc_minima_breach_price"]
+                    ._get_unit(soc_minima_breach_price),
+                    query_window=(start, end),
+                    resolution=resolution,
+                    beliefs_before=belief_time,
+                    fallback_attribute="soc-minima-breach-price",
+                    fill_sides=True,
+                )
                 # Set up commitments DataFrame
                 # soc_minima_d is a temp variable because add_storage_constraints can't deal with Series yet
                 soc_minima_d = get_continuous_series_sensor_or_quantity(
@@ -572,21 +569,18 @@ class MetaStorageScheduler(Scheduler):
                 )
             if self.flex_context.get("soc_maxima_breach_price") is not None:
                 soc_maxima_breach_price = self.flex_context["soc_maxima_breach_price"]
-                soc_maxima_breach_price = (
-                    get_continuous_series_sensor_or_quantity(
-                        variable_quantity=soc_maxima_breach_price,
-                        actuator=asset,
-                        unit=FlexContextSchema()
-                        .declared_fields["soc_maxima_breach_price"]
-                        ._get_unit(soc_maxima_breach_price),
-                        query_window=(start, end),
-                        resolution=resolution,
-                        beliefs_before=belief_time,
-                        fallback_attribute="soc-maxima-breach-price",
-                        fill_sides=True,
-                    )
-                    + "*h",
-                )  # e.g. from EUR/(kWh*h) to EUR/kWh
+                soc_maxima_breach_price = get_continuous_series_sensor_or_quantity(
+                    variable_quantity=soc_maxima_breach_price,
+                    actuator=asset,
+                    unit=FlexContextSchema()
+                    .declared_fields["soc_maxima_breach_price"]
+                    ._get_unit(soc_maxima_breach_price),
+                    query_window=(start, end),
+                    resolution=resolution,
+                    beliefs_before=belief_time,
+                    fallback_attribute="soc-maxima-breach-price",
+                    fill_sides=True,
+                )
                 # Set up commitments DataFrame
                 # soc_maxima_d is a temp variable because add_storage_constraints can't deal with Series yet
                 soc_maxima_d = get_continuous_series_sensor_or_quantity(

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -2004,8 +2004,9 @@ def test_add_storage_constraint_from_sensor(
     scheduler_info = scheduler._prepare()
     storage_constraints = scheduler_info[5][0]
 
-    expected_target_start = pd.Timedelta(expected_start) + start
-    expected_target_end = pd.Timedelta(expected_end) + start
+    # Start (date) + start (time) - resolution (due to device_constraints indexing states by the start of their preceding time slot)
+    expected_target_start = start + pd.Timedelta(expected_start) - resolution
+    expected_target_end = start + pd.Timedelta(expected_end) - resolution
     expected_soc_target_value = 0.5 * timedelta(hours=1) / resolution
 
     # convert dates from UTC to local time (Europe/Amsterdam)

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -2003,6 +2003,12 @@ def test_add_storage_constraint_from_sensor(
     }
 
     flex_model["soc-targets"] = {"sensor": soc_targets.id}
+    flex_model["soc-maxima"] = [
+        {
+            "datetime": "2015-01-01T13:45:00+01:00",
+            "value": "0.4 MWh",
+        }
+    ]
 
     scheduler: Scheduler = StorageScheduler(
         battery, start, end, resolution, flex_model=flex_model
@@ -2036,7 +2042,10 @@ def test_add_storage_constraint_from_sensor(
     soc_schedule = integrate_time_series(
         consumption_schedule, soc_at_start, decimal_precision=6
     )
-    comparison_df = pd.concat([equals, soc_schedule], axis=1).dropna()
+    # Note the equality constraints are shifted back to account for how they define the index to denote
+    # the start of the event that ends in the given equality state, whereas the index of the soc_schedule
+    # denotes the exact time of the given SoC state
+    comparison_df = pd.concat([equals.shift(1), soc_schedule], axis=1).dropna()
     assert (
         len(comparison_df)
     ) == n_constraints, f"we expect {n_constraints} device constraints"

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -2035,7 +2035,7 @@ def test_soc_maxima_minima_targets(db, add_battery_assets, soc_sensors):
     power = add_battery_assets["Test battery with dynamic power capacity"].sensors[0]
     epex_da = get_test_sensor(db)
 
-    soc_maxima, soc_minima, soc_targets, values = soc_sensors
+    soc_maxima, soc_minima, soc_targets, expected_soc_schedule = soc_sensors
 
     tz = pytz.timezone("Europe/Amsterdam")
     start = tz.localize(datetime(2015, 1, 1))
@@ -2078,7 +2078,7 @@ def test_soc_maxima_minima_targets(db, add_battery_assets, soc_sensors):
     soc = check_constraints(power, schedule, soc_at_start)
 
     # soc targets are achieved
-    assert all(abs(soc[9:].values - values[:-1]) < 1e-5)
+    assert all(abs(soc[8:].values - expected_soc_schedule) < 1e-5)
 
     # remove soc-targets and use soc-maxima and soc-minima
     del flex_model["soc-targets"]
@@ -2091,7 +2091,7 @@ def test_soc_maxima_minima_targets(db, add_battery_assets, soc_sensors):
     # soc-maxima and soc-minima constraints are respected
     # this yields the same results as with the SOC targets
     # because soc-maxima = soc-minima = soc-targets
-    assert all(abs(soc[9:].values - values[:-1]) < 1e-5)
+    assert all(abs(soc[8:].values - expected_soc_schedule) < 1e-5)
 
 
 @pytest.mark.parametrize("unit", [None, "MWh", "kWh"])

--- a/flexmeasures/data/models/planning/tests/test_storage.py
+++ b/flexmeasures/data/models/planning/tests/test_storage.py
@@ -36,7 +36,7 @@ def test_battery_solver_multi_commitment(add_battery_assets, db):
             "soc-min": "0 MWh",
             "soc-max": "1 MWh",
             "power-capacity": "1 MW",
-            "soc-targets": [
+            "soc-minima": [
                 {
                     "datetime": "2015-01-02T00:00:00+01:00",
                     "value": "1 MWh",
@@ -78,6 +78,7 @@ def test_battery_solver_multi_commitment(add_battery_assets, db):
                 }
                 for i in production_prices.index
             ],
+            "soc-minima-breach-price": "100 EUR/kWh/min",  # high breach price (to mimic a hard constraint)
         },
         return_multiple=True,
     )

--- a/flexmeasures/data/models/planning/tests/test_storage.py
+++ b/flexmeasures/data/models/planning/tests/test_storage.py
@@ -86,6 +86,8 @@ def test_battery_solver_multi_commitment(add_battery_assets, db):
 
     schedule = results[0]["data"]
     costs = results[1]["data"]
+    costs_unit = results[1]["unit"]
+    assert costs_unit == "EUR"
 
     # Check if constraints were met
     check_constraints(battery, schedule, soc_at_start)

--- a/flexmeasures/data/models/planning/utils.py
+++ b/flexmeasures/data/models/planning/utils.py
@@ -510,13 +510,14 @@ def get_continuous_series_sensor_or_quantity(
     resolution: timedelta,
     beliefs_before: datetime | None = None,
     fallback_attribute: str | None = None,
+    min_value: float | int = np.nan,
     max_value: float | int | pd.Series = np.nan,
     as_instantaneous_events: bool = False,
     resolve_overlaps: str = "first",
     fill_sides: bool = False,
 ) -> pd.Series:
     """Creates a time series from a sensor, time series specification, or quantity within a specified window,
-    falling back to a given `fallback_attribute` and making sure no values exceed `max_value`.
+    falling back to a given `fallback_attribute` and making sure values stay within the domain [min_value, max_value].
 
     :param variable_quantity:       A sensor recording the data, a time series specification or a fixed quantity.
     :param actuator:                The actuator from which relevant defaults are retrieved.
@@ -525,6 +526,7 @@ def get_continuous_series_sensor_or_quantity(
     :param resolution:              The resolution or time interval for the data.
     :param beliefs_before:          Timestamp for prior beliefs or knowledge.
     :param fallback_attribute:      Attribute serving as a fallback default in case no quantity or sensor is given.
+    :param min_value:               Minimum value.
     :param max_value:               Maximum value (also replacing NaN values).
     :param as_instantaneous_events: optionally, convert to instantaneous events, in which case the passed resolution is
                                     interpreted as the desired frequency of the data.
@@ -556,6 +558,9 @@ def get_continuous_series_sensor_or_quantity(
 
     # Apply upper limit
     time_series = nanmin_of_series_and_value(time_series, max_value)
+
+    # Apply lower limit
+    time_series = time_series.clip(lower=min_value)
 
     return time_series
 

--- a/flexmeasures/data/models/planning/utils.py
+++ b/flexmeasures/data/models/planning/utils.py
@@ -429,7 +429,7 @@ def get_series_from_quantity_or_sensor(
             index=index,
             variable_quantity=variable_quantity,
             unit=unit,
-            resolution=resolution,
+            resolution=resolution if not as_instantaneous_events else timedelta(0),
             resolve_overlaps=resolve_overlaps,
             fill_sides=fill_sides,
         )

--- a/flexmeasures/data/models/planning/utils.py
+++ b/flexmeasures/data/models/planning/utils.py
@@ -354,7 +354,12 @@ def get_series_from_quantity_or_sensor(
         if np.isnan(variable_quantity.magnitude):
             magnitude = np.nan
         else:
-            magnitude = variable_quantity.to(unit).magnitude
+            magnitude = convert_units(
+                variable_quantity.magnitude,
+                str(variable_quantity.units),
+                unit,
+                resolution,
+            )
         time_series = pd.Series(magnitude, index=index, name="event_value")
     elif isinstance(variable_quantity, Sensor):
         bdf: tb.BeliefsDataFrame = TimedBelief.search(
@@ -370,7 +375,9 @@ def get_series_from_quantity_or_sensor(
         if as_instantaneous_events:
             bdf = bdf.resample_events(timedelta(0), boundary_policy=resolve_overlaps)
         time_series = simplify_index(bdf).reindex(index).squeeze()
-        time_series = convert_units(time_series, variable_quantity.unit, unit)
+        time_series = convert_units(
+            time_series, variable_quantity.unit, unit, resolution
+        )
     elif isinstance(variable_quantity, list):
         time_series = process_time_series_segments(
             index=index,
@@ -425,7 +432,9 @@ def process_time_series_segments(
             if np.isnan(value.magnitude):
                 value = np.nan
             else:
-                value = value.to(unit).magnitude
+                value = convert_units(
+                    value.magnitude, str(value.units), unit, resolution
+                )
         start = event["start"]
         end = event["end"]
         # Assign the value to the corresponding segment in the DataFrame

--- a/flexmeasures/data/models/planning/utils.py
+++ b/flexmeasures/data/models/planning/utils.py
@@ -503,7 +503,7 @@ def process_time_series_segments(
 
 
 def get_continuous_series_sensor_or_quantity(
-    variable_quantity: Sensor | list[dict] | ur.Quantity | None,
+    variable_quantity: Sensor | list[dict] | ur.Quantity | pd.Series | None,
     actuator: Sensor | Asset,
     unit: ur.Quantity | str,
     query_window: tuple[datetime, datetime],
@@ -538,6 +538,8 @@ def get_continuous_series_sensor_or_quantity(
                                     - The last available value serves as a naive forecast.
     :returns:                       time series data with missing values handled based on the chosen method.
     """
+    if isinstance(variable_quantity, pd.Series):
+        return variable_quantity
     if variable_quantity is None:
         variable_quantity = get_quantity_from_attribute(
             entity=actuator,

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -47,6 +47,10 @@ class FlexContextSchema(Schema):
         value_validator=validate.Range(min=0),
         default=None,
     )
+    # Dev field
+    relax_soc_constraints = fields.Bool(
+        data_key="relax-soc-constraints", load_default=False
+    )
 
     # Energy commitments
     ems_power_capacity_in_mw = VariableQuantityField(
@@ -135,6 +139,19 @@ class FlexContextSchema(Schema):
     inflexible_device_sensors = fields.List(
         SensorIdField(), data_key="inflexible-device-sensors"
     )
+
+    @validates_schema
+    def process_relax_soc_constraints(self, data: dict, **kwargs):
+        """Fill in default soc breach prices when asked to relax SoC constraints.
+
+        todo: this assumes EUR currency is used for all prices
+        """
+        if data["relax_soc_constraints"]:
+            if data.get("soc_minima_breach_price") is None:
+                data["soc_minima_breach_price"] = ur.Quantity("1000 EUR/kWh")
+            if data.get("soc_maxima_breach_price") is None:
+                data["soc_maxima_breach_price"] = ur.Quantity("1000 EUR/kWh")
+        return data
 
     @validates_schema
     def check_prices(self, data: dict, **kwargs):

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -244,6 +244,7 @@ class FlexContextSchema(Schema):
                         f"Prices must share the same monetary unit. '{field_name}' uses '{currency_unit}', but '{previous_field_name}' used '{shared_currency_unit}'.",
                         field_name=field_name,
                     )
+        data["shared_currency_unit"] = shared_currency_unit
         return data
 
 

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -34,14 +34,14 @@ class FlexContextSchema(Schema):
 
     # Device commitments
     soc_minima_breach_price = VariableQuantityField(
-        "/MWh",
+        "/(MWh*h)",
         data_key="soc-minima-breach-price",
         required=False,
         value_validator=validate.Range(min=0),
         default=None,
     )
     soc_maxima_breach_price = VariableQuantityField(
-        "/MWh",
+        "/(MWh*h)",
         data_key="soc-maxima-breach-price",
         required=False,
         value_validator=validate.Range(min=0),

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -184,9 +184,7 @@ class FlexContextSchema(Schema):
         for field in self.declared_fields:
             if field[-5:] == "price" and field in data:
                 price_field = self.declared_fields[field]
-                price_unit = self._get_variable_quantity_unit(
-                    price_field.data_key, data[field]
-                )
+                price_unit = price_field._get_unit(price_field.data_key, data[field])
                 currency_unit = price_unit.split("/")[0]
 
                 if previous_currency_unit is None:
@@ -216,30 +214,6 @@ class FlexContextSchema(Schema):
                         field_name=field_name,
                     )
         return data
-
-    def _get_variable_quantity_unit(
-        self, field_name: str, variable_quantity: ur.Quantity | list[dict | Sensor]
-    ) -> str:
-        """Gets the unit from the variable quantity."""
-        if isinstance(variable_quantity, ur.Quantity):
-            unit = str(variable_quantity.units)
-        elif isinstance(variable_quantity, list):
-            unit = str(variable_quantity[0]["value"].units)
-            if not all(
-                str(variable_quantity[j]["value"].units) == unit
-                for j in range(len(variable_quantity))
-            ):
-                raise ValidationError(
-                    "Segments of a time series must share the same unit.",
-                    field_name=field_name,
-                )
-        elif isinstance(variable_quantity, Sensor):
-            unit = variable_quantity.unit
-        else:
-            raise NotImplementedError(
-                f"Unexpected type '{type(variable_quantity)}' for variable_quantity describing '{field_name}': {variable_quantity}."
-            )
-        return unit
 
 
 class DBFlexContextSchema(FlexContextSchema):

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -71,6 +71,7 @@ class FlexContextSchema(Schema):
         return_magnitude=False,
     )
 
+    # Capacity breach commitments
     ems_production_capacity_in_mw = VariableQuantityField(
         "MW",
         required=False,

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -215,20 +215,24 @@ class FlexContextSchema(Schema):
                 currency_unit = price_unit.split("/")[0]
 
                 if previous_currency_unit is None:
-                    previous_currency_unit = currency_unit
+                    previous_currency_unit = str(
+                        ur.Quantity(currency_unit).to_base_units().units
+                    )
                     previous_field_name = price_field.data_key
-                elif units_are_convertible(currency_unit, previous_currency_unit):
+                if units_are_convertible(currency_unit, previous_currency_unit):
                     # Make sure all compatible currency units are on the same scale (e.g. not kEUR mixed with EUR)
                     if currency_unit != previous_currency_unit:
-                        denominator_unit = price_unit.split("/")[1]
+                        denominator_unit = str(
+                            ur.Unit(currency_unit) / ur.Unit(price_unit)
+                        )
                         if isinstance(data[field], ur.Quantity):
                             data[field] = data[field].to(
-                                f"{previous_currency_unit}/{denominator_unit}"
+                                f"{previous_currency_unit}/({denominator_unit})"
                             )
                         elif isinstance(data[field], list):
                             for j in range(len(data[field])):
                                 data[field][j]["value"] = data[field][j]["value"].to(
-                                    f"{previous_currency_unit}/{denominator_unit}"
+                                    f"{previous_currency_unit}/({denominator_unit})"
                                 )
                         elif isinstance(data[field], Sensor):
                             raise ValidationError(

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -184,7 +184,7 @@ class FlexContextSchema(Schema):
         for field in self.declared_fields:
             if field[-5:] == "price" and field in data:
                 price_field = self.declared_fields[field]
-                price_unit = price_field._get_unit(price_field.data_key, data[field])
+                price_unit = price_field._get_unit(data[field])
                 currency_unit = price_unit.split("/")[0]
 
                 if previous_currency_unit is None:

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -212,7 +212,11 @@ class FlexContextSchema(Schema):
             if field[-5:] == "price" and field in data:
                 price_field = self.declared_fields[field]
                 price_unit = price_field._get_unit(data[field])
-                currency_unit = price_unit.split("/")[0]
+                currency_unit = str(
+                    (
+                        ur.Quantity(price_unit) / ur.Quantity(f"1{price_field.to_unit}")
+                    ).units
+                )
 
                 if shared_currency_unit is None:
                     shared_currency_unit = str(

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -183,8 +183,10 @@ class FlexContextSchema(Schema):
         previous_field_name = None
         for field in self.declared_fields:
             if field[-5:] == "price" and field in data:
-                price_unit = self._get_variable_quantity_unit(field, data[field])
                 price_field = self.declared_fields[field]
+                price_unit = self._get_variable_quantity_unit(
+                    price_field.data_key, data[field]
+                )
                 currency_unit = price_unit.split("/")[0]
 
                 if previous_currency_unit is None:
@@ -216,7 +218,7 @@ class FlexContextSchema(Schema):
         return data
 
     def _get_variable_quantity_unit(
-        self, field: str, variable_quantity: ur.Quantity | list[dict | Sensor]
+        self, field_name: str, variable_quantity: ur.Quantity | list[dict | Sensor]
     ) -> str:
         """Gets the unit from the variable quantity."""
         if isinstance(variable_quantity, ur.Quantity):
@@ -227,7 +229,6 @@ class FlexContextSchema(Schema):
                 str(variable_quantity[j]["value"].units) == unit
                 for j in range(len(variable_quantity))
             ):
-                field_name = self.declared_fields[field].data_key
                 raise ValidationError(
                     "Segments of a time series must share the same unit.",
                     field_name=field_name,
@@ -236,7 +237,7 @@ class FlexContextSchema(Schema):
             unit = variable_quantity.unit
         else:
             raise NotImplementedError(
-                f"Unexpected type '{type(variable_quantity)}' for '{field}': {variable_quantity}."
+                f"Unexpected type '{type(variable_quantity)}' for variable_quantity describing '{field_name}': {variable_quantity}."
             )
         return unit
 

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -89,6 +89,14 @@ class StorageFlexModelSchema(Schema):
         "MW", data_key="production-capacity", required=False
     )
 
+    # Activation prices
+    prefer_curtailing_later = fields.Bool(
+        data_key="prefer-curtailing-later", load_default=True
+    )
+    prefer_charging_sooner = fields.Bool(
+        data_key="prefer-charging-sooner", load_default=True
+    )
+
     # Timezone placeholders for the soc_maxima, soc_minima and soc_targets fields are overridden in __init__
     soc_maxima = VariableQuantityField(
         to_unit="MWh",
@@ -135,9 +143,6 @@ class StorageFlexModelSchema(Schema):
     )
 
     storage_efficiency = VariableQuantityField("%", data_key="storage-efficiency")
-    prefer_charging_sooner = fields.Bool(
-        data_key="prefer-charging-sooner", load_default=True
-    )
 
     soc_gain = fields.List(
         VariableQuantityField("MW"),

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -376,7 +376,7 @@ class VariableQuantityField(MarshmallowClickMixin, fields.Field):
         return super().convert(_value, param, ctx, **kwargs)
 
     def _get_unit(self, variable_quantity: ur.Quantity | list[dict | Sensor]) -> str:
-        """Gets the unit from the variable quantity."""
+        """Obtain the unit from the variable quantity."""
         if isinstance(variable_quantity, ur.Quantity):
             unit = str(variable_quantity.units)
         elif isinstance(variable_quantity, list):

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -375,9 +375,7 @@ class VariableQuantityField(MarshmallowClickMixin, fields.Field):
 
         return super().convert(_value, param, ctx, **kwargs)
 
-    def _get_unit(
-        self, field_name: str, variable_quantity: ur.Quantity | list[dict | Sensor]
-    ) -> str:
+    def _get_unit(self, variable_quantity: ur.Quantity | list[dict | Sensor]) -> str:
         """Gets the unit from the variable quantity."""
         if isinstance(variable_quantity, ur.Quantity):
             unit = str(variable_quantity.units)
@@ -389,13 +387,13 @@ class VariableQuantityField(MarshmallowClickMixin, fields.Field):
             ):
                 raise ValidationError(
                     "Segments of a time series must share the same unit.",
-                    field_name=field_name,
+                    field_name=self.data_key,
                 )
         elif isinstance(variable_quantity, Sensor):
             unit = variable_quantity.unit
         else:
             raise NotImplementedError(
-                f"Unexpected type '{type(variable_quantity)}' for variable_quantity describing '{field_name}': {variable_quantity}."
+                f"Unexpected type '{type(variable_quantity)}' for variable_quantity describing '{self.data_key}': {variable_quantity}."
             )
         return unit
 

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -375,6 +375,30 @@ class VariableQuantityField(MarshmallowClickMixin, fields.Field):
 
         return super().convert(_value, param, ctx, **kwargs)
 
+    def _get_unit(
+        self, field_name: str, variable_quantity: ur.Quantity | list[dict | Sensor]
+    ) -> str:
+        """Gets the unit from the variable quantity."""
+        if isinstance(variable_quantity, ur.Quantity):
+            unit = str(variable_quantity.units)
+        elif isinstance(variable_quantity, list):
+            unit = str(variable_quantity[0]["value"].units)
+            if not all(
+                str(variable_quantity[j]["value"].units) == unit
+                for j in range(len(variable_quantity))
+            ):
+                raise ValidationError(
+                    "Segments of a time series must share the same unit.",
+                    field_name=field_name,
+                )
+        elif isinstance(variable_quantity, Sensor):
+            unit = variable_quantity.unit
+        else:
+            raise NotImplementedError(
+                f"Unexpected type '{type(variable_quantity)}' for variable_quantity describing '{field_name}': {variable_quantity}."
+            )
+        return unit
+
 
 class RepurposeValidatorToIgnoreSensorsAndLists(validate.Validator):
     """Validator that executes another validator (the one you initialize it with) only on non-Sensor and non-list values."""

--- a/flexmeasures/data/schemas/tests/test_scheduling.py
+++ b/flexmeasures/data/schemas/tests/test_scheduling.py
@@ -257,6 +257,25 @@ def test_efficiency_pair(
             },
             {"site-peak-production-price": "Must be greater than or equal to 0."},
         ),
+        (
+            {
+                "site-consumption-breach-price": [
+                    {
+                        "value": "1 KRW/MWh",
+                        "start": "2025-03-16T00:00+01",
+                        "duration": "P1D",
+                    },
+                    {
+                        "value": "1 KRW/MW",
+                        "start": "2025-03-16T00:00+01",
+                        "duration": "P1D",
+                    },
+                ],
+            },
+            {
+                "site-consumption-breach-price": "Segments of a time series must share the same unit."
+            },
+        ),
     ],
 )
 def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, fails):


### PR DESCRIPTION
## Description

User facing features:

- [x] Support flex-context fields for pricing SoC deviations from soc-minima/maxima, with a price unit that make costs independent of sensor resolution: EUR/(kWh*h)
- [x] New flex-context field: `relax-soc-constraints`
- [x] New flex-model field: `prefer-curtailing-later`
- [x] Documentation for new fields
- [x] Added changelog item in `documentation/changelog.rst`

Lower level features:

- [x] Support stock commitments per device (in `device_scheduler`)
- [x] Support flow commitments per device (in `device_scheduler`)

Fixes and tests:

- [x] Fixed price unit validation (the order of prices defined in the flex-context no longer matters)
- [x] Test new stock commitment
- [x] Test new fields

## Look & Feel

- To simply toggle on the new behaviour, include `{"relax-soc-constraints": true}` in your flex-context.
- For more fine-grained control over prioritizing various constraints of one another, set breach prices explicitly. For instance:
  - `{"soc-minima-breach-price": "2 EUR/kWh/min"}`
  - `{"soc-maxima-breach-price": "1 EUR/kWh/min"}`
  - Or alternatively, pass a time series, for example, to switch between a slight preference to return to a maximum SoC and a serious breach penalty:
    ```
    {
        "soc-maxima-breach-price": [
            {
                "start": "2025-04-01T10:00+02",
                "end": "2025-04-01T11:00+02",
                "value": "1 EUR/kWh/h",
            },
            {
                "start": "2025-04-01T11:00+02",
                "end": "2025-04-02T12:00+02",
                "value": "2 EUR/kWh/min",
            },
        ]
    }
    ```

## Further Improvements

- [ ] Copy new price fields from flex-context to flex-model (requires combined validation of currencies used in flex-context and flex-model prices)
- [ ] Support flex-model fields for pricing SoC deviations from **soc-targets**


## Related Items

- Inspired by #1120