### PR TITLE
Fix/jobs/last failed jobs sort order

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,7 +13,7 @@ New features
 -------------
 * Added form modal to edit an asset's ``flex_context`` [see `PR #1320 <https://github.com/FlexMeasures/flexmeasures/pull/1320>`_]
 * Better y-axis titles for charts that show multiple sensors with a shared unit [see `PR #1346 <https://github.com/FlexMeasures/flexmeasures/pull/1346>`_]
-* Add CLI command ``flexmeasures jobs save-last-failed`` for saving the last failed jobs [see `PR #1342 <https://www.github.com/FlexMeasures/flexmeasures/pull/1342>`_]
+* Add CLI command ``flexmeasures jobs save-last-failed`` for saving the last failed jobs [see `PR #1342 <https://www.github.com/FlexMeasures/flexmeasures/pull/1342>`_ and `PR #1359 <https://github.com/FlexMeasures/flexmeasures/pull/1359>`_]
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/cli/jobs.py
+++ b/flexmeasures/cli/jobs.py
@@ -198,7 +198,9 @@ def save_last_failed(n: int, queue_name: str, file: str):
                 file = new_file
 
         # Save the failed jobs to a CSV file
-        pd.DataFrame(failed_jobs).to_csv(file, index=False)
+        pd.DataFrame(failed_jobs).sort_values("Started at", ascending=False).to_csv(
+            file, index=False
+        )
         click.secho(f"Saved {len(failed_jobs)} failed jobs to {file}.", fg="green")
     else:
         click.secho("No failed jobs found.", fg="yellow")


### PR DESCRIPTION
## Description

- [x] I just noticed the saved jobs were ordered counter-intuitively, with the oldest ones on top.
- [x] Added changelog item in `documentation/changelog.rst`
