### PR TITLE
feat: CLI command to remove obsolete queue

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -12,6 +12,7 @@ v0.25.0 | February XX, 2025
 New features
 -------------
 * Add CLI command ``flexmeasures jobs save-last-failed`` for saving the last failed jobs [see `PR #1342 <https://www.github.com/FlexMeasures/flexmeasures/pull/1342>`_]
+* Add CLI command ``flexmeasures jobs delete-queue`` for deleting an obsolete queue [see `PR #1351 <https://www.github.com/FlexMeasures/flexmeasures/pull/1351>`_]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -8,6 +8,7 @@ since v0.25.0 | February XX, 2024
 =================================
 * Report parameters set using ``flexmeasures add report --parameters`` can use any argument supported by ``Sensor.search_beliefs`` to allow more control over input for the report.
 * Add ``flexmeasures jobs save-last-failed`` CLI command for saving the last n failed jobs (from the scheduling queue, by default).
+* Add ``flexmeasures jobs delete-queue`` CLI command for deleting an obsolete queue.
 
 since v0.24.0 | January 6, 2024
 =================================

--- a/flexmeasures/cli/jobs.py
+++ b/flexmeasures/cli/jobs.py
@@ -268,6 +268,38 @@ def clear_queue(queue: str, deferred: bool, scheduled: bool, failed: bool):
             wrap_up_message(count_after)
 
 
+@fm_jobs.command("delete-queue")
+@with_appcontext
+@click.option(
+    "--queue",
+    default=None,
+    required=True,
+    help="State which queue to delete.",
+)
+def delete_queue(queue: str):
+    """
+    Delete a job queue.
+    """
+    if not app.redis_connection.sismember("rq:queues", f"rq:queue:{queue}"):
+        click.secho(
+            f"Queue '{queue}' does not exist.",
+            **MsgStyle.ERROR,
+        )
+        raise click.Abort()
+    success = app.redis_connection.srem("rq:queues", f"rq:queue:{queue}")
+    if success:
+        click.secho(
+            f"Queue '{queue}' removed.",
+            **MsgStyle.SUCCESS,
+        )
+    else:
+        click.secho(
+            f"Failed to remove queue '{queue}'.",
+            **MsgStyle.ERROR,
+        )
+        raise click.Abort()
+
+
 def wrap_up_message(count_after: int):
     if count_after > 0:
         click.secho(


### PR DESCRIPTION
## Description

- [x] New CLI command to remove an obsolete queue
- [x] Added changelog item in `documentation/changelog.rst`

## How to test

```bash
flexmeasures shell
```

```python
from flask import current_app as app
app.redis_connection.sadd('rq:queues', 'rq:queue:testme')
exit()
```

Navigate to http://localhost:5000/tasks. The `testme` queue should be listed.

```bash
flexmeasures jobs delete-queue --queue 'testme'
```

Navigate to http://localhost:5000/tasks. The `testme` queue should no longer be listed.


## Further Improvements

Someone could create a test out of the above instructions.
