### PR TITLE
Added Defaults for generic_asset and data_source tables.

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -21,6 +21,7 @@ New features
 * New pages for `Properties`, `Graphs`, `Context`, `Status` and `Audit Log`. Simplified the main asset page. [see `PR #1416 <https://github.com/FlexMeasures/flexmeasures/pull/1416>`_, `PR #1387 <https://github.com/FlexMeasures/flexmeasures/pull/1387>`_, `PR #1442 <https://github.com/FlexMeasures/flexmeasures/pull/1442>`_, `PR #1470 <https://github.com/FlexMeasures/flexmeasures/pull/1470>`_, `PR #1473 <https://github.com/FlexMeasures/flexmeasures/pull/1473>`_, `PR #1478 <https://github.com/FlexMeasures/flexmeasures/pull/1478>`_, `PR #1480<https://github.com/FlexMeasures/flexmeasures/pull/1480>`_] and `PR #1482 <https://github.com/FlexMeasures/flexmeasures/pull/1482>`_]
 * Only show important sensors statuses (flex-context and graph sensors) on the status page [see `PR #1439 <https://github.com/FlexMeasures/flexmeasures/pull/1439>`_]
 * Let the user interact with the breadcrumbs on asset graphs page when the graphs are loading [see `PR #1472 <https://github.com/FlexMeasures/flexmeasures/pull/1472>`_]
+* Added DB migrations to apply server defaults to ``generic_asset`` and ``data_sources`` tables [see `PR #1488 <https://github.com/FlexMeasures/flexmeasures/pull/1488>`_]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -8,6 +8,8 @@ FlexMeasures Changelog
 v0.26.0 | May XX, 2025
 ============================
 
+.. warning:: Upgrading to this version requires running ``flexmeasures db upgrade`` (you can create a backup first with ``flexmeasures db-ops dump``).
+
 New features
 -------------
 

--- a/flexmeasures/data/migrations/versions/4dabf9663866_set_defaults_for_flex_context_and_.py
+++ b/flexmeasures/data/migrations/versions/4dabf9663866_set_defaults_for_flex_context_and_.py
@@ -1,0 +1,43 @@
+"""Set defaults for flex_context and sensors_to_show
+
+Revision ID: 4dabf9663866
+Revises: cb8df44ebda5
+Create Date: 2025-05-16 15:53:22.814840
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "4dabf9663866"
+down_revision = "cb8df44ebda5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "generic_asset",
+        "flex_context",
+        existing_type=sa.JSON(),
+        nullable=False,
+        server_default=sa.text("'{}'::json"),
+    )
+    op.alter_column(
+        "generic_asset",
+        "sensors_to_show",
+        existing_type=sa.JSON(),
+        nullable=False,
+        server_default=sa.text("'[]'::json"),
+    ),
+
+
+def downgrade():
+    op.alter_column(
+        "generic_asset", "flex_context", existing_type=sa.JSON(), nullable=False
+    ),
+    op.alter_column(
+        "generic_asset", "sensors_to_show", existing_type=sa.JSON(), nullable=False
+    )

--- a/flexmeasures/data/migrations/versions/ece7fb4207ed_adding_default_for_data_source_.py
+++ b/flexmeasures/data/migrations/versions/ece7fb4207ed_adding_default_for_data_source_.py
@@ -1,0 +1,33 @@
+"""Adding default for data_source attributes
+
+Revision ID: ece7fb4207ed
+Revises: 4dabf9663866
+Create Date: 2025-05-16 16:55:33.722545
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "ece7fb4207ed"
+down_revision = "4dabf9663866"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "data_source",
+        "attributes",
+        existing_type=sa.JSON(),
+        nullable=False,
+        server_default=sa.text("'{}'::json"),
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "data_source", "attributes", existing_type=sa.JSON(), nullable=False
+    )


### PR DESCRIPTION
## Description

Added defaults for `sensors_to_show` and `flex_context` in `generic_asset` table, and default for `attributes` in `data_source` to make it work with the new plugin [flexmeasures-weather](https://github.com/FlexMeasures/flexmeasures-weather).

## Look & Feel

No UI change.

## How to test

Can be tested if the Plugin for flexmeasures-weather is working fine.

## Further Improvements

None.

## Related Items

[flexmeasures-weather](https://github.com/FlexMeasures/flexmeasures-weather) Plugin

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
