### PR TITLE
feat: extend flexContext schema validation to only allow valid units

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -14,6 +14,7 @@ New features
 * Added form modal to edit an asset's ``flex_context`` [see `PR #1320 <https://github.com/FlexMeasures/flexmeasures/pull/1320>`_]
 * Better y-axis titles for charts that show multiple sensors with a shared unit [see `PR #1346 <https://github.com/FlexMeasures/flexmeasures/pull/1346>`_]
 * Add CLI command ``flexmeasures jobs save-last-failed`` for saving the last failed jobs [see `PR #1342 <https://www.github.com/FlexMeasures/flexmeasures/pull/1342>`_ and `PR #1359 <https://github.com/FlexMeasures/flexmeasures/pull/1359>`_]
+* Extended ``DBFlexContextSchema`` validation to include validation for units [see `PR #1364 <https://github.com/FlexMeasures/flexmeasures/pull/1364>`_]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -11,7 +11,7 @@ v0.25.0 | February XX, 2025
 
 New features
 -------------
-* Added form modal to edit an asset's ``flex_context`` [see `PR #1320 <https://github.com/FlexMeasures/flexmeasures/pull/1320>`_ and `PR #1365 <https://github.com/FlexMeasures/flexmeasures/pull/1365>`_ and `PR #1364 <https://github.com/FlexMeasures/flexmeasures/pull/1364>`_]
+* Added form modal to edit an asset's ``flex_context`` [see `PR #1320 <https://github.com/FlexMeasures/flexmeasures/pull/1320>`_, `PR #1365 <https://github.com/FlexMeasures/flexmeasures/pull/1365>`_ and `PR #1364 <https://github.com/FlexMeasures/flexmeasures/pull/1364>`_]
 * Better y-axis titles for charts that show multiple sensors with a shared unit [see `PR #1346 <https://github.com/FlexMeasures/flexmeasures/pull/1346>`_]
 * Add CLI command ``flexmeasures jobs save-last-failed`` for saving the last failed jobs [see `PR #1342 <https://www.github.com/FlexMeasures/flexmeasures/pull/1342>`_ and `PR #1359 <https://github.com/FlexMeasures/flexmeasures/pull/1359>`_]
 

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -11,10 +11,9 @@ v0.25.0 | February XX, 2025
 
 New features
 -------------
-* Added form modal to edit an asset's ``flex_context`` [see `PR #1320 <https://github.com/FlexMeasures/flexmeasures/pull/1365>`_ and `PR #1320 <https://github.com/FlexMeasures/flexmeasures/pull/1365>`]
+* Added form modal to edit an asset's ``flex_context`` [see `PR #1320 <https://github.com/FlexMeasures/flexmeasures/pull/1320>`_ and `PR #1365 <https://github.com/FlexMeasures/flexmeasures/pull/1365>`_ and `PR #1364 <https://github.com/FlexMeasures/flexmeasures/pull/1364>`_]
 * Better y-axis titles for charts that show multiple sensors with a shared unit [see `PR #1346 <https://github.com/FlexMeasures/flexmeasures/pull/1346>`_]
 * Add CLI command ``flexmeasures jobs save-last-failed`` for saving the last failed jobs [see `PR #1342 <https://www.github.com/FlexMeasures/flexmeasures/pull/1342>`_ and `PR #1359 <https://github.com/FlexMeasures/flexmeasures/pull/1359>`_]
-* Extended ``DBFlexContextSchema`` validation to include validation for units [see `PR #1364 <https://github.com/FlexMeasures/flexmeasures/pull/1364>`_]
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -232,18 +232,8 @@ class FlexContextSchema(Schema):
 
 class DBFlexContextSchema(FlexContextSchema):
     mapped_schema_keys = {
-        "consumption_price": "consumption-price",
-        "production_price": "production-price",
-        "ems_power_capacity_in_mw": "site-power-capacity",
-        "ems_production_capacity_in_mw": "site-production-capacity",
-        "ems_consumption_capacity_in_mw": "site-consumption-capacity",
-        "ems_consumption_breach_price": "site-consumption-breach-price",
-        "ems_production_breach_price": "site-production-breach-price",
-        "ems_peak_consumption_in_mw": "site-peak-consumption",
-        "ems_peak_consumption_price": "site-peak-consumption-price",
-        "ems_peak_production_in_mw": "site-peak-production",
-        "ems_peak_production_price": "site-peak-production-price",
-        "inflexible_device_sensors": "inflexible-device-sensors",
+        field: FlexContextSchema().declared_fields[field].data_key
+        for field in FlexContextSchema().declared_fields
     }
 
     @validates_schema

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -238,11 +238,7 @@ class DBFlexContextSchema(FlexContextSchema):
 
     @validates_schema
     def forbid_time_series_specs(self, data: dict, **kwargs):
-        """
-        Do not allow time series specs for the flex-context fields saved in the db.
-
-        This is a temporary restriction as future iterations will allow fixed prices on these fields as well.
-        """
+        """Do not allow time series specs for the flex-context fields saved in the db."""
 
         # List of keys to check for time series specs
         keys_to_check = []
@@ -333,7 +329,10 @@ class DBFlexContextSchema(FlexContextSchema):
                     )
 
     def _forbid_fixed_prices(self, data: dict, **kwargs):
