### PR TITLE
Fixed the graph page reload issue.

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -30,7 +30,7 @@ Bugfixes
 * Fixed two alternatives for expressing a variable quantity as a time series; specifically, those involving the ``duration`` field [see `PR #1433 <https://github.com/FlexMeasures/flexmeasures/pull/1433>`_]
 * The data dashboard now supports overlapping sensors with instantaneous and non-instantaneous resolutions [see `PR #1407 <https://github.com/FlexMeasures/flexmeasures/pull/1407>`_]
 * Fix map not loading when editing an asset [see `PR #1414 <https://github.com/FlexMeasures/flexmeasures/pull/1414>`_]
-
+* Fix bug on asset graphs page on page reload [see `PR #1442 <https://github.com/FlexMeasures/flexmeasures/pull/1442>`_]
 
 v0.25.0 | April 01, 2025
 ============================

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -17,7 +17,7 @@ New features
 * Extending sensor CRUD functionality to the UI [see `PR #1394 <https://github.com/FlexMeasures/flexmeasures/pull/1394>`_ and `PR #1413 <https://github.com/FlexMeasures/flexmeasures/pull/1413>`_]
 * Marker clusters on the dashboard map expand in a tree to show the hierarchical relationship of the assets they represent [see `PR #1410 <https://github.com/FlexMeasures/flexmeasures/pull/1410>`_]
 * Load the sensors individually on the Sensors status page. Reload the jobs table using Ajax calls. Improve page performance and avoid timeouts. [see `PR #1425 <https://github.com/FlexMeasures/flexmeasures/pull/1425>`_]
-* New pages for `Properties`, `Graphs`, `Context`, `Status` and `Audit Log`. Simplified the main asset page. [see `PR #1416 <https://github.com/FlexMeasures/flexmeasures/pull/1416>`_ and `PR #1387 <https://github.com/FlexMeasures/flexmeasures/pull/1387>`_]
+* New pages for `Properties`, `Graphs`, `Context`, `Status` and `Audit Log`. Simplified the main asset page. [see `PR #1416 <https://github.com/FlexMeasures/flexmeasures/pull/1416>`_, `PR #1387 <https://github.com/FlexMeasures/flexmeasures/pull/1387>`_ and `PR #1442 <https://github.com/FlexMeasures/flexmeasures/pull/1442>`_]
 
 Infrastructure / Support
 ----------------------
@@ -30,7 +30,6 @@ Bugfixes
 * Fixed two alternatives for expressing a variable quantity as a time series; specifically, those involving the ``duration`` field [see `PR #1433 <https://github.com/FlexMeasures/flexmeasures/pull/1433>`_]
 * The data dashboard now supports overlapping sensors with instantaneous and non-instantaneous resolutions [see `PR #1407 <https://github.com/FlexMeasures/flexmeasures/pull/1407>`_]
 * Fix map not loading when editing an asset [see `PR #1414 <https://github.com/FlexMeasures/flexmeasures/pull/1414>`_]
-* Fix bug on asset graphs page on page reload [see `PR #1442 <https://github.com/FlexMeasures/flexmeasures/pull/1442>`_]
 
 v0.25.0 | April 01, 2025
 ============================

--- a/flexmeasures/ui/crud/assets/views.py
+++ b/flexmeasures/ui/crud/assets/views.py
@@ -311,7 +311,7 @@ class AssetCrudUI(FlaskView):
     @login_required
     @use_kwargs(StartEndTimeSchema, location="query")
     @route("/<id>/graphs")
-    def graphs(self, id: str):
+    def graphs(self, id: str, start_time=None, end_time=None):
         """/assets/<id>/graphs"""
 
         get_asset_response = InternalApi().get(url_for("AssetAPI:fetch_one", id=id))


### PR DESCRIPTION
## Description

Fixed the bug on `assets/<int:id>/graphs` for `start_time` invalid parameter.

## Look & Feel

No change in the UI.

## How to test

- Go to the Assets page.
- Head to the graphs page.
- Reload the page and make sure it does not crash.

## Further Improvements

None.

## Related Items

Closes #1440 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
