### PR TITLE
Clarify config defaults that limit concurrent connections

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -27,6 +27,7 @@ Infrastructure / Support
 * Catch invalid time windows passed to ``flexmeasures add report`` [see `PR #1324 <https://github.com/FlexMeasures/flexmeasures/pull/1324>`_]
 * Test utility function for device scheduling in a multi-asset setting (sequential and simultaneous) [see `PR #1341 <https://github.com/FlexMeasures/flexmeasures/pull/1341>`_]
 * Add utils doctests to our CI pipeline [see `PR #1347 <https://github.com/FlexMeasures/flexmeasures/pull/1347>`_]
+* Clarify default limitations to concurrent connections [see `PR #1391 <https://github.com/FlexMeasures/flexmeasures/pull/1391>`_]
 
 Bugfixes
 -----------

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -29,6 +29,8 @@ class Config(object):
     SQLALCHEMY_TRACK_MODIFICATIONS: bool = False
     SQLALCHEMY_ENGINE_OPTIONS: dict = {
         "pool_recycle": 299,  # https://www.pythonanywhere.com/forums/topic/2599/
+        "pool_size": 5,  # 5 is SQLAlchemy's default for the maximum number of permanent connections to keep
+        "max_overflow": 10,  # 10 is SQLAlchemy's default for temporarily exceeding the pool_size if no connections are available
         # "pool_timeout": 20,
         "pool_pre_ping": True,  # https://docs.sqlalchemy.org/en/13/core/pooling.html#disconnect-handling-pessimistic
         "connect_args": {


### PR DESCRIPTION
## Description

For future reference, these are the current defaults limiting the number of db connections (Postgres itself defaults to a 100 concurrent connections).

- [x] add additional default `SQLALCHEMY_ENGINE_OPTIONS` relating to concurrent connections
- [x] Added changelog item in `documentation/changelog.rst`
