### PR TITLE
Describe the four supported user roles explicitly 

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -25,6 +25,7 @@ Infrastructure / Support
 * Move to using a ``pyproject.toml`` [see `PR #1419 <https://www.github.com/FlexMeasures/flexmeasures/pull/1419>`_]
 * Upgraded dependencies [see `PR #1400 <https://www.github.com/FlexMeasures/flexmeasures/pull/1400>`_, `PR #1444 <https://www.github.com/FlexMeasures/flexmeasures/pull/1444>`_ and `PR #1448 <https://www.github.com/FlexMeasures/flexmeasures/pull/1448>`_]
 * Save last N jobs from any queue and registry to a file, and support filtering by asset ID or sensor ID [see `PR #1411 <https://github.com/FlexMeasures/flexmeasures/pull/1411>`_]
+* Describe four supported user roles explicitly (docs and code) [see `PR #1451 <https://github.com/FlexMeasures/flexmeasures/pull/1451>`_]
 
 Bugfixes
 -----------

--- a/documentation/concepts/security_auth.rst
+++ b/documentation/concepts/security_auth.rst
@@ -67,7 +67,10 @@ We look into supported user roles in more detail below.
 Roles cannot be edited via the UI at the moment. They are decided when a user or account is created in the CLI (for adding roles later, we use the database for now). Editing roles in UI and CLI is future work.
 
 
-.. note:: Custom energy flexibility services which are developed on top of FlexMeasures can also add their own kind of authorization, at least for the endpoints they define - using roles. More on this in :ref:`auth-dev`. Here is an example for a custom authorization concept: services can use account roles to achieve their custom authorization. E.g. if several services run on one FlexMeasures server, each service could define a "MyService-subscriber" account role, to make sure that only users of such accounts can use the endpoints. DEvelopers are also free to add their own user roles and check on those in their custom code.
+.. note:: Custom energy flexibility services which are developed on top of FlexMeasures can also add their own kind of authorization, at least for the endpoints they define - using roles.
+          More on this in :ref:`auth-dev`. An example for a custom authorization concept is that services can use account roles to achieve their custom authorization.
+          E.g. if several services run on one FlexMeasures server, each service could define a "MyService-subscriber" account role, to make sure that only users of such accounts can use the endpoints.
+          Developers are also free to add their own user roles and check on those in their custom code.
 
 
 Supported User Roles
@@ -86,6 +89,9 @@ These roles are natively supported and give users more rights:
 Consultancy
 ^^^^^^^^^^^
 
-A special case of authorization is consultancy - a consultant account can read data from other accounts (usually their clients ― this is handy for servicing them). For this, accounts have an attribute called ``consultancy_account_id``. Users in the consultant account with the role `consultant` can read data in their client accounts. We plan to introduce some editing/creation capabilities in the future.
+A special case of authorization is consultancy - a consultancy account can read data from other accounts (usually their clients ― this is handy for servicing them).
+For this, accounts have an attribute called ``consultancy_account_id``. Users in the consultancy account with the role `consultant` can read data in their client accounts.
+We plan to introduce some editing/creation capabilities in the future.
 
-Setting an account as the consultant account is something only admins can do. It is possible via the ``/accounts`` PATCH endpoint, but also in the UI. You can also specify a consultant account when creating a client account, which for now happens only in the CLI: ``flexmeasures add account --name "Account2" --consultancy 1`` makes account 1 the consultant for account 2.
+Setting an account as the consultancy account is something only admins can do. 
+It is possible via the ``/accounts`` PATCH endpoint, but also in the UI. You can also specify a consultant account when creating a client account, which for now happens only in the CLI: ``flexmeasures add account --name "Account2" --consultancy 1`` makes account 1 the consultant for account 2.

--- a/flexmeasures/auth/policy.py
+++ b/flexmeasures/auth/policy.py
@@ -11,10 +11,12 @@ from flask_security import current_user
 from werkzeug.exceptions import Unauthorized, Forbidden
 
 
-PERMISSIONS = ["create-children", "read", "read-children", "update", "delete"]
+PERMISSIONS = ["create-children", "read", "update", "delete"]
 
 ADMIN_ROLE = "admin"
 ADMIN_READER_ROLE = "admin-reader"
+ACCOUNT_ADMIN_ROLE = "account-admin"
+CONSULTANT_ROLE = "consultant"
 
 # constants to allow access to certain groups
 EVERY_LOGGED_IN_USER = "every-logged-in-user"

--- a/flexmeasures/data/models/audit_log.py
+++ b/flexmeasures/data/models/audit_log.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from flask_security import current_user
 from sqlalchemy import DateTime, Column, Integer, String, ForeignKey
 
