### PR TITLE
docs: correct sensors-to-show settings in tutorials

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -32,6 +32,7 @@ Infrastructure / Support
 * Save last N jobs from any queue and registry to a file, and support filtering by asset ID or sensor ID [see `PR #1411 <https://github.com/FlexMeasures/flexmeasures/pull/1411>`_]
 * Describe four supported user roles explicitly (docs and code) [see `PR #1451 <https://github.com/FlexMeasures/flexmeasures/pull/1451>`_]
 * Updated the directory structure for crud operations for assets, sensors, users and accounts [see `PR #1467 <https://github.com/FlexMeasures/flexmeasures/pull/1467>`_ and `PR #1471 <https://github.com/FlexMeasures/flexmeasures/pull/1471>`_]
+* Docs: fix battery graph in tutorial, display plotted sensors when CLI shows asset info [see `PR #1501 <https://github.com/FlexMeasures/flexmeasures/pull/1501>`_
 
 Bugfixes
 -----------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -32,7 +32,7 @@ Infrastructure / Support
 * Save last N jobs from any queue and registry to a file, and support filtering by asset ID or sensor ID [see `PR #1411 <https://github.com/FlexMeasures/flexmeasures/pull/1411>`_]
 * Describe four supported user roles explicitly (docs and code) [see `PR #1451 <https://github.com/FlexMeasures/flexmeasures/pull/1451>`_]
 * Updated the directory structure for crud operations for assets, sensors, users and accounts [see `PR #1467 <https://github.com/FlexMeasures/flexmeasures/pull/1467>`_ and `PR #1471 <https://github.com/FlexMeasures/flexmeasures/pull/1471>`_]
-* Docs: fix battery graph in tutorial, display plotted sensors when CLI shows asset info [see `PR #1501 <https://github.com/FlexMeasures/flexmeasures/pull/1501>`_
+* Docs: fix graphs page for assets in toy tutorial, display plotted sensors when CLI shows asset info [see `PR #1501 <https://github.com/FlexMeasures/flexmeasures/pull/1501>`_
 
 Bugfixes
 -----------

--- a/documentation/tut/toy-example-expanded.rst
+++ b/documentation/tut/toy-example-expanded.rst
@@ -91,11 +91,11 @@ We can see the updated scheduling in the `FlexMeasures UI <http://localhost:5000
     :align: center
 |
 
-The `asset page for the battery <http://localhost:5000/assets/3>`_ now shows the solar data, too:
+The `graphs page for the battery <http://localhost:5000/assets/3/graphs>`_ now shows the solar data, too:
 
 .. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/asset-view-with-solar.png
     :align: center
-
+|
 
 Though this schedule is quite similar, we can see that it has changed from `the one we computed earlier <https://raw.githubusercontent.com/FlexMeasures/screenshots/main/tut/toy-schedule/asset-view-without-solar.png>`_ (when we did not take solar into account).
 

--- a/documentation/tut/toy-example-from-scratch.rst
+++ b/documentation/tut/toy-example-from-scratch.rst
@@ -69,7 +69,7 @@ We can also look at the charging schedule in the `FlexMeasures UI <http://localh
 
 Recall that we only asked for a 12 hour schedule here. We started our schedule *after* the high price peak (at 4am) and it also had to end *before* the second price peak fully realized (at 8pm). Our scheduler didn't have many opportunities to optimize, but it found some. For instance, it does buy at the lowest price (at 2pm) and sells it off at the highest price within the given 12 hours (at 6pm).
 
-The `asset page for the battery <http://localhost:5000/assets/3>`_ shows both prices and the schedule.
+The `battery's graph dashboard <http://localhost:5000/assets/3/graphs>`_ shows both prices and the schedule.
 
 .. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/asset-view-without-solar.png
     :align: center

--- a/documentation/tut/toy-example-process.rst
+++ b/documentation/tut/toy-example-process.rst
@@ -36,17 +36,15 @@ Before moving forward, we'll add the `process` asset and three sensors to store 
 
     $ flexmeasures add toy-account --kind process
     
-        Account '<Account Toy Account (ID:1)>' already exists. Skipping account creation. Use `flexmeasures delete account --id 1` if you need to remove it.
-        User with email toy-user@flexmeasures.io already exists in account Toy Account.
+        User with email toy-user@flexmeasures.io already exists in account Docker Toy Account.
         The sensor recording day-ahead prices is day-ahead prices (ID: 1).
-        Created <GenericAsset None: 'toy-process' (process)>
-        Created Power (INFLEXIBLE)
-        Created Power (BREAKABLE)
-        Created Power (SHIFTABLE)
-        The sensor recording the power of the INFLEXIBLE load is Power (INFLEXIBLE) (ID: 4).
-        The sensor recording the power of the BREAKABLE load is Power (BREAKABLE) (ID: 5).
-        The sensor recording the power of the SHIFTABLE load is Power (SHIFTABLE) (ID: 6).
-
+        Created <GenericAsset 5: 'toy-process' (process)>
+        Created <Sensor 4: Power (Inflexible), unit: MW res.: 0:15:00>
+        Created <Sensor 5: Power (Breakable), unit: MW res.: 0:15:00>
+        Created <Sensor 6: Power (Shiftable), unit: MW res.: 0:15:00>
+        The sensor recording the power of the inflexible load is Power (Inflexible) (ID: 4).
+        The sensor recording the power of the breakable load is Power (Breakable) (ID: 5).
+        The sensor recording the power of the shiftable load is Power (Shiftable) (ID: 6).
 
 
 Trigger an updated schedule
@@ -92,7 +90,8 @@ Finally, we'll schedule the process using the SHIFTABLE policy.
 Results
 ---------
 
-The image below shows the resulting schedules following each of the three policies. You will see similar results in your `FlexMeasures UI <http://localhost:5000/assets/5>`_. 
+The image below shows the resulting schedules following each of the three policies.
+You will see similar results in your `FlexMeasures UI <http://localhost:5000/assets/5/graphs>`_. 
 
  
 .. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/asset-view-process.png

--- a/documentation/tut/toy-example-reporter.rst
+++ b/documentation/tut/toy-example-reporter.rst
@@ -18,7 +18,9 @@ In essence, reporters apply arbitrary transformations to data coming from some s
 
     Moreover, it's possible to implement your custom reporters in plugins. Instructions for this to come.
 
-Now, coming back to the tutorial, we are going to use the `AggregatorReporter` and the `ProfitOrLossReporter`. In the first part, we'll use the `AggregatorReporter` to compute the (discharge) headroom of the battery in :ref:`tut_toy_schedule_expanded`. That way, we can verify the maximum power at which the battery can discharge at any point of time. In the second part, we'll use the `ProfitOrLossReporter` to compute the costs of operating the process of Tut. Part III in the different policies.
+Now, coming back to the tutorial, we are going to use the `AggregatorReporter` and the `ProfitOrLossReporter`.
+In the first part, we'll use the `AggregatorReporter` to compute the (discharge) headroom of the battery in :ref:`tut_toy_schedule_expanded`. That way, we can verify the maximum power at which the battery can discharge at any point of time.
+In the second part, we'll use the `ProfitOrLossReporter` to compute the costs of operating the process of Tut. Part III in the different policies.
 
 Before getting to the meat of the tutorial, we need to set up up all the entities. Instead of having to do that manually (e.g. using commands such as ``flexmeasures add sensor``), we have prepared a command that does that automatically.
 
@@ -32,14 +34,16 @@ Just as in previous sections, we need to run the command ``flexmeasures add toy-
     $ flexmeasures add toy-account --kind reporter
 
 Under the hood, this command is adding the following entities:
-    - A yearly sensor that stores the capacity of the grid connection.
+    - A sensor that stores the capacity of the grid connection (with a resolution of one year, so storing just one value:) ).
     - A power sensor, `headroom`, to store the remaining capacity for the battery. This is where we'll store the report.
     - A `ProfitOrLossReporter` configured to use the prices that we set up in Tut. Part II.
     - Three sensors to register the profits/losses from running the three different processes of Tut. Part III.
 
+.. note:: The above command should also print out the IDs of these sensors. We will use these IDs verbatim in this tutorial.
+
 Let's check it out! 
 
-Run the command below to show the values for the `grid connection capacity`:
+Run the command below to show the values for our newly-created `grid connection capacity`:
 
 .. code-block:: bash
 
@@ -80,21 +84,26 @@ That's because reporters belong to a bigger category of classes that also contai
 
     $ flexmeasures show data-sources --show-attributes --id 6
 
-         ID  Name          Type      User ID    Model           Version    Attributes                                  
-       ----  ------------  --------  ---------  --------------  ---------  -----------------------------------------   
-          6  FlexMeasures  reporter             ProfitOrLossReporter           {                                            
-                                                                               "data_generator": {                      
-                                                                                   "config": {                          
-                                                                                       "consumption_price_sensor": 1     
-                                                                                   }                                     
-                                                                               }                                          
-                                                                           }                                             
+        type: reporter
+        ========
+
+         ID  Name          User ID    Model                 Version    Attributes
+       ----  ------------  ---------  --------------------  ---------  ------------------------------------------
+          6  FlexMeasures             ProfitOrLossReporter             {
+                                                                       "data_generator": {
+                                                                           "config": {
+                                                                               "consumption_price_sensor": 1,
+                                                                               "loss_is_positive": true
+                                                                           }
+                                                                       }
+                                                                   }
 
 
 Compute headroom
 -------------------
 
-In this case, the discharge headroom is nothing but the difference between the grid connection capacity and the PV power. To compute that quantity, we can use the `AggregatorReporter` using the weights to make the PV to subtract the grid connection capacity.
+In this case, the discharge headroom is nothing but the difference between the grid connection capacity and the PV power.
+To compute that quantity, we can use the `AggregatorReporter` using the weights to make the PV to subtract the grid connection capacity.
 
 In practice, we need to create the `config` and `parameters`:
 
@@ -118,8 +127,9 @@ In practice, we need to create the `config` and `parameters`:
     $     'output' : [{'sensor' : 8}]
     $ }" > headroom-parameters.json
 
+The output sensor (ID: 8) is actually the one created just to store that information - the headroom our battery has when considering solar production.
 
-Finally, we can create the reporter with the following command:
+Finally, we can create the report with the following command:
 
 .. code-block:: bash
 
@@ -128,7 +138,7 @@ Finally, we can create the reporter with the following command:
        --start-offset DB,1D --end-offset DB,2D \
        --resolution PT15M
 
-Now we can visualize the headroom in the following `link <http://localhost:5000/sensors/8>`_, which should resemble the following image.
+Now we can visualize the diminished headroom in the following `link <http://localhost:5000/sensors/8/graphs>`_, which should resemble the following image:
 
 .. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/toy-schedule/sensor-data-headroom.png
     :align: center

--- a/documentation/tut/toy-example-reporter.rst
+++ b/documentation/tut/toy-example-reporter.rst
@@ -90,13 +90,13 @@ That's because reporters belong to a bigger category of classes that also contai
          ID  Name          User ID    Model                 Version    Attributes
        ----  ------------  ---------  --------------------  ---------  ------------------------------------------
           6  FlexMeasures             ProfitOrLossReporter             {
-                                                                       "data_generator": {
-                                                                           "config": {
-                                                                               "consumption_price_sensor": 1,
-                                                                               "loss_is_positive": true
+                                                                           "data_generator": {
+                                                                               "config": {
+                                                                                   "consumption_price_sensor": 1,
+                                                                                   "loss_is_positive": true
+                                                                               }
                                                                            }
                                                                        }
-                                                                   }
 
 
 Compute headroom

--- a/documentation/tut/toy-example-reporter.rst
+++ b/documentation/tut/toy-example-reporter.rst
@@ -3,9 +3,6 @@
 Toy example IV: Computing reports
 =====================================
 
-.. warning::
-    The reporting functionality is still in an early development stage. Beware that major changes might be introduced.
-    
 So far, we have worked on scheduling batteries and processes. Now, we are moving to one of the other three pillars of FlexMeasures: reporting. 
 
 In essence, reporters apply arbitrary transformations to data coming from some sensors (multiple inputs) and save the results to other sensors (multiple outputs). In practice, this allows to compute KPIs (such as profit and total daily energy production), to apply operations to beliefs (e.g. changing the sign of a power sensor for some time period), among other things.

--- a/documentation/tut/toy-example-setup.rst
+++ b/documentation/tut/toy-example-setup.rst
@@ -219,17 +219,15 @@ If you want, you can inspect what you created:
 
     $ flexmeasures show asset --id 3
 
-    ==================================
+    ===================================
     Asset toy-battery (ID: 3)
     Child of asset toy-building (ID: 2)
-    ==================================
-
-    Type     Location           Attributes                    Flex-Context
-    -------  -----------------  ----------------------------  ---------------------------- 
-    battery  (52.374, 4.88969)  capacity_in_mw: 0.5      consumption-price: {'sensor': 1}
-                                min_soc_in_mwh: 0.05
-                                max_soc_in_mwh: 0.45
-                                sensors_to_show: [1, [3, 2]]
+    ===================================
+    Type     Location           Flex-Context                      Sensors to show      Attributes
+    -------  -----------------  --------------------------------  -------------------  -----------------------
+    battery  (52.374, 4.88969)  consumption-price: {'sensor': 1}  Prices: [1]          capacity_in_mw: 500 kVA
+                                                              Power flows: [3, 2]  min_soc_in_mwh: 0.05
+                                                                                   max_soc_in_mwh: 0.45
 
     ====================================
     Child assets of toy-battery (ID: 3)
@@ -242,7 +240,7 @@ If you want, you can inspect what you created:
     ID  Name         Unit    Resolution    Timezone          Attributes
     ----  -----------  ------  ------------  ----------------  ------------
     2  discharging  MW      15 minutes    Europe/Amsterdam
-
+    
 
 Yes, that is quite a large battery :) 
 You can also see that the asset has some meta information about its scheduling. Within :ref:`flex_context`, we noted where to find the relevant optimization signal for electricity consumption (Sensor 1, which stores day-ahead prices). 

--- a/documentation/tut/toy-example-setup.rst
+++ b/documentation/tut/toy-example-setup.rst
@@ -226,8 +226,8 @@ If you want, you can inspect what you created:
     Type     Location           Flex-Context                      Sensors to show      Attributes
     -------  -----------------  --------------------------------  -------------------  -----------------------
     battery  (52.374, 4.88969)  consumption-price: {'sensor': 1}  Prices: [1]          capacity_in_mw: 500 kVA
-                                                              Power flows: [3, 2]  min_soc_in_mwh: 0.05
-                                                                                   max_soc_in_mwh: 0.45
+                                                                  Power flows: [3, 2]  min_soc_in_mwh: 0.05
+                                                                                       max_soc_in_mwh: 0.45
 
     ====================================
     Child assets of toy-battery (ID: 3)

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -2195,11 +2195,11 @@ def add_toy_account(kind: str, name: str):
         db.session.flush()
 
         process = shiftable_power.generic_asset
-        process.attributes["sensors_to_show"] = [
-            day_ahead_sensor.id,
-            inflexible_power.id,
-            breakable_power.id,
-            shiftable_power.id,
+        process.sensors_to_show = [
+            {"title": "Prices", "sensor": day_ahead_sensor.id},
+            {"title": "Inflexible", "sensor": inflexible_power.id},
+            {"title": "Breakable", "sensor": breakable_power.id},
+            {"title": "Shiftable", "sensor": shiftable_power.id},
         ]
 
         db.session.commit()

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -2152,12 +2152,12 @@ def add_toy_account(kind: str, name: str):
         # add day-ahead price sensor and PV production sensor to show on the battery's asset page
         db.session.flush()
         battery = discharging_sensor.generic_asset
-        battery.attributes["sensors_to_show"] = [
-            day_ahead_sensor.id,
-            [
-                production_sensor.id,
-                discharging_sensor.id,
-            ],
+        battery.sensors_to_show = [
+            {"title": "Prices", "sensor": day_ahead_sensor.id},
+            {
+                "title": "Power flows",
+                "sensors": [production_sensor.id, discharging_sensor.id],
+            },
         ]
 
         db.session.commit()

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -5,7 +5,7 @@ CLI commands for populating the database
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import Type
+from typing import Type, Dict, Any
 import isodate
 import json
 import yaml
@@ -2090,11 +2090,11 @@ def add_toy_account(kind: str, name: str):
         flex_context: dict | None = None,
         **asset_attributes,
     ):
-        asset_kwargs = dict()
+        asset_kwargs: Dict[str, Any] = {}
         if parent_asset_id is not None:
             asset_kwargs["parent_asset_id"] = parent_asset_id
-        if flex_context is None:
-            flex_context = {}
+        if flex_context is not None:
+            asset_kwargs["flex_context"] = flex_context
 
         asset = get_or_create_model(
             GenericAsset,
@@ -2103,9 +2103,10 @@ def add_toy_account(kind: str, name: str):
             owner=db.session.get(Account, account_id),
             latitude=location[0],
             longitude=location[1],
-            flex_context=flex_context,
             **asset_kwargs,
         )
+        if asset.flex_context is None:
+            asset.flex_context = {}
         if len(asset_attributes) > 0:
             asset.attributes = asset_attributes
 

--- a/flexmeasures/cli/data_show.py
+++ b/flexmeasures/cli/data_show.py
@@ -24,7 +24,10 @@ from flexmeasures.data.models.user import Account, AccountRole, User, Role
 from flexmeasures.data.models.data_sources import DataSource
 from flexmeasures.data.models.generic_assets import GenericAsset, GenericAssetType
 from flexmeasures.data.models.time_series import Sensor, TimedBelief
-from flexmeasures.data.schemas.generic_assets import GenericAssetIdField
+from flexmeasures.data.schemas.generic_assets import (
+    GenericAssetIdField,
+    SensorsToShowSchema,
+)
 from flexmeasures.data.schemas.sensors import SensorIdField
 from flexmeasures.data.schemas.account import AccountIdField
 from flexmeasures.data.schemas.sources import DataSourceIdField
@@ -202,16 +205,34 @@ def show_generic_asset(asset):
         )
     click.echo(f"======{len(asset.name) * '='}{separator_num * '='}\n")
 
+    standardized_sensors_to_show = SensorsToShowSchema().deserialize(
+        asset.sensors_to_show
+    )
     asset_data = [
         (
             asset.generic_asset_type.name,
             asset.location,
-            "".join([f"{k}: {v}\n" for k, v in asset.attributes.items()]),
             "".join([f"{k}: {v}\n" for k, v in asset.flex_context.items()]),
+            "".join(
+                [
+                    f"{graph['title']}: {graph['sensors']} \n"
+                    for graph in standardized_sensors_to_show
+                ]
+            ),
+            "".join([f"{k}: {v}\n" for k, v in asset.attributes.items()]),
         )
     ]
     click.echo(
-        tabulate(asset_data, headers=["Type", "Location", "Attributes", "Flex-Context"])
+        tabulate(
+            asset_data,
+            headers=[
+                "Type",
+                "Location",
+                "Flex-Context",
+                "Sensors to show",
+                "Attributes",
+            ],
+        )
     )
 
     child_asset_data = [


### PR DESCRIPTION
Configure the graphs page for the battery asset correctly in the tutorial.

Closes #1494 

Also, display `sensors_to_show` when the CLI shows the asset, and correct some links in the docs