### PR TITLE
Dev: run API tests in isolation without manual workaround

### DIFF
--- a/flexmeasures/api/conftest.py
+++ b/flexmeasures/api/conftest.py
@@ -1,12 +1,13 @@
 import pytest
 from pytest_mock import MockerFixture
+from flask import url_for
 from flask_login import login_user, logout_user
 
 from flexmeasures.api.tests.utils import UserContext
 
 
 @pytest.fixture
-def requesting_user(request):
+def requesting_user(request, client):
     """Use this fixture to log in a user for the scope of a test.
 
     Sets the user by passing it an email address (see usage examples below), or pass None to get the AnonymousUser.
@@ -33,6 +34,11 @@ def requesting_user(request):
     if email is not None:
         with UserContext(email) as user:
             login_user(user)
+            auth_token = user.get_auth_token()
+            client.get(
+                url_for("UserAPI:get", id=user.id),
+                headers={"Authorization": auth_token},
+            )
             yield user
             logout_user()
     else:


### PR DESCRIPTION
## Description

- [x] Fix: the `requesting_user` test fixture does a single API call so that Flask sees it's using its correct auth headers

Abandon this proposed fix; unfortunately the pipeline fails and I can't reproduce it locally.

Initially 5 steps failed. For example, [`lint-and-test / Test (on Python 3.8) (pull_request)`](https://github.com/FlexMeasures/flexmeasures/actions/runs/14168438946/job/39687274798?pr=1397) failed 44 tests with Redis errors such as `redis.exceptions.ResponseError: unknown command `client list`, with args beginning with:`, while [`lint-and-test / Test (on Python 3.8) (push)`](https://github.com/FlexMeasures/flexmeasures/actions/runs/14168395521/job/39686587304?pr=1397) succeeded.

I couldn't reproduces these locally, so I reran the failing steps. Then, [a different error floated up](https://github.com/FlexMeasures/flexmeasures/actions/runs/14168438946/job/39687274798?pr=1397): `ModuleNotFoundError: No module named 'setuptools.command.build'`.


