### PR TITLE
Ci/run doctests

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -55,6 +55,8 @@ jobs:
       - name: Install FlexMeasures & latest dependencies for tests
         run: make install-for-test pinned=no
         if: github.event_name == 'pull_request'
+      - name: Run all doctests in the utils subpackage
+        run: pytest flexmeasures/utils --doctest-modules
       - name: Run all tests except those marked to be skipped by GitHub AND record coverage
         run: pytest -v -m "not skip_github" --cov=flexmeasures --cov-branch --cov-report=lcov
       - name: Coveralls

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -57,8 +57,6 @@ jobs:
         if: github.event_name == 'pull_request'
       - name: Run all doctests in the utils subpackage
         run: pytest flexmeasures/utils --doctest-modules
-      - name: Run all tests except those marked to be skipped by GitHub AND record coverage
-        run: pytest -v -m "not skip_github" --cov=flexmeasures --cov-branch --cov-report=lcov
       - name: Coveralls
         uses: coverallsapp/github-action@v2
         with:

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -56,9 +56,9 @@ jobs:
         run: make install-for-test pinned=no
         if: github.event_name == 'pull_request'
       - name: Run all doctests in the data/schemas subpackage
-        run: pytest flexmeasures/data/schemas --doctest-modules
+        run: pytest flexmeasures/data/schemas --doctest-modules --ignore flexmeasures/data/schemas/tests
       - name: Run all doctests in the utils subpackage
-        run: pytest flexmeasures/utils --doctest-modules
+        run: pytest flexmeasures/utils --doctest-modules --ignore flexmeasures/utils/tests
       - name: Run all tests except those marked to be skipped by GitHub AND record coverage
         run: pytest -v -m "not skip_github" --cov=flexmeasures --cov-branch --cov-report=lcov
       - name: Coveralls

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -55,6 +55,8 @@ jobs:
       - name: Install FlexMeasures & latest dependencies for tests
         run: make install-for-test pinned=no
         if: github.event_name == 'pull_request'
+      - name: Run all doctests in the data/schemas subpackage
+        run: pytest flexmeasures/data/schemas --doctest-modules
       - name: Run all doctests in the utils subpackage
         run: pytest flexmeasures/utils --doctest-modules
       - name: Run all tests except those marked to be skipped by GitHub AND record coverage

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -57,6 +57,8 @@ jobs:
         if: github.event_name == 'pull_request'
       - name: Run all doctests in the utils subpackage
         run: pytest flexmeasures/utils --doctest-modules
+      - name: Run all tests except those marked to be skipped by GitHub AND record coverage
+        run: pytest -v -m "not skip_github" --cov=flexmeasures --cov-branch --cov-report=lcov
       - name: Coveralls
         uses: coverallsapp/github-action@v2
         with:

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -11,6 +11,7 @@ v0.25.0 | February XX, 2025
 
 New features
 -------------
+* Better y-axis titles for charts that show multiple sensors with a shared unit [see `PR #1346 <https://github.com/FlexMeasures/flexmeasures/pull/1346>`_]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -21,6 +21,7 @@ Infrastructure / Support
 * Extra reporter tests [see `PR #1317 <https://github.com/FlexMeasures/flexmeasures/pull/1317>`_]
 * Catch invalid time windows passed to ``flexmeasures add report`` [see `PR #1324 <https://github.com/FlexMeasures/flexmeasures/pull/1324>`_]
 * Test utility function for device scheduling in a multi-asset setting (sequential and simultaneous) [see `PR #1341 <https://github.com/FlexMeasures/flexmeasures/pull/1341>`_]
+* Add utils doctests to our CI pipeline [see `PR #1347 <https://github.com/FlexMeasures/flexmeasures/pull/1347>`_]
 
 Bugfixes
 -----------

--- a/flexmeasures/data/models/data_sources.py
+++ b/flexmeasures/data/models/data_sources.py
@@ -325,9 +325,9 @@ class DataSource(db.Model, tb.BeliefSourceDBMixin):
         For example:
 
             >>> DataSource("Seita", type="forecaster", model="naive", version="1.2").description
-            <<< "Seita's naive forecaster v1.2"
+            "Seita's naive forecaster v1.2"
             >>> DataSource("Seita", type="scheduler", model="StorageScheduler", version="2").description
-            <<< "Seita's StorageScheduler model v2"
+            "Seita's StorageScheduler model v2"
 
         """
         descr = self.name

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -29,7 +29,7 @@ class EfficiencyField(QuantityField):
         >>> ef.deserialize(0.9)
         <Quantity(90.0, 'percent')>
         >>> ef.deserialize("90%")
-        <Quantity(90.0, 'percent')>
+        <Quantity(90, 'percent')>
         >>> ef.deserialize("0%")
         Traceback (most recent call last):
         ...

--- a/flexmeasures/data/services/utils.py
+++ b/flexmeasures/data/services/utils.py
@@ -79,10 +79,10 @@ def get_or_create_model(
 
     For example:
     >>> weather_station_type = get_or_create_model(
-    >>>     GenericAssetType,
-    >>>     name="weather station",
-    >>>     description="A weather station with various sensors.",
-    >>> )
+    ...     GenericAssetType,
+    ...     name="weather station",
+    ...     description="A weather station with various sensors.",
+    ... )
     """
 
     # unpack custom initialization parameters that map to multiple database columns

