### PR TITLE
fix: DetachedInstanceError when writing to audit log

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -37,6 +37,7 @@ Bugfixes
 * Fix map not loading when editing an asset [see `PR #1414 <https://github.com/FlexMeasures/flexmeasures/pull/1414>`_]
 * Fix ``flexmeasures add schedule for-storage`` after flex-context database migration [see `PR #1417 <https://github.com/FlexMeasures/flexmeasures/pull/1417>`_ and `PR #1449 <https://github.com/FlexMeasures/flexmeasures/pull/1449>`_]
 * Fix overriding of flex-context when asset is edited on the UI [see `PR #1469 <https://github.com/FlexMeasures/flexmeasures/pull/1469>`_]
+* Support entering audit log entries by detached user instances [see `PR #1483 <https://github.com/FlexMeasures/flexmeasures/pull/1483>`_]
 
 v0.25.0 | April 01, 2025
 ============================

--- a/flexmeasures/data/models/audit_log.py
+++ b/flexmeasures/data/models/audit_log.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from flask_security import current_user
+from flask_security.core import AnonymousUser
 from sqlalchemy import DateTime, Column, Integer, String, ForeignKey
 
 from flexmeasures.auth.policy import AuthModelMixin, CONSULTANT_ROLE, ACCOUNT_ADMIN_ROLE
@@ -13,7 +14,7 @@ from flexmeasures.utils.time_utils import server_now
 
 def get_current_user_id_name():
     current_user_id, current_user_name = None, None
-    if current_user:
+    if current_user and not isinstance(current_user, AnonymousUser):
         current_user_id, current_user_name = current_user.id, current_user.username
     return current_user_id, current_user_name
 

--- a/flexmeasures/data/models/audit_log.py
+++ b/flexmeasures/data/models/audit_log.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-from flask import current_app
 from flask_security import current_user
 from sqlalchemy import DateTime, Column, Integer, String, ForeignKey
-from sqlalchemy.orm.exc import DetachedInstanceError
 
 from flexmeasures.auth.policy import AuthModelMixin, CONSULTANT_ROLE, ACCOUNT_ADMIN_ROLE
 from flexmeasures.data import db
@@ -15,17 +13,7 @@ from flexmeasures.utils.time_utils import server_now
 
 def get_current_user_id_name():
     current_user_id, current_user_name = None, None
-    try:
-        if (
-            current_user
-            and hasattr(current_user, "is_authenticated")
-            and current_user.is_authenticated
-        ):
-            current_user_id, current_user_name = current_user.id, current_user.username
-    except DetachedInstanceError:
-        current_app.logger.warning(
-            f"Audit log entry based on detached user instance (ID={current_user.id})"
-        )
+    if current_user:
         current_user_id, current_user_name = current_user.id, current_user.username
     return current_user_id, current_user_name
 

--- a/flexmeasures/data/models/audit_log.py
+++ b/flexmeasures/data/models/audit_log.py
@@ -179,7 +179,7 @@ class AssetAuditLog(db.Model, AuthModelMixin):
             event_datetime=server_now(),
             event=truncate_string(
                 event, 255
-            ),  # we truncate the event string if it exceed 255 characters by adding ellipses in the middle
+            ),  # we truncate the event string if it exceeds 255 characters by adding ellipses in the middle
             active_user_id=current_user_id,
             active_user_name=current_user_name,
             affected_asset_id=asset.id,


### PR DESCRIPTION
## Description

@victorgarcia98 encountered this in a plugin test. The error was raised when calling `current_user.is_authenticated`.

- [x] fix: don't crash on DetachedInstanceError when a detached user writes an audit log entry
- [x] I'm not sure why we even check whether the user is authenticated. Just checking if there is a `current_user` should be enough imo. @nhoening if you agree, I'll amend this PR accordingly.
- [x] Added changelog item in `documentation/changelog.rst`

## Related Items

Amends code introduced in #1072.