-        """Do not allow fixed consumption price or fixed production price in the flex-context fields saved in the db."""
+        """Do not allow fixed consumption price or fixed production price in the flex-context fields saved in the db.
+
+        This is a temporary restriction as future iterations will allow fixed prices on these fields as well.
+        """
         if "consumption_price" in data and not isinstance(
             data["consumption_price"], Sensor
         ):

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -253,7 +253,7 @@ class DBFlexContextSchema(FlexContextSchema):
         for field_var, field in keys_to_check:
             if field_var in data and isinstance(data[field_var], list):
                 raise ValidationError(
-                    f"Time series specs are not allowed in flex-context fields in the DB for '{field.data_key}'.",
+                    "A time series specification (listing segments) is not supported when storing flex-context fields. Use a fixed quantity or a sensor reference instead.",
                     field_name=field.data_key,
                 )
 

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -328,16 +328,16 @@ class DBFlexContextSchema(FlexContextSchema):
 
         This is a temporary restriction as future iterations will allow fixed prices on these fields as well.
         """
-        if "consumption_price" in data and not isinstance(
-            data["consumption_price"], Sensor
+        if "consumption_price" in data and isinstance(
+            data["consumption_price"], ur.Quantity
         ):
             raise ValidationError(
                 "Fixed prices are not currently supported for consumption-price in flex-context fields in the DB.",
                 field_name="consumption-price",
             )
 
-        if "production_price" in data and not isinstance(
-            data["production_price"], Sensor
+        if "production_price" in data and isinstance(
+            data["production_price"], ur.Quantity
         ):
             raise ValidationError(
                 "Fixed prices are not currently supported for production-price in flex-context fields in the DB.",

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -166,51 +166,6 @@ class FlexContextSchema(Schema):
 
         return data
 
-    @validates_schema
-    def validate_fields_unit(self, data: dict, **kwargs):
-        """Check that each field value has a valid unit."""
-
-        self._validate_price_fields(data)
-        self._validate_power_fields(data)
-        self._validate_inflexible_device_sensors(data)
-
-    def _validate_price_fields(self, data: dict):
-        """Validate price fields."""
-        self._validate_fields(data, "price", is_energy_price_unit)
-
-    def _validate_power_fields(self, data: dict):
-        """Validate power fields."""
-        self._validate_fields(data, "power", is_power_unit)
-
-    def _validate_fields(self, data: dict, field_type: str, unit_validator):
-        """Validate fields based on type and unit validator."""
-        fields = [field for field in data if field_type in field]
-        for field in fields:
-            if field in data:
-                if isinstance(data[field], str):
-                    if not unit_validator(data[field]):
-                        raise ValidationError(
-                            f"{field_type.capitalize()} field '{field}' must be a {field_type} unit."
-                        )
-                elif isinstance(data[field], Sensor):
-                    if not unit_validator(data[field].unit):
-                        raise ValidationError(
-                            f"{field_type.capitalize()} field '{field}' must be a {field_type} unit."
-                        )
-                else:
-                    raise ValidationError(
-                        f"{field_type.capitalize()} field '{field}' must be a fixed value or sensor."
-                    )
-
-    def _validate_inflexible_device_sensors(self, data: dict):
-        """Validate inflexible device sensors."""
-        if "inflexible_device_sensors" in data:
-            for sensor in data["inflexible_device_sensors"]:
-                if not is_power_unit(sensor.unit) and not is_energy_unit(sensor.unit):
-                    raise ValidationError(
-                        f"Inflexible device sensor '{sensor.id}' must have a power or energy unit."
-                    )
-
     def _try_to_convert_price_units(self, data):
         """Convert price units to the same unit and scale if they can (incl. same currency)."""
 
@@ -311,6 +266,51 @@ class DBFlexContextSchema(FlexContextSchema):
             raise ValidationError(
                 "Fixed prices are not currently supported for production_price in flex-context fields in the DB."
             )
+
+    @validates_schema
+    def validate_fields_unit(self, data: dict, **kwargs):
+        """Check that each field value has a valid unit."""
+
+        self._validate_price_fields(data)
+        self._validate_power_fields(data)
+        self._validate_inflexible_device_sensors(data)
+
+    def _validate_price_fields(self, data: dict):
+        """Validate price fields."""
+        self._validate_fields(data, "price", is_energy_price_unit)
+
+    def _validate_power_fields(self, data: dict):
+        """Validate power fields."""
+        self._validate_fields(data, "power", is_power_unit)
+
+    def _validate_fields(self, data: dict, field_type: str, unit_validator):
+        """Validate fields based on type and unit validator."""
+        fields = [field for field in data if field_type in field]
+        for field in fields:
+            if field in data:
+                if isinstance(data[field], str):
+                    if not unit_validator(data[field]):
+                        raise ValidationError(
+                            f"{field_type.capitalize()} field '{field}' must be a {field_type} unit."
+                        )
+                elif isinstance(data[field], Sensor):
+                    if not unit_validator(data[field].unit):
+                        raise ValidationError(
+                            f"{field_type.capitalize()} field '{field}' must be a {field_type} unit."
+                        )
+                else:
+                    raise ValidationError(
+                        f"{field_type.capitalize()} field '{field}' must be a fixed value or sensor."
+                    )
+
+    def _validate_inflexible_device_sensors(self, data: dict):
+        """Validate inflexible device sensors."""
+        if "inflexible_device_sensors" in data:
+            for sensor in data["inflexible_device_sensors"]:
+                if not is_power_unit(sensor.unit) and not is_energy_unit(sensor.unit):
+                    raise ValidationError(
+                        f"Inflexible device sensor '{sensor.id}' must have a power or energy unit."
+                    )
 
 
 class MultiSensorFlexModelSchema(Schema):

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -233,7 +233,11 @@ class FlexContextSchema(Schema):
 class DBFlexContextSchema(FlexContextSchema):
     @validates_schema
     def forbid_time_series_specs(self, data: dict, **kwargs):
-        """Do not allow time series specs for the flex-context fields saved in the db."""
+        """
+        Do not allow time series specs for the flex-context fields saved in the db.
+
+        This is a temporary restriction as future iterations will allow fixed prices on these fields as well.
+        """
 
         # List of keys to check for time series specs
         keys_to_check = []
@@ -327,7 +331,7 @@ class DBFlexContextSchema(FlexContextSchema):
             data["consumption_price"], Sensor
         ):
             raise ValidationError(
-                "Fixed prices are not currently supported for consumption_price in flex-context fields in the DB.",
+                "Fixed prices are not currently supported for consumption-price in flex-context fields in the DB.",
                 field_name="consumption_price",
             )
 
@@ -335,7 +339,7 @@ class DBFlexContextSchema(FlexContextSchema):
             data["production_price"], Sensor
         ):
             raise ValidationError(
-                "Fixed prices are not currently supported for production_price in flex-context fields in the DB.",
+                "Fixed prices are not currently supported for production-price in flex-context fields in the DB.",
                 field_name="production_price",
             )
 

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -292,7 +292,9 @@ class DBFlexContextSchema(FlexContextSchema):
 
         for field in price_fields:
             if field in data:
-                self._validate_field(data, "price", field, is_capacity_price_unit)
+                self._validate_field(
+                    data, "capacity-price", field, is_capacity_price_unit
+                )
 
     def _validate_power_fields(self, data: dict):
         """Validate power fields."""
@@ -310,17 +312,19 @@ class DBFlexContextSchema(FlexContextSchema):
 
     def _validate_field(self, data: dict, field_type: str, field: str, unit_validator):
         """Validate fields based on type and unit validator."""
+        unit_type = field_type
+        field_type = "capacity price" if field_type == "capacity-price" else field_type
 
         if isinstance(data[field], ur.Quantity):
             if not unit_validator(str(data[field].units)):
                 raise ValidationError(
-                    f"{field_type.capitalize()} field '{self.mapped_schema_keys[field]}' must be a {field_type} unit.",
+                    f"{field_type.capitalize()} field '{self.mapped_schema_keys[field]}' must be a {unit_type} unit.",
                     field_name=self.mapped_schema_keys[field],
                 )
         elif isinstance(data[field], Sensor):
             if not unit_validator(data[field].unit):
                 raise ValidationError(
-                    f"{field_type.capitalize()} field '{self.mapped_schema_keys[field]}' must be a {field_type} unit.",
+                    f"{field_type.capitalize()} field '{self.mapped_schema_keys[field]}' must be a {unit_type} unit.",
                     field_name=self.mapped_schema_keys[field],
                 )
         else:

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -245,13 +245,14 @@ class DBFlexContextSchema(FlexContextSchema):
         # All the keys in this list are all fields of type VariableQuantity
         for field_var, field in self.declared_fields.items():
             if isinstance(field, VariableQuantityField):
-                keys_to_check.append(field_var)
+                keys_to_check.append((field_var, field))
 
         # Check each key and raise a ValidationError if it's a list
-        for key in keys_to_check:
-            if key in data and isinstance(data[key], list):
+        for field_var, field in keys_to_check:
+            if field_var in data and isinstance(data[field_var], list):
                 raise ValidationError(
-                    f"Time series specs are not allowed in flex-context fields in the DB for '{key}'."
+                    f"Time series specs are not allowed in flex-context fields in the DB for '{field.data_key}'.",
+                    field_name=field.data_key,
                 )
 
     @validates_schema

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -293,7 +293,7 @@ class DBFlexContextSchema(FlexContextSchema):
         for field in price_fields:
             if field in data:
                 self._validate_field(
-                    data, "capacity-price", field, is_capacity_price_unit
+                    data, "capacity price", field, is_capacity_price_unit
                 )
 
     def _validate_power_fields(self, data: dict):
@@ -312,25 +312,23 @@ class DBFlexContextSchema(FlexContextSchema):
 
     def _validate_field(self, data: dict, field_type: str, field: str, unit_validator):
         """Validate fields based on type and unit validator."""
-        unit_type = field_type
-        field_type = "capacity price" if field_type == "capacity-price" else field_type
 
         if isinstance(data[field], ur.Quantity):
             if not unit_validator(str(data[field].units)):
                 raise ValidationError(
-                    f"{field_type.capitalize()} field '{self.mapped_schema_keys[field]}' must be a {unit_type} unit.",
+                    f"{field_type.capitalize()} field '{self.mapped_schema_keys[field]}' must have a {field_type} unit.",
                     field_name=self.mapped_schema_keys[field],
                 )
         elif isinstance(data[field], Sensor):
             if not unit_validator(data[field].unit):
                 raise ValidationError(
-                    f"{field_type.capitalize()} field '{self.mapped_schema_keys[field]}' must be a {unit_type} unit.",
+                    f"{field_type.capitalize()} field '{self.mapped_schema_keys[field]}' must have a {field_type} unit.",
                     field_name=self.mapped_schema_keys[field],
                 )
         else:
             if field != "consumption_price" and field != "production_price":
                 raise ValidationError(
-                    f"{field_type.capitalize()} field '{self.mapped_schema_keys[field]}' must be a fixed value or sensor.",
+                    f"{field_type.capitalize()} field '{self.mapped_schema_keys[field]}' must havbee a fixed value or sensor.",
                     field_name=self.mapped_schema_keys[field],
                 )
 

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -312,12 +312,6 @@ class DBFlexContextSchema(FlexContextSchema):
                     f"{field_type.capitalize()} field '{self.mapped_schema_keys[field]}' must have a {field_type} unit.",
                     field_name=self.mapped_schema_keys[field],
                 )
-        else:
-            if field != "consumption_price" and field != "production_price":
-                raise ValidationError(
-                    f"{field_type.capitalize()} field '{self.mapped_schema_keys[field]}' must have a fixed value or sensor.",
-                    field_name=self.mapped_schema_keys[field],
-                )
 
     def _validate_inflexible_device_sensors(self, data: dict):
         """Validate inflexible device sensors."""

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -318,7 +318,7 @@ class DBFlexContextSchema(FlexContextSchema):
         else:
             if field != "consumption_price" and field != "production_price":
                 raise ValidationError(
-                    f"{field_type.capitalize()} field '{self.mapped_schema_keys[field]}' must havbee a fixed value or sensor.",
+                    f"{field_type.capitalize()} field '{self.mapped_schema_keys[field]}' must have a fixed value or sensor.",
                     field_name=self.mapped_schema_keys[field],
                 )
 

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -21,7 +21,7 @@ from flexmeasures.data.schemas.times import AwareDateTimeField, PlanningDuration
 from flexmeasures.utils.unit_utils import (
     ur,
     units_are_convertible,
-    is_energy_price_unit,
+    is_capacity_price_unit,
     is_power_unit,
     is_energy_unit,
 )
@@ -277,7 +277,7 @@ class DBFlexContextSchema(FlexContextSchema):
 
         for field in price_fields:
             if field in data:
-                self._validate_field(data, "price", field, is_energy_price_unit)
+                self._validate_field(data, "price", field, is_capacity_price_unit)
 
     def _validate_power_fields(self, data: dict):
         """Validate power fields."""
@@ -291,7 +291,7 @@ class DBFlexContextSchema(FlexContextSchema):
 
         for field in power_fields:
             if field in data:
-                self._validate_field(data, "price", field, is_power_unit)
+                self._validate_field(data, "power", field, is_power_unit)
 
     def _validate_field(self, data: dict, field_type: str, field: str, unit_validator):
         """Validate fields based on type and unit validator."""

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -231,6 +231,21 @@ class FlexContextSchema(Schema):
 
 
 class DBFlexContextSchema(FlexContextSchema):
+    mapped_schema_keys = {
+        "consumption_price": "consumption-price",
+        "production_price": "production-price",
+        "ems_power_capacity_in_mw": "site-power-capacity",
+        "ems_production_capacity_in_mw": "site-production-capacity",
+        "ems_consumption_capacity_in_mw": "site-consumption-capacity",
+        "ems_consumption_breach_price": "site-consumption-breach-price",
+        "ems_production_breach_price": "site-production-breach-price",
+        "ems_peak_consumption_in_mw": "site-peak-consumption",
+        "ems_peak_consumption_price": "site-peak-consumption-price",
+        "ems_peak_production_in_mw": "site-peak-production",
+        "ems_peak_production_price": "site-peak-production-price",
+        "inflexible_device_sensors": "inflexible-device-sensors",
+    }
+
     @validates_schema
     def forbid_time_series_specs(self, data: dict, **kwargs):
         """
