### PR TITLE
fix: new flex-context fields require users to migrate from using deprecated flex-context fields

### DIFF
--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -205,6 +205,10 @@ class FlexContextSchema(Schema):
                 "site-production-breach-price",
                 "site-peak-consumption-price",
                 "site-peak-production-price",
+                "relax-soc-constraints",
+                "relax-capacity-constraints",
+                "consumption-breach-price",
+                "production-breach-price",
             )
         ):
             if field_map["consumption-price-sensor"] in data:

--- a/flexmeasures/data/tests/conftest.py
+++ b/flexmeasures/data/tests/conftest.py
@@ -428,8 +428,8 @@ def flex_description_sequential(
         },
     ]
     flex_context = {
-        "consumption-price-sensor": setup_markets_fresh_db["epex_da"].id,
-        "production-price-sensor": setup_markets_fresh_db["epex_da"].id,
+        "consumption-price": {"sensor": setup_markets_fresh_db["epex_da"].id},
+        "production-price": {"sensor": setup_markets_fresh_db["epex_da"].id},
         "inflexible-device-sensors": [
             sensors["Test Solar"].id,
             sensors["Test Building"].id,

--- a/flexmeasures/data/tests/test_scheduling_sequential.py
+++ b/flexmeasures/data/tests/test_scheduling_sequential.py
@@ -110,8 +110,8 @@ def test_create_sequential_jobs(db, app, flex_description_sequential, smart_buil
     ).values.all()  # 5 kW
 
     # Get price data
-    price_sensor_id = flex_description_sequential["flex_context"][
-        "consumption-price-sensor"
+    price_sensor_id = flex_description_sequential["flex_context"]["consumption-price"][
+        "sensor"
     ]
     price_sensor = db.session.get(Sensor, price_sensor_id)
     prices = price_sensor.search_beliefs(

--- a/flexmeasures/data/tests/test_scheduling_simultaneous.py
+++ b/flexmeasures/data/tests/test_scheduling_simultaneous.py
@@ -80,8 +80,8 @@ def test_create_simultaneous_jobs(
     ).values.any()  # 5 kW
 
     # Get price data
-    price_sensor_id = flex_description_sequential["flex_context"][
-        "consumption-price-sensor"
+    price_sensor_id = flex_description_sequential["flex_context"]["consumption-price"][
+        "sensor"
     ]
     price_sensor = db.session.get(Sensor, price_sensor_id)
     prices = price_sensor.search_beliefs(

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -53,7 +53,8 @@ Flask-Classful>=0.16
 Flask-Marshmallow
 Flask-Cors
 sentry-sdk[flask]
-marshmallow>=3
+# <4: https://github.com/FlexMeasures/flexmeasures/issues/1447
+marshmallow>=3,<4
 marshmallow-polyfield
 marshmallow-sqlalchemy>=0.23.1
 webargs


### PR DESCRIPTION
## Description

- [x] fix: add new fields to list of fields that require users to update from consumption-price-sensor to consumption-price, and from production-price-sensor to production-price
- [x] Added changelog item in `documentation/changelog.rst`

