### PR TITLE
Feat: Sensor edit page and button to delete sensor

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -12,7 +12,7 @@ New features
 
 * Support saving the storage schedule SOC using the ``flex-model`` field ``state-of-charge`` to the ``flex-model`` [see `PR #1392 <https://github.com/FlexMeasures/flexmeasures/pull/1392>`_]
 * Save changes in asset flex-context form right away [see `PR #1390 <https://github.com/FlexMeasures/flexmeasures/pull/1390>`_]
-* Introduced new page to create sensor for a parent asset [see `PR #1394 <https://github.com/FlexMeasures/flexmeasures/pull/1394>`_]
+* Extending sensor CRUD functionality to the UI [see `PR #1394 <https://github.com/FlexMeasures/flexmeasures/pull/1394>`_ and `PR #1413 <https://github.com/FlexMeasures/flexmeasures/pull/1413>`_] 
 * Marker clusters on the dashboard map expand in a tree to show the hierarchical relationship of the assets they represent [see `PR #1410 <https://github.com/FlexMeasures/flexmeasures/pull/1410>`_]
 
 Infrastructure / Support

--- a/flexmeasures/ui/templates/views/sensors.html
+++ b/flexmeasures/ui/templates/views/sensors.html
@@ -18,6 +18,26 @@
           </div>
           <div class="row on-top-md">
               <div class="col-md-2">
+                <div class="header-action-button">
+                    {% if user_can_delete_sensor %}
+                    <div>
+                        <button id="delete-asset-button" class="btn btn-sm btn-responsive btn-danger" onclick="deleteSensor()">
+                            Delete this sensor
+                        </button>
+                        <script>
+                            $("#delete-asset-button").click(function () {
+                                if (confirm("Are you sure you want to delete this asset and all time series data associated with it?")) {
+                                    return true;
+                                }
+                                else {
+                                    return false;
+                                }
+                            });
+                        </script>
+                    </div>
+                    {% endif %}
+                </div>
+
                   <div class="sidepanel-container">
                       <div class="left-sidepanel-label">Select dates</div>
                       <div class="sidepanel left-sidepanel">
@@ -35,6 +55,32 @@
                           <li><a class="dropdown-item" href="#" data-chart-type="weekly_heatmap">Weekly heatmap</a></li>
                       </ul>
                   </div>
+
+                  {% if user_can_update_sensor %}
+                  <div class="sidepanel-container">
+                      <div class="left-sidepanel-label">Edit sensor</div>
+                      <div class="sidepanel left-sidepanel"  style="text-align: left;">
+                              <fieldset>
+                                <h3>Edit {{ sensor.name }}</h3>
+                                <small>Owned by account: {{ sensor.generic_asset.account_id | accountname }} (ID: {{ sensor.generic_asset.account_id
+                                    }})</small>
+                                <form class="form-horizontal" method="POST">
+                                
+                                    <div class="form-group">
+                                        <label for="name" class="form-label">Name</label>
+                                        <input type="text" class="form-control" id="name" name="name" placeholder="e.g power" value="{{sensor.name}}" required />
+                                    </div>
+                                
+                                    <button class="btn btn-sm btn-responsive btn-success create-button" type="submit" onclick="updateSensor(event)"
+                                        style="margin-top: 20px; float: right; border: 1px solid var(--light-gray);">
+                                        Save
+                                    </button>
+                                </form>
+                        </fieldset>
+                      </div>
+                  </div>
+                  {% endif %}
+
               </div>
               <div class="col-sm-8">
                   <div id="sensorchart" class="card" style="width: 100%;"></div>
@@ -274,6 +320,82 @@
     <script src="https://cdn.jsdelivr.net/npm/litepicker/dist/litepicker.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/litepicker/dist/plugins/ranges.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/litepicker/dist/plugins/keyboardnav.js"></script>
+
+<script>
+    const apiBasePath = window.location.origin;
+    const parentAssetId = "{{sensor.generic_asset.id}}"
+
+    async function updateSensor(event) {
+        event.preventDefault();
+
+        const name = document.getElementById("name").value;
+
+        if (!name) {
+            showToast("Please fill in all fields.", "error");
+            return;
+        }
+
+        const data = { name: name }
+
+        const response = await fetch(apiBasePath + "/api/v3_0/sensors/{{ sensor.id }}", {
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(data),
+        });
+
+        if (response.ok) {
+            const responseData = await response.json();
+            const sensorId = responseData.id;
+            showToast("Sensor updated successfully.", "success");
+            document.getElementById("name").value = "";
+        } else {
+            const errorData = await response.json();
+            let errorMessage = response.statusText; // Default to statusText
+
+            const messageUnitError = errorData?.message?.json?.unit?.[0];
+            if (messageUnitError) {
+                errorMessage = messageUnitError;
+            } else if (errorData?.message) {
+                errorMessage = errorData.message;
+            } else if (errorData?.error) {
+                errorMessage = errorData.error;
+            }
+            showToast("Error: " + errorMessage, "error");
+        }
+    }
+
+    async function deleteSensor() {
+        const response = await fetch(apiBasePath + "/api/v3_0/sensors/{{ sensor.id }}", {
+            method: "DELETE",
+            headers: {
+                "Content-Type": "application/json",
+            },
+        });
+
+
+        if (response.status === 204) {
+            showToast("Sensor deleted successfully.", "success");
+            // delay for one second to show toast message
+            await new Promise(resolve => setTimeout(resolve, 1000));
+            window.location.href = apiBasePath + "/assets/" + parentAssetId;
+        } else {
+            const errorData = await response.json();
+            let errorMessage = response.statusText; // Default to statusText
+
+            const messageUnitError = errorData?.message?.json?.unit?.[0];
+            if (messageUnitError) {
+                errorMessage = messageUnitError;
+            } else if (errorData?.message) {
+                errorMessage = errorData.message;
+            } else if (errorData?.error) {
+                errorMessage = errorData.error;
+            }
+            showToast("Error: " + errorMessage, "error");
+        }
+    }
+</script>
 
     {% block leftsidepanel %} {{ super() }} {% endblock %}
     {% block sensorChartSetup %} {{ super() }} {% endblock %}

