### PR TITLE
Fix/toast accumulation

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -12,6 +12,7 @@ New features
 -------------
 
 * Allow editing users in the UI [see `PR #1502 <https://github.com/FlexMeasures/flexmeasures/pull/1502>`_]
+* Smarter toast notifications [see `PR #1530 <https://github.com/FlexMeasures/flexmeasures/pull/1530>`_]
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/ui/static/css/flexmeasures.css
+++ b/flexmeasures/ui/static/css/flexmeasures.css
@@ -2000,3 +2000,14 @@ body.touched [title]:hover:after {
 .bg-primary-custom {
     background-color: var(--primary-color) !important;
 }
+
+/* Toast highlighting */
+.toast.highlight {
+  animation: pulse 0.6s;
+}
+
+@keyframes pulse {
+  0%   { box-shadow: 0 0 0px 0 rgba(0, 123, 255, 0.8); }
+  50%  { box-shadow: 0 0 10px 4px rgba(0, 123, 255, 0.8); }
+  100% { box-shadow: 0 0 0px 0 rgba(0, 123, 255, 0.8); }
+}

--- a/flexmeasures/ui/static/css/flexmeasures.css
+++ b/flexmeasures/ui/static/css/flexmeasures.css
@@ -2007,7 +2007,7 @@ body.touched [title]:hover:after {
 }
 
 @keyframes pulse {
-  0%   { box-shadow: 0 0 0px 0 rgba(0, 123, 255, 0.8); }
-  50%  { box-shadow: 0 0 10px 4px rgba(0, 123, 255, 0.8); }
-  100% { box-shadow: 0 0 0px 0 rgba(0, 123, 255, 0.8); }
+  0%   { box-shadow: 0 0 0px 0 var(--secondary-color); }
+  50%  { box-shadow: 0 0 10px 4px var(--secondary-color); }
+  100% { box-shadow: 0 0 0px 0 var(--secondary-color); }
 }

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -828,6 +828,13 @@
             initiateToastCloseBtn(closeToastBtn);
         });
 
+        function maybeHideCloseToastBtn() {
+            const remainingToasts = toastStack.querySelectorAll(".toast");
+            if (remainingToasts.length === 0) {
+                closeToastBtn.style.display = "none";
+            }
+        }
+
         function initiateToastCloseBtn(closeToastBtn){
             // hide button
             closeToastBtn.style.display = "none";
@@ -905,6 +912,7 @@
                 const toastInstance = new bootstrap.Toast(toast);
                 toastInstance.dispose();
                 toast.remove();
+                maybeHideCloseToastBtn();
             });            
           }
     </script>

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -911,6 +911,16 @@
         
             showAllToasts();
 
+            // Dispose and remove toast when it's autohidden
+            toast.addEventListener("hidden.bs.toast", function () {
+                const instance = bootstrap.Toast.getInstance(toast);
+                if (instance) {
+                    instance.dispose();
+                }
+                toast.remove();
+                maybeHideCloseToastBtn();
+            });
+
             // destroy only this toast if the close(X) button is clicked
             toast.querySelector(".btn-close").addEventListener("click", function () {
                 const toastInstance = new bootstrap.Toast(toast);

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -862,7 +862,7 @@
             });
         }
 
-        function showToast(message, type) {
+        function showToast(message, type, { highlightDuplicates = true, showDuplicateCount = true } = {}) {
             let colorClass;
             let colorStyle = "";
             let title;
@@ -882,6 +882,36 @@
                 "background-color: {{ primary_color }};";
               title = "Info";
             }
+
+            // Search for an existing toast with the same message
+            const existingToasts = toastStack.querySelectorAll(".toast");
+            for (const t of existingToasts) {
+                const body = t.querySelector(".toast-body");
+                if (body && body.dataset.originalMessage === message) {
+                    // It's a duplicate
+                    if (showDuplicateCount) {
+                        let count = parseInt(body.dataset.count || "1") + 1;
+                        body.dataset.count = count;
+                        body.innerHTML = `${message} <span class="text-muted ms-2">(x${count})</span>`;
+                    }
+
+                    if (highlightDuplicates) {
+                        t.classList.remove("highlight");
+                        void t.offsetWidth; // Trigger reflow for CSS animation restart
+                        t.classList.add("highlight");
+                    }
+
+                    // Reinitialize and show the toast again
+                    const oldInstance = bootstrap.Toast.getInstance(t);
+                    if (oldInstance) {
+                        oldInstance.dispose();
+                    }
+                    const newInstance = new bootstrap.Toast(t);
+                    newInstance.show();
+
+                    return; // Don't create a new toast
+                }
+            }
         
             // Create the toast HTML
             const toast = document.createElement("div");
@@ -898,7 +928,7 @@
                 <strong class="me-auto">${title}</strong>
                 <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
               </div>
-              <div class="toast-body">
+            <div class="toast-body" data-original-message="${message}" data-count="1">
                 ${message}
               </div>
             `;

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -869,12 +869,15 @@
         
             // Determine the type of toast
             if (type == "error") {
+              delay = 10000;
               colorClass = "bg-danger";
               title = "Error";
             } else if (type == "success") {
+              delay = 2000;
               colorClass = "bg-success";
               title = "Success";
             } else {
+              delay = 5000;
               colorStyle =
                 "background-color: {{ primary_color }};";
               title = "Info";
@@ -884,6 +887,7 @@
             const toast = document.createElement("div");
             toast.classList.add("toast", "mb-1");
             toast.setAttribute("data-bs-autohide", "true");
+            toast.setAttribute("data-bs-delay", delay);
             toast.setAttribute("role", "alert");
             toast.setAttribute("aria-live", "assertive");
             toast.setAttribute("aria-atomic", "true");


### PR DESCRIPTION
## Description

Summary of the changes introduced in this PR. Try to use bullet points as much as possible.

- [x] Stop resurfacing old toasts (dispose and remove them after auto-hiding)
- [x] Show a duplicate count on toasts showing the same message
- [x] Highlight existing toasts if they are triggered again
- [x] Let error messages linger longer than success messages (info messages keep the 5s default)
- [x] Remove the `Close All` button if there is nothing left to close
- [x] Added changelog item in `documentation/changelog.rst`

## Look & Feel

For example:

![image](https://github.com/user-attachments/assets/f3cf1f2d-ccbe-48d0-aca3-7b28023d0f36)

https://github.com/user-attachments/assets/5f6c5ce3-6512-483b-ad84-47d1b26ccd6a


## How to test

I recommend testing in combination with #1529 by selecting a DST transition repeatedly.
