### PR TITLE
Feat: Show only the flex_context and sensors_to_show sensors.

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -18,6 +18,7 @@ New features
 * Marker clusters on the dashboard map expand in a tree to show the hierarchical relationship of the assets they represent [see `PR #1410 <https://github.com/FlexMeasures/flexmeasures/pull/1410>`_]
 * Load the sensors individually on the Sensors status page. Reload the jobs table using Ajax calls. Improve page performance and avoid timeouts. [see `PR #1425 <https://github.com/FlexMeasures/flexmeasures/pull/1425>`_]
 * New pages for `Properties`, `Graphs`, `Context`, `Status` and `Audit Log`. Simplified the main asset page. [see `PR #1416 <https://github.com/FlexMeasures/flexmeasures/pull/1416>`_ and `PR #1387 <https://github.com/FlexMeasures/flexmeasures/pull/1387>`_]
+* Only show important sensors statuses (flex-context and graph sensors) on the status page [see `PR #1439 <https://github.com/FlexMeasures/flexmeasures/pull/1439>`_]
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/api/common/schemas/tests/test_sensor_data_schema.py
+++ b/flexmeasures/api/common/schemas/tests/test_sensor_data_schema.py
@@ -401,12 +401,26 @@ def test_asset_sensors_metadata(
 
     status_data = get_asset_sensors_metadata(asset=asset)
 
-    assert status_data == [
+    assert status_data != [
         {
             "name": "wind speed",
             "id": wind_sensor.id,
             "asset_name": asset.name,
         },
+        {
+            "name": "temperature",
+            "id": temperature_sensor.id,
+            "asset_name": asset.name,
+        },
+        {
+            "name": "production price",
+            "id": production_price_sensor.id,
+            "asset_name": battery_asset.name,
+        },
+    ]
+
+    # Make sure the Wind speed is not in the sensor data as it is not in sensors_to_show or flex-context
+    assert status_data == [
         {
             "name": "temperature",
             "id": temperature_sensor.id,

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -130,6 +130,7 @@ class GenericAsset(db.Model, AuthModelMixin):
 
     def validate_sensors_to_show(
         self,
+        suggest_default_sensors: bool = True,
     ) -> list[dict[str, str | None | "Sensor" | list["Sensor"]]]:  # noqa: F821
         """
         Validate and transform the 'sensors_to_show' attribute into the latest format for use in graph-making code.
@@ -159,6 +160,10 @@ class GenericAsset(db.Model, AuthModelMixin):
                 [43, 44], 45, 46
             ]
 
+        Parameters:
+        - suggest_default_sensors: If True, the function will suggest default sensors if 'sensors_to_show' is not set.
+        - If False, the function will return an empty list if 'sensors_to_show' is not set.
+
         Returned structure:
         - The function returns a list of dictionaries, with each dictionary containing either a 'sensor' (for individual sensors) or 'sensors' (for groups of sensors), and an optional 'title'.
         - Example output:
@@ -171,11 +176,13 @@ class GenericAsset(db.Model, AuthModelMixin):
             ]
 
         If the 'sensors_to_show' attribute is missing, the function defaults to showing two of the asset's sensors, grouped together if they share the same unit, or separately if not.
+        If the suggest_default_sensors flag is set to False, the function will not suggest default sensors and will return an empty list if 'sensors_to_show' is not set.
 
+        Note:
         Unauthorized sensors are filtered out, and a warning is logged. Only sensors the user has permission to access are included in the final result.
         """
         # If not set, use defaults (show first 2 sensors)
-        if not self.sensors_to_show:
+        if not self.sensors_to_show and suggest_default_sensors:
             sensors_to_show = self.sensors[:2]
             if (
                 len(sensors_to_show) == 2

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -290,25 +290,30 @@ def get_asset_sensors_metadata(
         if isinstance(asset.flex_context[field], dict)
         and field != "inflexible-device-sensors"
     }
-    for asset, is_child_asset in (
-        (asset, False),
-        *[(child_asset, True) for child_asset in asset.child_assets],
-    ):
-        sensors_list = list(asset.sensors)
-        if not is_child_asset:
-            sensors_list += [
-                *inflexible_device_sensors,
-                *context_sensors.values(),
-            ]
-        for sensor in sensors_list:
-            if sensor is None or sensor.id in sensor_ids:
-                continue
-            sensor_status = {}
-            sensor_status["id"] = sensor.id
-            sensor_status["name"] = sensor.name
-            sensor_status["asset_name"] = sensor.generic_asset.name
-            sensor_ids.add(sensor.id)
-            sensors.append(sensor_status)
+
+    # Get the sensors to show for the asset
+    sensors_to_show = []
+    for item in asset.sensors_to_show:
+        if isinstance(item, dict) and "sensors" in item:
+            for sensor in item["sensors"]:
+                field = Sensor.query.get(sensor)
+                sensors_to_show.append(field)
+
+    sensors_list = [
+        *inflexible_device_sensors,
+        *context_sensors.values(),
+        *sensors_to_show,
+    ]
+
+    for sensor in sensors_list:
+        if sensor is None or sensor.id in sensor_ids:
+            continue
+        sensor_status = {}
+        sensor_status["id"] = sensor.id
+        sensor_status["name"] = sensor.name
+        sensor_status["asset_name"] = sensor.generic_asset.name
+        sensor_ids.add(sensor.id)
+        sensors.append(sensor_status)
     return sensors
 
 

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -291,15 +291,15 @@ def get_asset_sensors_metadata(
         and field != "inflexible-device-sensors"
     }
 
-    # Get the sensors to show for the asset
+    # Get sensors to show using the validate_sensors_to_show method
     sensors_to_show = []
-    asset_sensors_to_show = asset.sensors_to_show
-    if asset_sensors_to_show is not None:
-        for item in asset.sensors_to_show:
-            if isinstance(item, dict) and "sensors" in item:
-                for sensor in item["sensors"]:
-                    sensor_to_show = Sensor.query.get(sensor)
-                    sensors_to_show.append(sensor_to_show)
+    validated_asset_sensors = asset.validate_sensors_to_show()
+    sensor_groups = [
+        sensor["sensors"] for sensor in validated_asset_sensors if sensor is not None
+    ]
+    for group_of_sensors in sensor_groups:
+        for sensor in group_of_sensors:
+            sensors_to_show.append(sensor)
 
     sensors_list = [
         *inflexible_device_sensors,
@@ -316,6 +316,7 @@ def get_asset_sensors_metadata(
         sensor_status["asset_name"] = sensor.generic_asset.name
         sensor_ids.add(sensor.id)
         sensors.append(sensor_status)
+
     return sensors
 
 

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -297,9 +297,8 @@ def get_asset_sensors_metadata(
     sensor_groups = [
         sensor["sensors"] for sensor in validated_asset_sensors if sensor is not None
     ]
-    for group_of_sensors in sensor_groups:
-        for sensor in group_of_sensors:
-            sensors_to_show.append(sensor)
+    merged_sensor_groups = sum(sensor_groups, [])
+    sensors_to_show.extend(merged_sensor_groups)
 
     sensors_list = [
         *inflexible_device_sensors,

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -293,7 +293,9 @@ def get_asset_sensors_metadata(
 
     # Get sensors to show using the validate_sensors_to_show method
     sensors_to_show = []
-    validated_asset_sensors = asset.validate_sensors_to_show()
+    validated_asset_sensors = asset.validate_sensors_to_show(
+        suggest_default_sensors=True
+    )
     sensor_groups = [
         sensor["sensors"] for sensor in validated_asset_sensors if sensor is not None
     ]
@@ -301,9 +303,9 @@ def get_asset_sensors_metadata(
     sensors_to_show.extend(merged_sensor_groups)
 
     sensors_list = [
-        *inflexible_device_sensors,
-        *context_sensors.values(),
         *sensors_to_show,
+        *context_sensors.values(),
+        *inflexible_device_sensors,
     ]
 
     for sensor in sensors_list:

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -294,7 +294,7 @@ def get_asset_sensors_metadata(
     # Get sensors to show using the validate_sensors_to_show method
     sensors_to_show = []
     validated_asset_sensors = asset.validate_sensors_to_show(
-        suggest_default_sensors=True
+        suggest_default_sensors=False
     )
     sensor_groups = [
         sensor["sensors"] for sensor in validated_asset_sensors if sensor is not None
@@ -303,9 +303,9 @@ def get_asset_sensors_metadata(
     sensors_to_show.extend(merged_sensor_groups)
 
     sensors_list = [
-        *sensors_to_show,
-        *context_sensors.values(),
         *inflexible_device_sensors,
+        *context_sensors.values(),
+        *sensors_to_show,
     ]
 
     for sensor in sensors_list:

--- a/flexmeasures/ui/templates/views/status.html
+++ b/flexmeasures/ui/templates/views/status.html
@@ -22,7 +22,9 @@
 
 A red traffic light indicates that the last time a record was made was too long ago (it is 'stale'). Hover the light to learn more about why it is displayed red. It could be a source for errors down the line if that sensor data is necessary for forecasts and schedules to be made.
 
-How long ago is considered too long (stale) depends on the sensor, usually we use the sensor's resolution times two. If the source type means we expect future data ('forecaster', 'scheduler'), data should extend 12 hours into the future." style="margin-left: 10px;"></span>
+How long ago is considered too long (stale) depends on the sensor, usually we use the sensor's resolution times two. If the source type means we expect future data ('forecaster', 'scheduler'), data should extend 12 hours into the future.
+
+Sensors shown on this page are the ones relevant for correct functioning of the asset. We list the ones linked in the flex-context and the graphs page." style="margin-left: 10px;"></span>
                 </h4>
                 <table id="sensor_statuses" class="table table-striped paginate">
                     <thead>


### PR DESCRIPTION
## Description

Removed the logic to fetch all the sensors for a given asset. Only fetching important sensors (Sensors from flex-context and sensors_to_show)

## Look & Feel

No difference in look and feel.

## How to test

- Go to the status page for a sensor.
- Check only limited sensors are being loaded that belong to `flex-context` and `sensors_to_show`.

## Further Improvements

- Nothing.

## Related Items

Closes #1349 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
