### PR TITLE
fix: recursive error while rendering flexmeasures_template

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -33,6 +33,7 @@ Infrastructure / Support
 * For MacOS developers, install HiGHS solver automatically [see `PR #1187 <https://github.com/FlexMeasures/flexmeasures/pull/1187>`_]
 * Migrate data for the ``sensors_to_show`` asset attribute to a dedicated column in the database table for assets [see `PR #1200 <https://github.com/FlexMeasures/flexmeasures/pull/1200>`_ and `PR #1282 <https://github.com/FlexMeasures/flexmeasures/pull/1282>`_]
 * Add support for installing FlexMeasures under Python 3.12 [see `PR #1233 <https://github.com/FlexMeasures/flexmeasures/pull/1233>`_]
+* Better error handling in UI, for example, in case of a forgotten ``flexmeasures db upgrade`` [see `PR #1302 <https://github.com/FlexMeasures/flexmeasures/pull/1302>`_]
 
 Bugfixes
 -----------

--- a/flexmeasures/ui/error_handlers.py
+++ b/flexmeasures/ui/error_handlers.py
@@ -25,15 +25,14 @@ def handle_generic_http_exception(e: HTTPException):
         error_code = e.code
     error_text = getattr(e, "description", str(e))
     kwargs = dict(
-        "error.html",
         error_class=e.__class__.__name__,
         error_description="We encountered an Http exception.",
         error_message=error_text,
     )
     try:
-        return (render_flexmeasures_template(**kwargs), error_code)
+        return (render_flexmeasures_template("error.html", **kwargs), error_code)
     except Exception:  # noqa: B902
-        return (render_template(**kwargs), error_code)
+        return (render_template("error.html", **kwargs), error_code)
 
 
 def handle_500_error(e: InternalServerError):

--- a/flexmeasures/ui/error_handlers.py
+++ b/flexmeasures/ui/error_handlers.py
@@ -1,6 +1,6 @@
 """Error views for UI purposes."""
 
-from flask import Flask, render_template
+from flask import Flask
 from werkzeug.exceptions import BadRequest, InternalServerError, HTTPException
 
 from flexmeasures.ui.utils.view_utils import render_flexmeasures_template
@@ -24,16 +24,15 @@ def handle_generic_http_exception(e: HTTPException):
     if hasattr(e, "code") and e.code is not None:
         error_code = e.code
     error_text = getattr(e, "description", str(e))
