### PR TITLE
Reporter for dropping data outside of allowed range

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -14,6 +14,7 @@ Infrastructure / Support
 ----------------------
 * Enhance reporting infrastructure by ensuring that all ``Sensor.search_beliefs`` filters can be used as report parameters [see `PR #1318 <https://github.com/FlexMeasures/flexmeasures/pull/1318>`_]
 * Improve searching for multi-sourced data by returning data from only the latest version of a data generator (e.g. forecaster or scheduler) by default, when using ``Sensor.search_beliefs`` [see `PR #1306 <https://github.com/FlexMeasures/flexmeasures/pull/1306>`_]
+* Extra reporter tests [see `PR #1317 <https://github.com/FlexMeasures/flexmeasures/pull/1317>`_]
 
 Bugfixes
 -----------

--- a/flexmeasures/data/models/reporting/tests/test_pandas_reporter.py
+++ b/flexmeasures/data/models/reporting/tests/test_pandas_reporter.py
@@ -254,9 +254,9 @@ def test_pandas_reporter_valid_range(app, setup_dummy_data, shortcut):
                 "df_output": "ranged values",
             },
             {
-                "df_input": "ranged values",
+                # "df_input": "ranged values",  # redundant: defaults to previous df_output
                 "method": "dropna",
-                "df_output": "ranged values",
+                # "df_output": "ranged values",  # redundant: defaults to current df_input
             },
         ]
     else:
@@ -280,15 +280,15 @@ def test_pandas_reporter_valid_range(app, setup_dummy_data, shortcut):
                 "df_output": "ranged values",
             },
             {
-                "df_input": "ranged values",
+                # "df_input": "ranged values",  # redundant: defaults to previous df_output
                 "method": "where",
                 "args": ["@lt_value"],
-                "df_output": "ranged values",
+                # "df_output": "ranged values",  # redundant: defaults to current df_input
             },
             {
-                "df_input": "ranged values",
+                # "df_input": "ranged values",  # redundant: defaults to previous df_output
                 "method": "dropna",
-                "df_output": "ranged values",
+                # "df_output": "ranged values",  # redundant: defaults to current df_input
             },
         ]
 

--- a/flexmeasures/data/models/reporting/tests/test_pandas_reporter.py
+++ b/flexmeasures/data/models/reporting/tests/test_pandas_reporter.py
@@ -236,40 +236,40 @@ def test_pandas_reporter_valid_range(app, setup_dummy_data):
 
     reporter_config = dict(
         required_input=[
-            {"name": "any_values"},
+            {"name": "any values"},
         ],
         required_output=[
-            {"name": "ranged_values"},
+            {"name": "ranged values"},
         ],
         transformations=[
             {
-                "df_input": "any_values",
+                "df_input": "any values",
                 "method": "gt",
                 "args": [range[0]],
                 "df_output": "gt_value",
             },
             {
-                "df_input": "any_values",
+                "df_input": "any values",
                 "method": "lt",
                 "args": [range[1]],
                 "df_output": "lt_value",
             },
             {
-                "df_input": "any_values",
+                "df_input": "any values",
                 "method": "where",
                 "args": ["@gt_value"],
-                "df_output": "ranged_values",
+                "df_output": "ranged values",
             },
             {
-                "df_input": "ranged_values",
+                "df_input": "ranged values",
                 "method": "where",
                 "args": ["@lt_value"],
-                "df_output": "ranged_values",
+                "df_output": "ranged values",
             },
             {
-                "df_input": "ranged_values",
+                "df_input": "ranged values",
                 "method": "dropna",
-                "df_output": "ranged_values",
+                "df_output": "ranged values",
             },
         ],
     )
@@ -279,10 +279,10 @@ def test_pandas_reporter_valid_range(app, setup_dummy_data):
     start = datetime(2023, 4, 10, tzinfo=utc)
     end = datetime(2023, 4, 11, tzinfo=utc)
     input = [
-        dict(name="any_values", sensor=s1),
+        dict(name="any values", sensor=s1),
     ]
     output = [
-        dict(name="ranged_values", sensor=s1),
+        dict(name="ranged values", sensor=s1),
     ]
 
     report = reporter.compute(start=start, end=end, input=input, output=output)


### PR DESCRIPTION
## Description

- [x] feat: add test showing what transformations can be used to select only values within a certain range
- [x] Added changelog item in `documentation/changelog.rst`

## Look & Feel

An example `reporter-config.yaml`:
```yaml
# This reporter config drops all values outside the range (1, 9]

# Required input and output specifications
required_input:
  - name: any values  # Input data column
required_output:
  - name: ranged values  # Output data column

# List of transformation steps for the range (1, 9]
transformations:

  # Greater than 1
  - df_input: any values  # Input data column for this step
    df_output: gt output  # Output data column for this step
    method: gt  # Greater than
    args: [1]     # 1
  # Less than or equal to 9
  - df_input: any values
    df_output: le output
    method: le  # Less than or equal to
    args: [9]     # 9
  # Apply 1st filter
  - df_input: any values
    df_output: ranged values
    method: where
    args: ["@gt_value"]
  # Apply 2nd filter
  - method: where
    args: ["@le_value"]
  # Drop all outside the range
  - method: dropna
```

Alternatively (shorter, using pandas.eval internally):

```yaml
# This reporter config drops all values outside the range (1, 9]

# Required input and output specifications
required_input:
  - name: any values  # Input data column
required_output:
  - name: ranged values  # Output data column

# List of transformation steps for the range (1, 9]
transformations:

  - df_input: any values
    df_output: mask
    method: eval
    args: ["event_value > 1 & event_value <= 9"]
  - df_input: any values
    df_output: ranged values
    method: where
    args: ["@mask"]
  - method: dropna
```

And a matching `report-parameters.yaml`:

```yaml
# These report parameters take the most recent belief of sensor 42 as input, and save the output back to sensor 42 (sourced by a `PandasReporter`)

input:
  - sensor: 42
    name: any values
output:
  - sensor: 42
    name: ranged values
```


## How to test

Test included.

## Further Improvements

- [x] Discuss allowing the range to be specified in the input rather than than the config.