@@ -299,20 +314,20 @@ class DBFlexContextSchema(FlexContextSchema):
         if isinstance(data[field], ur.Quantity):
             if not unit_validator(str(data[field].units)):
                 raise ValidationError(
-                    f"{field_type.capitalize()} field '{field}' must be a {field_type} unit.",
-                    field_name=field,
+                    f"{field_type.capitalize()} field '{self.mapped_schema_keys[field]}' must be a {field_type} unit.",
+                    field_name=self.mapped_schema_keys[field],
                 )
         elif isinstance(data[field], Sensor):
             if not unit_validator(data[field].unit):
                 raise ValidationError(
-                    f"{field_type.capitalize()} field '{field}' must be a {field_type} unit.",
-                    field_name=field,
+                    f"{field_type.capitalize()} field '{self.mapped_schema_keys[field]}' must be a {field_type} unit.",
+                    field_name=self.mapped_schema_keys[field],
                 )
         else:
             if field != "consumption_price" and field != "production_price":
                 raise ValidationError(
-                    f"{field_type.capitalize()} field '{field}' must be a fixed value or sensor.",
-                    field_name=field,
+                    f"{field_type.capitalize()} field '{self.mapped_schema_keys[field]}' must be a fixed value or sensor.",
+                    field_name=self.mapped_schema_keys[field],
                 )
 
     def _validate_inflexible_device_sensors(self, data: dict):
