### PR TITLE
Static breadcrumb for asset views

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -18,7 +18,7 @@ New features
 * Extending sensor CRUD functionality to the UI [see `PR #1394 <https://github.com/FlexMeasures/flexmeasures/pull/1394>`_ and `PR #1413 <https://github.com/FlexMeasures/flexmeasures/pull/1413>`_]
 * Marker clusters on the dashboard map expand in a tree to show the hierarchical relationship of the assets they represent [see `PR #1410 <https://github.com/FlexMeasures/flexmeasures/pull/1410>`_]
 * Load the sensors individually on the Sensors status page. Reload the jobs table using Ajax calls. Improve page performance and avoid timeouts. [see `PR #1425 <https://github.com/FlexMeasures/flexmeasures/pull/1425>`_ and `PR #1466 <https://github.com/FlexMeasures/flexmeasures/pull/1466>`_]
-* New pages for `Properties`, `Graphs`, `Context`, `Status` and `Audit Log`. Simplified the main asset page. [see `PR #1416 <https://github.com/FlexMeasures/flexmeasures/pull/1416>`_, `PR #1387 <https://github.com/FlexMeasures/flexmeasures/pull/1387>`_ and `PR #1442 <https://github.com/FlexMeasures/flexmeasures/pull/1442>`_]
+* New pages for `Properties`, `Graphs`, `Context`, `Status` and `Audit Log`. Simplified the main asset page. [see `PR #1416 <https://github.com/FlexMeasures/flexmeasures/pull/1416>`_, `PR #1387 <https://github.com/FlexMeasures/flexmeasures/pull/1387>`_, `PR #1442 <https://github.com/FlexMeasures/flexmeasures/pull/1442>`_ and `PR #1473 <https://github.com/FlexMeasures/flexmeasures/pull/1473>`_]
 * Only show important sensors statuses (flex-context and graph sensors) on the status page [see `PR #1439 <https://github.com/FlexMeasures/flexmeasures/pull/1439>`_]
 * Let the user interact with the breadcrumbs on asset graphs page when the graphs are loading [see `PR #1472 <https://github.com/FlexMeasures/flexmeasures/pull/1472>`_]g
 

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -216,7 +216,7 @@
             {% endfor %}
             {% if breadcrumb_info["views"]|length > 0 %}
             <li class="breadcrumb-item dropdown active">
-                <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown"  aria-expanded="false" role="button">{{ breadcrumb_info["views"][0]["name"] }}</a>
+                <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown"  aria-expanded="false" role="button">{{ breadcrumb_info["current_asset_view"] }}</a>
                 <ul class="dropdown-menu">
                     {% for view in breadcrumb_info["views"] %}
                     <li><a  class="p-3 dropdown-item" href="{{ view['url'] }}">{{ view["name"] }}</a></li>

--- a/flexmeasures/ui/utils/breadcrumb_utils.py
+++ b/flexmeasures/ui/utils/breadcrumb_utils.py
@@ -17,6 +17,7 @@ def get_breadcrumb_info(
     if entity is not None and isinstance(entity, Asset):
         # Add additional Views CTAs for Assets
         try:
+            breadcrumb["current_asset_view"] = current_page
             breadcrumb["views"] = [
                 {
                     "url": url_for("AssetCrudUI:get", id=entity.id),
@@ -45,31 +46,10 @@ def get_breadcrumb_info(
                 },
             ]
 
-            # If a current_page is provided, reorder the breadcrumb views
-            if current_page:
-                breadcrumb["views"] = reorder_breadcrumb(
-                    breadcrumb["views"], current_page
-                )
-
         except Exception as e:
             print("Error in updating breadcrumb variables:", e)
 
     return breadcrumb
-
-
-def reorder_breadcrumb(breadcrumbs, current_page):
-    # Find the breadcrumb that matches the current_page
-    current_page_breadcrumb = next(
-        (item for item in breadcrumbs if item["name"] == current_page), None
-    )
-
-    if current_page_breadcrumb:
-        # Remove the current page breadcrumb from the list
-        breadcrumbs = [item for item in breadcrumbs if item["name"] != current_page]
-        # Insert the current page breadcrumb at index 0
-        breadcrumbs.insert(0, current_page_breadcrumb)
-
-    return breadcrumbs
 
 
 def get_ancestry(entity: Sensor | Asset | Account | None) -> list[dict]:


### PR DESCRIPTION
## Description

Show same breadcrumb dropdown on all the asset view pages.

## Look & Feel

![image](https://github.com/user-attachments/assets/d4b47538-e6e7-4701-95a2-09bb23eaa715)

## How to test

- Go to the asset page.
- Check the dropdown on the context page.
- Compare the dropdown on any other page let's say `Properties` and make sure they are the same in order of the views.

## Further Improvements

- None

## Related Items

Closes #1458 
Slightly dependent on [PR #1470](https://github.com/FlexMeasures/flexmeasures/pull/1470). So should be merged only after 1470 is merged.

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
