### PR TITLE
Fix/durations in variablequantity timeseries specs

### DIFF
--- a/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
+++ b/flexmeasures/api/v3_0/tests/test_sensor_schedules.py
@@ -363,7 +363,11 @@ def test_get_schedule_fallback_not_redirect(
                 "storage-efficiency", 1
             ),
             "soc-targets": [
-                {"value": target_soc, "datetime": "2015-01-02T02:00:00+01:00"}
+                {
+                    "value": target_soc,
+                    "start": "2015-01-02T02:00:00+01:00",
+                    "duration": "PT0H",
+                }
             ],
         },
     }


### PR DESCRIPTION
## Description

- [x] Fix bug with `duration` field in timeseries specs
- [ ] Added changelog item in `documentation/changelog.rst`

## How to test

- `test_get_schedule_fallback_not_redirect` now makes sure this bug is fixed

## Related Items

Closes #1432.
