### PR TITLE
Fix/prefer curtailing later rather than later

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -36,6 +36,7 @@ Infrastructure / Support
 Bugfixes
 -----------
 * Fixed two alternatives for expressing a variable quantity as a time series; specifically, those involving the ``duration`` field [see `PR #1433 <https://github.com/FlexMeasures/flexmeasures/pull/1433>`_]
+* Fix the preference to delay curtailment of any device [see `PR #1498 <https://github.com/FlexMeasures/flexmeasures/pull/1498>`_]
 * The data dashboard now supports overlapping sensors with instantaneous and non-instantaneous resolutions [see `PR #1407 <https://github.com/FlexMeasures/flexmeasures/pull/1407>`_]
 * Fix map not loading when editing an asset [see `PR #1414 <https://github.com/FlexMeasures/flexmeasures/pull/1414>`_]
 * Fix ``flexmeasures add schedule for-storage`` after flex-context database migration [see `PR #1417 <https://github.com/FlexMeasures/flexmeasures/pull/1417>`_ and `PR #1449 <https://github.com/FlexMeasures/flexmeasures/pull/1449>`_]

--- a/flexmeasures/data/models/planning/__init__.py
+++ b/flexmeasures/data/models/planning/__init__.py
@@ -250,19 +250,15 @@ class Commitment:
 
         # Try to set the time series index for the commitment
         if self.index is None:
-            if isinstance(self.quantity, pd.Series) and isinstance(
-                self.quantity.index, pd.DatetimeIndex
-            ):
-                self.index = self.quantity.index
-            elif isinstance(self.upwards_deviation_price, pd.Series) and isinstance(
-                self.upwards_deviation_price.index, pd.DatetimeIndex
-            ):
-                self.index = self.upwards_deviation_price.index
-            elif isinstance(self.downwards_deviation_price, pd.Series) and isinstance(
-                self.downwards_deviation_price.index, pd.DatetimeIndex
-            ):
-                self.index = self.downwards_deviation_price.index
-            else:
+            for series_attr in series_attributes:
+                if (
+                    hasattr(self, series_attr)
+                    and isinstance(getattr(self, series_attr), pd.Series)
+                    and isinstance(getattr(self, series_attr).index, pd.DatetimeIndex)
+                ):
+                    self.index = getattr(self, series_attr).index
+                    break
+            if self.index is None:
                 raise ValueError(
                     "Commitment must be initialized with a pd.DatetimeIndex. Hint: use the `index` argument."
                 )

--- a/flexmeasures/data/models/planning/__init__.py
+++ b/flexmeasures/data/models/planning/__init__.py
@@ -238,6 +238,12 @@ class Commitment:
     downwards_deviation_price: pd.Series = 0
 
     def __post_init__(self):
+        # Convert from single-column DataFrame to Series
+        if isinstance(self.upwards_deviation_price, pd.DataFrame):
+            self.upwards_deviation_price = self.upwards_deviation_price.squeeze()
+        if isinstance(self.downwards_deviation_price, pd.DataFrame):
+            self.downwards_deviation_price = self.downwards_deviation_price.squeeze()
+
         # Try to set the time series index for the commitment
         if self.index is None:
             if isinstance(self.quantity, pd.Series) and isinstance(

--- a/flexmeasures/data/models/planning/__init__.py
+++ b/flexmeasures/data/models/planning/__init__.py
@@ -264,20 +264,16 @@ class Commitment:
                 )
 
         # Force type conversion of repr fields to pd.Series
