### PR TITLE
fix: `infer_datetime_format` is no longer required

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -28,7 +28,7 @@ New features
 Infrastructure / Support
 ----------------------
 * Move to using a ``pyproject.toml`` [see `PR #1419 <https://www.github.com/FlexMeasures/flexmeasures/pull/1419>`_]
-* Upgraded dependencies [see `PR #1400 <https://www.github.com/FlexMeasures/flexmeasures/pull/1400>`_, `PR #1444 <https://www.github.com/FlexMeasures/flexmeasures/pull/1444>`_, `PR #1448 <https://www.github.com/FlexMeasures/flexmeasures/pull/1448>`_, `PR #1484 <https://www.github.com/FlexMeasures/flexmeasures/pull/1484>`_ and `PR #1490 <https://www.github.com/FlexMeasures/flexmeasures/pull/1490>`_]
+* Upgraded dependencies [see `PR #1400 <https://www.github.com/FlexMeasures/flexmeasures/pull/1400>`_, `PR #1444 <https://www.github.com/FlexMeasures/flexmeasures/pull/1444>`_, `PR #1448 <https://www.github.com/FlexMeasures/flexmeasures/pull/1448>`_, `PR #1484 <https://www.github.com/FlexMeasures/flexmeasures/pull/1484>`_, `PR #1490 <https://www.github.com/FlexMeasures/flexmeasures/pull/1490>`_ and `PR #1497 <https://www.github.com/FlexMeasures/flexmeasures/pull/1497>`_]
 * Save last N jobs from any queue and registry to a file, and support filtering by asset ID or sensor ID [see `PR #1411 <https://github.com/FlexMeasures/flexmeasures/pull/1411>`_]
 * Describe four supported user roles explicitly (docs and code) [see `PR #1451 <https://github.com/FlexMeasures/flexmeasures/pull/1451>`_]
 * Updated the directory structure for crud operations for assets, sensors, users and accounts [see `PR #1467 <https://github.com/FlexMeasures/flexmeasures/pull/1467>`_ and `PR #1471 <https://github.com/FlexMeasures/flexmeasures/pull/1471>`_]

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -707,7 +707,6 @@ def add_beliefs(
 
     # Set up optional parameters for read_csv
     if file.split(".")[-1].lower() == "csv":
-        kwargs["infer_datetime_format"] = True
         kwargs["delimiter"] = delimiter
         kwargs["decimal"] = decimal
         kwargs["thousands"] = thousands


### PR DESCRIPTION
## Description

- [x] Remove obsolete argument to `pd.read_csv`
- [x] Added changelog item in `documentation/changelog.rst`

<!--
Note regarding our changelog:
- The 'New features' section targets API / CLI / UI users.
- The 'Infrastructure / Support' section targets plugin developers and hosts.
-->

## Related Items

- Addresses one of the FutureWarnings in #1491.
- https://github.com/SeitaBV/timely-beliefs/issues/198