-from flexmeasures.auth.policy import AuthModelMixin
+from flexmeasures.auth.policy import AuthModelMixin, CONSULTANT_ROLE, ACCOUNT_ADMIN_ROLE
 from flexmeasures.data import db
 from flexmeasures.data.models.generic_assets import GenericAsset
 from flexmeasures.data.models.time_series import Sensor
@@ -67,8 +67,11 @@ class AuditLog(db.Model, AuthModelMixin):
                 return {
                     "read": [
                         f"user:{self.user_id}",
-                        (f"account:{self.account_id}", "role:account-admin"),
-                        (f"account:{self.consultancy_account_id}", "role:consultant"),
+                        (f"account:{self.account_id}", f"role:{ACCOUNT_ADMIN_ROLE}"),
+                        (
+                            f"account:{self.consultancy_account_id}",
+                            f"role:{CONSULTANT_ROLE}",
+                        ),
                     ],
                 }
 
@@ -95,8 +98,11 @@ class AuditLog(db.Model, AuthModelMixin):
                     return {}
                 return {
                     "read": [
-                        (f"account:{self.account_id}", "role:account-admin"),
-                        (f"account:{self.consultancy_account_id}", "role:consultant"),
+                        (f"account:{self.account_id}", f"role:{ACCOUNT_ADMIN_ROLE}"),
+                        (
+                            f"account:{self.consultancy_account_id}",
+                            f"role:{CONSULTANT_ROLE}",
+                        ),
                     ],
                 }
 

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -22,7 +22,11 @@ from flexmeasures.data.models.parsing_utils import parse_source_arg
 from flexmeasures.data.models.user import User
 from flexmeasures.data.queries.annotations import query_asset_annotations
 from flexmeasures.data.services.timerange import get_timerange
-from flexmeasures.auth.policy import AuthModelMixin, EVERY_LOGGED_IN_USER
+from flexmeasures.auth.policy import (
+    AuthModelMixin,
+    EVERY_LOGGED_IN_USER,
+    ACCOUNT_ADMIN_ROLE,
+)
 from flexmeasures.utils import geo_utils
 from flexmeasures.utils.coding_utils import flatten_unique
 from flexmeasures.utils.time_utils import determine_minimum_resampling_resolution
@@ -114,7 +118,7 @@ class GenericAsset(db.Model, AuthModelMixin):
                 else EVERY_LOGGED_IN_USER
             ),
             "update": f"account:{self.account_id}",
-            "delete": (f"account:{self.account_id}", "role:account-admin"),
+            "delete": (f"account:{self.account_id}", f"role:{ACCOUNT_ADMIN_ROLE}"),
         }
 
     def __repr__(self):

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -16,7 +16,7 @@ import timely_beliefs as tb
 from timely_beliefs.beliefs.probabilistic_utils import get_median_belief
 import timely_beliefs.utils as tb_utils
 
-from flexmeasures.auth.policy import AuthModelMixin
+from flexmeasures.auth.policy import AuthModelMixin, ACCOUNT_ADMIN_ROLE
 from flexmeasures.data import db
 from flexmeasures.data.models.data_sources import keep_latest_version
 from flexmeasures.data.models.parsing_utils import parse_source_arg
@@ -113,11 +113,11 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
             "read": self.generic_asset.__acl__()["read"],
             "update": (
                 f"account:{self.generic_asset.account_id}",
-                "role:account-admin",
+                f"role:{ACCOUNT_ADMIN_ROLE}",
             ),
             "delete": (
                 f"account:{self.generic_asset.account_id}",
-                "role:account-admin",
+                f"role:{ACCOUNT_ADMIN_ROLE}",
             ),
         }
 

--- a/flexmeasures/data/models/user.py
+++ b/flexmeasures/data/models/user.py
@@ -18,7 +18,7 @@ from flexmeasures.data.models.annotations import (
     to_annotation_frame,
 )
 from flexmeasures.data.models.parsing_utils import parse_source_arg
-from flexmeasures.auth.policy import AuthModelMixin
+from flexmeasures.auth.policy import AuthModelMixin, CONSULTANT_ROLE, ACCOUNT_ADMIN_ROLE
 
 if TYPE_CHECKING:
     from flexmeasures.data.models.data_sources import DataSource
@@ -97,10 +97,10 @@ class Account(db.Model, AuthModelMixin):
         read_access = [f"account:{self.id}"]
         if self.consultancy_account_id is not None:
             read_access.append(
-                (f"account:{self.consultancy_account_id}", "role:consultant")
+                (f"account:{self.consultancy_account_id}", f"role:{CONSULTANT_ROLE}")
             )
         return {
-            "create-children": (f"account:{self.id}", "role:account-admin"),
+            "create-children": (f"account:{self.id}", f"role:{ACCOUNT_ADMIN_ROLE}"),
             "read": read_access,
             "update": f"account:{self.id}",
         }
