### PR TITLE
Fix: make code safer against flexcontext being none

### DIFF
--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -2093,6 +2093,8 @@ def add_toy_account(kind: str, name: str):
         asset_kwargs = dict()
         if parent_asset_id is not None:
             asset_kwargs["parent_asset_id"] = parent_asset_id
+        if flex_context is None:
+            flex_context = {}
 
         asset = get_or_create_model(
             GenericAsset,

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -181,7 +181,10 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
             return self.generic_asset.attributes[attribute]
         if hasattr(self.generic_asset.flex_context, attribute):
             return getattr(self.generic_asset.flex_context, attribute)
-        if attribute in self.generic_asset.flex_context:
+        if (
+            self.generic_asset.flex_context
+            and attribute in self.generic_asset.flex_context
+        ):
             return self.generic_asset.flex_context[attribute]
 
         return default


### PR DESCRIPTION
Closes #1495 

Also improves:

- tutorial code will not actually write `None` as flex context
- convenience lookup functions will look up the hierarchy, as their docstring says 