### PR TITLE
Chore/debug using click 8.2

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -25,7 +25,7 @@ New features
 Infrastructure / Support
 ----------------------
 * Move to using a ``pyproject.toml`` [see `PR #1419 <https://www.github.com/FlexMeasures/flexmeasures/pull/1419>`_]
-* Upgraded dependencies [see `PR #1400 <https://www.github.com/FlexMeasures/flexmeasures/pull/1400>`_, `PR #1444 <https://www.github.com/FlexMeasures/flexmeasures/pull/1444>`_ and `PR #1448 <https://www.github.com/FlexMeasures/flexmeasures/pull/1448>`_]
+* Upgraded dependencies [see `PR #1400 <https://www.github.com/FlexMeasures/flexmeasures/pull/1400>`_, `PR #1444 <https://www.github.com/FlexMeasures/flexmeasures/pull/1444>`_, `PR #1448 <https://www.github.com/FlexMeasures/flexmeasures/pull/1448>`_ and `PR #1484 <https://www.github.com/FlexMeasures/flexmeasures/pull/1484>`_]
 * Save last N jobs from any queue and registry to a file, and support filtering by asset ID or sensor ID [see `PR #1411 <https://github.com/FlexMeasures/flexmeasures/pull/1411>`_]
 * Describe four supported user roles explicitly (docs and code) [see `PR #1451 <https://github.com/FlexMeasures/flexmeasures/pull/1451>`_]
 * Updated the directory structure for crud operations for assets, sensors, users and accounts [see `PR #1467 <https://github.com/FlexMeasures/flexmeasures/pull/1467>`_ and `PR #1471 <https://github.com/FlexMeasures/flexmeasures/pull/1471>`_]

--- a/flexmeasures/data/schemas/utils.py
+++ b/flexmeasures/data/schemas/utils.py
@@ -12,7 +12,7 @@ class MarshmallowClickMixin(click.ParamType):
         super().__init__(*args, **kwargs)
         self.name = self.__class__.__name__
 
-    def get_metavar(self, param):
+    def get_metavar(self, param, **kwargs):
         return self.__class__.__name__
 
     def convert(self, value, param, ctx, **kwargs):


### PR DESCRIPTION
## Description

- [x] Click 8.2.0 was recently released, and it broke our `MarshmallowClickMixin`. This fixes it.
- [x] Added changelog item in `documentation/changelog.rst`

## How to test

`pytest -k test_cli_help`
