### PR TITLE
Refactor/check units in time series segment

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -20,6 +20,7 @@ New features
 Infrastructure / Support
 ----------------------
 * Support multi-asset scheduling in the ``StorageScheduler`` and job queueing - functionality for (plugin) developers (incl. prep work for future API endpoint for multi-asset scheduling) [see `PR #1313 <https://github.com/FlexMeasures/flexmeasures/pull/1313>`_]
+* Validate shared units are used in time series segments of flex-context prices [see `PR #1396 <https://github.com/FlexMeasures/flexmeasures/pull/1396>`_]
 * Migrate data for the ``flex_context`` of an asset to a dedicated column in the database table for assets [see `PR #1293 <https://github.com/FlexMeasures/flexmeasures/pull/1293>`_, `PR #1354 <https://github.com/FlexMeasures/flexmeasures/pull/1354>`_ and `PR #1380 <https://github.com/FlexMeasures/flexmeasures/pull/1380>`_]
 * Enhance reporting infrastructure by ensuring that all ``Sensor.search_beliefs`` filters can be used as report parameters [see `PR #1318 <https://github.com/FlexMeasures/flexmeasures/pull/1318>`_]
 * Improve searching for multi-sourced data by returning data from only the latest version of a data generator (e.g. forecaster or scheduler) by default, when using ``Sensor.search_beliefs`` [see `PR #1306 <https://github.com/FlexMeasures/flexmeasures/pull/1306>`_]

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -152,15 +152,9 @@ class MetaStorageScheduler(Scheduler):
         up_deviation_prices = get_continuous_series_sensor_or_quantity(
             variable_quantity=consumption_price,
             actuator=asset,
-            unit=(
-                consumption_price.unit
-                if isinstance(consumption_price, Sensor)
-                else (
-                    consumption_price[0]["value"].units
-                    if isinstance(consumption_price, list)
-                    else str(consumption_price.units)
-                )
-            ),
+            unit=FlexContextSchema()
+            .declared_fields["consumption_price"]
+            ._get_unit(consumption_price),
             query_window=(start, end),
             resolution=resolution,
             beliefs_before=belief_time,
@@ -170,15 +164,9 @@ class MetaStorageScheduler(Scheduler):
         down_deviation_prices = get_continuous_series_sensor_or_quantity(
             variable_quantity=production_price,
             actuator=asset,
-            unit=(
-                production_price.unit
-                if isinstance(production_price, Sensor)
-                else (
-                    production_price[0]["value"].units
-                    if isinstance(production_price, list)
-                    else str(production_price.units)
-                )
-            ),
+            unit=FlexContextSchema()
+            .declared_fields["production_price"]
+            ._get_unit(production_price),
             query_window=(start, end),
             resolution=resolution,
             beliefs_before=belief_time,
@@ -277,15 +265,9 @@ class MetaStorageScheduler(Scheduler):
             ems_peak_consumption_price = get_continuous_series_sensor_or_quantity(
                 variable_quantity=ems_peak_consumption_price,
                 actuator=asset,
-                unit=(
-                    ems_peak_consumption_price.unit
-                    if isinstance(ems_peak_consumption_price, Sensor)
-                    else (
-                        ems_peak_consumption_price[0]["value"].units
-                        if isinstance(ems_peak_consumption_price, list)
-                        else str(ems_peak_consumption_price.units)
-                    )
-                ),
+                unit=FlexContextSchema()
+                .declared_fields["ems_peak_consumption_price"]
+                ._get_unit(ems_peak_consumption_price),
                 query_window=(start, end),
                 resolution=resolution,
                 beliefs_before=belief_time,
@@ -319,15 +301,9 @@ class MetaStorageScheduler(Scheduler):
             ems_peak_production_price = get_continuous_series_sensor_or_quantity(
                 variable_quantity=ems_peak_production_price,
                 actuator=asset,
-                unit=(
-                    ems_peak_production_price.unit
-                    if isinstance(ems_peak_production_price, Sensor)
-                    else (
-                        ems_peak_production_price[0]["value"].units
-                        if isinstance(ems_peak_production_price, list)
-                        else str(ems_peak_production_price.units)
-                    )
-                ),
+                unit=FlexContextSchema()
+                .declared_fields["ems_peak_production_price"]
+                ._get_unit(ems_peak_production_price),
                 query_window=(start, end),
                 resolution=resolution,
                 beliefs_before=belief_time,
@@ -363,15 +339,9 @@ class MetaStorageScheduler(Scheduler):
             ems_consumption_breach_price = get_continuous_series_sensor_or_quantity(
                 variable_quantity=ems_consumption_breach_price,
                 actuator=asset,
-                unit=(
-                    ems_consumption_breach_price.unit
-                    if isinstance(ems_consumption_breach_price, Sensor)
-                    else (
-                        ems_consumption_breach_price[0]["value"].units
-                        if isinstance(ems_consumption_breach_price, list)
-                        else str(ems_consumption_breach_price.units)
-                    )
-                ),
+                unit=FlexContextSchema()
+                .declared_fields["ems_consumption_breach_price"]
+                ._get_unit(ems_consumption_breach_price),
                 query_window=(start, end),
                 resolution=resolution,
                 beliefs_before=belief_time,
@@ -411,15 +381,9 @@ class MetaStorageScheduler(Scheduler):
             ems_production_breach_price = get_continuous_series_sensor_or_quantity(
                 variable_quantity=ems_production_breach_price,
                 actuator=asset,
-                unit=(
-                    ems_production_breach_price.unit
-                    if isinstance(ems_production_breach_price, Sensor)
-                    else (
-                        ems_production_breach_price[0]["value"].units
-                        if isinstance(ems_production_breach_price, list)
-                        else str(ems_production_breach_price.units)
-                    )
-                ),
+                unit=FlexContextSchema()
+                .declared_fields["ems_production_breach_price"]
+                ._get_unit(ems_production_breach_price),
                 query_window=(start, end),
                 resolution=resolution,
                 beliefs_before=belief_time,

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -175,7 +175,7 @@ class FlexContextSchema(Schema):
         for field in self.declared_fields:
             if field[-5:] == "price" and field in data:
                 price_field = self.declared_fields[field]
-                price_unit = price_field._get_unit(price_field.data_key, data[field])
+                price_unit = price_field._get_unit(data[field])
                 currency_unit = price_unit.split("/")[0]
 
                 if previous_currency_unit is None:

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -175,9 +175,7 @@ class FlexContextSchema(Schema):
         for field in self.declared_fields:
             if field[-5:] == "price" and field in data:
                 price_field = self.declared_fields[field]
-                price_unit = self._get_variable_quantity_unit(
-                    price_field.data_key, data[field]
-                )
+                price_unit = price_field._get_unit(price_field.data_key, data[field])
                 currency_unit = price_unit.split("/")[0]
 
                 if previous_currency_unit is None:
@@ -207,30 +205,6 @@ class FlexContextSchema(Schema):
                         field_name=field_name,
                     )
         return data
-
-    def _get_variable_quantity_unit(
-        self, field_name: str, variable_quantity: ur.Quantity | list[dict | Sensor]
-    ) -> str:
-        """Gets the unit from the variable quantity."""
-        if isinstance(variable_quantity, ur.Quantity):
-            unit = str(variable_quantity.units)
-        elif isinstance(variable_quantity, list):
-            unit = str(variable_quantity[0]["value"].units)
-            if not all(
-                str(variable_quantity[j]["value"].units) == unit
-                for j in range(len(variable_quantity))
-            ):
-                raise ValidationError(
-                    "Segments of a time series must share the same unit.",
-                    field_name=field_name,
-                )
-        elif isinstance(variable_quantity, Sensor):
-            unit = variable_quantity.unit
-        else:
-            raise NotImplementedError(
-                f"Unexpected type '{type(variable_quantity)}' for variable_quantity describing '{field_name}': {variable_quantity}."
-            )
-        return unit
 
 
 class DBFlexContextSchema(FlexContextSchema):

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -174,8 +174,10 @@ class FlexContextSchema(Schema):
         previous_field_name = None
         for field in self.declared_fields:
             if field[-5:] == "price" and field in data:
-                price_unit = self._get_variable_quantity_unit(field, data[field])
                 price_field = self.declared_fields[field]
+                price_unit = self._get_variable_quantity_unit(
+                    price_field.data_key, data[field]
+                )
                 currency_unit = price_unit.split("/")[0]
 
                 if previous_currency_unit is None:
@@ -207,7 +209,7 @@ class FlexContextSchema(Schema):
         return data
 
     def _get_variable_quantity_unit(
-        self, field: str, variable_quantity: ur.Quantity | list[dict | Sensor]
+        self, field_name: str, variable_quantity: ur.Quantity | list[dict | Sensor]
     ) -> str:
         """Gets the unit from the variable quantity."""
         if isinstance(variable_quantity, ur.Quantity):
@@ -218,7 +220,6 @@ class FlexContextSchema(Schema):
                 str(variable_quantity[j]["value"].units) == unit
                 for j in range(len(variable_quantity))
             ):
-                field_name = self.declared_fields[field].data_key
                 raise ValidationError(
                     "Segments of a time series must share the same unit.",
                     field_name=field_name,
@@ -227,7 +228,7 @@ class FlexContextSchema(Schema):
             unit = variable_quantity.unit
         else:
             raise NotImplementedError(
-                f"Unexpected type '{type(variable_quantity)}' for '{field}': {variable_quantity}."
+                f"Unexpected type '{type(variable_quantity)}' for variable_quantity describing '{field_name}': {variable_quantity}."
             )
         return unit
 

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -376,7 +376,7 @@ class VariableQuantityField(MarshmallowClickMixin, fields.Field):
         return super().convert(_value, param, ctx, **kwargs)
 
     def _get_unit(self, variable_quantity: ur.Quantity | list[dict | Sensor]) -> str:
-        """Gets the unit from the variable quantity."""
+        """Obtain the unit from the variable quantity."""
         if isinstance(variable_quantity, ur.Quantity):
             unit = str(variable_quantity.units)
         elif isinstance(variable_quantity, list):

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -375,9 +375,7 @@ class VariableQuantityField(MarshmallowClickMixin, fields.Field):
 
         return super().convert(_value, param, ctx, **kwargs)
 
-    def _get_unit(
-        self, field_name: str, variable_quantity: ur.Quantity | list[dict | Sensor]
-    ) -> str:
+    def _get_unit(self, variable_quantity: ur.Quantity | list[dict | Sensor]) -> str:
         """Gets the unit from the variable quantity."""
         if isinstance(variable_quantity, ur.Quantity):
             unit = str(variable_quantity.units)
@@ -389,13 +387,13 @@ class VariableQuantityField(MarshmallowClickMixin, fields.Field):
             ):
                 raise ValidationError(
                     "Segments of a time series must share the same unit.",
-                    field_name=field_name,
+                    field_name=self.data_key,
                 )
         elif isinstance(variable_quantity, Sensor):
             unit = variable_quantity.unit
         else:
             raise NotImplementedError(
-                f"Unexpected type '{type(variable_quantity)}' for variable_quantity describing '{field_name}': {variable_quantity}."
+                f"Unexpected type '{type(variable_quantity)}' for variable_quantity describing '{self.data_key}': {variable_quantity}."
             )
         return unit
 

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -375,6 +375,30 @@ class VariableQuantityField(MarshmallowClickMixin, fields.Field):
 
         return super().convert(_value, param, ctx, **kwargs)
 
+    def _get_unit(
+        self, field_name: str, variable_quantity: ur.Quantity | list[dict | Sensor]
+    ) -> str:
+        """Gets the unit from the variable quantity."""
+        if isinstance(variable_quantity, ur.Quantity):
+            unit = str(variable_quantity.units)
+        elif isinstance(variable_quantity, list):
+            unit = str(variable_quantity[0]["value"].units)
+            if not all(
+                str(variable_quantity[j]["value"].units) == unit
+                for j in range(len(variable_quantity))
+            ):
+                raise ValidationError(
+                    "Segments of a time series must share the same unit.",
+                    field_name=field_name,
+                )
+        elif isinstance(variable_quantity, Sensor):
+            unit = variable_quantity.unit
+        else:
+            raise NotImplementedError(
+                f"Unexpected type '{type(variable_quantity)}' for variable_quantity describing '{field_name}': {variable_quantity}."
+            )
+        return unit
+
 
 class RepurposeValidatorToIgnoreSensorsAndLists(validate.Validator):
     """Validator that executes another validator (the one you initialize it with) only on non-Sensor and non-list values."""

--- a/flexmeasures/data/schemas/tests/test_scheduling.py
+++ b/flexmeasures/data/schemas/tests/test_scheduling.py
@@ -257,6 +257,25 @@ def test_efficiency_pair(
             },
             {"site-peak-production-price": "Must be greater than or equal to 0."},
         ),
+        (
+            {
+                "site-consumption-breach-price": [
+                    {
+                        "value": "1 KRW/MWh",
+                        "start": "2025-03-16T00:00+01",
+                        "duration": "P1D",
+                    },
+                    {
+                        "value": "1 KRW/MW",
+                        "start": "2025-03-16T00:00+01",
+                        "duration": "P1D",
+                    },
+                ],
+            },
+            {
+                "site-consumption-breach-price": "Segments of a time series must share the same unit."
+            },
+        ),
     ],
 )
 def test_flex_context_schema(db, app, setup_site_capacity_sensor, flex_context, fails):


### PR DESCRIPTION
## Description

- [x] Some refactoring to reduce the number of places dealing with getting the price unit out of a flex-context field
- [x] Require that segments of a time series must share the same unit
- [x] Added changelog item in `documentation/changelog.rst`


## Look & Feel

Just refactoring.

## How to test

- `test_flex_context_schema` has been amended with an extra test case

## Related Items

- Spun off from #1300 as a separate PR.