-        if not isinstance(self.device, pd.Series):
-            self.device = pd.Series(self.device, index=self.index)
-        if not isinstance(self.quantity, pd.Series):
-            self.quantity = pd.Series(self.quantity, index=self.index)
-        if not isinstance(self.upwards_deviation_price, pd.Series):
-            self.upwards_deviation_price = pd.Series(
-                self.upwards_deviation_price,
-                index=self.index,
-            )
-        if not isinstance(self.downwards_deviation_price, pd.Series):
-            self.downwards_deviation_price = pd.Series(
-                self.downwards_deviation_price,
-                index=self.index,
-            )
+        for series_attr in series_attributes:
+            if hasattr(self, series_attr) and not isinstance(
+                getattr(self, series_attr), pd.Series
+            ):
+                setattr(
+                    self,
+                    series_attr,
+                    pd.Series(getattr(self, series_attr), index=self.index),
+                )
+
         if self._type == "any":
             # add all time steps to the same group
             self.group = pd.Series(0, index=self.index)

--- a/flexmeasures/data/models/planning/__init__.py
+++ b/flexmeasures/data/models/planning/__init__.py
@@ -239,10 +239,14 @@ class Commitment:
 
     def __post_init__(self):
         # Convert from single-column DataFrame to Series
-        if isinstance(self.upwards_deviation_price, pd.DataFrame):
-            self.upwards_deviation_price = self.upwards_deviation_price.squeeze()
-        if isinstance(self.downwards_deviation_price, pd.DataFrame):
-            self.downwards_deviation_price = self.downwards_deviation_price.squeeze()
+        series_attributes = [
+            attr for attr, _type in self.__annotations__.items() if _type == "pd.Series"
+        ]
+        for series_attr in series_attributes:
+            if hasattr(self, series_attr) and isinstance(
+                getattr(self, series_attr), pd.DataFrame
+            ):
+                setattr(self, series_attr, getattr(self, series_attr).squeeze())
 
         # Try to set the time series index for the commitment
         if self.index is None:

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -455,11 +455,11 @@ class MetaStorageScheduler(Scheduler):
         # Flow commitments per device
 
         # Add tiny price slope to prefer curtailing later rather than now.
