### PR TITLE
Feature/viz/mix sensor resolutions

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -19,6 +19,15 @@ Bugfixes
 -----------
 
 
+
+v0.25.1 | April XX, 2025
+============================
+
+Bugfixes
+-----------
+* The data dashboard now supports overlapping sensors with instantaneous and non-instantaneous resolutions [see `PR #1407 <https://github.com/FlexMeasures/flexmeasures/pull/1407>`_]
+
+
 v0.25.0 | April 01, 2025
 ============================
 

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -19,14 +19,6 @@ Infrastructure / Support
 
 Bugfixes
 -----------
-
-
-
-v0.25.1 | April XX, 2025
-============================
-
-Bugfixes
------------
 * The data dashboard now supports overlapping sensors with instantaneous and non-instantaneous resolutions [see `PR #1407 <https://github.com/FlexMeasures/flexmeasures/pull/1407>`_]
 
 

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -666,17 +666,16 @@ def create_line_layer(
     sensor_field_definition: dict,
     combine_legend: bool,
 ):
+    # Use linear interpolation if any of the sensors shown within one row is instantaneous; otherwise, use step-after
     event_resolutions = list(set([sensor.event_resolution for sensor in sensors]))
-    assert all(res == timedelta(0) for res in event_resolutions) or all(
-        res != timedelta(0) for res in event_resolutions
-    ), "Sensors shown within one row must all be instantaneous (zero event resolution) or all be non-instantatneous (non-zero event resolution)."
-    event_resolution = event_resolutions[0]
+    if any(res == timedelta(0) for res in event_resolutions):
+        interpolate = "linear"
+    else:
+        interpolate = "step-after"
     line_layer = {
         "mark": {
             "type": "line",
-            "interpolate": (
-                "step-after" if event_resolution != timedelta(0) else "linear"
-            ),
+            "interpolate": interpolate,
             "clip": True,
         },
         "encoding": {

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -667,8 +667,7 @@ def create_line_layer(
     combine_legend: bool,
 ):
     # Use linear interpolation if any of the sensors shown within one row is instantaneous; otherwise, use step-after
-    event_resolutions = list(set([sensor.event_resolution for sensor in sensors]))
-    if any(res == timedelta(0) for res in event_resolutions):
+    if any(sensor.event_resolution == timedelta(0) for sensor in sensors):
         interpolate = "linear"
     else:
         interpolate = "step-after"


### PR DESCRIPTION
## Description

- [x] Support overlapping sensors with instantaneous and non-instantaneous resolutions in the data dashboard
- [x] Added changelog item in `documentation/changelog.rst`

## Look & Feel

In this example, the soc limits were 15-minute sensors, while the soc sensor was recording instantaneous values. Notice that the downwards step becomes more sloped, but at least it shows. (Ignore the soc-max breach.)

![image](https://github.com/user-attachments/assets/91b30843-5f1b-4c1a-83df-7ed2f4344699)

## How to test

In a data dashboard, select a instantaneous sensor and non-instantaneous sensor to be shown in the same sub-chart.

## Potential improvements

- [x] I can't seem to get separate line layers for instantaneous and non-instantaneous sensors to work. :(

## Related Items

Closes #1327.
