### PR TITLE
fix map on asset page: whitespacing in braces

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -20,6 +20,7 @@ Infrastructure / Support
 Bugfixes
 -----------
 * The data dashboard now supports overlapping sensors with instantaneous and non-instantaneous resolutions [see `PR #1407 <https://github.com/FlexMeasures/flexmeasures/pull/1407>`_]
+* Fix map not loading when editing an asset [see `PR #1414 <https://github.com/FlexMeasures/flexmeasures/pull/1414>`_]
 
 
 v0.25.0 | April 01, 2025

--- a/flexmeasures/ui/templates/crud/asset.html
+++ b/flexmeasures/ui/templates/crud/asset.html
@@ -1602,7 +1602,7 @@
     });
     var marker = L
         .marker(
-            [{{ asset.latitude | replace("None", 10) }}, { { asset.longitude | replace("None", 10) } }],
+            [{{ asset.latitude | replace("None", 10) }}, {{ asset.longitude | replace("None", 10) }}],
     { icon: asset_icon }
         ).addTo(assetMap);
 


### PR DESCRIPTION
## Description

The asset editing form did not show map due to wrong whitespacing in template, introduced in [this PR on flex-context editing](https://github.com/FlexMeasures/flexmeasures/pull/1320/files#diff-35947be2b92ac9806a287658b5d3040ecf94da73a369c735b2eb701419f03a83R1504) (asset.html, line 1504).

- [x] fix whitespace
- [x] Added changelog item in `documentation/changelog.rst`

