### PR TITLE
fix: Fixed bug where editing asset overrides its flex-context

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -35,6 +35,7 @@ Bugfixes
 * The data dashboard now supports overlapping sensors with instantaneous and non-instantaneous resolutions [see `PR #1407 <https://github.com/FlexMeasures/flexmeasures/pull/1407>`_]
 * Fix map not loading when editing an asset [see `PR #1414 <https://github.com/FlexMeasures/flexmeasures/pull/1414>`_]
 * Fix ``flexmeasures add schedule for-storage`` after flex-context database migration [see `PR #1417 <https://github.com/FlexMeasures/flexmeasures/pull/1417>`_ and `PR #1449 <https://github.com/FlexMeasures/flexmeasures/pull/1449>`_]
+* Fix overriding of flex-context when asset is edited on the UI [see `PR #1469 <https://github.com/FlexMeasures/flexmeasures/pull/1469>`_]
 
 v0.25.0 | April 01, 2025
 ============================

--- a/flexmeasures/ui/views/assets/forms.py
+++ b/flexmeasures/ui/views/assets/forms.py
@@ -32,14 +32,6 @@ class AssetForm(FlaskForm):
         render_kw={"placeholder": "--Click the map or enter a longitude--"},
     )
     attributes = StringField("Other attributes (JSON)", default="{}")
-    flex_context = StringField(
-        "Flex context",
-        default="{}",
-        description=(
-            "This field accepts a JSON string to define the flex-context."
-            " These are defaults that, if needed, users can temporarily override when calling for a schedule via the API, by setting different flex-context fields in the API request."
-        ),
-    )
 
     def validate_on_submit(self):
         if (


### PR DESCRIPTION
## Description

This PR contains a fix to the issue where editing an asset in the Ui overrides its flex context.

## Look & Feel

None. Under the hood change.

## How to test

1. Find an asset with a flex context
2. edit any of the asset's fields, e.g asset name
3. Confirm that the asset's flex-conext is still intact 

## Further Improvements

None

## Related Items

This PR closes #1468 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
