### PR TITLE
Feat/PV curtailment (or: Fix/PV curtailment in case of negative production)

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -20,6 +20,7 @@ New features
 Infrastructure / Support
 ----------------------
 * Support multi-asset scheduling in the ``StorageScheduler`` and job queueing - functionality for (plugin) developers (incl. prep work for future API endpoint for multi-asset scheduling) [see `PR #1313 <https://github.com/FlexMeasures/flexmeasures/pull/1313>`_]
+* Support PV curtailment in the ``StorageScheduler`` [see `PR #1395 <https://github.com/FlexMeasures/flexmeasures/pull/1395>`_]
 * Migrate data for the ``flex_context`` of an asset to a dedicated column in the database table for assets [see `PR #1293 <https://github.com/FlexMeasures/flexmeasures/pull/1293>`_, `PR #1354 <https://github.com/FlexMeasures/flexmeasures/pull/1354>`_ and `PR #1380 <https://github.com/FlexMeasures/flexmeasures/pull/1380>`_]
 * Enhance reporting infrastructure by ensuring that all ``Sensor.search_beliefs`` filters can be used as report parameters [see `PR #1318 <https://github.com/FlexMeasures/flexmeasures/pull/1318>`_]
 * Improve searching for multi-sourced data by returning data from only the latest version of a data generator (e.g. forecaster or scheduler) by default, when using ``Sensor.search_beliefs`` [see `PR #1306 <https://github.com/FlexMeasures/flexmeasures/pull/1306>`_]

--- a/documentation/features/scheduling.rst
+++ b/documentation/features/scheduling.rst
@@ -224,7 +224,7 @@ For more details on the possible formats for field values, see :ref:`variable_qu
      - Device-level power constraint on consumption. How much power can be drawn by this asset. [#minimum_overlap]_
    * - ``production-capacity``
      - ``"0kW"`` (only consumption)
-     - Device-level power constraint on production. How much power can be supplied by this asset. [#minimum_overlap]_
+     - Device-level power constraint on production. How much power can be supplied by this asset. For :abbr:`PV (photovoltaic solar panels)` curtailment, set this to reference your sensor containing PV power forecasts. [#minimum_overlap]_
 
 .. [#quantity_field] Can only be set as a fixed quantity.
 

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -507,17 +507,18 @@ class MetaStorageScheduler(Scheduler):
                     resolve_overlaps="min",
                 )
 
-            device_constraints[d] = add_storage_constraints(
-                start,
-                end,
-                resolution,
-                soc_at_start[d],
-                soc_targets[d],
-                soc_maxima[d],
-                soc_minima[d],
-                soc_max[d],
-                soc_min[d],
-            )
+            if soc_at_start[d] is not None:
+                device_constraints[d] = add_storage_constraints(
+                    start,
+                    end,
+                    resolution,
+                    soc_at_start[d],
+                    soc_targets[d],
+                    soc_maxima[d],
+                    soc_minima[d],
+                    soc_max[d],
+                    soc_min[d],
+                )
 
             power_capacity_in_mw[d] = get_continuous_series_sensor_or_quantity(
                 variable_quantity=power_capacity_in_mw[d],
@@ -1017,7 +1018,11 @@ class StorageScheduler(MetaStorageScheduler):
             ems_constraints,
             commitments=commitments,
             initial_stock=[
-                soc_at_start_d * (timedelta(hours=1) / resolution)
+                (
+                    soc_at_start_d * (timedelta(hours=1) / resolution)
+                    if soc_at_start_d is not None
+                    else 0
+                )
                 for soc_at_start_d in soc_at_start
             ],
         )

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -526,6 +526,7 @@ class MetaStorageScheduler(Scheduler):
                 query_window=(start, end),
                 resolution=resolution,
                 beliefs_before=belief_time,
+                min_value=0,  # capacities are positive by definition
                 resolve_overlaps="min",
             )
 
@@ -543,6 +544,7 @@ class MetaStorageScheduler(Scheduler):
                     beliefs_before=belief_time,
                     fallback_attribute="production_capacity",
                     max_value=power_capacity_in_mw[d],
+                    min_value=0,  # capacities are positive by definition
                     resolve_overlaps="min",
                 )
             if sensor_d.get_attribute("is_strictly_non_negative"):
@@ -557,6 +559,7 @@ class MetaStorageScheduler(Scheduler):
                         resolution=resolution,
                         beliefs_before=belief_time,
                         fallback_attribute="consumption_capacity",
+                        min_value=0,  # capacities are positive by definition
                         max_value=power_capacity_in_mw[d],
                         resolve_overlaps="min",
                     )

--- a/flexmeasures/data/models/planning/utils.py
+++ b/flexmeasures/data/models/planning/utils.py
@@ -453,13 +453,14 @@ def get_continuous_series_sensor_or_quantity(
     resolution: timedelta,
     beliefs_before: datetime | None = None,
     fallback_attribute: str | None = None,
+    min_value: float | int = np.nan,
     max_value: float | int | pd.Series = np.nan,
     as_instantaneous_events: bool = False,
     resolve_overlaps: str = "first",
     fill_sides: bool = False,
 ) -> pd.Series:
     """Creates a time series from a sensor, time series specification, or quantity within a specified window,
-    falling back to a given `fallback_attribute` and making sure no values exceed `max_value`.
+    falling back to a given `fallback_attribute` and making sure values stay within the domain [min_value, max_value].
 
     :param variable_quantity:       A sensor recording the data, a time series specification or a fixed quantity.
     :param actuator:                The actuator from which relevant defaults are retrieved.
@@ -468,6 +469,7 @@ def get_continuous_series_sensor_or_quantity(
     :param resolution:              The resolution or time interval for the data.
     :param beliefs_before:          Timestamp for prior beliefs or knowledge.
     :param fallback_attribute:      Attribute serving as a fallback default in case no quantity or sensor is given.
+    :param min_value:               Minimum value.
     :param max_value:               Maximum value (also replacing NaN values).
     :param as_instantaneous_events: optionally, convert to instantaneous events, in which case the passed resolution is
                                     interpreted as the desired frequency of the data.
@@ -499,6 +501,9 @@ def get_continuous_series_sensor_or_quantity(
 
     # Apply upper limit
     time_series = nanmin_of_series_and_value(time_series, max_value)
+
+    # Apply lower limit
+    time_series = time_series.clip(lower=min_value)
 
     return time_series
 

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -55,7 +55,7 @@ class StorageFlexModelSchema(Schema):
     """
 
     soc_at_start = QuantityField(
-        required=True,
+        required=False,
         to_unit="MWh",
         default_src_unit="dimensionless",  # placeholder, overridden in __init__
         return_magnitude=True,


### PR DESCRIPTION
## Description

Curtailment was basically already supported by passing the sensor containing PV power forecasts as the production capacity, with `"production-capacity": {"sensor": sensor.id}`. However, things would break down if that sensor contained negative values (which happens when a PV system uses a usually very small amount of power at night).

- [x] Only use positive values for flex-model capacities
- [x] No longer require setting a dummy state of charge for PV curtailment
- [x] Added changelog item in `documentation/changelog.rst`

## Further Improvements

- [ ] Add test
- [x] Add documentation (basically #926)

## Related Items

- I wanted this feature to have its own changelog entry, so I split it off from #1300 (which also contains some improvements relating to the preference of self-consumption over curtailment.
- Related to #1333 and #926