-        # We penalise the future with at most 1 per thousand times the energy price spread.
+        # The price slope is ranged to be a smaller fraction of the energy price spread than the slope to prefer charging sooner
         for d, prefer_curtailing_later_d in enumerate(prefer_curtailing_later):
             if prefer_curtailing_later_d:
                 tiny_price_slope = (
-                    add_tiny_price_slope(up_deviation_prices, "event_value")
+                    add_tiny_price_slope(up_deviation_prices, "event_value", d=10**-7)
                     - up_deviation_prices
                 )
                 commitment = FlowCommitment(

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -123,7 +123,7 @@ class MetaStorageScheduler(Scheduler):
             flex_model_d.get("prefer_charging_sooner") for flex_model_d in flex_model
         ]
         prefer_curtailing_later = [
-            flex_model_d.get("prefer_curtailing_sooner") for flex_model_d in flex_model
+            flex_model_d.get("prefer_curtailing_later") for flex_model_d in flex_model
         ]
         soc_gain = [flex_model_d.get("soc_gain") for flex_model_d in flex_model]
         soc_usage = [flex_model_d.get("soc_usage") for flex_model_d in flex_model]

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -461,7 +461,7 @@ class MetaStorageScheduler(Scheduler):
                 tiny_price_slope = (
                     add_tiny_price_slope(up_deviation_prices, "event_value")
                     - up_deviation_prices
-                )
+                )["event_value"]
                 commitment = FlowCommitment(
                     name=f"prefer curtailing device {d} later",
                     # Prefer curtailing consumption later by making later consumption more expensive

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -461,7 +461,7 @@ class MetaStorageScheduler(Scheduler):
                 tiny_price_slope = (
                     add_tiny_price_slope(up_deviation_prices, "event_value")
                     - up_deviation_prices
-                )["event_value"]
+                )
                 commitment = FlowCommitment(
                     name=f"prefer curtailing device {d} later",
                     # Prefer curtailing consumption later by making later consumption more expensive

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -2212,8 +2212,8 @@ def test_battery_storage_different_units(
             "power-capacity",
             [
                 {
-                    "start": "2015-01-02T14:00+01",
-                    "end": "2015-01-02T16:00+01",
+                    "start": "2015-01-02T15:00+01",
+                    "end": "2015-01-02T17:00+01",
                     "value": "850 kW",
                 }
             ],
@@ -2223,7 +2223,7 @@ def test_battery_storage_different_units(
             "power-capacity",
             [
                 {
-                    "start": "2015-01-02T14:00+01",
+                    "start": "2015-01-02T15:00+01",
                     "duration": "PT2H",
                     "value": "850 kW",
                 }
@@ -2234,17 +2234,18 @@ def test_battery_storage_different_units(
             "soc-maxima",
             [
                 {
-                    "datetime": "2015-01-02T15:00+01",
+                    "datetime": "2015-01-02T16:00+01",
                     "value": "950 kWh",
                 }
             ],
         ),
-        # Must end up at a minimum of 200 kWh, for which it is cheapest to charge to 950 and then to discharge to 200
+        # Must end up at a maximum of 200 kWh, for which it is cheapest to charge to 950 and then to discharge to 200
         (
-            "soc-minima",
+            "soc-maxima",
             [
                 {
-                    "datetime": "2015-01-02T16:00+01",
+                    "start": "2015-01-02T16:45+01",
+                    "duration": "PT15M",
                     "value": "200 kWh",
                 }
             ],
@@ -2275,8 +2276,8 @@ def test_battery_storage_with_time_series_in_flex_model(
     tz = pytz.timezone("Europe/Amsterdam")
 
     # transition from cheap to expensive (90 -> 100)
-    start = tz.localize(datetime(2015, 1, 2, 14, 0, 0))
-    end = tz.localize(datetime(2015, 1, 2, 16, 0, 0))
+    start = tz.localize(datetime(2015, 1, 2, 15, 0, 0))
+    end = tz.localize(datetime(2015, 1, 2, 17, 0, 0))
     resolution = timedelta(minutes=15)
 
     flex_model = {

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -766,8 +766,7 @@ def test_soc_bounds_timeseries(db, add_battery_assets):
 
     soc_schedule_2 = compute_schedule(flex_model)
 
-    # check that, in this case, adding the constraints
-    # alter the SOC profile
+    # check that, in this case, adding the constraints alters the SOC profile
     assert not soc_schedule_2.equals(soc_schedule_1)
 
     # check that global minimum is achieved

--- a/flexmeasures/data/models/planning/utils.py
+++ b/flexmeasures/data/models/planning/utils.py
@@ -69,12 +69,13 @@ def initialize_index(
 
 
 def add_tiny_price_slope(
-    prices: pd.DataFrame, col_name: str = "event_value", d: float = 10**-3
+    orig_prices: pd.DataFrame, col_name: str = "event_value", d: float = 10**-3
 ) -> pd.DataFrame:
     """Add tiny price slope to col_name to represent e.g. inflation as a simple linear price increase.
     This is meant to break ties, when multiple time slots have equal prices, in favour of acting sooner.
     We penalise the future with at most d times the price spread (1 per thousand by default).
     """
+    prices = orig_prices.copy()
     price_spread = prices[col_name].max() - prices[col_name].min()
     if price_spread > 0:
         max_penalty = price_spread * d


### PR DESCRIPTION
## Description

- [x] Fix the default preference to curtail later
- [x] Added changelog item in `documentation/changelog.rst`

# Look & Feel

In case curtailment is unavoidable and it doesn't financially matter when a local battery is charged, we prefer to postpone curtailing as much as possible.

Before (left) the choice between charging the local battery and PV curtailment is assigned to arbitrary time slots, whereas after (right) the local battery is charged first before resorting to PV curtailment:

<img src="https://github.com/user-attachments/assets/6c3b41ee-b58c-4a0f-8e10-a4e2d0f10b9e" width="380" /> <img src="https://github.com/user-attachments/assets/21d6be15-7876-4da4-906a-9eced6a34c0d" width="380" />