--- a/flexmeasures/ui/templates/views/sensors.html
+++ b/flexmeasures/ui/templates/views/sensors.html
@@ -26,7 +26,7 @@
                         </button>
                         <script>
                             $("#delete-asset-button").click(function () {
-                                if (confirm("Are you sure you want to delete this asset and all time series data associated with it?")) {
+                                if (confirm("Are you sure you want to delete this sensor and all time series data associated with it?")) {
                                     return true;
                                 }
                                 else {

--- a/flexmeasures/ui/templates/views/sensors.html
+++ b/flexmeasures/ui/templates/views/sensors.html
@@ -349,7 +349,8 @@
             const sensorId = responseData.id;
             document.getElementById("name").value = "";
             showToast("Sensor updated successfully.", "success");
-            showToast("Loading...", "info");
+            await new Promise(resolve => setTimeout(resolve, 500));
+            showToast("Reloading page...", "info");
             await new Promise(resolve => setTimeout(resolve, 2000));
             window.location.reload();
         } else {

--- a/flexmeasures/ui/templates/views/sensors.html
+++ b/flexmeasures/ui/templates/views/sensors.html
@@ -62,8 +62,7 @@
                       <div class="sidepanel left-sidepanel"  style="text-align: left;">
                               <fieldset>
                                 <h3>Edit {{ sensor.name }}</h3>
-                                <small>Owned by account: {{ sensor.generic_asset.account_id | accountname }} (ID: {{ sensor.generic_asset.account_id
-                                    }})</small>
+                                <small>Parent asset: {{ sensor.generic_asset.name }} (ID: {{ sensor.generic_asset.id }} )</small>
                                 <form class="form-horizontal" method="POST">
                                 
                                     <div class="form-group">

--- a/flexmeasures/ui/templates/views/sensors.html
+++ b/flexmeasures/ui/templates/views/sensors.html
@@ -348,6 +348,9 @@
             const responseData = await response.json();
             const sensorId = responseData.id;
             document.getElementById("name").value = "";
+            showToast("Sensor updated successfully.", "success");
+            showToast("Loading...", "info");
+            await new Promise(resolve => setTimeout(resolve, 2000));
             window.location.reload();
         } else {
             const errorData = await response.json();

--- a/flexmeasures/ui/templates/views/sensors.html
+++ b/flexmeasures/ui/templates/views/sensors.html
@@ -347,8 +347,8 @@
         if (response.ok) {
             const responseData = await response.json();
             const sensorId = responseData.id;
-            showToast("Sensor updated successfully.", "success");
             document.getElementById("name").value = "";
+            window.location.reload();
         } else {
             const errorData = await response.json();
             let errorMessage = response.statusText; // Default to statusText

--- a/flexmeasures/ui/views/sensors.py
+++ b/flexmeasures/ui/views/sensors.py
@@ -15,6 +15,10 @@ from flexmeasures import Sensor
 from flexmeasures.ui.utils.view_utils import render_flexmeasures_template
 from flexmeasures.ui.utils.chart_defaults import chart_options
 from flexmeasures.ui.utils.breadcrumb_utils import get_breadcrumb_info
+from flexmeasures.ui.crud.assets.utils import (
+    user_can_delete,
+    user_can_update,
+)
 
 
 class SensorUI(FlaskView):
@@ -80,6 +84,8 @@ class SensorUI(FlaskView):
         return render_flexmeasures_template(
             "views/sensors.html",
             sensor=sensor,
+            user_can_update_sensor=user_can_update(sensor),
+            user_can_delete_sensor=user_can_delete(sensor),
             msg="",
             breadcrumb_info=get_breadcrumb_info(sensor),
             event_starts_after=request.args.get("start_time"),


### PR DESCRIPTION
## Description

This PR introduces a new page to edit sensors as well as including a `delete sensor button` on this same page

## Look & Feel
![image](https://github.com/user-attachments/assets/c6dc1500-9f21-4cf6-8058-61b24641ee5b)

## How to test

1. Open any asset containing sensors
2. Click on a sensor, which takes you to a details page
3. Navigate to the left side of the screen, where you will see the "Edit Sensor" button
4. Hover on it, change the sensor name, and observe if the new name is persisted
5. To delete a sensor, navigate to the top left of the sensor details page
6. Spot the "delete sensor" button and click on it.
7. This will delete the sensor(you also see a toast message) and then redirect you to the parent asset

## Further Improvements

None

## Related Items

This PR closes #1356 
This PR closes #1412 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
