### PR TITLE
Chore/update timely-beliefs 3.2.0

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -25,7 +25,7 @@ New features
 Infrastructure / Support
 ----------------------
 * Move to using a ``pyproject.toml`` [see `PR #1419 <https://www.github.com/FlexMeasures/flexmeasures/pull/1419>`_]
-* Upgraded dependencies [see `PR #1400 <https://www.github.com/FlexMeasures/flexmeasures/pull/1400>`_, `PR #1444 <https://www.github.com/FlexMeasures/flexmeasures/pull/1444>`_, `PR #1448 <https://www.github.com/FlexMeasures/flexmeasures/pull/1448>`_ and `PR #1484 <https://www.github.com/FlexMeasures/flexmeasures/pull/1484>`_]
+* Upgraded dependencies [see `PR #1400 <https://www.github.com/FlexMeasures/flexmeasures/pull/1400>`_, `PR #1444 <https://www.github.com/FlexMeasures/flexmeasures/pull/1444>`_, `PR #1448 <https://www.github.com/FlexMeasures/flexmeasures/pull/1448>`_, `PR #1484 <https://www.github.com/FlexMeasures/flexmeasures/pull/1484>`_ and `PR #1490 <https://www.github.com/FlexMeasures/flexmeasures/pull/1490>`_]
 * Save last N jobs from any queue and registry to a file, and support filtering by asset ID or sensor ID [see `PR #1411 <https://github.com/FlexMeasures/flexmeasures/pull/1411>`_]
 * Describe four supported user roles explicitly (docs and code) [see `PR #1451 <https://github.com/FlexMeasures/flexmeasures/pull/1451>`_]
 * Updated the directory structure for crud operations for assets, sensors, users and accounts [see `PR #1467 <https://github.com/FlexMeasures/flexmeasures/pull/1467>`_ and `PR #1471 <https://github.com/FlexMeasures/flexmeasures/pull/1471>`_]

--- a/requirements/3.10/app.txt
+++ b/requirements/3.10/app.txt
@@ -333,7 +333,7 @@ tabulate==0.9.0
     # via -r requirements/app.in
 threadpoolctl==3.6.0
     # via scikit-learn
-timely-beliefs[forecast]==3.1.0
+timely-beliefs[forecast]==3.2.0
     # via -r requirements/app.in
 timetomodel==0.7.3
     # via -r requirements/app.in

--- a/requirements/3.11/app.txt
+++ b/requirements/3.11/app.txt
@@ -331,7 +331,7 @@ tabulate==0.9.0
     # via -r requirements/app.in
 threadpoolctl==3.6.0
     # via scikit-learn
-timely-beliefs[forecast]==3.1.0
+timely-beliefs[forecast]==3.2.0
     # via -r requirements/app.in
 timetomodel==0.7.3
     # via -r requirements/app.in

--- a/requirements/3.12/app.txt
+++ b/requirements/3.12/app.txt
@@ -331,7 +331,7 @@ tabulate==0.9.0
     # via -r requirements/app.in
 threadpoolctl==3.6.0
     # via scikit-learn
-timely-beliefs[forecast]==3.1.0
+timely-beliefs[forecast]==3.2.0
     # via -r requirements/app.in
 timetomodel==0.7.3
     # via -r requirements/app.in

--- a/requirements/3.8/app.txt
+++ b/requirements/3.8/app.txt
@@ -337,7 +337,7 @@ tabulate==0.9.0
     # via -r requirements/app.in
 threadpoolctl==3.5.0
     # via scikit-learn
-timely-beliefs[forecast]==3.1.0
+timely-beliefs[forecast]==3.2.0
     # via -r requirements/app.in
 timetomodel==0.7.3
     # via -r requirements/app.in

--- a/requirements/3.9/app.txt
+++ b/requirements/3.9/app.txt
@@ -336,7 +336,7 @@ tabulate==0.9.0
     # via -r requirements/app.in
 threadpoolctl==3.6.0
     # via scikit-learn
-timely-beliefs[forecast]==3.1.0
+timely-beliefs[forecast]==3.2.0
     # via -r requirements/app.in
 timetomodel==0.7.3
     # via -r requirements/app.in

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -34,7 +34,7 @@ pyomo>=5.6,<6.9
 tabulate
 timetomodel>=0.7.3
 # 3.0.2: significantly faster db queries, incl. bulk saving, 3.1: numpy/pandas upgrade
-timely-beliefs[forecast]>=3.1
+timely-beliefs[forecast]>=3.2
 python-dotenv
 # a backport, not needed in Python3.8
 importlib_metadata


### PR DESCRIPTION
## Description

- [x] Just updating timely-beliefs to get rid of a FutureWarning in the logs related to deprecating `.fillna` with a method such as `method="ffill"`.
- [x] Added changelog item in `documentation/changelog.rst`
