### PR TITLE
handle unexpected Datatypes in flex-context Db regression

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -18,7 +18,7 @@ New features
 Infrastructure / Support
 ----------------------
 * Support multi-asset scheduling in the ``StorageScheduler`` and job queueing - functionality for (plugin) developers (incl. prep work for future API endpoint for multi-asset scheduling) [see `PR #1313 <https://github.com/FlexMeasures/flexmeasures/pull/1313>`_]
-* Migrate data for the ``flex_context`` of an asset to a dedicated column in the database table for assets [see `PR #1293 <https://github.com/FlexMeasures/flexmeasures/pull/1293>`_]
+* Migrate data for the ``flex_context`` of an asset to a dedicated column in the database table for assets [see `PR #1293 <https://github.com/FlexMeasures/flexmeasures/pull/1293>`_ and `PR #1354 <https://github.com/FlexMeasures/flexmeasures/pull/1354>`_]
 * Enhance reporting infrastructure by ensuring that all ``Sensor.search_beliefs`` filters can be used as report parameters [see `PR #1318 <https://github.com/FlexMeasures/flexmeasures/pull/1318>`_]
 * Improve searching for multi-sourced data by returning data from only the latest version of a data generator (e.g. forecaster or scheduler) by default, when using ``Sensor.search_beliefs`` [see `PR #1306 <https://github.com/FlexMeasures/flexmeasures/pull/1306>`_]
 * Extra reporter tests [see `PR #1317 <https://github.com/FlexMeasures/flexmeasures/pull/1317>`_]

--- a/flexmeasures/data/migrations/versions/cb8df44ebda5_flexcontext_field.py
+++ b/flexmeasures/data/migrations/versions/cb8df44ebda5_flexcontext_field.py
@@ -69,6 +69,16 @@ def build_flex_context(
         "inflexible-device-sensors": [s[0] for s in inflexible_device_sensors],
     }
 
+    if flex_context["consumption-price"]["sensor"] is None and market_id is None:
+        if attributes_data.get("consumption_price") is not None:
+            flex_context["consumption-price"] = attributes_data.get("consumption_price")
+            attributes_data.pop("consumption_price", None)
+
+    if flex_context["production-price"]["sensor"] is None:
+        if attributes_data.get("production_price") is not None:
+            flex_context["production-price"] = attributes_data.get("production_price")
+            attributes_data.pop("production_price", None)
+
     capacity_data = {
         "site-power-capacity": capacity_in_mw,
         "site-consumption-capacity": consumption_capacity_in_mw,
@@ -355,17 +365,17 @@ def downgrade():
         )
 
         if capacity_in_mw is not None:
-            if not isinstance(capacity_in_mw, dict):
+            if isinstance(capacity_in_mw, str):
                 capacity_in_mw = float(capacity_in_mw.replace(" kW", "")) / 1000
 
         if consumption_capacity_in_mw is not None:
-            if not isinstance(consumption_capacity_in_mw, dict):
+            if isinstance(consumption_capacity_in_mw, str):
                 consumption_capacity_in_mw = (
                     float(consumption_capacity_in_mw.replace(" kW", "")) / 1000
                 )
 
         if production_capacity_in_mw is not None:
-            if not isinstance(production_capacity_in_mw, dict):
+            if isinstance(production_capacity_in_mw, str):
                 production_capacity_in_mw = (
                     float(production_capacity_in_mw.replace(" kW", "")) / 1000
                 )

--- a/flexmeasures/data/migrations/versions/cb8df44ebda5_flexcontext_field.py
+++ b/flexmeasures/data/migrations/versions/cb8df44ebda5_flexcontext_field.py
@@ -9,6 +9,8 @@ Create Date: 2024-12-16 18:39:34.168732
 from alembic import op
 import sqlalchemy as sa
 
+from flexmeasures.utils.unit_utils import is_power_unit, ur
+
 # revision identifiers, used by Alembic.
 revision = "cb8df44ebda5"
 down_revision = "2ba59c7c954e"
@@ -368,25 +370,29 @@ def downgrade():
         )
 
         if capacity_in_mw is not None:
-            if isinstance(capacity_in_mw, str) and "kW" in capacity_in_mw:
-                capacity_in_mw = float(capacity_in_mw.replace("kW", "")) / 1000
+            if isinstance(capacity_in_mw, str) and is_power_unit(capacity_in_mw):
+                capacity_in_mw = (
+                    ur.Quantity(capacity_in_mw).to(ur.Quantity("MW")).magnitude
+                )
 
         if consumption_capacity_in_mw is not None:
