### PR TITLE
Make action buttons right-clickable

### DIFF
--- a/flexmeasures/ui/static/css/flexmeasures.css
+++ b/flexmeasures/ui/static/css/flexmeasures.css
@@ -96,7 +96,7 @@ button.btn:hover {
     background: var(--nav-hover-background-color);
 }
 
-form button[type="submit"] {
+button[type="submit"] {
     background: var(--primary-color) !important;
     outline: none !important;
     border: none;
@@ -110,6 +110,13 @@ form button[type="submit"] {
     -moz-transition: .4s;
     -ms-transition: .4s;
     -o-transition: .4s;
+}
+button[type="submit"] a {
+    color: var(--nav-default-color);
+    text-decoration: none;
+}
+button.btn:hover a {
+    color: var(--nav-hover-color);
 }
 
 #spinner {

--- a/flexmeasures/ui/templates/admin/logged_in_user.html
+++ b/flexmeasures/ui/templates/admin/logged_in_user.html
@@ -8,14 +8,14 @@
     <div class="col-md-2 on-top-md">
       <div class="header-action-button mt-3">
         <div class="user-action-button">
-          <form action="/logout" method="get">
-            <button class="btn btn-sm btn-responsive btn-info" type="submit">Log Out</button>
-          </form>
+          <button class="btn btn-sm btn-responsive btn-info" type="submit">
+            <a href="/logout">Log Out</a>
+          </button>
         </div>
         <div class="user-action-button">
-          <form action="/users/reset_password_for/{{ logged_in_user.id }}" method="get">
-            <button class="btn btn-sm btn-info" type="submit" title="Reset the password and send instructions how to choose a new one.">Reset Password</button>
-          </form>
+          <button class="btn btn-sm btn-info" type="submit">
+            <a href="/users/reset_password_for/{{ logged_in_user.id }}" title="Reset the password and send instructions how to choose a new one.">Reset password</a>
+          </button>
         </div>
       </div>
     </div>

--- a/flexmeasures/ui/templates/crud/account.html
+++ b/flexmeasures/ui/templates/crud/account.html
@@ -3,15 +3,13 @@ Account overview {% endblock %} {% block divs %}
 
 <div class="pl-3">
   {% if can_view_account_auditlog %}
-  <form action="/accounts/auditlog/{{ account.id }}" method="get">
     <button
       class="btn btn-sm btn-responsive btn-info m-4"
       type="submit"
       title="View history of user actions."
     >
-      Audit log
+      <a href="/accounts/auditlog/{{ account.id }}">Audit log</a>
     </button>
-  </form>
   {% endif %}
 </div>
 <div class="container-fluid">

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -20,18 +20,16 @@
             <div class="header-action-button">
                 {% if user_can_create_assets %}
                 <div>
-                    <form action="/assets/new" method="get">
-                        <button class="btn btn-sm btn-responsive btn-success create-button mb-3" type="submit">Create
-                            new asset</button>
-                    </form>
+                    <button class="btn btn-sm btn-responsive btn-success create-button mb-3" type="submit">
+                        <a href="/assets/new">Create new asset</a>
+                    </button>
                 </div>
                 {% endif %}
                 {% if user_can_delete_asset %}
                 <div>
-                    <form action="/assets/delete_with_data/{{ asset.id }}" method="get">
-                        <button id="delete-asset-button" class="btn btn-sm btn-responsive btn-danger"
-                            type="submit">Delete this asset</button>
-                    </form>
+                    <button id="delete-asset-button" class="btn btn-sm btn-responsive btn-danger" type="submit">
+                        <a href="/assets/delete_with_data/{{ asset.id }}">Delete this asset</a>
+                    </button>
                     <script>
                         $("#delete-asset-button").click(function () {
                             if (confirm("Are you sure you want to delete this asset and all time series data associated with it?")) {
@@ -47,16 +45,14 @@
             </div>
             <div class="header-action-button">
                 <div>
-                    <form action="/assets/{{ asset.id }}/status" method="get">
-                        <button id="asset-status-button" class="btn btn-sm btn-responsive btn-info" type="submit">Asset
-                            status</button>
-                    </form>
+                    <button id="asset-status-button" class="btn btn-sm btn-responsive btn-info" type="submit">
+                        <a href="/assets/{{ asset.id }}/status" title="Inspect status of relevant sensors and jobs.">Asset status</a>
+                    </button>
                 </div>
                 <div>
-                    <form action="/assets/auditlog/{{ asset.id }}" method="get">
-                        <button class="btn btn-sm btn-responsive btn-info" type="submit"
-                            title="View history of asset related actions.">Audit log</button>
-                    </form>
+                    <button class="btn btn-sm btn-responsive btn-info" type="submit">
+                        <a href="/assets/auditlog/{{ asset.id }}" title="View history of actions related to this asset.">Audit log</a>
+                    </button>
                 </div>
             </div>
             <div class="sidepanel-container">

--- a/flexmeasures/ui/templates/crud/asset_new.html
+++ b/flexmeasures/ui/templates/crud/asset_new.html
@@ -9,9 +9,9 @@
 <div class="container-fluid">
     <div class="row">
         <div class="col-md-12">
-            <form action="../../assets" method="get">
-                <button class="btn btn-sm btn-responsive btn-info" type="submit">Go to asset overview</button>
-            </form>
+            <button class="btn btn-sm btn-responsive btn-info" type="submit">
+                <a href="../../assets">Go to asset overview</a>
+            </button>
         </div>
         <div class="col-md-10">
         </div>

--- a/flexmeasures/ui/templates/crud/assets.html
+++ b/flexmeasures/ui/templates/crud/assets.html
@@ -88,7 +88,7 @@
             callback({"data": clean_response, "recordsTotal": response["num-records"], "recordsFiltered": response["filtered-records"]});
           },
           error: function (request, status, error) {
-            console.log("Error: ", error)
+            showToast(error, "error");
           }
         });
       }
@@ -103,9 +103,9 @@
       <div class="header-action-button mt-3">
         <div>
           {% if user_can_create_assets %}
-          <form action="/assets/new" method="get">
-            <button class="btn btn-sm btn-success mb-2 create-button" type="submit">Create new asset</button>
-          </form>
+          <button class="btn btn-sm btn-success mb-2 create-button" type="submit">
+            <a href="/assets/new">Create new asset</a>
+          </button>
           {% endif %}
         </div>
       </div>

--- a/flexmeasures/ui/templates/views/new_dashboard.html
+++ b/flexmeasures/ui/templates/views/new_dashboard.html
@@ -133,9 +133,9 @@
                                 <div class="row top-buffer">
                                     <div class="col-sm-6"></div>
                                     <div class="col-sm-6">
-                                        <form action="assets/{{ asset.id }}" method="get">
-                                            <button class="btn btn-sm btn-responsive btn-info" type="submit">View</button>
-                                        </form>
+                                        <button class="btn btn-sm btn-responsive btn-info" type="submit">
+                                            <a href="assets/{{ asset.id }}">View</a>
+                                        </button>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Description

Several pages have action buttons, and it annoys me that they are not right-clickable.
The reason was that they are placed in `form` elements, even though these forms have the "Get" method, so this could be a link instead.

## How to test 

Go to an asset page, right-click on the "Audit Log" log.

The style of action buttons on all pages where I found action buttons like this should also still look good, of course.