### PR TITLE
Fix/API/backwards compatibility 0.26.0

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -105,9 +105,6 @@ Infrastructure / Support
 * Add utils doctests to our CI pipeline [see `PR #1347 <https://github.com/FlexMeasures/flexmeasures/pull/1347>`_]
 * Clarify default limitations to concurrent connections [see `PR #1391 <https://github.com/FlexMeasures/flexmeasures/pull/1391>`_]
 
-Bugfixes
------------
-
 
 v0.24.1 | February 27, 2025
 ============================

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -18,6 +18,14 @@ Bugfixes
 -----------
 
 
+v0.26.1 | June 09, 2025
+============================
+
+Bugfixes
+-----------
+* Fixed backwards compatibility for users still using deprecated flex-context fields [see `PR #1528 <https://github.com/FlexMeasures/flexmeasures/pull/1528>`_]
+
+
 v0.26.0 | June 03, 2025
 ============================
 

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -197,7 +197,7 @@ class FlexContextSchema(Schema):
             for field_var, field in self.declared_fields.items()
         }
         if any(
-            field_map[field] in data
+            field_map[field] in data and data[field_map[field]]
             for field in (
                 "soc-minima-breach-price",
                 "soc-maxima-breach-price",

--- a/flexmeasures/data/tests/conftest.py
+++ b/flexmeasures/data/tests/conftest.py
@@ -428,8 +428,8 @@ def flex_description_sequential(
         },
     ]
     flex_context = {
-        "consumption-price": {"sensor": setup_markets_fresh_db["epex_da"].id},
-        "production-price": {"sensor": setup_markets_fresh_db["epex_da"].id},
+        "consumption-price-sensor": setup_markets_fresh_db["epex_da"].id,
+        "production-price-sensor": setup_markets_fresh_db["epex_da"].id,
         "inflexible-device-sensors": [
             sensors["Test Solar"].id,
             sensors["Test Building"].id,

--- a/flexmeasures/data/tests/test_scheduling_sequential.py
+++ b/flexmeasures/data/tests/test_scheduling_sequential.py
@@ -110,8 +110,8 @@ def test_create_sequential_jobs(db, app, flex_description_sequential, smart_buil
     ).values.all()  # 5 kW
 
     # Get price data
-    price_sensor_id = flex_description_sequential["flex_context"]["consumption-price"][
-        "sensor"
+    price_sensor_id = flex_description_sequential["flex_context"][
+        "consumption-price-sensor"
     ]
     price_sensor = db.session.get(Sensor, price_sensor_id)
     prices = price_sensor.search_beliefs(

--- a/flexmeasures/data/tests/test_scheduling_simultaneous.py
+++ b/flexmeasures/data/tests/test_scheduling_simultaneous.py
@@ -91,8 +91,8 @@ def test_create_simultaneous_jobs(
         )
 
     # Get price data
-    price_sensor_id = flex_description_sequential["flex_context"]["consumption-price"][
-        "sensor"
+    price_sensor_id = flex_description_sequential["flex_context"][
+        "consumption-price-sensor"
     ]
     price_sensor = db.session.get(Sensor, price_sensor_id)
     prices = price_sensor.search_beliefs(


### PR DESCRIPTION
## Description

- [x] Fix backwards compatibility for API users still using the deprecated `consumption-price-sensor` and/or `production-price-sensor` flex-context fields
- [x] Added changelog item in `documentation/changelog.rst`

## Look & Feel

API users were getting the following error message in their response:
```
Please switch to using `consumption-price: {"sensor": <sensor_id>}`.
```
which they should only get when using one of the newer flex-context fields.

## Related Items

- Regression from #1446.
