### PR TITLE
Feat/cli/jobs/save last failed

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -11,6 +11,7 @@ v0.25.0 | February XX, 2025
 
 New features
 -------------
+* Add CLI command ``flexmeasures jobs save-last-failed`` for saving the last failed jobs [see `PR #1342 <https://www.github.com/FlexMeasures/flexmeasures/pull/1342>`_]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -7,6 +7,7 @@ FlexMeasures CLI Changelog
 since v0.25.0 | February XX, 2024
 =================================
 * Report parameters set using ``flexmeasures add report --parameters`` can use any argument supported by ``Sensor.search_beliefs`` to allow more control over input for the report.
+* Add ``flexmeasures jobs save-last-failed`` CLI command for saving the last n failed jobs (from the scheduling queue, by default).
 
 since v0.24.0 | January 6, 2024
 =================================


### PR DESCRIPTION
## Description

Summary of the changes introduced in this PR. Try to use bullet points as much as possible.

- [x] New CLI command to save the last n failed jobs (10 jobs from the scheduling queue, by default)
- [x] Added changelog item in `documentation/changelog.rst`
- [x] Added CLI changelog item in `documentation/cli/change_log.rst`

## Look & Feel

```
flexmeasures jobs save-last-failed
flexmeasures jobs save-last-failed --n 5 --queue scheduling --file "last-5-failed.csv"
```

![image](https://github.com/user-attachments/assets/e1a4ff59-1117-4c37-aa7c-c253a97cb3f9)