@@ -322,7 +337,7 @@ class DBFlexContextSchema(FlexContextSchema):
                 if not is_power_unit(sensor.unit) and not is_energy_unit(sensor.unit):
                     raise ValidationError(
                         f"Inflexible device sensor '{sensor.id}' must have a power or energy unit.",
-                        field_name="inflexible_device_sensors",
+                        field_name="inflexible-device-sensors",
                     )
 
     def _forbid_fixed_prices(self, data: dict, **kwargs):
@@ -332,7 +347,7 @@ class DBFlexContextSchema(FlexContextSchema):
         ):
             raise ValidationError(
                 "Fixed prices are not currently supported for consumption-price in flex-context fields in the DB.",
-                field_name="consumption_price",
+                field_name="consumption-price",
             )
 
         if "production_price" in data and not isinstance(
@@ -340,7 +355,7 @@ class DBFlexContextSchema(FlexContextSchema):
         ):
             raise ValidationError(
                 "Fixed prices are not currently supported for production-price in flex-context fields in the DB.",
-                field_name="production_price",
+                field_name="production-price",
             )
 
 

--- a/flexmeasures/data/schemas/tests/test_scheduling.py
+++ b/flexmeasures/data/schemas/tests/test_scheduling.py
@@ -309,6 +309,20 @@ def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, 
             },
         ),
         (
+            {
+                "site-power-capacity": [
+                    {
+                        "value": "100 kW",
+                        "start": "2025-03-18T00:00+01:00",
+                        "duration": "P2D",
+                    }
+                ]
+            },
+            {
+                "site-power-capacity": "Power field 'site-power-capacity' must have a fixed value or sensor."
+            },
+        ),
+        (
             {"site-power-capacity": "5 kWh"},
             {"site-power-capacity": "Cannot convert value `5 kWh` to 'MW'"},
         ),