--- a/flexmeasures/utils/calculations.py
+++ b/flexmeasures/utils/calculations.py
@@ -117,23 +117,23 @@ def integrate_time_series(
     The unit of time is hours: i.e. the stock unit is flow unit times hours (e.g. a flow in kW becomes a stock in kWh).
     Optionally, set a decimal precision to round off the results (useful for tests failing over machine precision).
 
-    >>> s = pd.Series([1, 2, 3, 4], index=pd.date_range(datetime(2001, 1, 1, 5), datetime(2001, 1, 1, 6), freq=timedelta(minutes=15), inclusive="left"))
+    >>> s = pd.Series([1, 2, 3, 4], index=pd.date_range("2001-01-01T05:00", "2001-01-01T06:00", freq=timedelta(minutes=15), inclusive="left"))
     >>> integrate_time_series(s, 10)
-        2001-01-01 05:00:00    10.00
-        2001-01-01 05:15:00    10.25
-        2001-01-01 05:30:00    10.75
-        2001-01-01 05:45:00    11.50
-        2001-01-01 06:00:00    12.50
-        Freq: D, dtype: float64
+    2001-01-01 05:00:00    10.00
+    2001-01-01 05:15:00    10.25
+    2001-01-01 05:30:00    10.75
+    2001-01-01 05:45:00    11.50
+    2001-01-01 06:00:00    12.50
+    dtype: float64
 
-    >>> s = pd.Series([1, 2, 3, 4], index=pd.date_range(datetime(2001, 1, 1, 5), datetime(2001, 1, 1, 7), freq=timedelta(minutes=30), inclusive="left"))
+    >>> s = pd.Series([1, 2, 3, 4], index=pd.date_range("2001-01-01T05:00", "2001-01-01T07:00", freq=timedelta(minutes=30), inclusive="left"))
     >>> integrate_time_series(s, 10)
-        2001-01-01 05:00:00    10.0
-        2001-01-01 05:30:00    10.5
-        2001-01-01 06:00:00    11.5
-        2001-01-01 06:30:00    13.0
-        2001-01-01 07:00:00    15.0
-        dtype: float64
+    2001-01-01 05:00:00    10.0
+    2001-01-01 05:30:00    10.5
+    2001-01-01 06:00:00    11.5
+    2001-01-01 06:30:00    13.0
+    2001-01-01 07:00:00    15.0
+    dtype: float64
     """
     resolution = pd.to_timedelta(series.index.freq)
     storage_efficiency = (

--- a/flexmeasures/utils/flexmeasures_inflection.py
+++ b/flexmeasures/utils/flexmeasures_inflection.py
@@ -32,7 +32,8 @@ def parameterize(word):
     """Parameterize the word, so it can be used as a python or javascript variable name.
     For example:
     >>> word = "Acme® EV-Charger™"
-    "acme_ev_chargertm"
+    >>> parameterize(word)
+    'acme_ev_chargertm'
     """
     return inflection.parameterize(word).replace("-", "_")
 
@@ -51,9 +52,9 @@ def titleize(word):
     because it has less unintended side effects. For example:
      >>> word = "two PV panels"
      >>> titleize(word)
-     "Two Pv Panels"
+     'Two Pv Panels'
      >>> capitalize(word)
-     "Two PV panels"
+     'Two PV panels'
     """
     word = inflection.titleize(word)
     for ac in ACRONYMS:

--- a/flexmeasures/utils/flexmeasures_inflection.py
+++ b/flexmeasures/utils/flexmeasures_inflection.py
@@ -29,10 +29,9 @@ def humanize(word):
 
 
 def parameterize(word):
-    """Parameterize the word, so it can be used as a python or javascript variable name.
+    """Parameterize the word, so it can be used as a Python or JavaScript variable name.
     For example:
-    >>> word = "Acme® EV-Charger™"
-    >>> parameterize(word)
+    >>> parameterize("Acme® EV-Charger™")
     'acme_ev_chargertm'
     """
     return inflection.parameterize(word).replace("-", "_")

--- a/flexmeasures/utils/time_utils.py
+++ b/flexmeasures/utils/time_utils.py
@@ -339,7 +339,7 @@ def to_http_time(dt: pd.Timestamp | datetime) -> str:
     """Formats datetime using the Internet Message Format fixdate.
 
     >>> to_http_time(pd.Timestamp("2022-12-13 14:06:23Z"))
-    Tue, 13 Dec 2022 14:06:23 GMT
+    'Tue, 13 Dec 2022 14:06:23 GMT'
 
     References
     ----------
@@ -425,7 +425,6 @@ def to_utc_timestamp(value):
     >>> to_utc_timestamp("Sun, 28 Apr 2024 08:55:58 GMT")
     1714294558.0
     >>> to_utc_timestamp(None)
-    None
     """
     if value is None:
         return None

--- a/flexmeasures/utils/unit_utils.py
+++ b/flexmeasures/utils/unit_utils.py
@@ -251,6 +251,8 @@ def get_unit_dimension(unit: str) -> str:
     'energy'
     >>> get_unit_dimension("EUR/MWh")
     'energy price'
+    >>> get_unit_dimension("EUR/kW")  # e.g. a capacity price or a peak price
+    'price'
     >>> get_unit_dimension("%")
     'percentage'
     >>> get_unit_dimension("°C")

--- a/flexmeasures/utils/unit_utils.py
+++ b/flexmeasures/utils/unit_utils.py
@@ -116,8 +116,10 @@ def determine_unit_conversion_multiplier(
 
 def determine_flow_unit(stock_unit: str, time_unit: str = "h"):
     """For example:
-    >>> determine_flow_unit("m³")  # m³/h
-    >>> determine_flow_unit("kWh")  # kW
+    >>> determine_flow_unit("m³")
+    'm³/h'
+    >>> determine_flow_unit("kWh")
+    'kW'
     """
     flow = to_preferred(ur.Quantity(stock_unit) / ur.Quantity(time_unit))
     return "{:~P}".format(flow.units)
@@ -127,8 +129,10 @@ def determine_stock_unit(flow_unit: str, time_unit: str = "h"):
     """Determine the shortest unit of stock, given a unit of flow.
 
     For example:
-    >>> determine_stock_unit("m³/h")  # m³
-    >>> determine_stock_unit("kW")  # kWh
+    >>> determine_stock_unit("m³/h")
+    'm³'
+    >>> determine_stock_unit("kW")
+    'kWh'
     """
     stock = to_preferred(ur.Quantity(flow_unit) * ur.Quantity(time_unit))
     return "{:~P}".format(stock.units)
@@ -138,10 +142,14 @@ def units_are_convertible(
     from_unit: str, to_unit: str, duration_known: bool = True
 ) -> bool:
     """For example, a sensor with W units allows data to be posted with units:
-    >>> units_are_convertible("kW", "W")  # True (units just have different prefixes)
-    >>> units_are_convertible("J/s", "W")  # True (units can be converted using some multiplier)
-    >>> units_are_convertible("Wh", "W")  # True (units that represent a stock delta can, knowing the duration, be converted to a flow)
-    >>> units_are_convertible("°C", "W")  # False
+    >>> units_are_convertible("kW", "W")  # units just have different prefixes
+    True
+    >>> units_are_convertible("J/s", "W")  # units can be converted using some multiplier
+    True
+    >>> units_are_convertible("Wh", "W")  # units that represent a stock delta can, knowing the duration, be converted to a flow
+    True
+    >>> units_are_convertible("°C", "W")
+    False
     """
     if not is_valid_unit(from_unit) or not is_valid_unit(to_unit):
         return False
@@ -190,13 +198,13 @@ def is_energy_unit(unit: str) -> bool:
 
 def is_currency_unit(unit: str | pint.Quantity | pint.Unit) -> bool:
     """For Example:
-    >>> is_energy_price_unit("EUR")
+    >>> is_currency_unit("EUR")
     True
-    >>> is_energy_price_unit("KRW")
+    >>> is_currency_unit("KRW")
     True
-    >>> is_energy_price_unit("potatoe")
+    >>> is_currency_unit("potatoe")
     False
-    >>> is_energy_price_unit("MW")
+    >>> is_currency_unit("MW")
     False
     """
     if isinstance(unit, pint.Quantity):


### PR DESCRIPTION
## Description

- [x] The CI now runs the doctests in our utils subpackage
- [x] The CI now runs the doctests in our data/schemas subpackage
- [x] Added changelog item in `documentation/changelog.rst`

<!--
Note regarding our changelog:
- The 'New features' section targets API / CLI / UI users.
- The 'Infrastructure / Support' section targets plugin developers and hosts.
-->

## Look & Feel

Here's an example doctest we have:
```
def parameterize(word):
    """Parameterize the word, so it can be used as a Python or JavaScript variable name.
    For example:
    >>> parameterize("Acme® EV-Charger™")
    'acme_ev_chargertm'
    """
    return inflection.parameterize(word).replace("-", "_")
```

## How to test

The CI takes care of this.

## Further Improvements

Some of our other subpackages have some doctests, too. Some of them require app contexts and I couldn't get that to work easily. Most of them also appear to be meant more like an example than as a unit test. I usually only made use of doctests as unit tests for util functions.
