### PR TITLE
Added spinner to the refreshing row on refresh.

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -17,9 +17,8 @@ New features
 * Save changes in asset flex-context form right away [see `PR #1390 <https://github.com/FlexMeasures/flexmeasures/pull/1390>`_]
 * Extending sensor CRUD functionality to the UI [see `PR #1394 <https://github.com/FlexMeasures/flexmeasures/pull/1394>`_ and `PR #1413 <https://github.com/FlexMeasures/flexmeasures/pull/1413>`_]
 * Marker clusters on the dashboard map expand in a tree to show the hierarchical relationship of the assets they represent [see `PR #1410 <https://github.com/FlexMeasures/flexmeasures/pull/1410>`_]
-* Load the sensors individually on the Sensors status page. Reload the jobs table using Ajax calls. Improve page performance and avoid timeouts. [see `PR #1425 <https://github.com/FlexMeasures/flexmeasures/pull/1425>`_]
+* Load the sensors individually on the Sensors status page. Reload the jobs table using Ajax calls. Improve page performance and avoid timeouts. [see `PR #1425 <https://github.com/FlexMeasures/flexmeasures/pull/1425>`_ and `PR #1466 <https://github.com/FlexMeasures/flexmeasures/pull/1466>`_]
 * New pages for `Properties`, `Graphs`, `Context`, `Status` and `Audit Log`. Simplified the main asset page. [see `PR #1416 <https://github.com/FlexMeasures/flexmeasures/pull/1416>`_, `PR #1387 <https://github.com/FlexMeasures/flexmeasures/pull/1387>`_ and `PR #1442 <https://github.com/FlexMeasures/flexmeasures/pull/1442>`_]
-* Added `spinner` to the sensors table in the sensors page when reloading a particular row. [see `PR #1466 <https://github.com/FlexMeasures/flexmeasures/pull/1466>`_]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -19,6 +19,7 @@ New features
 * Marker clusters on the dashboard map expand in a tree to show the hierarchical relationship of the assets they represent [see `PR #1410 <https://github.com/FlexMeasures/flexmeasures/pull/1410>`_]
 * Load the sensors individually on the Sensors status page. Reload the jobs table using Ajax calls. Improve page performance and avoid timeouts. [see `PR #1425 <https://github.com/FlexMeasures/flexmeasures/pull/1425>`_]
 * New pages for `Properties`, `Graphs`, `Context`, `Status` and `Audit Log`. Simplified the main asset page. [see `PR #1416 <https://github.com/FlexMeasures/flexmeasures/pull/1416>`_, `PR #1387 <https://github.com/FlexMeasures/flexmeasures/pull/1387>`_ and `PR #1442 <https://github.com/FlexMeasures/flexmeasures/pull/1442>`_]
+* Added `spinner` to the sensors table in the sensors page when reloading a particular row. [see `PR #1466 <https://github.com/FlexMeasures/flexmeasures/pull/1466>`_]
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/ui/static/js/flexmeasures.js
+++ b/flexmeasures/ui/static/js/flexmeasures.js
@@ -486,9 +486,9 @@ function getTimeAgo(timestamp) {
 
 
 // Function to return a loading row for a table
-function getLoadingRow() {
+function getLoadingRow(id="loading-row") {
     const loading_row = `
-        <tr id="loading-row">
+        <tr id="${id}">
             <td colspan="5" class="text-center">
                 <i class="fa fa-spinner fa-spin"></i> Loading...
             </td>

--- a/flexmeasures/ui/templates/views/status.html
+++ b/flexmeasures/ui/templates/views/status.html
@@ -95,7 +95,17 @@ Note that jobs do not live forever, so only rather recent jobs (usually younger 
             
             const sensorId = $(this).attr('id').split('_')[2];
             const rowId = `row_${sensorId}`;
-            getSensorData(sensorId, rowId);
+
+            // Check if the sensor info text is empty
+            // This is to determine if we need to show the sensor info or not in case of refresh
+            const sensorInfoText = $(`#sensor_info_${sensorId}`);
+            const show_info = (sensorInfoText.html().trim() === "") ? false : true;
+            
+            // Add Loading Row
+            $(`#${rowId}`).replaceWith(getLoadingRow(rowId));
+
+            // Fetch and update sensor data
+            getSensorData(sensorId, rowId, show_info);
         });
     });
 
@@ -104,7 +114,7 @@ Note that jobs do not live forever, so only rather recent jobs (usually younger 
     var lastSensorName = '';
     var assetId = "{{ asset.id }}";
 
-    function getSensorData(sensor_id, row_id = null) {
+    function getSensorData(sensor_id, row_id = null, show_info = false) {
 
         /**
          * Fetches sensor data and updates the sensor status table dynamically.
@@ -120,6 +130,7 @@ Note that jobs do not live forever, so only rather recent jobs (usually younger 
          * @param {string|null} [row_id=null] - The ID of the table row to update (optional).
          * The row_id is basically used to make a refresh call on a particular sensor and then update only 
          * that row in the table. If not provided, a new row will be appended to the table.
+         * @param {boolean} [show_info=false] - Whether to show sensor info or not incase of refresh.
          * 
          * @returns {void}
          * 
@@ -148,7 +159,7 @@ Note that jobs do not live forever, so only rather recent jobs (usually younger 
                     const isNewSensorName = lastSensorName !== sensor.name;
                     lastSensorName = sensor.name;
 
-                    const sensorInfo = isNewSensorName
+                    const sensorInfo = (isNewSensorName || show_info)
                         ? `${sensor.name} (<a href="/sensors/${sensor.id}">${sensor.id}</a>) 
                         <span class="fa fa-info" title="Resolution: ${sensor.resolution}, Asset: '${sensor.asset_name}', reason for listing here: ${sensor.relation}" style="margin-left: 10px;"></span>`
                         : '';
@@ -174,7 +185,7 @@ Note that jobs do not live forever, so only rather recent jobs (usually younger 
 
                     const row = `
                         <tr title="View data" id="row_${sensor.id}">
-                            <td>${sensorInfo}</td>
+                            <td id="sensor_info_${sensor.id}">${sensorInfo}</td>
                             <td>${source_type}</td>
                             <td>${staleness_since}</td>
                             <td class="text-right">${status}<br><span class="time-ago" title="Refresh Sensor Status" data-timestamp="${lastCallTime}"><small>${refresh_icon}(${timeAgo})</small></span></td>


### PR DESCRIPTION
## Description

Added a `loading row` to the refresh logic so that a `spinner` appears on the refresh row on the sensors page until the api response is received.

## Look & Feel

![image](https://github.com/user-attachments/assets/d08843ef-1f1d-445e-ab35-464d9a84cf76)

## How to test

- Go to the Assets listing.
- Click on the Status button for any of the Asset.
- The sensors listing page is loaded with the sensors loaded dynamically.
- Click on the refresh icon at the extreme right of any row.
- A `spinner` should appear in that row overriding the contents of that row.
- Once the API reponse is fetched the row should show the updated data.

## Further Improvements

Nothing much.

## Related Items

Closes #1438 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