@@ -264,7 +264,7 @@ class User(db.Model, UserMixin, AuthModelMixin):
             "read": f"account:{self.account_id}",
             "update": [
                 f"user:{self.id}",
-                (f"account:{self.account_id}", "role:account-admin"),
+                (f"account:{self.account_id}", f"role:{ACCOUNT_ADMIN_ROLE}"),
             ],
         }
 

--- a/flexmeasures/data/scripts/data_gen.py
+++ b/flexmeasures/data/scripts/data_gen.py
@@ -87,11 +87,19 @@ def add_default_user_roles(db: SQLAlchemy):
     """
     Add a few useful user roles.
     """
+    from flexmeasures.auth import policy as auth_policy
+
     for role_name, role_description in (
-        ("admin", "Super user"),
-        ("admin-reader", "Can read everything"),
-        ("account-admin", "Can post and edit sensors and assets in their account"),
-        ("consultant", "Can read everything in consultancy client accounts"),
+        (auth_policy.ADMIN_ROLE, "Super user"),
+        (auth_policy.ADMIN_READER_ROLE, "Can read everything"),
+        (
+            auth_policy.ACCOUNT_ADMIN_ROLE,
+            "Can update and delete data in their account (e.g. assets, sensors, users, beliefs)",
+        ),
+        (
+            auth_policy.CONSULTANT_ROLE,
+            "Can read everything in consultancy client accounts",
+        ),
     ):
         role = db.session.execute(
             select(Role).filter_by(name=role_name)

--- a/flexmeasures/ui/__init__.py
+++ b/flexmeasures/ui/__init__.py
@@ -14,6 +14,7 @@ from humanize import naturaldelta
 
 from werkzeug.exceptions import Forbidden
 
+from flexmeasures.auth import policy as auth_policy
 from flexmeasures.auth.policy import ADMIN_ROLE, ADMIN_READER_ROLE
 from flexmeasures.utils.flexmeasures_inflection import (
     capitalize,
@@ -178,3 +179,10 @@ def add_jinja_variables(app):
         )
         else False
     )
+    for role_name in (
+        "ADMIN_ROLE",
+        "ADMIN_READER_ROLE",
+        "ACCOUNT_ADMIN_ROLE",
+        "CONSULTANT_ROLE",
+    ):
+        app.jinja_env.globals[role_name] = auth_policy.__dict__[role_name]

--- a/flexmeasures/ui/templates/crud/account.html
+++ b/flexmeasures/ui/templates/crud/account.html
@@ -419,7 +419,7 @@ $(document).ready(function () {
   $("#inactiveUsersCheckbox").change(function () {
       includeInactive = this.checked;
       table.api().ajax.reload();
-      if (!includeInactive) {
+      if (includeInactive) {
         tableTitle.text("All users");
       } else {
         tableTitle.text("All active users");

--- a/flexmeasures/ui/templates/defaults.jinja
+++ b/flexmeasures/ui/templates/defaults.jinja
@@ -37,8 +37,8 @@
 
 
 {% if current_user.is_authenticated %}
-    {% set has_admin_reader_rights = True if (current_user.has_role('admin') or current_user.has_role('admin-reader') or FLEXMEASURES_MODE == "demo") %}
-    {% set is_consultant = True if current_user.has_role('consultant') %}
+    {% set has_admin_reader_rights = True if (current_user.has_role(ADMIN_ROLE) or current_user.has_role(ADMIN_READER_ROLE) or FLEXMEASURES_MODE == "demo") %}
+    {% set is_consultant = True if current_user.has_role(CONSULTANT_ROLE) %}
     {% if has_admin_reader_rights %}
         {% do navigation_bar.append(('assets', 'assets', 'Assets', '', 'list-ul'))  %}
         {% do navigation_bar.append(('users', 'users', 'Users', '', 'users')) %}


### PR DESCRIPTION
## Description

We want to make explicit which user roles are actually supported in FlexMeasures.

List roles we allow / handle:

- admin
- admin-reader
- account-admin
- consultant

[This section in the docs](https://flexmeasures.readthedocs.io/stable/concepts/security_auth.html#authorization) lists them briefly, but it should get more space. Also we should be clearer on adding roles in plugins.

In auth/policy.py, all four supported roles should be explicitly mentioned, as well, as constants

- [x] Clearer security/auth docs
- [x] Make all four role names constants in the code
- [x] Added changelog item in `documentation/changelog.rst`


## Look & Feel

Will only be relevant to devs.
