### PR TITLE
feat: create sensor for asset page

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -12,6 +12,7 @@ New features
 
 * Support saving the storage schedule SOC using the ``flex-model`` field ``state-of-charge`` to the ``flex-model`` [see `PR #1392 <https://github.com/FlexMeasures/flexmeasures/pull/1392>`_]
 * Save changes in asset flex-context form right away [see `PR #1390 <https://github.com/FlexMeasures/flexmeasures/pull/1390>`_]
+* Introduced new page to create sensor for a parent asset [see `PR #1394 <https://github.com/FlexMeasures/flexmeasures/pull/1394>`_]
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/ui/crud/assets/views.py
+++ b/flexmeasures/ui/crud/assets/views.py
@@ -147,7 +147,7 @@ class AssetCrudUI(FlaskView):
         asset = GenericAsset.query.get(id)
         if asset is None:
             raise NotFound
-        check_access(asset, "read")
+        check_access(asset, "create-children")
 
         return render_flexmeasures_template(
             "crud/sensor_new.html",

--- a/flexmeasures/ui/crud/assets/views.py
+++ b/flexmeasures/ui/crud/assets/views.py
@@ -141,6 +141,22 @@ class AssetCrudUI(FlaskView):
         )
 
     @login_required
+    @route("/<id>/sensor/new")
+    def create_sensor(self, id: str):
+        """POST to /assets/<id>/sensor/new"""
+
+        asset = GenericAsset.query.get(id)
+        if asset is None:
+            raise NotFound
+        check_access(asset, "read")
+
+        return render_flexmeasures_template(
+            "crud/sensor_new.html",
+            asset=asset,
+            available_units=available_units(),
+        )
+
+    @login_required
     @route("/<id>/status")
     def status(self, id: str):
         """GET from /assets/<id>/status to show the staleness of the asset's sensors."""

--- a/flexmeasures/ui/crud/assets/views.py
+++ b/flexmeasures/ui/crud/assets/views.py
@@ -143,8 +143,7 @@ class AssetCrudUI(FlaskView):
     @login_required
     @route("/<id>/sensor/new")
     def create_sensor(self, id: str):
-        """POST to /assets/<id>/sensor/new"""
-
+        """GET to /assets/<id>/sensor/new"""
         asset = GenericAsset.query.get(id)
         if asset is None:
             raise NotFound

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -244,7 +244,11 @@
 
             <div class="sensors-asset card">
                 <h3>All sensors for {{ asset.name }}</h3>
+               
                 <div class="table-responsive">
+                    <button class="btn btn-sm btn-responsive btn-info" type="submit">
+                        <a href="/assets/{{asset.id}}/sensor/new">Create Sensor</a>
+                    </button>
                     <table class="table table-striped paginate nav-on-click" title="View data" id="sensorsTable">
                     </table>
                 </div>

--- a/flexmeasures/ui/templates/crud/sensor_new.html
+++ b/flexmeasures/ui/templates/crud/sensor_new.html
@@ -60,7 +60,7 @@ sensor {% endblock %} {% block divs %}
             class="form-select"
             onchange="document.getElementById('unit').value = this.value"
           >
-            <option selected>Units</option>
+            <option selected>Choose from units already in use</option>
             {% for unit in available_units %}
             <option>{{ unit }}</option>
             {% endfor %}

--- a/flexmeasures/ui/templates/crud/sensor_new.html
+++ b/flexmeasures/ui/templates/crud/sensor_new.html
@@ -9,7 +9,15 @@ sensor {% endblock %} {% block divs %}
       </button>
     </div>
   </div>
+
   <form id="sensorForm" class="form p-4" method="POST">
+    <div
+      id="alertbox"
+      class="alert alert-success"
+      role="alert"
+      style="display: none"
+    ></div>
+
     <div class="mb-3">
       <label for="name" class="form-label">Name</label>
       <input
@@ -87,6 +95,7 @@ sensor {% endblock %} {% block divs %}
 <script type="text/javascript">
   const apiBasePath = window.location.origin;
   const sensorForm = document.getElementById("sensorForm");
