### PR TITLE
Better y-axis titles when showing multiple sensors

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -55,6 +55,10 @@ jobs:
       - name: Install FlexMeasures & latest dependencies for tests
         run: make install-for-test pinned=no
         if: github.event_name == 'pull_request'
+      - name: Run all doctests in the data/schemas subpackage
+        run: pytest flexmeasures/data/schemas --doctest-modules --ignore flexmeasures/data/schemas/tests
+      - name: Run all doctests in the utils subpackage
+        run: pytest flexmeasures/utils --doctest-modules --ignore flexmeasures/utils/tests
       - name: Run all tests except those marked to be skipped by GitHub AND record coverage
         run: pytest -v -m "not skip_github" --cov=flexmeasures --cov-branch --cov-report=lcov
       - name: Coveralls

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -11,6 +11,7 @@ v0.25.0 | February XX, 2025
 
 New features
 -------------
+* Better y-axis titles for charts that show multiple sensors with a shared unit [see `PR #1346 <https://github.com/FlexMeasures/flexmeasures/pull/1346>`_]
 
 Infrastructure / Support
 ----------------------
@@ -20,6 +21,7 @@ Infrastructure / Support
 * Extra reporter tests [see `PR #1317 <https://github.com/FlexMeasures/flexmeasures/pull/1317>`_]
 * Catch invalid time windows passed to ``flexmeasures add report`` [see `PR #1324 <https://github.com/FlexMeasures/flexmeasures/pull/1324>`_]
 * Test utility function for device scheduling in a multi-asset setting (sequential and simultaneous) [see `PR #1341 <https://github.com/FlexMeasures/flexmeasures/pull/1341>`_]
+* Add utils doctests to our CI pipeline [see `PR #1347 <https://github.com/FlexMeasures/flexmeasures/pull/1347>`_]
 
 Bugfixes
 -----------

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -11,6 +11,7 @@ from flexmeasures.utils.unit_utils import (
     is_power_unit,
     is_energy_unit,
     is_energy_price_unit,
+    is_temperature_unit,
 )
 
 
@@ -666,6 +667,8 @@ def determine_shared_sensor_type(sensors: list["Sensor"]) -> str:  # noqa F821
         return "energy"
     elif is_energy_price_unit(shared_unit):
         return "energy price"
+    elif is_temperature_unit(shared_unit):
+        return "temperature"
     return "value"
 
 

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -7,12 +7,7 @@ from flexmeasures.utils.flexmeasures_inflection import (
     capitalize,
 )
 from flexmeasures.utils.coding_utils import flatten_unique
