### PR TITLE
Chore/actions/cache v2 deprecation

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -39,7 +39,7 @@ jobs:
           git fetch --prune --unshallow
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: "Caching for dependencies (.txt) - restore existing or ensure new cache will be made"
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache
         with:
           path: ${{ env.pythonLocation }}

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -18,8 +18,7 @@ jobs:
 
   test:
     needs: check
-    # fixed for now due to problems with 22.04 (see #551), try -latest sometime
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -16,6 +16,7 @@ Infrastructure / Support
 * Improve searching for multi-sourced data by returning data from only the latest version of a data generator (e.g. forecaster or scheduler) by default, when using ``Sensor.search_beliefs`` [see `PR #1306 <https://github.com/FlexMeasures/flexmeasures/pull/1306>`_]
 * Extra reporter tests [see `PR #1317 <https://github.com/FlexMeasures/flexmeasures/pull/1317>`_]
 * Catch invalid time windows passed to ``flexmeasures add report`` [see `PR #1324 <https://github.com/FlexMeasures/flexmeasures/pull/1324>`_]
+* Update cache and Ubuntu versions used for testing in GitHub Actions [see `PR #1329 <https://github.com/FlexMeasures/flexmeasures/pull/1329>`_]
 
 Bugfixes
 -----------


### PR DESCRIPTION
## Description

A [scheduled brownout](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down) caught my attention.

- [x] Update to using `actions/cache@v4`
- [x] Resolve a long-standing todo in `lint-and-test.yaml`
- [x] Added changelog item in `documentation/changelog.rst`
