### PR TITLE
fix: asset editing form did not show map due to wrong whitespacing in template

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -15,6 +15,8 @@ Infrastructure / Support
 
 Bugfixes
 -----------
+* Fix map not loading when editing an asset [see `PR #1310 <https://github.com/FlexMeasures/flexmeasures/pull/1310>`_]
+
 
 
 v0.24.0 | January 7, 2025

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -922,7 +922,7 @@
     });
     var marker = L
         .marker(
-            [{{ asset.latitude | replace("None", 10) }}, { { asset.longitude | replace("None", 10) } }],
+            [{{ asset.latitude | replace("None", 10) }}, {{ asset.longitude | replace("None", 10) }}],
     { icon: asset_icon }
         ).addTo(assetMap);
 


### PR DESCRIPTION
## Description

Summary of the changes introduced in this PR. Try to use bullet points as much as possible.

- [X] fixes #1309 
- [ ] Added changelog item in `documentation/changelog.rst`

## Look & Feel

The asset editing form loads correctly.

## How to test

Load any asset page.
