### PR TITLE
Refresh statistics for sensor on changing the selected date

### DIFF
--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -943,12 +943,23 @@ class SensorAPI(FlaskView):
     @route("/<id>/stats", methods=["GET"])
     @use_kwargs({"sensor": SensorIdField(data_key="id")}, location="path")
     @use_kwargs(
-        {"sort_keys": fields.Boolean(data_key="sort", load_default=True)},
+        {
+            "sort_keys": fields.Boolean(data_key="sort", load_default=True),
+            "event_start_time": fields.Str(load_default=None),
+            "event_end_time": fields.Str(load_default=None),
+        },
         location="query",
     )
     @permission_required_for_context("read", ctx_arg_name="sensor")
     @as_json
-    def get_stats(self, id, sensor: Sensor, sort_keys: bool):
+    def get_stats(
+        self,
+        id,
+        sensor: Sensor,
+        event_start_time: str,
+        event_end_time: str,
+        sort_keys: bool,
+    ):
         """Fetch stats for a given sensor.
 
         .. :quickref: Sensor; Get sensor stats
@@ -982,7 +993,10 @@ class SensorAPI(FlaskView):
         :status 422: UNPROCESSABLE_ENTITY
         """
 
-        return get_sensor_stats(sensor, sort_keys), 200
+        return (
+            get_sensor_stats(sensor, event_start_time, event_end_time, sort_keys),
+            200,
+        )
 
     @route("/<id>/status", methods=["GET"])
     @use_kwargs({"sensor": SensorIdField(data_key="id")}, location="path")

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -448,23 +448,39 @@ def build_asset_jobs_data(
 
 
 @lru_cache()
-def _get_sensor_stats(sensor: Sensor, sort_keys: bool, ttl_hash=None) -> dict:
+def _get_sensor_stats(
+    sensor: Sensor,
+    event_end_time: str,
+    event_start_time: str,
+    sort_keys: bool,
+    ttl_hash=None,
+) -> dict:
+    # parse incoming datetimes (or leave None)
+    start_dt = pd.to_datetime(event_start_time) if event_start_time else None
+    end_dt = pd.to_datetime(event_end_time) if event_end_time else None
+
     # Subquery for filtered aggregates
-    subquery_for_filtered_aggregates = (
-        sa.select(
-            TimedBelief.source_id,
-            sa.func.max(TimedBelief.event_value).label("max_event_value"),
-            sa.func.avg(TimedBelief.event_value).label("avg_event_value"),
-            sa.func.sum(TimedBelief.event_value).label("sum_event_value"),
-            sa.func.min(TimedBelief.event_value).label("min_event_value"),
-        )
-        .filter(TimedBelief.event_value != float("NaN"))
-        .filter(TimedBelief.sensor_id == sensor.id)
-        .group_by(TimedBelief.source_id)
-        .subquery()
+    subq = sa.select(
+        TimedBelief.source_id,
+        sa.func.max(TimedBelief.event_value).label("max_event_value"),
+        sa.func.avg(TimedBelief.event_value).label("avg_event_value"),
+        sa.func.sum(TimedBelief.event_value).label("sum_event_value"),
+        sa.func.min(TimedBelief.event_value).label("min_event_value"),
+    ).filter(
+        TimedBelief.event_value != float("NaN"),
+        TimedBelief.sensor_id == sensor.id,
     )
 
-    raw_stats = db.session.execute(
+    # apply start/end filters if provided
+    if start_dt:
+        subq = subq.filter(TimedBelief.event_start >= start_dt)
+    if end_dt:
+        subq = subq.filter(TimedBelief.event_start <= end_dt)
+
+    subquery_for_filtered_aggregates = subq.group_by(TimedBelief.source_id).subquery()
+
+    # build main query
+    q = (
         sa.select(
             DataSource.name,
             sa.func.min(TimedBelief.event_start).label("min_event_start"),
@@ -487,7 +503,16 @@ def _get_sensor_stats(sensor: Sensor, sort_keys: bool, ttl_hash=None) -> dict:
             subquery_for_filtered_aggregates.c.source_id == TimedBelief.source_id,
         )
         .filter(TimedBelief.sensor_id == sensor.id)
-        .group_by(
+    )
+
+    # apply the same start/end filters to the main query
+    if start_dt:
+        q = q.filter(TimedBelief.event_start >= start_dt)
+    if end_dt:
+        q = q.filter(TimedBelief.event_start <= end_dt)
+
+    raw_stats = db.session.execute(
+        q.group_by(
             DataSource.name,
             subquery_for_filtered_aggregates.c.min_event_value,
             subquery_for_filtered_aggregates.c.max_event_value,
@@ -544,6 +569,10 @@ def _get_ttl_hash(seconds=120) -> int:
     return round(time.time() / seconds)
 
 
-def get_sensor_stats(sensor: Sensor, sort_keys: bool = True) -> dict:
+def get_sensor_stats(
+    sensor: Sensor, event_start_time: str, event_end_time: str, sort_keys: bool = True
+) -> dict:
     """Get stats for a sensor"""
-    return _get_sensor_stats(sensor, sort_keys, ttl_hash=_get_ttl_hash())
+    return _get_sensor_stats(
+        sensor, event_end_time, event_start_time, sort_keys, ttl_hash=_get_ttl_hash()
+    )

--- a/flexmeasures/ui/static/js/flexmeasures.js
+++ b/flexmeasures/ui/static/js/flexmeasures.js
@@ -496,3 +496,109 @@ function getLoadingRow(id="loading-row") {
     `;
     return loading_row;
 }
+
+function unpackData(data) {
+    return Object.fromEntries(
+        Object.entries(data).map(([key, value]) => {
+            if (Array.isArray(value) && value.every(item => Array.isArray(item) && item.length === 2)) {
+                return [key, Object.fromEntries(value)];
+            }
+            console.error(`Invalid entry for key: ${key}`, value);
+            return [key, value];
+        })
+    );
+}
+
+function getLatestBeliefName(data) {
+    return Object.keys(data).reduce((latest, name) => {
+        const currentBeliefTime = new Date(data[name]["Last recorded"]);
+        const latestBeliefTime = latest ? new Date(data[latest]["Last recorded"]) : new Date(0);
+        return currentBeliefTime > latestBeliefTime ? name : latest;
+    }, null);
+}
+
+function updateStatsTable(stats) {
+    const tableBody = document.getElementById('statsTableBody');
+    tableBody.innerHTML = ''; // Clear the table body
+
+    Object.entries(stats).forEach(([key, val]) => {
+        const row = document.createElement('tr');
+        const keyCell = document.createElement('th');
+        const valueCell = document.createElement('td');
+
+        keyCell.textContent = key;
+        // Round value to 2 decimal points if it's a number
+        if (typeof val === 'number' & key != 'Number of values') {
+            valueCell.textContent = val.toFixed(4);
+        } else {
+            valueCell.textContent = val;
+        }
+
+        row.appendChild(keyCell);
+        row.appendChild(valueCell);
+        tableBody.appendChild(row);
+    });
+}
+
+function loadSensorStats(sensor_id, event_start_time="", event_end_time="") {
+    console.log("Loading sensor stats for sensor " + sensor_id);
+    const spinner = document.getElementById('spinner-run-simulation');
+    const dropdownContainer = document.getElementById('sourceKeyDropdownContainer');
+    const dropdownMenu = document.getElementById('sourceKeyDropdownMenu');
+    const dropdownButton = document.getElementById('sourceKeyDropdown');
+    const noDataWarning = document.getElementById('noDataWarning');
+    const fetchError = document.getElementById('fetchError');
+    // Show the spinner
+    spinner.classList.remove('d-none');
+    fetch('/api/v3_0/sensors/' + sensor_id + '/stats?sort=false&event_start_time=' + event_start_time + '&event_end_time=' + event_end_time)
+    .then(response => response.json())
+    .then(data => {
+        // Remove 'status' sourceKey
+        delete data['status'];
+        data = unpackData(data);
+
+        if (Object.keys(data).length > 0) {
+            // Show the header and dropdown container
+            dropdownContainer.classList.remove('d-none');
+
+            // Populate the dropdown menu with sourceKeys
+            Object.keys(data).forEach(sourceKey => {
+                const dropdownItem = document.createElement('li');
+                const dropdownLink = document.createElement('a');
+                dropdownLink.className = 'dropdown-item';
+                dropdownLink.href = '#';
+                dropdownLink.textContent = sourceKey;
+                dropdownLink.dataset.sourceKey = sourceKey;
+
+                dropdownLink.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    const selectedSourceKey = event.target.dataset.sourceKey;
+                    dropdownButton.textContent = selectedSourceKey;
+                    updateStatsTable(data[selectedSourceKey]);
+                });
+
+                dropdownItem.appendChild(dropdownLink);
+                dropdownMenu.appendChild(dropdownItem);
+            });
+
+            // Update the table with the first sourceKey's data by default
+            const firstSourceKey = getLatestBeliefName(data);
+            dropdownButton.textContent = firstSourceKey;
+            updateStatsTable(data[firstSourceKey]);
+        } else {
+            // If the stats table is empty, make the properties table full width
+            noDataWarning.classList.remove('d-none');
+        }
+    })
+    .catch(error => {
+        console.error('Error:', error);
+        dropdownContainer.classList.add('d-none');
+        fetchError.textContent = 'There was a problem fetching statistics for this sensor\'s data: ' + error.message;
+        fetchError.classList.remove('d-none');
+    })
+    .finally(() => {
+        // Hide the spinner
+        spinner.classList.add('d-none');
+    });
+
+}

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -503,6 +503,10 @@
         var queryStartDate = (startDate != null) ? (startDate.toISOString()) : (null);
         var queryEndDate = (endDate != null) ? (endDate.toISOString()) : (null);
 
+        {% if active_page == "sensors" %}
+            loadSensorStats({{ sensor.id }}, queryStartDate, queryEndDate);
+        {% endif %}
+
         stopReplay()
 
         $("#spinner").show();

--- a/flexmeasures/ui/templates/sensors/index.html
+++ b/flexmeasures/ui/templates/sensors/index.html
@@ -4,8 +4,6 @@
 
 {% block title %} Sensor data {% endblock %}
 
-
-
 {% block divs %}
 
     {% block breadcrumbs %} {{ super() }} {% endblock %}
@@ -139,114 +137,6 @@
                         <div class="alert alert-danger d-none" id="fetchError">
                             There was a problem fetching statistics for this sensor's data.
                         </div>
-                        <script>
-                            document.addEventListener('DOMContentLoaded', function() {
-                                const spinner = document.getElementById('spinner-run-simulation');
-                                const tableBody = document.getElementById('statsTableBody');
-                                const dropdownMenu = document.getElementById('sourceKeyDropdownMenu');
-                                const dropdownButton = document.getElementById('sourceKeyDropdown');
-                                const dropdownContainer = document.getElementById('sourceKeyDropdownContainer');
-                                const propertiesContainer = document.getElementById('propertiesContainer');
-                                const statsContainer = document.getElementById('statsContainer');
-                                const noDataWarning = document.getElementById('noDataWarning');
-                                const fetchError = document.getElementById('fetchError');
-
-
-                                // Show the spinner
-                                spinner.classList.remove('d-none');
-                                fetch('/api/v3_0/sensors/' + {{ sensor.id }} + '/stats?sort=false')
-                                    .then(response => response.json())
-                                    .then(data => {
-                                        // Remove 'status' sourceKey
-                                        delete data['status'];
-                                        data = unpackData(data);
-
-                                        if (Object.keys(data).length > 0) {
-                                            // Show the header and dropdown container
-                                            dropdownContainer.classList.remove('d-none');
-
-                                            // Populate the dropdown menu with sourceKeys
-                                            Object.keys(data).forEach(sourceKey => {
-                                                const dropdownItem = document.createElement('li');
-                                                const dropdownLink = document.createElement('a');
-                                                dropdownLink.className = 'dropdown-item';
-                                                dropdownLink.href = '#';
-                                                dropdownLink.textContent = sourceKey;
-                                                dropdownLink.dataset.sourceKey = sourceKey;
-
-                                                dropdownLink.addEventListener('click', function(event) {
-                                                    event.preventDefault();
-                                                    const selectedSourceKey = event.target.dataset.sourceKey;
-                                                    dropdownButton.textContent = selectedSourceKey;
-                                                    updateTable(data[selectedSourceKey]);
-                                                });
-
-                                                dropdownItem.appendChild(dropdownLink);
-                                                dropdownMenu.appendChild(dropdownItem);
-                                            });
-
-                                            // Update the table with the first sourceKey's data by default
-                                            const firstSourceKey = getLatestBeliefName(data);
-                                            dropdownButton.textContent = firstSourceKey;
-                                            updateTable(data[firstSourceKey]);
-                                        } else {
-                                            // If the stats table is empty, make the properties table full width
-                                            noDataWarning.classList.remove('d-none');
-                                        }
-                                    })
-                                    .catch(error => {
-                                        console.error('Error:', error);
-                                        dropdownContainer.classList.add('d-none');
-                                        fetchError.textContent = 'There was a problem fetching statistics for this sensor\'s data: ' + error.message;
-                                        fetchError.classList.remove('d-none');
-                                    })
-                                    .finally(() => {
-                                        // Hide the spinner
-                                        spinner.classList.add('d-none');
-                                    });
-                                function updateTable(stats) {
-                                    tableBody.innerHTML = ''; // Clear the table body
-
-                                    Object.entries(stats).forEach(([key, val]) => {
-                                        const row = document.createElement('tr');
-                                        const keyCell = document.createElement('th');
-                                        const valueCell = document.createElement('td');
-
-                                        keyCell.textContent = key;
-                                        // Round value to 2 decimal points if it's a number
-                                        if (typeof val === 'number' & key != 'Number of values') {
-                                            valueCell.textContent = val.toFixed(4);
-                                        } else {
-                                            valueCell.textContent = val;
-                                        }
-
-                                        row.appendChild(keyCell);
-                                        row.appendChild(valueCell);
-                                        tableBody.appendChild(row);
-                                    });
-                                }
-
-                                function getLatestBeliefName(data) {
-                                    return Object.keys(data).reduce((latest, name) => {
-                                        const currentBeliefTime = new Date(data[name]["Last recorded"]);
-                                        const latestBeliefTime = latest ? new Date(data[latest]["Last recorded"]) : new Date(0);
-                                        return currentBeliefTime > latestBeliefTime ? name : latest;
-                                    }, null);
-                                }
-
-                                function unpackData(data) {
-                                    return Object.fromEntries(
-                                        Object.entries(data).map(([key, value]) => {
-                                            if (Array.isArray(value) && value.every(item => Array.isArray(item) && item.length === 2)) {
-                                                return [key, Object.fromEntries(value)];
-                                            }
-                                            console.error(`Invalid entry for key: ${key}`, value);
-                                            return [key, value];
-                                        })
-                                    );
-                                }
-                            });
-                        </script>
                       </div>
                   </div>
               </div>


### PR DESCRIPTION
## Description

Added new call for the `/stats` for sensors if the date selected is updated on the sensors page.

## Look & Feel

No particular change in UI.

## How to test

- Go to the sensors page.
- Update the selected date from the collapsable sidebar for date.
- The statistics table should be update.

## Further Improvements

-

## Related Items

Closes #1241 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
