### PR TITLE
Updated the siblings rendering for assets with owner as Account.

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -24,6 +24,7 @@ New features
 * Only show important sensors statuses (flex-context and graph sensors) on the status page [see `PR #1439 <https://github.com/FlexMeasures/flexmeasures/pull/1439>`_]
 * Let the user interact with the breadcrumbs on asset graphs page when the graphs are loading [see `PR #1472 <https://github.com/FlexMeasures/flexmeasures/pull/1472>`_]
 * Added DB migrations to apply server defaults to ``generic_asset`` and ``data_sources`` tables [see `PR #1488 <https://github.com/FlexMeasures/flexmeasures/pull/1488>`_]
+* Show visually distinct siblings and children in the assets dropdown [see `PR #1504 <https://github.com/FlexMeasures/flexmeasures/pull/1504>`_]
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/ui/utils/breadcrumb_utils.py
+++ b/flexmeasures/ui/utils/breadcrumb_utils.py
@@ -141,10 +141,7 @@ def get_siblings(entity: Sensor | Asset | Account | None) -> list[dict]:
         if entity.parent_asset is not None:
             sibling_assets = entity.parent_asset.child_assets
         elif entity.owner is not None:
-            if isinstance(entity.owner, Account):
-                sibling_assets = []
-            else:
-                sibling_assets = entity.owner.generic_assets
+            sibling_assets = []
         else:
             session = current_app.db.session
             sibling_assets = session.scalars(

--- a/flexmeasures/ui/utils/breadcrumb_utils.py
+++ b/flexmeasures/ui/utils/breadcrumb_utils.py
@@ -141,7 +141,10 @@ def get_siblings(entity: Sensor | Asset | Account | None) -> list[dict]:
         if entity.parent_asset is not None:
             sibling_assets = entity.parent_asset.child_assets
         elif entity.owner is not None:
-            sibling_assets = entity.owner.generic_assets
+            if isinstance(entity.owner, Account):
+                sibling_assets = []
+            else:
+                sibling_assets = entity.owner.generic_assets
         else:
             session = current_app.db.session
             sibling_assets = session.scalars(

--- a/flexmeasures/ui/utils/breadcrumb_utils.py
+++ b/flexmeasures/ui/utils/breadcrumb_utils.py
@@ -150,7 +150,9 @@ def get_siblings(entity: Sensor | Asset | Account | None) -> list[dict]:
         else:
             session = current_app.db.session
             sibling_assets = session.scalars(
-                select(Asset).filter(Asset.account_id.is_(None))
+                select(Asset).filter(
+                    Asset.account_id.is_(None), Asset.parent_asset_id.is_(None)
+                )
             ).all()
 
         siblings = [

--- a/flexmeasures/ui/utils/breadcrumb_utils.py
+++ b/flexmeasures/ui/utils/breadcrumb_utils.py
@@ -141,7 +141,12 @@ def get_siblings(entity: Sensor | Asset | Account | None) -> list[dict]:
         if entity.parent_asset is not None:
             sibling_assets = entity.parent_asset.child_assets
         elif entity.owner is not None:
-            sibling_assets = []
+            session = current_app.db.session
+            sibling_assets = session.scalars(
+                select(Asset).filter(
+                    Asset.parent_asset_id.is_(None), Asset.owner == entity.owner
+                )
+            ).all()
         else:
             session = current_app.db.session
             sibling_assets = session.scalars(


### PR DESCRIPTION
## Description

Updated the code so that an asset for which the Parent asset is an Account should not show all the other assets as it's siblings.

## Look & Feel

![image](https://github.com/user-attachments/assets/a0ff9dc1-484c-4798-81dd-86700cea96cc)

## How to test

Create assets for which the parent is an Account and then visit that asset.

## Further Improvements

-

## Related Items

Closes #1459 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
