### PR TITLE
Prevent duplicates in the result bdf of `simplify_index`

### DIFF
--- a/flexmeasures/data/queries/utils.py
+++ b/flexmeasures/data/queries/utils.py
@@ -15,7 +15,6 @@ from sqlalchemy import select, Select
 
 from flexmeasures.data.config import db
 from flexmeasures.data.models.generic_assets import GenericAsset, GenericAssetType
-from flexmeasures.data.models.time_series import Sensor
 from flexmeasures.data.models.data_sources import DataSource
 from flexmeasures.utils import flexmeasures_inflection
 from flexmeasures.auth.policy import user_has_admin_access
@@ -222,7 +221,7 @@ def simplify_index(
     bdf: tb.BeliefsDataFrame,
     index_levels_to_columns: list[str] | None = None,
     keep_duplicate_value: str | None = None,
-    keep_duplicate_column: GenericAsset | GenericAssetType | Sensor | None = None,
+    keep_duplicate_column: GenericAsset | GenericAssetType | None = None,
 ) -> pd.DataFrame:
     """Drops indices other than event_start.
     Optionally, salvage index levels as new columns.


### PR DESCRIPTION
## Description

The function [`simplify_index`](https://github.com/FlexMeasures/flexmeasures/blob/main/flexmeasures/data/queries/utils.py#L219)  does not prevent duplicates.
Changes:

- [x]  Added two parameters:

- `keep_duplicate_column`:Specifies the column to filter by.
- `keep_duplicate_value`: The value in the specified column to keep.

- [x] Ensured duplicates are either removed (if possible) or an exception is raised.

## How to Test
Steps:
1.    Use the `fix/keep-beliefs-from-Simulation-source-in-evse-power-sensor`  branch, as it includes adaptations for this change.
2.    Select a project, complete the setup phase, and run the smart charging scenario.
3.    Ensure that no warning related to fill_null_values appears, unlike the previous issue:

![image](https://github.com/user-attachments/assets/f3c4f79d-d517-493b-8d49-b4ff44213d7c)
 
## Related Items

This PR closes #750 and enables the merging of future PR in smartbuilings .

---