-from flexmeasures.utils.unit_utils import (
-    is_power_unit,
-    is_energy_unit,
-    is_energy_price_unit,
-    is_temperature_unit,
-)
+from flexmeasures.utils.unit_utils import get_unit_dimension
 
 
 def create_bar_chart_or_histogram_specs(
@@ -661,15 +656,7 @@ def determine_shared_sensor_type(sensors: list["Sensor"]) -> str:  # noqa F821
 
     # Check the units for common cases
     shared_unit = determine_shared_unit(sensors)
-    if is_power_unit(shared_unit):
-        return "power"
-    elif is_energy_unit(shared_unit):
-        return "energy"
-    elif is_energy_price_unit(shared_unit):
-        return "energy price"
-    elif is_temperature_unit(shared_unit):
-        return "temperature"
-    return "value"
+    return get_unit_dimension(shared_unit)
 
 
 def create_line_layer(

--- a/flexmeasures/data/models/data_sources.py
+++ b/flexmeasures/data/models/data_sources.py
@@ -325,9 +325,9 @@ class DataSource(db.Model, tb.BeliefSourceDBMixin):
         For example:
 
             >>> DataSource("Seita", type="forecaster", model="naive", version="1.2").description
-            <<< "Seita's naive forecaster v1.2"
+            "Seita's naive forecaster v1.2"
             >>> DataSource("Seita", type="scheduler", model="StorageScheduler", version="2").description
-            <<< "Seita's StorageScheduler model v2"
+            "Seita's StorageScheduler model v2"
 
         """
         descr = self.name

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -29,7 +29,7 @@ class EfficiencyField(QuantityField):
         >>> ef.deserialize(0.9)
         <Quantity(90.0, 'percent')>
         >>> ef.deserialize("90%")
-        <Quantity(90.0, 'percent')>
+        <Quantity(90, 'percent')>
         >>> ef.deserialize("0%")
         Traceback (most recent call last):
         ...

--- a/flexmeasures/data/services/utils.py
+++ b/flexmeasures/data/services/utils.py
@@ -79,10 +79,10 @@ def get_or_create_model(
 
     For example:
     >>> weather_station_type = get_or_create_model(
-    >>>     GenericAssetType,
-    >>>     name="weather station",
-    >>>     description="A weather station with various sensors.",
-    >>> )
+    ...     GenericAssetType,
+    ...     name="weather station",
+    ...     description="A weather station with various sensors.",
+    ... )
     """
 
     # unpack custom initialization parameters that map to multiple database columns

--- a/flexmeasures/utils/calculations.py
+++ b/flexmeasures/utils/calculations.py
@@ -117,23 +117,23 @@ def integrate_time_series(
     The unit of time is hours: i.e. the stock unit is flow unit times hours (e.g. a flow in kW becomes a stock in kWh).
     Optionally, set a decimal precision to round off the results (useful for tests failing over machine precision).
 
-    >>> s = pd.Series([1, 2, 3, 4], index=pd.date_range(datetime(2001, 1, 1, 5), datetime(2001, 1, 1, 6), freq=timedelta(minutes=15), inclusive="left"))
+    >>> s = pd.Series([1, 2, 3, 4], index=pd.date_range("2001-01-01T05:00", "2001-01-01T06:00", freq=timedelta(minutes=15), inclusive="left"))
     >>> integrate_time_series(s, 10)
-        2001-01-01 05:00:00    10.00
-        2001-01-01 05:15:00    10.25
-        2001-01-01 05:30:00    10.75
-        2001-01-01 05:45:00    11.50
-        2001-01-01 06:00:00    12.50
-        Freq: D, dtype: float64
+    2001-01-01 05:00:00    10.00
+    2001-01-01 05:15:00    10.25
+    2001-01-01 05:30:00    10.75
+    2001-01-01 05:45:00    11.50
+    2001-01-01 06:00:00    12.50
+    dtype: float64
 
-    >>> s = pd.Series([1, 2, 3, 4], index=pd.date_range(datetime(2001, 1, 1, 5), datetime(2001, 1, 1, 7), freq=timedelta(minutes=30), inclusive="left"))
+    >>> s = pd.Series([1, 2, 3, 4], index=pd.date_range("2001-01-01T05:00", "2001-01-01T07:00", freq=timedelta(minutes=30), inclusive="left"))
     >>> integrate_time_series(s, 10)
-        2001-01-01 05:00:00    10.0
-        2001-01-01 05:30:00    10.5
-        2001-01-01 06:00:00    11.5
-        2001-01-01 06:30:00    13.0
-        2001-01-01 07:00:00    15.0
-        dtype: float64
+    2001-01-01 05:00:00    10.0
+    2001-01-01 05:30:00    10.5
+    2001-01-01 06:00:00    11.5
+    2001-01-01 06:30:00    13.0
+    2001-01-01 07:00:00    15.0
+    dtype: float64
     """
     resolution = pd.to_timedelta(series.index.freq)
     storage_efficiency = (

--- a/flexmeasures/utils/flexmeasures_inflection.py
+++ b/flexmeasures/utils/flexmeasures_inflection.py
@@ -29,10 +29,10 @@ def humanize(word):
 
 
 def parameterize(word):
-    """Parameterize the word, so it can be used as a python or javascript variable name.
+    """Parameterize the word, so it can be used as a Python or JavaScript variable name.
     For example:
-    >>> word = "Acme® EV-Charger™"
-    "acme_ev_chargertm"
+    >>> parameterize("Acme® EV-Charger™")
+    'acme_ev_chargertm'
     """
     return inflection.parameterize(word).replace("-", "_")
 
@@ -51,9 +51,9 @@ def titleize(word):
     because it has less unintended side effects. For example:
      >>> word = "two PV panels"
      >>> titleize(word)
-     "Two Pv Panels"
+     'Two Pv Panels'
      >>> capitalize(word)
-     "Two PV panels"
+     'Two PV panels'
     """
     word = inflection.titleize(word)
     for ac in ACRONYMS:

--- a/flexmeasures/utils/time_utils.py
+++ b/flexmeasures/utils/time_utils.py
@@ -339,7 +339,7 @@ def to_http_time(dt: pd.Timestamp | datetime) -> str:
     """Formats datetime using the Internet Message Format fixdate.
 
     >>> to_http_time(pd.Timestamp("2022-12-13 14:06:23Z"))
-    Tue, 13 Dec 2022 14:06:23 GMT
+    'Tue, 13 Dec 2022 14:06:23 GMT'
 
     References
     ----------
@@ -425,7 +425,6 @@ def to_utc_timestamp(value):
     >>> to_utc_timestamp("Sun, 28 Apr 2024 08:55:58 GMT")
     1714294558.0
     >>> to_utc_timestamp(None)
-    None
     """
     if value is None:
         return None

--- a/flexmeasures/utils/unit_utils.py
+++ b/flexmeasures/utils/unit_utils.py
@@ -251,6 +251,22 @@ def is_energy_price_unit(unit: str) -> bool:
     return False
 
 
+def is_speed_unit(unit: str) -> bool:
+    """For example:
+    >>> is_speed_unit("m/s")
+    True
+    >>> is_speed_unit("km/h")
+    True
+    >>> is_speed_unit("W")
+    False
+    >>> is_speed_unit("m/s²")
+    False
+    """
+    if not is_valid_unit(unit):
+        return False
+    return ur.Quantity(unit).dimensionality == ur.Quantity("m/s").dimensionality
+
+
 def get_unit_dimension(unit: str) -> str:
     """For example:
     >>> get_unit_dimension("kW")
@@ -271,6 +287,8 @@ def get_unit_dimension(unit: str) -> str:
     'length'
     >>> get_unit_dimension("h")
     'time'
+    >>> get_unit_dimension("m/s")
+    'speed'
     """
     if is_power_unit(unit):
         return "power"
@@ -282,6 +300,8 @@ def get_unit_dimension(unit: str) -> str:
         return "price"
     if is_currency_unit(unit):
         return "currency"
+    if is_speed_unit(unit):
+        return "speed"
     if unit == "%":
         return "percentage"
     dimensions = ur.Quantity(unit).dimensionality

--- a/flexmeasures/utils/unit_utils.py
+++ b/flexmeasures/utils/unit_utils.py
@@ -172,6 +172,20 @@ def is_power_unit(unit: str) -> bool:
     return ur.Quantity(unit).dimensionality == ur.Quantity("W").dimensionality
 
 
+def is_temperature_unit(unit: str) -> bool:
+    """For example:
+    >>> is_temperature_unit("°C")
+    True
+    >>> is_temperature_unit("K")
+    True
+    >>> is_temperature_unit("kW")
+    False
+    """
+    if not is_valid_unit(unit):
+        return False
+    return ur.Quantity(unit).dimensionality == ur.Quantity("K").dimensionality
+
+
 def is_energy_unit(unit: str) -> bool:
     """For example:
     >>> is_energy_unit("kW")

--- a/flexmeasures/utils/unit_utils.py
+++ b/flexmeasures/utils/unit_utils.py
@@ -116,8 +116,10 @@ def determine_unit_conversion_multiplier(
 
 def determine_flow_unit(stock_unit: str, time_unit: str = "h"):
     """For example:
-    >>> determine_flow_unit("m³")  # m³/h
-    >>> determine_flow_unit("kWh")  # kW
+    >>> determine_flow_unit("m³")
+    'm³/h'
+    >>> determine_flow_unit("kWh")
+    'kW'
     """
     flow = to_preferred(ur.Quantity(stock_unit) / ur.Quantity(time_unit))
     return "{:~P}".format(flow.units)
@@ -127,8 +129,10 @@ def determine_stock_unit(flow_unit: str, time_unit: str = "h"):
     """Determine the shortest unit of stock, given a unit of flow.
 
     For example:
-    >>> determine_stock_unit("m³/h")  # m³
-    >>> determine_stock_unit("kW")  # kWh
+    >>> determine_stock_unit("m³/h")
+    'm³'
+    >>> determine_stock_unit("kW")
+    'kWh'
     """
     stock = to_preferred(ur.Quantity(flow_unit) * ur.Quantity(time_unit))
     return "{:~P}".format(stock.units)
@@ -138,10 +142,14 @@ def units_are_convertible(
     from_unit: str, to_unit: str, duration_known: bool = True
 ) -> bool:
     """For example, a sensor with W units allows data to be posted with units:
-    >>> units_are_convertible("kW", "W")  # True (units just have different prefixes)
-    >>> units_are_convertible("J/s", "W")  # True (units can be converted using some multiplier)
-    >>> units_are_convertible("Wh", "W")  # True (units that represent a stock delta can, knowing the duration, be converted to a flow)
-    >>> units_are_convertible("°C", "W")  # False
+    >>> units_are_convertible("kW", "W")  # units just have different prefixes
+    True
+    >>> units_are_convertible("J/s", "W")  # units can be converted using some multiplier
+    True
+    >>> units_are_convertible("Wh", "W")  # units that represent a stock delta can, knowing the duration, be converted to a flow
+    True
+    >>> units_are_convertible("°C", "W")
+    False
     """
     if not is_valid_unit(from_unit) or not is_valid_unit(to_unit):
         return False
@@ -190,13 +198,13 @@ def is_energy_unit(unit: str) -> bool:
 
 def is_currency_unit(unit: str | pint.Quantity | pint.Unit) -> bool:
     """For Example:
-    >>> is_energy_price_unit("EUR")
+    >>> is_currency_unit("EUR")
     True
-    >>> is_energy_price_unit("KRW")
+    >>> is_currency_unit("KRW")
     True
-    >>> is_energy_price_unit("potatoe")
+    >>> is_currency_unit("potatoe")
     False
-    >>> is_energy_price_unit("MW")
+    >>> is_currency_unit("MW")
     False
     """
     if isinstance(unit, pint.Quantity):
@@ -251,6 +259,8 @@ def get_unit_dimension(unit: str) -> str:
     'energy'
     >>> get_unit_dimension("EUR/MWh")
     'energy price'
+    >>> get_unit_dimension("EUR/kW")  # e.g. a capacity price or a peak price
+    'price'
     >>> get_unit_dimension("%")
     'percentage'
     >>> get_unit_dimension("°C")

--- a/flexmeasures/utils/unit_utils.py
+++ b/flexmeasures/utils/unit_utils.py
@@ -172,20 +172,6 @@ def is_power_unit(unit: str) -> bool:
     return ur.Quantity(unit).dimensionality == ur.Quantity("W").dimensionality
 
 
-def is_temperature_unit(unit: str) -> bool:
-    """For example:
-    >>> is_temperature_unit("°C")
-    True
-    >>> is_temperature_unit("K")
-    True
-    >>> is_temperature_unit("kW")
-    False
-    """
-    if not is_valid_unit(unit):
-        return False
-    return ur.Quantity(unit).dimensionality == ur.Quantity("K").dimensionality
-
-
 def is_energy_unit(unit: str) -> bool:
     """For example:
     >>> is_energy_unit("kW")
@@ -240,6 +226,37 @@ def is_energy_price_unit(unit: str) -> bool:
     ):
         return True
     return False
+
+
+def get_unit_dimension(unit: str) -> str:
+    """For example:
+    >>> get_unit_dimension("kW")
+    'power'
+    >>> get_unit_dimension("kWh")
+    'energy'
+    >>> get_unit_dimension("EUR/MWh")
+    'energy price'
+    >>> get_unit_dimension("%")
+    'percentage'
+    >>> get_unit_dimension("°C")
+    'temperature'
+    >>> get_unit_dimension("m")
+    'length'
+    >>> get_unit_dimension("h")
+    'time'
+    """
+    if is_power_unit(unit):
+        return "power"
+    if is_energy_unit(unit):
+        return "energy"
+    if is_energy_price_unit(unit):
+        return "energy price"
+    if unit == "%":
+        return "percentage"
+    dimensions = ur.Quantity(unit).dimensionality
+    if len(dimensions) == 1:
+        return list(dimensions.keys())[0][1:-1]
+    return "value"
 
 
 def _convert_time_units(

--- a/flexmeasures/utils/unit_utils.py
+++ b/flexmeasures/utils/unit_utils.py
@@ -207,6 +207,26 @@ def is_currency_unit(unit: str | pint.Quantity | pint.Unit) -> bool:
     return Currency(code=unit) in list_all_currencies()
 
 
+def is_price_unit(unit: str) -> bool:
+    """For example:
+    >>> is_price_unit("EUR/MWh")
+    True
+    >>> is_price_unit("KRW/MWh")
+    True
+    >>> is_price_unit("KRW/MW")
+    True
+    >>> is_price_unit("beans/MW")
+    False
+    """
+    if (
+        unit[:3] in [str(c) for c in list_all_currencies()]
+        and len(unit) > 3
+        and unit[3] == "/"
+    ):
+        return True
+    return False
+
+
 def is_energy_price_unit(unit: str) -> bool:
     """For example:
     >>> is_energy_price_unit("EUR/MWh")
@@ -218,12 +238,7 @@ def is_energy_price_unit(unit: str) -> bool:
     >>> is_energy_price_unit("beans/MW")
     False
     """
-    if (
-        unit[:3] in [str(c) for c in list_all_currencies()]
-        and len(unit) > 3
-        and unit[3] == "/"
-        and is_energy_unit(unit[4:])
-    ):
+    if is_price_unit(unit) and is_energy_unit(unit[4:]):
         return True
     return False
 
@@ -251,6 +266,8 @@ def get_unit_dimension(unit: str) -> str:
         return "energy"
     if is_energy_price_unit(unit):
         return "energy price"
+    if is_price_unit(unit):
+        return "price"
     if unit == "%":
         return "percentage"
     dimensions = ur.Quantity(unit).dimensionality

--- a/flexmeasures/utils/unit_utils.py
+++ b/flexmeasures/utils/unit_utils.py
@@ -261,6 +261,8 @@ def get_unit_dimension(unit: str) -> str:
     'energy price'
     >>> get_unit_dimension("EUR/kW")  # e.g. a capacity price or a peak price
     'price'
+    >>> get_unit_dimension("AUD")
+    'currency'
     >>> get_unit_dimension("%")
     'percentage'
     >>> get_unit_dimension("°C")
@@ -278,6 +280,8 @@ def get_unit_dimension(unit: str) -> str:
         return "energy price"
     if is_price_unit(unit):
         return "price"
+    if is_currency_unit(unit):
+        return "currency"
     if unit == "%":
         return "percentage"
     dimensions = ur.Quantity(unit).dimensionality


### PR DESCRIPTION
## Description

- [x] Add support for more shared base units in y-axis titles
- [x] Add support for shared price units, currencies, speeds and percentages
- [x] Added changelog item in `documentation/changelog.rst`

## Look & Feel

Before:

![image](https://github.com/user-attachments/assets/e3d46368-215a-4e94-bb2d-420cccd47ac0)

After (notice the y-axis title changed from `Value` to `Temperature`):

![image](https://github.com/user-attachments/assets/42cdf68e-e409-4064-b7c4-8e77407b9710)


## How to test

The docstrings of the new unit util functions include doctests. Doctests aren't part of the automated test suite, though, but they will be - #1347
