### PR TITLE
1312 make request profiling work with pytinstrument

### DIFF
--- a/flexmeasures/app.py
+++ b/flexmeasures/app.py
@@ -219,7 +219,7 @@ def create(  # noqa C901
                 if not hasattr(g, "profiler"):
                     return app
                 g.profiler.stop()
-                output_html = g.profiler.output_html(timeline=True)
+                output_html = g.profiler.output_html()
                 endpoint = request.endpoint
                 if endpoint is None:
                     endpoint = "unknown"

--- a/requirements/3.10/dev.txt
+++ b/requirements/3.10/dev.txt
@@ -58,7 +58,7 @@ pycodestyle==2.12.1
     # via flake8
 pyflakes==3.2.0
     # via flake8
-pyinstrument==4.7.3
+pyinstrument
     # via -r requirements/dev.in
 pyproject-hooks==1.2.0
     # via build

--- a/requirements/3.11/dev.txt
+++ b/requirements/3.11/dev.txt
@@ -54,7 +54,7 @@ pycodestyle==2.12.1
     # via flake8
 pyflakes==3.2.0
     # via flake8
-pyinstrument==4.7.3
+pyinstrument
     # via -r requirements/dev.in
 pytest-runner==6.0.1
     # via -r requirements/dev.in

--- a/requirements/3.12/dev.txt
+++ b/requirements/3.12/dev.txt
@@ -54,7 +54,7 @@ pycodestyle==2.12.1
     # via flake8
 pyflakes==3.2.0
     # via flake8
-pyinstrument==4.7.3
+pyinstrument
     # via -r requirements/dev.in
 pytest-runner==6.0.1
     # via -r requirements/dev.in

--- a/requirements/3.8/dev.txt
+++ b/requirements/3.8/dev.txt
@@ -53,7 +53,7 @@ pycodestyle==2.12.1
     # via flake8
 pyflakes==3.2.0
     # via flake8
-pyinstrument==4.7.3
+pyinstrument
     # via -r requirements/dev.in
 pytest-runner==6.0.1
     # via -r requirements/dev.in

--- a/requirements/3.9/dev.txt
+++ b/requirements/3.9/dev.txt
@@ -54,7 +54,7 @@ pycodestyle==2.12.1
     # via flake8
 pyflakes==3.2.0
     # via flake8
-pyinstrument==4.7.3
+pyinstrument
     # via -r requirements/dev.in
 pytest-runner==6.0.1
     # via -r requirements/dev.in

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -8,7 +8,6 @@ pytest-runner
 # https://github.com/pypa/setuptools-scm/issues/1111 broke builds on 3.8 and 3.9
 setuptools_scm<8.1
 watchdog
-# https://github.com/FlexMeasures/flexmeasures/issues/1312
 pyinstrument
 # below: for releasing
 build

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -9,7 +9,7 @@ pytest-runner
 setuptools_scm<8.1
 watchdog
 # https://github.com/FlexMeasures/flexmeasures/issues/1312
-pyinstrument <= 4.7.3
+pyinstrument
 # below: for releasing
 build
 packaging>=24.2


### PR DESCRIPTION
## Description

Summary of the changes introduced in this PR. Try to use bullet points as much as possible.

- Updated the `teardown` function code to work with `pyinstrument==5.0.1` (latest version.).
- Updated the `requirements` files.

## Look & Feel

No UI change.

## How to test

Make sure profiling works.

## Further Improvements

None

## Related Items

Closes #1312 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
