### PR TITLE
ci: so not fail when coveralls fails

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -59,6 +59,7 @@ jobs:
         run: pytest -v -m "not skip_github" --cov=flexmeasures --cov-branch --cov-report=lcov
       - name: Coveralls
         uses: coverallsapp/github-action@v2
+        fail-on-error: false
         if: ${{ matrix.coverage == 'yes' }}
     env:
       PGHOST: 127.0.0.1

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -59,7 +59,8 @@ jobs:
         run: pytest -v -m "not skip_github" --cov=flexmeasures --cov-branch --cov-report=lcov
       - name: Coveralls
         uses: coverallsapp/github-action@v2
-        fail-on-error: false
+        with:
+          fail-on-error: false
         if: ${{ matrix.coverage == 'yes' }}
     env:
       PGHOST: 127.0.0.1


### PR DESCRIPTION
## Description

Sometimes GitHub Actions fails because Coveralls has some hickups. That should not be the case