--- a/flexmeasures/data/schemas/tests/test_scheduling.py
+++ b/flexmeasures/data/schemas/tests/test_scheduling.py
@@ -293,12 +293,12 @@ def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, 
         (
             {"consumption-price": "13000 kW"},
             {
-                "consumption_price": "Fixed prices are not currently supported for consumption-price in flex-context fields in the DB.",
+                "consumption-price": "Fixed prices are not currently supported for consumption-price in flex-context fields in the DB.",
             },
         ),
         (
             {"production-price": {"sensor": "site-power-capacity"}},
-            {"production_price": "Price field 'production_price' must be a price unit"},
+            {"production-price": "Price field 'production-price' must be a price unit"},
         ),
         (
             {"site-power-capacity": "5 kWh"},
@@ -323,7 +323,7 @@ def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, 
         (
             {"site-consumption-breach-price": "6 kWh"},
             {
-                "ems_consumption_breach_price": "Price field 'ems_consumption_breach_price' must be a price unit."
+                "site-consumption-breach-price": "Price field 'site-consumption-breach-price' must be a price unit."
             },
         ),
         (
@@ -333,7 +333,7 @@ def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, 
         (
             {"site-production-breach-price": "550 KRW/MWh"},
             {
-                "ems_production_breach_price": "Price field 'ems_production_breach_price' must be a price unit."
+                "site-production-breach-price": "Price field 'site-production-breach-price' must be a price unit."
             },
         ),
         (
@@ -369,7 +369,7 @@ def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, 
         (
             {"site-peak-production-price": "4500 NGN/MWh"},
             {
-                "ems_peak_production_price": "Price field 'ems_peak_production_price' must be a price unit."
+                "site-peak-production-price": "Price field 'site-peak-production-price' must be a price unit."
             },
         ),
         (

--- a/flexmeasures/data/schemas/tests/test_scheduling.py
+++ b/flexmeasures/data/schemas/tests/test_scheduling.py
@@ -327,17 +327,17 @@ def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, 
             },
         ),
         (
-            {"site-consumption-breach-price": "450 EUR/MWh"},
+            {"site-consumption-breach-price": "450 EUR/MW"},
             False,
         ),
         (
-            {"site-production-breach-price": "550 KRW/MW"},
+            {"site-production-breach-price": "550 KRW/MWh"},
             {
                 "ems_production_breach_price": "Price field 'ems_production_breach_price' must be a price unit."
             },
         ),
         (
-            {"site-production-breach-price": "3500 NGN/MWh"},
+            {"site-production-breach-price": "3500 NGN/MW"},
             False,
         ),
         (
@@ -355,7 +355,7 @@ def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, 
             },
         ),
         (
-            {"site-peak-consumption-price": "100 EUR/MWh"},
+            {"site-peak-consumption-price": "100 EUR/MW"},
             False,
         ),
         (
@@ -367,13 +367,13 @@ def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, 
             False,
         ),
         (
-            {"site-peak-production-price": "4500 NGN/MW"},
+            {"site-peak-production-price": "4500 NGN/MWh"},
             {
                 "ems_peak_production_price": "Price field 'ems_peak_production_price' must be a price unit."
             },
         ),
         (
-            {"site-peak-consumption-price": "700 JPY/MWh"},
+            {"site-peak-consumption-price": "700 JPY/MW"},
             False,
         ),
     ],

--- a/flexmeasures/data/schemas/tests/test_scheduling.py
+++ b/flexmeasures/data/schemas/tests/test_scheduling.py
@@ -293,7 +293,7 @@ def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, 
         (
             {"consumption-price": "13000 kW"},
             {
-                "consumption_price": "Fixed prices are not currently supported for consumption_price in flex-context fields in the DB.",
+                "consumption_price": "Fixed prices are not currently supported for consumption-price in flex-context fields in the DB.",
             },
         ),
         (
@@ -306,9 +306,7 @@ def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, 
         ),
         (
             {"site-consumption-capacity": "6 kWh"},
-            {
-                "site-consumption-capacity": "Cannot convert value `6 kWh` to 'MW'"
-            },  # For some reason i can use the original key name with hyphens
+            {"site-consumption-capacity": "Cannot convert value `6 kWh` to 'MW'"},
         ),
         (
             {"site-consumption-capacity": "6000 kW"},
@@ -316,9 +314,7 @@ def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, 
         ),
         (
             {"site-production-capacity": "6 kWh"},
-            {
-                "site-production-capacity": "Cannot convert value `6 kWh` to 'MW'"
-            },  # For some reason i can use the original key name with hyphens
+            {"site-production-capacity": "Cannot convert value `6 kWh` to 'MW'"},
         ),
         (
             {"site-production-capacity": "7000 kW"},

--- a/flexmeasures/data/schemas/tests/test_scheduling.py
+++ b/flexmeasures/data/schemas/tests/test_scheduling.py
@@ -299,7 +299,7 @@ def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, 
         (
             {"production-price": {"sensor": "site-power-capacity"}},
             {
-                "production-price": "Capacity price field 'production-price' must be a capacity-price unit"
+                "production-price": "Capacity price field 'production-price' must have a capacity price unit"
             },
         ),
         (
@@ -325,7 +325,7 @@ def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, 
         (
             {"site-consumption-breach-price": "6 kWh"},
             {
-                "site-consumption-breach-price": "Capacity price field 'site-consumption-breach-price' must be a capacity-price unit."
+                "site-consumption-breach-price": "Capacity price field 'site-consumption-breach-price' must have a capacity price unit."
             },
         ),
         (
@@ -335,7 +335,7 @@ def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, 
         (
             {"site-production-breach-price": "550 EUR/MWh"},
             {
-                "site-production-breach-price": "Capacity price field 'site-production-breach-price' must be a capacity-price unit."
+                "site-production-breach-price": "Capacity price field 'site-production-breach-price' must have a capacity price unit."
             },
         ),
         (
@@ -371,7 +371,7 @@ def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, 
         (
             {"site-peak-production-price": "4500 EUR/MWh"},
             {
-                "site-peak-production-price": "Capacity price field 'site-peak-production-price' must be a capacity-price unit."
+                "site-peak-production-price": "Capacity price field 'site-peak-production-price' must have a capacity price unit."
             },
         ),
         (

--- a/flexmeasures/data/schemas/tests/test_scheduling.py
+++ b/flexmeasures/data/schemas/tests/test_scheduling.py
@@ -303,6 +303,12 @@ def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, 
             },
         ),
         (
+            {"site-power-capacity": 100},
+            {
+                "site-power-capacity": f"Unsupported value type. `{type(100)}` was provided but only dict, list and str are supported."
+            },
+        ),
+        (
             {"site-power-capacity": "5 kWh"},
             {"site-power-capacity": "Cannot convert value `5 kWh` to 'MW'"},
         ),

--- a/flexmeasures/data/schemas/tests/test_scheduling.py
+++ b/flexmeasures/data/schemas/tests/test_scheduling.py
@@ -323,6 +323,20 @@ def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, 
             },
         ),
         (
+            {
+                "site-power-capacity": [
+                    {
+                        "value": "100 kW",
+                        "start": "2025-03-18T00:00+01:00",
+                        "duration": "P2D",
+                    }
+                ]
+            },
+            {
+                "site-power-capacity": "Time series specs are not allowed in flex-context fields in the DB for 'site-power-capacity'"
+            },
+        ),
+        (
             {"site-power-capacity": "5 kWh"},
             {"site-power-capacity": "Cannot convert value `5 kWh` to 'MW'"},
         ),

--- a/flexmeasures/data/schemas/tests/test_scheduling.py
+++ b/flexmeasures/data/schemas/tests/test_scheduling.py
@@ -319,20 +319,6 @@ def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, 
                 ]
             },
             {
-                "site-power-capacity": "Power field 'site-power-capacity' must have a fixed value or sensor."
-            },
-        ),
-        (
-            {
-                "site-power-capacity": [
-                    {
-                        "value": "100 kW",
-                        "start": "2025-03-18T00:00+01:00",
-                        "duration": "P2D",
-                    }
-                ]
-            },
-            {
                 "site-power-capacity": "Time series specs are not allowed in flex-context fields in the DB for 'site-power-capacity'"
             },
         ),

