### PR TITLE
fix: duplicate sphinx key was overwriting crucial setting

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,7 @@ version: 2
 
 sphinx:
   configuration: documentation/conf.py
+  fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF
 #formats:
@@ -24,6 +25,3 @@ python:
     - requirements: requirements/3.9/app.txt
     - requirements: requirements/3.9/docs.txt
 
-
-sphinx:
-  fail_on_warning: true


### PR DESCRIPTION
Closes #1315 

The problem was a duplicate key `sphinx` which should not overwrite silently, but does.

[This build](https://readthedocs.org/projects/flexmeasures/builds/26933574/) was made with the altered .readthedocs.yml (click on the "cat .readthedocs.yaml" step to see it) and ran fine.