+  const alertBox = document.getElementById("alertbox");
 
   function validateEventResolution(eventResolution) {
     // Regular expression to match duration format (PT[H|M|S])
@@ -150,7 +159,15 @@ sensor {% endblock %} {% block divs %}
     });
 
     if (response.ok) {
+      const responseData = await response.json();
+      const sensorId = responseData.id;
       showToast("Sensor created successfully.", "success");
+      alertBox.innerHTML = `Sensor created successfully. You can visit your new sensor <a target="_blank" href='/sensors/${sensorId}'>here</a>.`;
+      alertBox.style.display = "block";
+      // set all fields value to empty string
+      document.getElementById("name").value = "";
+      document.getElementById("eventResolution").value = "";
+      document.getElementById("unit").value = "";
     } else {
       const errorData = await response.json();
       let errorMessage = response.statusText; // Default to statusText

--- a/flexmeasures/ui/templates/crud/sensor_new.html
+++ b/flexmeasures/ui/templates/crud/sensor_new.html
@@ -22,7 +22,17 @@ sensor {% endblock %} {% block divs %}
       />
     </div>
     <div class="mb-3">
-      <label for="eventResolution" class="form-label">Event Resolution</label>
+      <label for="eventResolution" class="form-label"
+        >Event Resolution
+
+        <i class="fa fa-info-circle ps-2"
+        data-bs-toggle="tooltip"
+        data-bs-placement="bottom"
+        title="Enter an ISO 8601 duration (e.g., PT1H for one hour, PT15M for 15 minutes)."
+        style="font-size: 16px;"
+
+    ></i>
+      </label>
       <input
         type="text"
         class="form-control"
@@ -34,30 +44,15 @@ sensor {% endblock %} {% block divs %}
     </div>
     <div class="mb-3">
       <label for="unit" class="form-label">Unit</label>
-      <div class="row">
-        <div class="col-8 pe-0">
-          <input
-            type="text"
-            class="form-control"
-            id="unit"
-            name="unit"
-            placeholder="kW"
-            required
-          />
-        </div>
-        <div class="col-4 ps-1">
           <select
             id="unit"
             class="form-select"
-            onchange="document.getElementById('unit').value = this.value"
           >
             <option selected>Units</option>
             {% for unit in available_units %}
             <option>{{ unit }}</option>
             {% endfor %}
           </select>
-        </div>
-      </div>
     </div>
     <button type="submit" class="btn btn-primary" onclick="createSensor(event)">
       Create
@@ -109,7 +104,7 @@ sensor {% endblock %} {% block divs %}
 
     if (!validateEventResolution(eventResolution)) {
       showToast(
-        "Invalid event resolution format. Please use ISO 8601 duration format (PT[H|M|S]).",
+        `Invalid event resolution format "${eventResolution}". Please use ISO 8601 duration format (PT[H|M|S]).`,
         "error"
       );
       return;
@@ -121,7 +116,6 @@ sensor {% endblock %} {% block divs %}
       unit: unit,
       generic_asset_id: "{{ asset.id }}",
     };
-    console.log("data: ", JSON.stringify(data));
 
     fetch(apiBasePath + "/api/v3_0/sensors", {
       method: "POST",
@@ -133,11 +127,11 @@ sensor {% endblock %} {% block divs %}
       .then((response) => {
         if (response.ok) {
           showToast("Sensor created successfully.", "success");
-          // window.location.href = "/assets/{{asset.id}}";
         } else {
           response.json().then((data) => {
             const errorData = response.json();
-            const errorMessage = errorData?.message || errorData?.error || response.statusText;
+            const errorMessage =
+              errorData?.message || errorData?.error || response.statusText;
             showToast("Error: " + errorMessage, "error");
           });
         }

--- a/flexmeasures/ui/templates/crud/sensor_new.html
+++ b/flexmeasures/ui/templates/crud/sensor_new.html
@@ -1,0 +1,151 @@
+{% extends "base.html" %} {% set active_page = "assets" %} {% block title %} New
+sensor {% endblock %} {% block divs %}
+
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-md-12">
+      <button class="btn btn-sm btn-responsive btn-info" type="submit">
+        <a href="/assets/{{asset.id}}">Go to parent asset</a>
+      </button>
+    </div>
+  </div>
+  <form id="sensorForm" class="form p-4" method="POST">
+    <div class="mb-3">
+      <label for="name" class="form-label">Name</label>
+      <input
+        type="text"
+        class="form-control"
+        id="name"
+        name="name"
+        placeholder="power"
+        required
+      />
+    </div>
+    <div class="mb-3">
+      <label for="eventResolution" class="form-label">Event Resolution</label>
+      <input
+        type="text"
+        class="form-control"
+        id="eventResolution"
+        name="event_resolution"
+        placeholder="PT1H"
+        required
+      />
+    </div>
+    <div class="mb-3">
+      <label for="unit" class="form-label">Unit</label>
+      <div class="row">
+        <div class="col-8 pe-0">
+          <input
+            type="text"
+            class="form-control"
+            id="unit"
+            name="unit"
+            placeholder="kW"
+            required
+          />
+        </div>
+        <div class="col-4 ps-1">
+          <select
+            id="unit"
+            class="form-select"
+            onchange="document.getElementById('unit').value = this.value"
+          >
+            <option selected>Units</option>
+            {% for unit in available_units %}
+            <option>{{ unit }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+    </div>
+    <button type="submit" class="btn btn-primary" onclick="createSensor(event)">
+      Create
+    </button>
+  </form>
+</div>
+
+<script type="text/javascript">
+  const apiBasePath = window.location.origin;
+  const sensorForm = document.getElementById("sensorForm");
+
+  function validateEventResolution(eventResolution) {
+    // Regular expression to match duration format (PT[H|M|S])
+    const regex = /^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/;
+
+    if (!regex.test(eventResolution)) {
+      return false;
+    }
+
+    const matches = regex.exec(eventResolution);
+
+    // At least one of H, M, or S must be present.
+    if (!matches[1] && !matches[2] && !matches[3]) {
+      return false;
+    }
+
+    let hours = parseInt(matches[1]) || 0;
+    let minutes = parseInt(matches[2]) || 0;
+    let seconds = parseInt(matches[3]) || 0;
+
+    if (hours > 24) {
+      return false;
+    }
+
+    return true;
+  }
+
+  function createSensor(event) {
+    event.preventDefault();
+
+    const name = document.getElementById("name").value;
+    const eventResolution = document.getElementById("eventResolution").value;
+    const unit = document.getElementById("unit").value;
+
+    if (!name || !eventResolution || !unit) {
+      showToast("Please fill all fields.", "error");
+      return;
+    }
+
+    if (!validateEventResolution(eventResolution)) {
+      showToast(
+        "Invalid event resolution format. Please use ISO 8601 duration format (PT[H|M|S]).",
+        "error"
+      );
+      return;
+    }
+
+    const data = {
+      name: name,
+      event_resolution: eventResolution,
+      unit: unit,
+      generic_asset_id: "{{ asset.id }}",
+    };
+    console.log("data: ", JSON.stringify(data));
+
+    fetch(apiBasePath + "/api/v3_0/sensors", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
+    })
+      .then((response) => {
+        if (response.ok) {
+          showToast("Sensor created successfully.", "success");
+          // window.location.href = "/assets/{{asset.id}}";
+        } else {
+          response.json().then((data) => {
+            const errorData = response.json();
+            const errorMessage = errorData?.message || errorData?.error || response.statusText;
+            showToast("Error: " + errorMessage, "error");
+          });
+        }
+      })
+      .catch((error) => {
+        showToast("Error: " + error, "error");
+      });
+  }
+</script>
+
+{% endblock %}

--- a/flexmeasures/ui/templates/crud/sensor_new.html
+++ b/flexmeasures/ui/templates/crud/sensor_new.html
@@ -17,7 +17,7 @@ sensor {% endblock %} {% block divs %}
         class="form-control"
         id="name"
         name="name"
-        placeholder="power"
+        placeholder="e.g power"
         required
       />
     </div>
@@ -38,7 +38,7 @@ sensor {% endblock %} {% block divs %}
         class="form-control"
         id="eventResolution"
         name="event_resolution"
-        placeholder="PT1H"
+        placeholder="e.g. PT1H (which is one hour) or PT15M (15 minutes)"
         required
       />
     </div>
@@ -98,7 +98,7 @@ sensor {% endblock %} {% block divs %}
     const unit = document.getElementById("unit").value;
 
     if (!name || !eventResolution || !unit) {
-      showToast("Please fill all fields.", "error");
+      showToast("Please fill in all fields.", "error");
       return;
     }
 

--- a/flexmeasures/ui/templates/crud/sensor_new.html
+++ b/flexmeasures/ui/templates/crud/sensor_new.html
@@ -50,7 +50,7 @@ sensor {% endblock %} {% block divs %}
           class="fa fa-info-circle ps-2"
           data-bs-toggle="tooltip"
           data-bs-placement="bottom"
-          title="Choose a unit from the list or type a custom unit (ensure it's recognized by 'pint' library)."
+          title="The unit of the sensor's data (e.g. kW or EUR/MWh). Choose a unit from the list or type a custom unit (ensure it's recognized by 'pint' library)."
           style="font-size: 16px"
         ></i>
       </label>

--- a/flexmeasures/ui/templates/crud/sensor_new.html
+++ b/flexmeasures/ui/templates/crud/sensor_new.html
@@ -38,7 +38,7 @@ sensor {% endblock %} {% block divs %}
         class="form-control"
         id="eventResolution"
         name="event_resolution"
-        placeholder="e.g. PT1H (which is one hour) or PT15M (15 minutes)"
+        placeholder="Expected resolution of the sensor's data. E.g. PT1H (which is one hour) or PT15M (15 minutes)"
         required
       />
     </div>

--- a/flexmeasures/ui/templates/crud/sensor_new.html
+++ b/flexmeasures/ui/templates/crud/sensor_new.html
@@ -25,13 +25,13 @@ sensor {% endblock %} {% block divs %}
       <label for="eventResolution" class="form-label"
         >Event Resolution
 
-        <i class="fa fa-info-circle ps-2"
-        data-bs-toggle="tooltip"
-        data-bs-placement="bottom"
-        title="Enter an ISO 8601 duration (e.g., PT1H for one hour, PT15M for 15 minutes)."
-        style="font-size: 16px;"
-
-    ></i>
+        <i
+          class="fa fa-info-circle ps-2"
+          data-bs-toggle="tooltip"
+          data-bs-placement="bottom"
+          title="Enter an ISO 8601 duration (e.g., PT1H for one hour, PT15M for 15 minutes)."
+          style="font-size: 16px"
+        ></i>
       </label>
       <input
         type="text"
@@ -43,16 +43,40 @@ sensor {% endblock %} {% block divs %}
       />
     </div>
     <div class="mb-3">
-      <label for="unit" class="form-label">Unit</label>
+      <label for="unit" class="form-label"
+        >Unit
+
+        <i
+          class="fa fa-info-circle ps-2"
+          data-bs-toggle="tooltip"
+          data-bs-placement="bottom"
+          title="Choose a unit from the list or type a custom unit (ensure it's recognized by 'pint' library)."
+          style="font-size: 16px"
+        ></i>
+      </label>
+      <div class="row">
+        <div class="col-4 pe-0">
           <select
-            id="unit"
             class="form-select"
+            onchange="document.getElementById('unit').value = this.value"
           >
             <option selected>Units</option>
             {% for unit in available_units %}
             <option>{{ unit }}</option>
             {% endfor %}
           </select>
+        </div>
+        <div class="col-8 ps-1">
+          <input
+            type="text"
+            class="form-control"
+            id="unit"
+            name="unit"
+            placeholder="kW"
+            required
+          />
+        </div>
+      </div>
     </div>
     <button type="submit" class="btn btn-primary" onclick="createSensor(event)">
       Create
@@ -90,7 +114,7 @@ sensor {% endblock %} {% block divs %}
     return true;
   }
 
-  function createSensor(event) {
+  async function createSensor(event) {
     event.preventDefault();
 
     const name = document.getElementById("name").value;
@@ -117,28 +141,30 @@ sensor {% endblock %} {% block divs %}
       generic_asset_id: "{{ asset.id }}",
     };
 
-    fetch(apiBasePath + "/api/v3_0/sensors", {
+    const response = await fetch(apiBasePath + "/api/v3_0/sensors", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
       body: JSON.stringify(data),
-    })
-      .then((response) => {
-        if (response.ok) {
-          showToast("Sensor created successfully.", "success");
-        } else {
-          response.json().then((data) => {
-            const errorData = response.json();
-            const errorMessage =
-              errorData?.message || errorData?.error || response.statusText;
-            showToast("Error: " + errorMessage, "error");
-          });
-        }
-      })
-      .catch((error) => {
-        showToast("Error: " + error, "error");
-      });
+    });
+
+    if (response.ok) {
+      showToast("Sensor created successfully.", "success");
+    } else {
+      const errorData = await response.json();
+      let errorMessage = response.statusText; // Default to statusText
+
+      const messageUnitError = errorData?.message?.json?.unit?.[0];
+      if (messageUnitError) {
+        errorMessage = messageUnitError;
+      } else if (errorData?.message) {
+        errorMessage = errorData.message;
+      } else if (errorData?.error) {
+        errorMessage = errorData.error;
+      }
+      showToast("Error: " + errorMessage, "error");
+    }
   }
 </script>
 

--- a/flexmeasures/ui/templates/crud/sensor_new.html
+++ b/flexmeasures/ui/templates/crud/sensor_new.html
@@ -72,7 +72,7 @@ sensor {% endblock %} {% block divs %}
             class="form-control"
             id="unit"
             name="unit"
-            placeholder="kW"
+            placeholder="Type in any unit by hand, e.g. 'kW' or 'EUR/kWh'"
             required
           />
         </div>


### PR DESCRIPTION
## Description

This PR adds a page for users to be able to create a new sensor for an asset

## Look & Feel
![image](https://github.com/user-attachments/assets/9325be39-7358-4eb5-b329-497448e6fdc8)

## How to test

1. Visit any asset
2. scroll to the sensor table and click on the "create sensor" button

## Further Improvements

None

## Related Items
Closes #1393 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