--- a/flexmeasures/data/schemas/tests/test_scheduling.py
+++ b/flexmeasures/data/schemas/tests/test_scheduling.py
@@ -298,7 +298,9 @@ def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, 
         ),
         (
             {"production-price": {"sensor": "site-power-capacity"}},
-            {"production-price": "Price field 'production-price' must be a price unit"},
+            {
+                "production-price": "Capacity price field 'production-price' must be a capacity-price unit"
+            },
         ),
         (
             {"site-power-capacity": "5 kWh"},
@@ -323,7 +325,7 @@ def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, 
         (
             {"site-consumption-breach-price": "6 kWh"},
             {
-                "site-consumption-breach-price": "Price field 'site-consumption-breach-price' must be a price unit."
+                "site-consumption-breach-price": "Capacity price field 'site-consumption-breach-price' must be a capacity-price unit."
             },
         ),
         (
@@ -331,13 +333,13 @@ def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, 
             False,
         ),
         (
-            {"site-production-breach-price": "550 KRW/MWh"},
+            {"site-production-breach-price": "550 EUR/MWh"},
             {
-                "site-production-breach-price": "Price field 'site-production-breach-price' must be a price unit."
+                "site-production-breach-price": "Capacity price field 'site-production-breach-price' must be a capacity-price unit."
             },
         ),
         (
-            {"site-production-breach-price": "3500 NGN/MW"},
+            {"site-production-breach-price": "3500 EUR/MW"},
             False,
         ),
         (
@@ -367,13 +369,13 @@ def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, 
             False,
         ),
         (
-            {"site-peak-production-price": "4500 NGN/MWh"},
+            {"site-peak-production-price": "4500 EUR/MWh"},
             {
-                "site-peak-production-price": "Price field 'site-peak-production-price' must be a price unit."
+                "site-peak-production-price": "Capacity price field 'site-peak-production-price' must be a capacity-price unit."
             },
         ),
         (
-            {"site-peak-consumption-price": "700 JPY/MW"},
+            {"site-peak-consumption-price": "700 EUR/MW"},
             False,
         ),
     ],
