### PR TITLE
fix: Fixed UI&UX bugs on flexcontext modal dialouge

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -11,7 +11,7 @@ v0.25.0 | February XX, 2025
 
 New features
 -------------
-* Added form modal to edit an asset's ``flex_context`` [see `PR #1320 <https://github.com/FlexMeasures/flexmeasures/pull/1320>`_]
+* Added form modal to edit an asset's ``flex_context`` [see `PR #1320 <https://github.com/FlexMeasures/flexmeasures/pull/1365>`_ and `PR #1320 <https://github.com/FlexMeasures/flexmeasures/pull/1365>`]
 * Better y-axis titles for charts that show multiple sensors with a shared unit [see `PR #1346 <https://github.com/FlexMeasures/flexmeasures/pull/1346>`_]
 * Add CLI command ``flexmeasures jobs save-last-failed`` for saving the last failed jobs [see `PR #1342 <https://www.github.com/FlexMeasures/flexmeasures/pull/1342>`_ and `PR #1359 <https://github.com/FlexMeasures/flexmeasures/pull/1359>`_]
 
@@ -28,7 +28,6 @@ Infrastructure / Support
 
 Bugfixes
 -----------
-* Fix a couple of issues with the new ``flex_context`` form modal [see `PR #1365 <https://github.com/FlexMeasures/flexmeasures/pull/1365>`_]
 
 v0.24.1 | February 27, 2025
 ============================

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -28,7 +28,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
-
+* Fix a couple of issues with the new ``flex_context`` form modal [see `PR #1365 <https://github.com/FlexMeasures/flexmeasures/pull/1365>`_]
 
 v0.24.1 | February 27, 2025
 ============================

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -1149,6 +1149,8 @@
         }
 
         renderFlexSelectOptions();
+        selectFlexField();
+        renderSelectInfoCards();
     }
 
     async function udpateFlexContextFieldValue(dataType, sensorId) {
@@ -1171,7 +1173,11 @@
             assetFlexContext[flexId] = powerCapacityInputValue;
         } else if (dataType === "sensor" && sensorId) {
             if (flexId === "inflexible-device-sensors") {
-                assetFlexContext[flexId].push(sensorId);
+                if (assetFlexContext[flexId]) {
+                    assetFlexContext[flexId].push(sensorId);
+                } else {
+                    assetFlexContext[flexId] = [sensorId];
+                }
             } else {
                 assetFlexContext[flexId] = { sensor: sensorId };
             }
@@ -1254,7 +1260,7 @@
                         ${sensorsOnly ? `
                         <div class="tab-pane fade show active bg-dynamic-val rounded-bottom" id="pills-dynamic" role="tabpanel" aria-labelledby="pills-dynamic-tab">
                             <div id="select-sensor-input" class="flex-input-group mb-4 p-2">
-                                <label for="sensor" class="form-label">Look up Sensor:
+                                <label for="sensor" class="form-label">Look up Sensor for <b>${getFlexContextFieldTitle(contextKey)} </b>
                                     <i class="fa fa-info-circle ps-2"
                                         data-bs-toggle="tooltip"
                                         data-bs-placement="bottom"
@@ -1389,21 +1395,25 @@
     });
 
     function renderSelectInfoCards(contextKey, description, allowedUnits, isArray = false) {
-        return `
-            <div>
-                <div class="alert alert-info" role="alert">
-                    <b> About ${getFlexContextFieldTitle(contextKey)}
-                    <div class="pt-2 fw-normal">
-                        ${description}
-                    </div>
+        if (contextKey) {
+            return `
+                <div>
+                    <div class="alert alert-info" role="alert">
+                        <b> About ${getFlexContextFieldTitle(contextKey)}
+                        <div class="pt-2 fw-normal">
+                            ${description}
+                        </div>
 
-                    <div class="pt-3 fw-bold"> 
-                        Example Units: <span class="fw-normal"> ${allowedUnits.join(", ")} </span>
+                        <div class="pt-3 fw-bold"> 
+                            Example Units: <span class="fw-normal"> ${allowedUnits.join(", ")} </span>
+                        </div>
+                        
                     </div>
-                    
                 </div>
-            </div>
-        `;
+            `;
+        } else {
+            flexInfoContainer.innerHTML = "";
+        }
     }
 
     function handleFlexSelectChange(selectedOption) {


### PR DESCRIPTION
## Description

This PR fixes a few bugs discovered in the FlexContext modal dialogue.

1. For fields that render only Sensor, the form didn't show the name of the field it was currently targetting
2. On rare occasions when the modal is pulled up but the inflexible devices field was not pre-rendered, the form  refuses to add a sensor to this field
3. The `About` section and `Form` section tend to show still when no field is selected(was a previous issue in original PR but was left for a follow up OR as the solution couldn't be resolved then)

## Look & Feel

The dialogue should look something like below when no field is selected

![image](https://github.com/user-attachments/assets/60c1e64e-31e0-438a-84b0-4e0ce65a81dd)

## How to test

1. Go to asset's page and click on an asset
2. Go ahead to edit the asset's flex-context
3. Try out all the above listed bugs and see if they still persists

## Further Improvements

None

## Related Items

This PR closes #1366 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