-            if (
-                isinstance(consumption_capacity_in_mw, str)
-                and "kW" in consumption_capacity_in_mw
+            if isinstance(consumption_capacity_in_mw, str) and is_power_unit(
+                consumption_capacity_in_mw
             ):
                 consumption_capacity_in_mw = (
-                    float(consumption_capacity_in_mw.replace("kW", "")) / 1000
+                    ur.Quantity(consumption_capacity_in_mw)
+                    .to(ur.Quantity("MW"))
+                    .magnitude
                 )
 
         if production_capacity_in_mw is not None:
-            if (
-                isinstance(production_capacity_in_mw, str)
-                and "kW" in production_capacity_in_mw
+            if isinstance(production_capacity_in_mw, str) and is_power_unit(
+                production_capacity_in_mw
             ):
                 production_capacity_in_mw = (
-                    float(production_capacity_in_mw.replace("kW", "")) / 1000
+                    ur.Quantity(production_capacity_in_mw)
+                    .to(ur.Quantity("MW"))
+                    .magnitude
                 )
 
         if consumption_price_as_str is not None:

--- a/flexmeasures/data/migrations/versions/cb8df44ebda5_flexcontext_field.py
+++ b/flexmeasures/data/migrations/versions/cb8df44ebda5_flexcontext_field.py
@@ -355,17 +355,17 @@ def downgrade():
         )
 
         if capacity_in_mw is not None:
-            if not isinstance(capacity_in_mw, str):
+            if not isinstance(capacity_in_mw, dict):
                 capacity_in_mw = float(capacity_in_mw.replace(" kW", "")) / 1000
 
         if consumption_capacity_in_mw is not None:
-            if not isinstance(consumption_capacity_in_mw, str):
+            if not isinstance(consumption_capacity_in_mw, dict):
                 consumption_capacity_in_mw = (
                     float(consumption_capacity_in_mw.replace(" kW", "")) / 1000
                 )
 
         if production_capacity_in_mw is not None:
-            if not isinstance(production_capacity_in_mw, str):
+            if not isinstance(production_capacity_in_mw, dict):
                 production_capacity_in_mw = (
                     float(production_capacity_in_mw.replace(" kW", "")) / 1000
                 )

--- a/flexmeasures/data/migrations/versions/cb8df44ebda5_flexcontext_field.py
+++ b/flexmeasures/data/migrations/versions/cb8df44ebda5_flexcontext_field.py
@@ -87,7 +87,7 @@ def build_flex_context(
     for key, value in capacity_data.items():
         if value is not None:
             if isinstance(value, (int, float)):
-                flex_context[key] = f"{int(value * 1000)} kW"
+                flex_context[key] = f"{int(value * 1000)}kW"
             else:
                 flex_context[key] = value
 
@@ -369,7 +369,7 @@ def downgrade():
 
         if capacity_in_mw is not None:
             if isinstance(capacity_in_mw, str) and "kW" in capacity_in_mw:
-                capacity_in_mw = float(capacity_in_mw.replace(" kW", "")) / 1000
+                capacity_in_mw = float(capacity_in_mw.replace("kW", "")) / 1000
 
         if consumption_capacity_in_mw is not None:
             if (
@@ -377,7 +377,7 @@ def downgrade():
                 and "kW" in consumption_capacity_in_mw
             ):
                 consumption_capacity_in_mw = (
-                    float(consumption_capacity_in_mw.replace(" kW", "")) / 1000
+                    float(consumption_capacity_in_mw.replace("kW", "")) / 1000
                 )
 
         if production_capacity_in_mw is not None:
@@ -386,7 +386,7 @@ def downgrade():
                 and "kW" in production_capacity_in_mw
             ):
                 production_capacity_in_mw = (
-                    float(production_capacity_in_mw.replace(" kW", "")) / 1000
+                    float(production_capacity_in_mw.replace("kW", "")) / 1000
                 )
 
         if consumption_price_as_str is not None:

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pint
 from marshmallow import (
     Schema,
     fields,
@@ -245,14 +246,18 @@ class DBFlexContextSchema(FlexContextSchema):
     @validates_schema
     def forbid_fixed_prices(self, data: dict, **kwargs):
         """Do not allow fixed consumption price or fixed production price in the flex-context fields saved in the db."""
-        if "consumption_price" in data and isinstance(data["consumption_price"], str):
+        if "consumption_price" in data and isinstance(
+            data["consumption_price"], pint.Quantity
+        ):
             raise ValidationError(
-                "Fixed prices are not currently supported in flex-context fields in the DB."
+                "Fixed prices are not currently supported for consumption_price in flex-context fields in the DB."
             )
 
-        if "production_price" in data and isinstance(data["production_price"], str):
+        if "production_price" in data and isinstance(
+            data["production_price"], pint.Quantity
+        ):
             raise ValidationError(
-                "Fixed prices are not currently supported in flex-context fields in the DB."
+                "Fixed prices are not currently supported for production_price in flex-context fields in the DB."
             )
 
 


### PR DESCRIPTION
## Description

This modifies the flex_context migration file to do the following

1. Handle some unexpected data types from flexcontext keys(when DB column is regressed(downgrade)
2. Adapt the upgrade to the change added to the downgrade(dumping of unexpected datatype value as-is into attributes)

Lastly, this PR also contains a fix to a hidden bug in the DBFlexContextSchema, which was allowing `consumption-price` and `production-price` to hold fixed values that they aren't designed to handle currently

## Look & Feel

None; this is a DB-level operation

## How to test

1. Go to an asset and add a fixed value to `consumption_price`
3. Run the downgrade command
4. instead of creahin you should see that fixed value inside the attributes of that asset

## Further Improvements

Probably enforce validation of the fronted/API to prevent these datatypes?

## Related Items

This PR closes #1355 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