@@ -392,7 +394,6 @@ def test_db_flex_context_schema(
 
     if fails:
         with pytest.raises(ValidationError) as e_info:
-            print("flex_context", flex_context)
             schema.load(flex_context)
         print(e_info.value.messages)
         for field_name, expected_message in fails.items():

--- a/flexmeasures/data/schemas/tests/test_scheduling.py
+++ b/flexmeasures/data/schemas/tests/test_scheduling.py
@@ -339,7 +339,7 @@ def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, 
                 ]
             },
             {
-                "site-power-capacity": "Time series specs are not allowed in flex-context fields in the DB for 'site-power-capacity'"
+                "site-power-capacity": "A time series specification (listing segments) is not supported when storing flex-context fields. Use a fixed quantity or a sensor reference instead."
             },
         ),
         (

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -1441,11 +1441,11 @@
             flexInfoContainer.innerHTML = renderSelectInfoCards("site-consumption-capacity", description, allowedUnits);
         } else if (selectedOption == "site-consumption-breach-price") {
             const description = "This value represents the price that will be paid if the site consumes more power than the site consumption capacity. This value will be used in the optimization";
-            const allowedUnits = ["EUR/MWh", "JPY/MWh", "USD/MWh, and other currencies."];
+            const allowedUnits = ["EUR/MWh", "JPY/kWh", "USD/MWh, and other currencies."];
             flexInfoContainer.innerHTML = renderSelectInfoCards("site-consumption-breach-price", description, allowedUnits);
         } else if (selectedOption == "site-production-breach-price") {
             const description = "This value represents the price that will be paid if the site produces more power than the site production capacity. This value will be used in the optimization";
-            const allowedUnits = ["EUR/MWh", "JPY/MWh", "USD/MWh, and other currencies."];
+            const allowedUnits = ["EUR/MWh", "JPY/kWh", "USD/MWh, and other currencies."];
             flexInfoContainer.innerHTML = renderSelectInfoCards("site-production-breach-price", description, allowedUnits);
         } else if (selectedOption == "site-peak-consumption") {
             const description = "This value represents the peak consumption of the site. This value will be used in the optimization";
@@ -1457,11 +1457,11 @@
             flexInfoContainer.innerHTML = renderSelectInfoCards("site-peak-production", description, allowedUnits);
         } else if (selectedOption == "site-peak-consumption-price") {
             const description = "This value represents the price that will be paid if the site consumes more power than the site peak consumption. This value will be used in the optimization";
-            const allowedUnits = ["EUR/MWh", "JPY/MWh", "USD/MWh, and other currencies."];
+            const allowedUnits = ["EUR/MWh", "JPY/kWh", "USD/MWh, and other currencies."];
             flexInfoContainer.innerHTML = renderSelectInfoCards("site-peak-consumption-price", description, allowedUnits);
         } else if (selectedOption == "site-peak-production-price") {
             const description = "This value represents the price that will be paid if the site produces more power than the site peak production. This value will be used in the optimization";
-            const allowedUnits = ["EUR/MWh", "JPY/MWh", "USD/MWh, and other currencies."];
+            const allowedUnits = ["EUR/MWh", "JPY/kWh", "USD/MWh, and other currencies."];
             flexInfoContainer.innerHTML = renderSelectInfoCards("site-peak-production-price", description, allowedUnits);
         } else if (selectedOption == "inflexible-device-sensors") {
             const description = "This value represents the sensors that are inflexible and cannot be controlled. These sensors will be used in the optimization";

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -1421,11 +1421,11 @@
         const alertStyle = "alert alert-light";
         if (selectedOption === "consumption-price") {
             const description = "Set the sensor that represents the consumption price of the site. This value will be used in the optimization";
-            const allowedUnits = ["EUR", "EUR/MWh"];
+            const allowedUnits = ["EUR/MWh", "JPY/MWh", "USD/MWh, and other currencies."];
             flexInfoContainer.innerHTML = renderSelectInfoCards("consumption-price", description, allowedUnits);
         } else if (selectedOption === "production-price") {
             const description = "Set the sensor that represents the production price of the site. This value will be used in the optimization";
-            const allowedUnits = ["EUR", "EUR/MWh"];
+            const allowedUnits = ["EUR/MWh", "JPY/MWh", "USD/MWh, and other currencies."];
             flexInfoContainer.innerHTML = renderSelectInfoCards("production-price", description, allowedUnits);
         } else if (selectedOption == "site-power-capacity") {
             const description = "This value represents the maximum power that the site can consume or produce. This value will be used in the optimization";
@@ -1433,39 +1433,39 @@
             flexInfoContainer.innerHTML = renderSelectInfoCards("site-power-capacity", description, allowedUnits);
         } else if (selectedOption == "site-production-capacity") {
             const description = "This value represents the maximum power that the site can produce. This value will be used in the optimization";
-            const allowedUnits = ["kW", "kWh"];
+            const allowedUnits = ["kW"];
             flexInfoContainer.innerHTML = renderSelectInfoCards("site-production-capacity", description, allowedUnits);
         } else if (selectedOption == "site-consumption-capacity") {
             const description = "This value represents the maximum power that the site can consume. This value will be used in the optimization";
-            const allowedUnits = ["kW", "kWh"];
+            const allowedUnits = ["kW"];
             flexInfoContainer.innerHTML = renderSelectInfoCards("site-consumption-capacity", description, allowedUnits);
         } else if (selectedOption == "site-consumption-breach-price") {
             const description = "This value represents the price that will be paid if the site consumes more power than the site consumption capacity. This value will be used in the optimization";
-            const allowedUnits = ["EUR", "EUR/MWh"];
+            const allowedUnits = ["EUR/MWh", "JPY/MWh", "USD/MWh, and other currencies."];
             flexInfoContainer.innerHTML = renderSelectInfoCards("site-consumption-breach-price", description, allowedUnits);
         } else if (selectedOption == "site-production-breach-price") {
             const description = "This value represents the price that will be paid if the site produces more power than the site production capacity. This value will be used in the optimization";
-            const allowedUnits = ["EUR", "EUR/MWh"];
+            const allowedUnits = ["EUR/MWh", "JPY/MWh", "USD/MWh, and other currencies."];
             flexInfoContainer.innerHTML = renderSelectInfoCards("site-production-breach-price", description, allowedUnits);
         } else if (selectedOption == "site-peak-consumption") {
             const description = "This value represents the peak consumption of the site. This value will be used in the optimization";
-            const allowedUnits = ["kW", "kWh"];
+            const allowedUnits = ["kW"];
             flexInfoContainer.innerHTML = renderSelectInfoCards("site-peak-consumption", description, allowedUnits);
         } else if (selectedOption == "site-peak-production") {
             const description = "This value represents the peak production of the site. This value will be used in the optimization";
-            const allowedUnits = ["kW", "kWh"];
+            const allowedUnits = ["kW"];
             flexInfoContainer.innerHTML = renderSelectInfoCards("site-peak-production", description, allowedUnits);
         } else if (selectedOption == "site-peak-consumption-price") {
             const description = "This value represents the price that will be paid if the site consumes more power than the site peak consumption. This value will be used in the optimization";
-            const allowedUnits = ["EUR", "EUR/MWh"];
+            const allowedUnits = ["EUR/MWh", "JPY/MWh", "USD/MWh, and other currencies."];
             flexInfoContainer.innerHTML = renderSelectInfoCards("site-peak-consumption-price", description, allowedUnits);
         } else if (selectedOption == "site-peak-production-price") {
             const description = "This value represents the price that will be paid if the site produces more power than the site peak production. This value will be used in the optimization";
-            const allowedUnits = ["EUR", "EUR/MWh"];
+            const allowedUnits = ["EUR/MWh", "JPY/MWh", "USD/MWh, and other currencies."];
             flexInfoContainer.innerHTML = renderSelectInfoCards("site-peak-production-price", description, allowedUnits);
         } else if (selectedOption == "inflexible-device-sensors") {
             const description = "This value represents the sensors that are inflexible and cannot be controlled. These sensors will be used in the optimization";
-            const allowedUnits = ["sensors only"];
+            const allowedUnits = ["kW"];
             flexInfoContainer.innerHTML = renderSelectInfoCards("inflexible-device-sensors", description, allowedUnits);
         }
     }

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -1421,11 +1421,11 @@
         const alertStyle = "alert alert-light";
         if (selectedOption === "consumption-price") {
             const description = "Set the sensor that represents the consumption price of the site. This value will be used in the optimization";
-            const allowedUnits = ["EUR/MWh"];
+            const allowedUnits = ["EUR/MWh", "JPY/kWh", "USD/MWh, and other currencies."];
             flexInfoContainer.innerHTML = renderSelectInfoCards("consumption-price", description, allowedUnits);
         } else if (selectedOption === "production-price") {
             const description = "Set the sensor that represents the production price of the site. This value will be used in the optimization";
-            const allowedUnits = ["EUR/MWh"];
+            const allowedUnits = ["EUR/MWh", "JPY/kWh", "USD/MWh, and other currencies."];
             flexInfoContainer.innerHTML = renderSelectInfoCards("production-price", description, allowedUnits);
         } else if (selectedOption == "site-power-capacity") {
             const description = "This value represents the maximum power that the site can consume or produce. This value will be used in the optimization";
@@ -1441,11 +1441,11 @@
             flexInfoContainer.innerHTML = renderSelectInfoCards("site-consumption-capacity", description, allowedUnits);
         } else if (selectedOption == "site-consumption-breach-price") {
             const description = "This value represents the price that will be paid if the site consumes more power than the site consumption capacity. This value will be used in the optimization";
-            const allowedUnits = ["EUR/MWh", "JPY/kWh", "USD/MWh, and other currencies."];
+            const allowedUnits = ["EUR/MW", "JPY/kW", "USD/MW, and other currencies."];
             flexInfoContainer.innerHTML = renderSelectInfoCards("site-consumption-breach-price", description, allowedUnits);
         } else if (selectedOption == "site-production-breach-price") {
             const description = "This value represents the price that will be paid if the site produces more power than the site production capacity. This value will be used in the optimization";
-            const allowedUnits = ["EUR/MWh", "JPY/kWh", "USD/MWh, and other currencies."];
+            const allowedUnits = ["EUR/MW", "JPY/kW", "USD/MW, and other currencies."];
             flexInfoContainer.innerHTML = renderSelectInfoCards("site-production-breach-price", description, allowedUnits);
         } else if (selectedOption == "site-peak-consumption") {
             const description = "This value represents the peak consumption of the site. This value will be used in the optimization";
@@ -1457,11 +1457,11 @@
             flexInfoContainer.innerHTML = renderSelectInfoCards("site-peak-production", description, allowedUnits);
         } else if (selectedOption == "site-peak-consumption-price") {
             const description = "This value represents the price that will be paid if the site consumes more power than the site peak consumption. This value will be used in the optimization";
-            const allowedUnits = ["EUR/MWh", "JPY/kWh", "USD/MWh, and other currencies."];
+            const allowedUnits = ["EUR/MW", "JPY/kW", "USD/MW, and other currencies."];
             flexInfoContainer.innerHTML = renderSelectInfoCards("site-peak-consumption-price", description, allowedUnits);
         } else if (selectedOption == "site-peak-production-price") {
             const description = "This value represents the price that will be paid if the site produces more power than the site peak production. This value will be used in the optimization";
-            const allowedUnits = ["EUR/MWh", "JPY/kWh", "USD/MWh, and other currencies."];
+            const allowedUnits = ["EUR/MW", "JPY/kW", "USD/MW, and other currencies."];
             flexInfoContainer.innerHTML = renderSelectInfoCards("site-peak-production-price", description, allowedUnits);
         } else if (selectedOption == "inflexible-device-sensors") {
             const description = "This value represents the sensors that are inflexible and cannot be controlled. These sensors will be used in the optimization";

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -1421,15 +1421,15 @@
         const alertStyle = "alert alert-light";
         if (selectedOption === "consumption-price") {
             const description = "Set the sensor that represents the consumption price of the site. This value will be used in the optimization";
-            const allowedUnits = ["EUR/MWh", "JPY/MWh", "USD/MWh, and other currencies."];
+            const allowedUnits = ["EUR/MWh"];
             flexInfoContainer.innerHTML = renderSelectInfoCards("consumption-price", description, allowedUnits);
         } else if (selectedOption === "production-price") {
             const description = "Set the sensor that represents the production price of the site. This value will be used in the optimization";
-            const allowedUnits = ["EUR/MWh", "JPY/MWh", "USD/MWh, and other currencies."];
+            const allowedUnits = ["EUR/MWh"];
             flexInfoContainer.innerHTML = renderSelectInfoCards("production-price", description, allowedUnits);
         } else if (selectedOption == "site-power-capacity") {
             const description = "This value represents the maximum power that the site can consume or produce. This value will be used in the optimization";
-            const allowedUnits = ["kW"];
+            const allowedUnits = ["kW", "kVA", "MVA"];
             flexInfoContainer.innerHTML = renderSelectInfoCards("site-power-capacity", description, allowedUnits);
         } else if (selectedOption == "site-production-capacity") {
             const description = "This value represents the maximum power that the site can produce. This value will be used in the optimization";

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -202,7 +202,7 @@ class TestingConfig(Config):
     SECRET_KEY: str = "dummy-key-for-testing"
     SECURITY_PASSWORD_SALT: str = "$2b$19$abcdefghijklmnopqrstuv"
     SQLALCHEMY_DATABASE_URI: str = (
-        "postgresql://postgres:postgres@localhost/flexmeasures_test"
+        "postgresql://flexmeasures_test:flexmeasures_test@localhost/flexmeasures_test"
     )
     # SQLALCHEMY_ECHO = True
     FLEXMEASURES_TASK_CHECK_AUTH_TOKEN: str = "test-task-check-token"

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -202,7 +202,7 @@ class TestingConfig(Config):
     SECRET_KEY: str = "dummy-key-for-testing"
     SECURITY_PASSWORD_SALT: str = "$2b$19$abcdefghijklmnopqrstuv"
     SQLALCHEMY_DATABASE_URI: str = (
-        "postgresql://flexmeasures_test:flexmeasures_test@localhost/flexmeasures_test"
+        "postgresql://postgres:postgres@localhost/flexmeasures_test"
     )
     # SQLALCHEMY_ECHO = True
     FLEXMEASURES_TASK_CHECK_AUTH_TOKEN: str = "test-task-check-token"

--- a/flexmeasures/utils/unit_utils.py
+++ b/flexmeasures/utils/unit_utils.py
@@ -251,6 +251,22 @@ def is_energy_price_unit(unit: str) -> bool:
     return False
 
 
+def is_capacity_price_unit(unit: str) -> bool:
+    """For example:
+    >>> is_capacity_price_unit("EUR/MW")
+    True
+    >>> is_capacity_price_unit("KRW/MW")
+    True
+    >>> is_capacity_price_unit("KRW/MWh")
+    False
+    >>> is_capacity_price_unit("beans/MWh")
+    False
+    """
+    if is_price_unit(unit) and is_power_unit(unit[4:]):
+        return True
+    return False
+
+
 def is_speed_unit(unit: str) -> bool:
     """For example:
     >>> is_speed_unit("m/s")


### PR DESCRIPTION
## Description

This PR extends the FlexContextSchema validation to also cover for field value unit validations

## Look & Feel

No visual description as it's a backend 

## How to test

1. Go to asset's page and click on an asset
2. Go ahead to edit the asset's flex-context
3. Try any of the following

- Add a non-energy price unit to any price field
- Add a non-power unit to any power field

## Further Improvements

In this PR I noticed a rarely occurring bug with the modal UI, a follow up PR will be made to fix this bug and another one reported by @nhoening 

## Related Items

This PR closes #1353 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