-    kwargs = dict(
-        "error.html",
-        error_class=e.__class__.__name__,
-        error_description="We encountered an Http exception.",
-        error_message=error_text,
+    return (
+        render_flexmeasures_template(
+            "error.html",
+            error_class=e.__class__.__name__,
+            error_description="We encountered an Http exception.",
+            error_message=error_text,
+        ),
+        error_code,
     )
-    try:
-        return (render_flexmeasures_template(**kwargs), error_code)
-    except Exception:  # noqa: B902
-        return (render_template(**kwargs), error_code)
 
 
 def handle_500_error(e: InternalServerError):

--- a/flexmeasures/ui/error_handlers.py
+++ b/flexmeasures/ui/error_handlers.py
@@ -1,6 +1,6 @@
 """Error views for UI purposes."""
 
-from flask import Flask
+from flask import Flask, render_template
 from werkzeug.exceptions import BadRequest, InternalServerError, HTTPException
 
 from flexmeasures.ui.utils.view_utils import render_flexmeasures_template
@@ -24,15 +24,16 @@ def handle_generic_http_exception(e: HTTPException):
     if hasattr(e, "code") and e.code is not None:
         error_code = e.code
     error_text = getattr(e, "description", str(e))
-    return (
-        render_flexmeasures_template(
-            "error.html",
-            error_class=e.__class__.__name__,
-            error_description="We encountered an Http exception.",
-            error_message=error_text,
-        ),
-        error_code,
+    kwargs = dict(
+        "error.html",
+        error_class=e.__class__.__name__,
+        error_description="We encountered an Http exception.",
+        error_message=error_text,
     )
+    try:
+        return (render_flexmeasures_template(**kwargs), error_code)
+    except Exception:  # noqa: B902
+        return (render_template(**kwargs), error_code)
 
 
 def handle_500_error(e: InternalServerError):

--- a/flexmeasures/ui/error_handlers.py
+++ b/flexmeasures/ui/error_handlers.py
@@ -25,14 +25,15 @@ def handle_generic_http_exception(e: HTTPException):
         error_code = e.code
     error_text = getattr(e, "description", str(e))
     kwargs = dict(
+        "error.html",
         error_class=e.__class__.__name__,
         error_description="We encountered an Http exception.",
         error_message=error_text,
     )
     try:
-        return (render_flexmeasures_template("error.html", **kwargs), error_code)
+        return (render_flexmeasures_template(**kwargs), error_code)
     except Exception:  # noqa: B902
-        return (render_template("error.html", **kwargs), error_code)
+        return (render_template(**kwargs), error_code)
 
 
 def handle_500_error(e: InternalServerError):

--- a/flexmeasures/ui/utils/view_utils.py
+++ b/flexmeasures/ui/utils/view_utils.py
@@ -31,8 +31,9 @@ def fall_back_to_flask_template(render_function):
         try:
             return render_function(template_name, *args, **kwargs)
         except Exception as e:
-            current_app.logger.error(
-                f"render_flexmeasures_template failed to load {template_name}, due to {e}."
+            current_app.logger.warning(
+                f"""Rendering via Flask's render_template("{template_name}"). """
+                f"""Failed to render via {render_function.__name__}("{template_name}") due to {e}."""
             )
             return render_template(template_name, **kwargs)
 

--- a/flexmeasures/ui/utils/view_utils.py
+++ b/flexmeasures/ui/utils/view_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import wraps
 import json
 import os
 import subprocess
@@ -22,6 +23,20 @@ from flexmeasures.ui.utils.chart_defaults import chart_options
 from flexmeasures.ui.utils.color_defaults import get_color_settings
 
 
+def fall_back_to_flask_template(render_function):
+    """In case the render_function is raising an error, fall back to using flask.render_template."""
+
+    @wraps(render_function)
+    def wrapper(template_name, *args, **kwargs):
+        try:
+            return render_function(template_name, *args, **kwargs)
+        except Exception:  # noqa: B902
+            return render_template(template_name, **kwargs)
+
+    return wrapper
+
+
+@fall_back_to_flask_template
 def render_flexmeasures_template(html_filename: str, **variables):
     """Render template and add all expected template variables, plus the ones given as **variables."""
     variables["FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY"] = current_app.config.get(

--- a/flexmeasures/ui/utils/view_utils.py
+++ b/flexmeasures/ui/utils/view_utils.py
@@ -34,10 +34,6 @@ def fall_back_to_flask_template(render_function):
             current_app.logger.error(
                 f"render_flexmeasures_template failed to load {template_name}, due to {e}."
             )
-            if template_name == "error.html":
-                current_app.logger.error(
-                    f"The error page was attempting to show: {kwargs}"
-                )
             return render_template(template_name, **kwargs)
 
     return wrapper

--- a/flexmeasures/ui/utils/view_utils.py
+++ b/flexmeasures/ui/utils/view_utils.py
@@ -34,6 +34,10 @@ def fall_back_to_flask_template(render_function):
             current_app.logger.error(
                 f"render_flexmeasures_template failed to load {template_name}, due to {e}."
             )
+            if template_name == "error.html":
+                current_app.logger.error(
+                    f"The error page was attempting to show: {kwargs}"
+                )
             return render_template(template_name, **kwargs)
 
     return wrapper

--- a/flexmeasures/ui/utils/view_utils.py
+++ b/flexmeasures/ui/utils/view_utils.py
@@ -30,7 +30,10 @@ def fall_back_to_flask_template(render_function):
     def wrapper(template_name, *args, **kwargs):
         try:
             return render_function(template_name, *args, **kwargs)
-        except Exception:  # noqa: B902
+        except Exception as e:
+            current_app.logger.error(
+                f"render_flexmeasures_template failed to load {template_name}, due to {e}."
+            )
             return render_template(template_name, **kwargs)
 
     return wrapper


### PR DESCRIPTION
## Description

- [x] Improve error handler: in case `render_flexmeasures_template` is also raising an error, fall back to using `flask.render_template`
- [x] Added changelog item in `documentation/changelog.rst`

## Look & Feel

Before:

![image](https://github.com/user-attachments/assets/c588bc9b-19cb-4528-a493-7232428810de)

After:

![image](https://github.com/user-attachments/assets/1af96562-55ce-4751-a5b3-c801e8af6f51)

## How to test

- `git checkout 79352c038088c079c29fd215f4b9bf5ca78e64af`
- `flexmeasures db downgrade 0af134879301` (create an intentional mismatch between the server code and the db version)
- `flexmeasures run`
- Log in to the UI to trigger a `ProgrammingError`

## Rejected Ideas

The failing part in `render_flexmeasures_template` that retriggered the `ProgrammingError` in this particular case was:

```
    account: Account | None = (
        current_user.account if current_user.is_authenticated else None
    )
```

Rather than try-excepting this particular line (or otherwise making it more robust), I opted to make the HTTP error handler more robust. This error handler is the default for failing UI requests.

## Further Improvements

Possibly, the other error handlers should also fall back to the standard `flask.render_template` in case `render_flexmeasures_template` raises an exception. What do you think?


## Related Items

- The DB upgrade to 0.24.

