### PR TITLE
Feature/treeSpiderfy

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,6 +13,7 @@ New features
 * Support saving the storage schedule SOC using the ``flex-model`` field ``state-of-charge`` to the ``flex-model`` [see `PR #1392 <https://github.com/FlexMeasures/flexmeasures/pull/1392>`_]
 * Save changes in asset flex-context form right away [see `PR #1390 <https://github.com/FlexMeasures/flexmeasures/pull/1390>`_]
 * Introduced new page to create sensor for a parent asset [see `PR #1394 <https://github.com/FlexMeasures/flexmeasures/pull/1394>`_]
+* Marker clusters on the dashboard map expand in a tree to show the hierarchical relationship of the assets they represent [see `PR #1410 <https://github.com/FlexMeasures/flexmeasures/pull/1410>`_]
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/ui/static/js/map-init.js
+++ b/flexmeasures/ui/static/js/map-init.js
@@ -77,6 +77,26 @@ function removeSpiderLegs(markerCluster) {
  */
 function computeCenteredTreeLayout(markers, centerPt, spacingX = 50, spacingY = 100, treeSpacing = 100) {
     const nodeMap = new Map();
+
+    // Add virtual parent nodes if they are missing a marker (no lat/lng)
+    const allParentIds = new Set(markers.map(m => m.options.parentId).filter(id => id !== null));
+    for (const parentId of allParentIds) {
+        if (!nodeMap.has(parentId)) {
+            // Use the first child with this parent to determine location
+            const child = markers.find(m => m.options.parentId === parentId);
+            if (child) {
+                nodeMap.set(parentId, {
+                    id: parentId,
+                    parentId: null,
+                    children: [],
+                    x: 0,
+                    y: 0,
+                    virtual: true // you can tag it if needed
+                });
+            }
+        }
+    }
+
     markers.forEach(marker => {
         const { id, parentId } = marker.options;
         nodeMap.set(id, { ...marker.options, children: [], x: 0, y: 0 });

--- a/flexmeasures/ui/static/js/map-init.js
+++ b/flexmeasures/ui/static/js/map-init.js
@@ -30,3 +30,283 @@ function clickPan(e, data) {
     targetLatLng = assetMap.unproject(targetPoint, targetZoom);
     assetMap.setView(targetLatLng, targetZoom);
 }
+
+
+/**
+ * Injects a custom spiderfy layout function into the marker cluster, passing both
+ * child markers and the cluster center point to the layout function.
+ *
+ * @param {L.MarkerCluster} markerCluster - The marker cluster instance to modify.
+ */
+function passMarkersToSpiderfyShapePositions (markerCluster) {
+    const childMarkers = markerCluster.getAllChildMarkers();
+    const centerPt = markerCluster._group._map.latLngToLayerPoint(markerCluster._latlng);
+    const shapeFn = markerCluster._group?.options?.spiderfyShapePositionsWithMarkers;
+    if (typeof shapeFn === 'function') {
+        markerCluster._group.options.spiderfyShapePositions = () =>
+            shapeFn(childMarkers, centerPt);
+    }
+}
+
+
+/**
+ * Removes all spider legs (connecting lines) from the map for the given marker cluster.
+ *
+ * @param {L.MarkerCluster} markerCluster - The marker cluster from which to remove spider legs.
+ */
+function removeSpiderLegs(markerCluster) {
+    const map = markerCluster._group._map;
+    for (const marker of markerCluster.getAllChildMarkers()) {
+        if (marker._spiderLeg) {
+            map.removeLayer(marker._spiderLeg);
+        }
+    }
+}
+
+
+/**
+ * Computes a tree-based layout for markers, organizing them into a forest centered
+ * around a given point. Markers must have `id` and `parentId` options.
+ *
+ * @param {Array<L.Marker>} markers - Array of markers with hierarchical relationships.
+ * @param {L.Point} centerPt - The center point to base the layout around.
+ * @param {number} [spacingX=50] - Horizontal spacing between sibling nodes.
+ * @param {number} [spacingY=100] - Vertical spacing between levels.
+ * @param {number} [treeSpacing=100] - Spacing between root trees.
+ * @returns {Array<L.Point>} Array of new positions (as layer points) for the markers.
+ */
+function computeCenteredTreeLayout(markers, centerPt, spacingX = 50, spacingY = 100, treeSpacing = 100) {
+    const nodeMap = new Map();
+    markers.forEach(marker => {
+        const { id, parentId } = marker.options;
+        nodeMap.set(id, { ...marker.options, children: [], x: 0, y: 0 });
+    });
+
+    let roots = [];
+    nodeMap.forEach(node => {
+        if (node.parentId === null) {
+            roots.push(node);
+        } else {
+            const parent = nodeMap.get(node.parentId);
+            if (parent) {
+                parent.children.push(node);
+            }
+        }
+    });
+
+    const positionMap = new Map(); // id -> { dx, dy, level }
+    let currentX = 0;
+
+    function layoutTree(node, depth) {
+        if (node.children.length === 0) {
+            node.x = currentX;
+            currentX += spacingX;
+        } else {
+            for (const child of node.children) {
+                layoutTree(child, depth + 1);
+            }
+            const xs = node.children.map(child => child.x);
+            node.x = (Math.min(...xs) + Math.max(...xs)) / 2;
+        }
+        node.y = depth * spacingY;
+        positionMap.set(node.id, { dx: node.x, dy: node.y, level: depth });
+    }
+
+    let globalXOffset = 0;
+
+    for (const root of roots) {
+        const startX = currentX;
+        layoutTree(root, 0);
+
+        // Adjust all dx in this tree by (startX - minX)
+        const treeNodes = [...nodeMap.values()].filter(n => positionMap.has(n.id));
+        const minX = Math.min(...treeNodes.map(n => positionMap.get(n.id).dx));
+        const offset = startX - minX;
+        for (const n of treeNodes) {
+            const pos = positionMap.get(n.id);
+            pos.dx += offset;
+        }
+
+        // Update currentX for next tree
+        const maxX = Math.max(...treeNodes.map(n => positionMap.get(n.id).dx));
+        currentX = maxX + treeSpacing;
+    }
+
+    // === Center the forest around (0, 0) ===
+
+    const allPositions = Array.from(positionMap.values());
+
+    const minDx = Math.min(...allPositions.map(p => p.dx));
+    const maxDx = Math.max(...allPositions.map(p => p.dx));
+    const centerX = (minDx + maxDx) / 2;
+
+    const maxLevel = Math.max(...allPositions.map(p => p.level));
+    const centerLevel = maxLevel / 2;
+    const centerY = centerLevel * spacingY;
+
+    for (const pos of allPositions) {
+        pos.dx -= centerX;
+        pos.dy -= centerY;
+    }
+
+    // Final result in original order
+    return markers.map(marker => {
+        const { dx, dy } = positionMap.get(marker.options.id);
+        // console.log(marker.options.id, ": ", dx, ", ", dy);
+        return L.point(
+            {
+                x: centerPt.x + dx,
+                y: centerPt.y + dy
+            }
+        );
+    });
+}
+
+
+/**
+ * Performs a tree-style animated spiderfy for a cluster, using parent-child relationships
+ * between markers to create animated spider legs from parent to child.
+ *
+ * @param {Array<L.Marker>} childMarkers - The markers to be spiderfied.
+ * @param {Array<L.Point>} positions - The target layer point positions for the markers.
+ */
+function _animationTreeSpiderfy(childMarkers, positions) {
+    var me = this,
+        group = this._group,
+        map = group._map,
+        fg = group._featureGroup,
+        thisLayerLatLng = this._latlng,
+        thisLayerPos = map.latLngToLayerPoint(thisLayerLatLng),
+        svg = L.Path.SVG,
+        legOptions = L.extend({}, this._group.options.spiderLegPolylineOptions), // Copy the options so that we can modify them for animation.
+        finalLegOpacity = legOptions.opacity,
+        i, m, leg, legPath, legLength, newPos;
+
+    if (finalLegOpacity === undefined) {
+        finalLegOpacity = L.MarkerClusterGroup.prototype.options.spiderLegPolylineOptions.opacity;
+    }
+
+    if (svg) {
+        // If the initial opacity of the spider leg is not 0 then it appears before the animation starts.
+        legOptions.opacity = 0;
+
+        // Add the class for CSS transitions.
+        legOptions.className = (legOptions.className || '') + ' leaflet-cluster-spider-leg';
+    } else {
+        // Make sure we have a defined opacity.
+        // legOptions.opacity = finalLegOpacity;
+        legOptions.opacity = 0;  // Seita monkeypatch
+    }
+
+    group._ignoreMove = true;
+
+    // Seita monkeypatch
+    // Build a quick lookup map by marker id
+    const markerMap = new Map(childMarkers.map(m => [m.options.id, m]));
+
+    // Add markers and spider legs to map, hidden at our center point.
+    // Traverse in ascending order to make sure that inner circleMarkers are on top of further legs. Normal markers are re-ordered by newPosition.
+    // The reverse order trick no longer improves performance on modern browsers.
+    for (i = 0; i < childMarkers.length; i++) {
+        m = childMarkers[i];
+        childPos = positions[i]
+
+         // Seita monkeypatch
+        const parentId = m.options.parentId;
+        var hasParentPos = true;
+        if (parentId == null) {
+            hasParentPos = false;
+        };
+        const parentMarker = markerMap.get(parentId);
+        if (!parentMarker) {
+            hasParentPos = false;
+        };
+        const parentPos = positions[childMarkers.indexOf(parentMarker)];
+        if (!parentPos) {
+            hasParentPos = false;
+        };
+
+        newPos = map.layerPointToLatLng(positions[i]);
+        if (hasParentPos == true) {
+            oldPos = map.layerPointToLatLng(parentPos);
+        } else {
+            oldPos = newPos;
+        }
+
+        // Add the leg before the marker, so that in case the latter is a circleMarker, the leg is behind it.
+        leg = new L.Polyline([oldPos, newPos], legOptions);
+        // leg = new L.Polyline([thisLayerLatLng, newPos], legOptions);
+        map.addLayer(leg);
+        m._spiderLeg = leg;
+
+        // Explanations: https://jakearchibald.com/2013/animated-line-drawing-svg/
+        // In our case the transition property is declared in the CSS file.
+        if (svg) {
+            legPath = leg._path;
+            legLength = legPath.getTotalLength() + 0.1; // Need a small extra length to avoid remaining dot in Firefox.
+            legPath.style.strokeDasharray = legLength; // Just 1 length is enough, it will be duplicated.
+            legPath.style.strokeDashoffset = legLength;
+        }
+    }
+    for (i = 0; i < childMarkers.length; i++) {
+        m = childMarkers[i];
+        // If it is a marker, add it now and we'll animate it out
+        if (m.setZIndexOffset) {
+            m.setZIndexOffset(1000000); // Make normal markers appear on top of EVERYTHING
+        }
+        if (m.clusterHide) {
+            m.clusterHide();
+        }
+
+        // Vectors just get immediately added
+        fg.addLayer(m);
+
+        if (m._setPos) {
+            m._setPos(thisLayerPos);
+        }
+    }
+
+    group._forceLayout();
+    group._animationStart();
+
+    // Reveal markers and spider legs.
+    for (i = childMarkers.length - 1; i >= 0; i--) {
+        newPos = map.layerPointToLatLng(positions[i]);
+        m = childMarkers[i];
+
+        //Move marker to new position
+        m._preSpiderfyLatlng = m._latlng;
+        m.setLatLng(newPos);
+
+        if (m.clusterShow) {
+            m.clusterShow();
+        }
+
+        // Animate leg (animation is actually delegated to CSS transition).
+        if (svg) {
+            leg = m._spiderLeg;
+            legPath = leg._path;
+            legPath.style.strokeDashoffset = 0;
+            //legPath.style.strokeOpacity = finalLegOpacity;
+            leg.setStyle({opacity: finalLegOpacity});
+        }
+    }
+    this.setOpacity(0.3);
+
+    group._ignoreMove = false;
+
+    setTimeout(function () {
+        group._animationEnd();
+        group.fire('spiderfied', {
+            cluster: me,
+            markers: childMarkers
+        });
+
+        // Seita monkeypatch
+        for (i = childMarkers.length - 1; i >= 0; i--) {
+            m = childMarkers[i];
+            leg = m._spiderLeg;
+            leg.setStyle({opacity: finalLegOpacity});
+        }
+    }, 200);
+}

--- a/flexmeasures/ui/templates/views/new_dashboard.html
+++ b/flexmeasures/ui/templates/views/new_dashboard.html
@@ -119,7 +119,7 @@
     }} = L
         .marker(
             [{{ asset.location[0] }}, {{ asset.location[1] }}],
-            { icon: {{ asset.generic_asset_type.name | parameterize | pluralize }}_icon, id: "{{ asset.id }}"}
+            { icon: {{ asset.generic_asset_type.name | parameterize | pluralize }}_icon, id: {{ asset.id }}, parentId: {% if asset.parent_asset_id is none %}null{% else %}{{ asset.parent_asset_id }}{% endif %} }
     )
         .bindPopup(`
                             <div class="leaflet-marker-popup">

--- a/flexmeasures/ui/templates/views/new_dashboard.html
+++ b/flexmeasures/ui/templates/views/new_dashboard.html
@@ -80,7 +80,7 @@
 <!-- Initialise the map -->
 <script src="https://cdn.jsdelivr.net/npm/leaflet@1.7.1/dist/leaflet-src.min.js"></script>
 <script src="{{ url_for('flexmeasures_ui.static', filename='js/map-init.js') }}"></script>
-<script src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js"></script>
+<script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
 <script
     src="https://unpkg.com/leaflet.markercluster.layersupport@2.0.1/dist/leaflet.markercluster.layersupport.js"></script>
 

--- a/flexmeasures/ui/templates/views/new_dashboard.html
+++ b/flexmeasures/ui/templates/views/new_dashboard.html
@@ -78,11 +78,10 @@
 
 
 <!-- Initialise the map -->
-<script src="https://cdn.jsdelivr.net/npm/leaflet@1.7.1/dist/leaflet-src.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/leaflet@{{ js_versions.leaflet }}/dist/leaflet-src.min.js"></script>
 <script src="{{ url_for('flexmeasures_ui.static', filename='js/map-init.js') }}"></script>
-<script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
-<script
-    src="https://unpkg.com/leaflet.markercluster.layersupport@2.0.1/dist/leaflet.markercluster.layersupport.js"></script>
+<script src="https://unpkg.com/leaflet.markercluster@{{ js_versions.leafletmarkercluster }}/dist/leaflet.markercluster.js"></script>
+<script src="https://unpkg.com/leaflet.markercluster.layersupport@{{ js_versions.leafletmarkerclusterlayersupport }}/dist/leaflet.markercluster.layersupport.js"></script>
 
 <script type="text/javascript">
 

--- a/flexmeasures/ui/templates/views/new_dashboard.html
+++ b/flexmeasures/ui/templates/views/new_dashboard.html
@@ -79,7 +79,7 @@
 
 <!-- Initialise the map -->
 <script src="https://cdn.jsdelivr.net/npm/leaflet@{{ js_versions.leaflet }}/dist/leaflet-src.min.js"></script>
-<script src="{{ url_for('flexmeasures_ui.static', filename='js/map-init.js') }}"></script>
+<script src="{{ url_for('flexmeasures_ui.static', filename='js/map-init.js') }}?v={{ flexmeasures_version }}"></script>
 <script src="https://unpkg.com/leaflet.markercluster@{{ js_versions.leafletmarkercluster }}/dist/leaflet.markercluster.js"></script>
 <script src="https://unpkg.com/leaflet.markercluster.layersupport@{{ js_versions.leafletmarkerclusterlayersupport }}/dist/leaflet.markercluster.layersupport.js"></script>
 

--- a/flexmeasures/ui/templates/views/new_dashboard.html
+++ b/flexmeasures/ui/templates/views/new_dashboard.html
@@ -161,6 +161,33 @@
     {% endfor %}
     {% endfor %}
 
+    // Monkeypatch spiderfy
+    const originalSpiderfy = L.MarkerCluster.prototype.spiderfy;
+    L.MarkerCluster.include({
+        spiderfy: function () {
+            // Send spiderfyShapePositions the markers themselves, rather than just the number of markers
+            passMarkersToSpiderfyShapePositions(this)
+            return originalSpiderfy.call(this);
+        }
+    });
+
+    // Monkeypatch _animationSpiderfy
+    const originalAnimationSpiderfy = L.MarkerCluster.prototype._animationSpiderfy;
+    L.MarkerCluster.include({
+        _animationSpiderfy: _animationTreeSpiderfy,
+    });
+
+    // Monkeypatch unspiderfy
+    const originalUnspiderfy = L.MarkerCluster.prototype.unspiderfy;
+    L.MarkerCluster.include({
+        unspiderfy: function () {
+            // Remove spider legs straight away (the default animation does not suit a tree view)
+            removeSpiderLegs(this);
+            return originalUnspiderfy.call(this);
+        }
+    });
+
+
     // create Map with tiles
     var assetMap = L
         .map('mapid', { center: [{{ map_center[0] }}, {{ map_center[1] }}], zoom: 6 })
@@ -170,7 +197,10 @@
             });
         });
     addTileLayer(assetMap, '{{ mapboxAccessToken }}');
-    var mcgLayerSupportGroup = L.markerClusterGroup.layerSupport();
+    var mcgLayerSupportGroup = L.markerClusterGroup.layerSupport({
+        spiderfyShapePositionsWithMarkers: computeCenteredTreeLayout
+    });
+
     var control = L.control.layers(null, null, { collapsed: true });
 
     // add a layer for each asset type

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -132,6 +132,9 @@ class Config(object):
         vegaembed="6.21.0",
         vegalite="5.5.0",  # "5.6.0" has a problematic bar chart: see our sensor page and https://github.com/vega/vega-lite/issues/8496
         currencysymbolmap="5.1.0",
+        leaflet="1.7.1",
+        leafletmarkercluster="1.5.3",
+        leafletmarkerclusterlayersupport="2.0.1",
         # todo: expand with other js versions used in FlexMeasures
     )
     FLEXMEASURES_JSON_COMPACT = False

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -132,7 +132,7 @@ class Config(object):
         vegaembed="6.21.0",
         vegalite="5.5.0",  # "5.6.0" has a problematic bar chart: see our sensor page and https://github.com/vega/vega-lite/issues/8496
         currencysymbolmap="5.1.0",
-        leaflet="1.7.1",
+        leaflet="1.9.4",
         leafletmarkercluster="1.5.3",
         leafletmarkerclusterlayersupport="2.0.1",
         # todo: expand with other js versions used in FlexMeasures


### PR DESCRIPTION
## Description

Show marker clusters representing asset hierarchies (on a single geo-location) as trees.

- [x] Use treeSpiderfy instead of spiralSpiderfy
- [x] Added changelog item in `documentation/changelog.rst`

## Look & Feel

![image](https://github.com/user-attachments/assets/ec4e0723-f612-4b7c-a3ff-c9b4eea3d5c7)

Before (spiral) and after (tree):

![Peek 2025-04-07 09-54](https://github.com/user-attachments/assets/25254fe6-aeb9-4fb8-a3ae-ebd2ad05bdf3)

## How to test

- Make an asset hierarchy if you don't have one, using `flexmeasures add asset --name <name> --latitude 52.37 --longitude 4.89 --account 1 --asset-type 1 --parent-asset <parent-id>`
- Visit the dashboard and click on your asset hierarchy.

## Further Improvements

- Rather than monkeypatching, some of this should probably be a PR in leaflet.markerCluster instead.
- The marker tree only includes parts of the asset tree that are geo-located to the same lat/lng, i.e. it excludes:
  - parts of the asset tree that are geo-located to a different lat/lng.
  - parts of the asset tree that aren't geo-located at all (no lat/lng).

## Related Items

- Ongoing work on presenting asset contexts.
