### PR TITLE
fix: reformated code to support python variables inside HTML

### DIFF
--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -921,10 +921,9 @@
         popupAnchor: [0, -50] // point from which the popup should open relative to the iconAnchor
     });
     var marker = L
-        .marker(
-            [{{ asset.latitude | replace("None", 10) }}, { { asset.longitude | replace("None", 10) } }],
-    { icon: asset_icon }
-        ).addTo(assetMap);
+    .marker(
+        [{{ asset.latitude | replace("None", 10) }}, {{ asset.longitude | replace("None", 10) }}], {icon: asset_icon}
+    ).addTo(assetMap);
 
     assetMap.on('click', function (e) {
         $("#latitude").val(e.latlng.lat.toFixed(4));


### PR DESCRIPTION
## Description

This PR fixed a small bug in the asset details page caused by misconfigured auto formatters.


## Look & Feel


## How to test

1. Visit the assets page
2. click on an asset to view its details

## Further Improvements

None

## Related Items

This PR closes issue #1309 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
