### PR TITLE
Feat/cli/jobs/save last

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -16,6 +16,7 @@ New features
 
 Infrastructure / Support
 ----------------------
+* Save last N jobs from any queue and registry to a file, and support filtering by asset ID or sensor ID [see `PR #1411 <https://github.com/FlexMeasures/flexmeasures/pull/1411>`_]
 
 Bugfixes
 -----------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -35,7 +35,7 @@ New features
 * Added form modal to edit an asset's ``flex_context`` [see `PR #1320 <https://github.com/FlexMeasures/flexmeasures/pull/1320>`_, `PR #1365 <https://github.com/FlexMeasures/flexmeasures/pull/1365>`_ and `PR #1364 <https://github.com/FlexMeasures/flexmeasures/pull/1364>`_]
 * Improve asset status page - distinguish better by data source type [see `PR #1022 <https://github.com/FlexMeasures/flexmeasures/pull/1022/>`_]
 * Better y-axis titles for charts that show multiple sensors with a shared unit [see `PR #1346 <https://github.com/FlexMeasures/flexmeasures/pull/1346>`_]
-* Add CLI command ``flexmeasures jobs save-last-failed`` for saving the last failed jobs [see `PR #1342 <https://www.github.com/FlexMeasures/flexmeasures/pull/1342>`_ and `PR #1359 <https://github.com/FlexMeasures/flexmeasures/pull/1359>`_]
+* Add CLI command ``flexmeasures jobs save-last-failed`` (since v0.26: ``flexmeasures jobs save-last``) for saving the last failed jobs [see `PR #1342 <https://www.github.com/FlexMeasures/flexmeasures/pull/1342>`_ and `PR #1359 <https://github.com/FlexMeasures/flexmeasures/pull/1359>`_]
 * Add CLI command ``flexmeasures jobs delete-queue`` for deleting an obsolete queue [see `PR #1351 <https://www.github.com/FlexMeasures/flexmeasures/pull/1351>`_]
 
 Infrastructure / Support

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -11,7 +11,7 @@ since v0.26.0 | April XX, 2025
 since v0.25.0 | April 01, 2025
 =================================
 * Report parameters set using ``flexmeasures add report --parameters`` can use any argument supported by ``Sensor.search_beliefs`` to allow more control over input for the report.
-* Add ``flexmeasures jobs save-last-failed`` CLI command for saving the last n failed jobs (from the scheduling queue, by default).
+* Add ``flexmeasures jobs save-last-failed`` (since v0.26: ``flexmeasures jobs save-last``) CLI command for saving the last n failed jobs (from the scheduling queue, by default).
 * Add ``flexmeasures jobs delete-queue`` CLI command for deleting an obsolete queue.
 
 since v0.24.0 | January 6, 2025

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -4,6 +4,10 @@
 FlexMeasures CLI Changelog
 **********************
 
+since v0.26.0 | April XX, 2025
+=================================
+* Switch to ``flexmeasures jobs save-last`` CLI command for saving the last n canceled/deferred/failed/finished/scheduled/started jobs (from the scheduling queue, by default).
+
 since v0.25.0 | April 01, 2025
 =================================
 * Report parameters set using ``flexmeasures add report --parameters`` can use any argument supported by ``Sensor.search_beliefs`` to allow more control over input for the report.

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -4,13 +4,13 @@
 FlexMeasures CLI Changelog
 **********************
 
-since v0.25.0 | April 01, 2024
+since v0.25.0 | April 01, 2025
 =================================
 * Report parameters set using ``flexmeasures add report --parameters`` can use any argument supported by ``Sensor.search_beliefs`` to allow more control over input for the report.
 * Add ``flexmeasures jobs save-last-failed`` CLI command for saving the last n failed jobs (from the scheduling queue, by default).
 * Add ``flexmeasures jobs delete-queue`` CLI command for deleting an obsolete queue.
 
-since v0.24.0 | January 6, 2024
+since v0.24.0 | January 6, 2025
 =================================
 
 * ``flexmeasures show beliefs`` shows datetime values on x-axis labels.

--- a/flexmeasures/cli/jobs.py
+++ b/flexmeasures/cli/jobs.py
@@ -263,9 +263,14 @@ def save_last(
         click.secho(
             f"Saved {len(found_jobs)} {registry_name} jobs to {file}.", fg="green"
         )
-    else:
+        return
+    elif asset_id:
+        filter_message = f" for asset {asset_id} among the last {n} jobs"
+    elif sensor_id:
         filter_message = f" for sensor {sensor_id} among the last {n} jobs"
-        click.secho(f"No {registry_name} jobs found{filter_message}.", fg="yellow")
+    else:
+        filter_message = ""
+    click.secho(f"No {registry_name} jobs found{filter_message}.", fg="yellow")
 
 
 @fm_jobs.command("clear-queue")


### PR DESCRIPTION
## Description

- [x] Fetch last jobs from any registry (e.g. finished) rather than only the failed
- [x] Filter last jobs by sensor ID
- [x] Added changelog item in `documentation/changelog.rst`
- [x] Added changelog item in `documentation/cli/change_log.rst`

NB breaking CLI change: `flexmeasures jobs save-last-failed` becomes `flexmeasures jobs save-last`.

## Look & Feel

`flexmeasures jobs save-last --queue scheduling --registry finished --n 100 --sensor 26 --file last-100-finished-for-sensor-26.csv`
