### PR TITLE
stop testing for Python3.8 in the CI

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py_version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        py_version: [ "3.9", "3.10", "3.11", "3.12" ]
         include:
           - python-version: "3.9"
             coverage: yes

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -8,6 +8,9 @@ FlexMeasures Changelog
 v0.27.0 | August XX, 2025
 ============================
 
+.. note::  Preparatory warning: The following release will not support Python 3.8 anymore.
+
+
 New features
 -------------
 
@@ -20,6 +23,7 @@ Infrastructure / Support
 ----------------------
 * Upgraded dependencies [see `PR #1527 <https://www.github.com/FlexMeasures/flexmeasures/pull/1527>`_ and `PR #1532 <https://www.github.com/FlexMeasures/flexmeasures/pull/1532>`_]
 * Improved authorization checks for modifying roles [see `PR #1517 <https://github.com/FlexMeasures/flexmeasures/pull/1517>`_]
+* Stopped testing Python3.8 in our GitHub Actions CI [see `PR #1541 <https://github.com/FlexMeasures/flexmeasures/pull/1541>`_]
 
 Bugfixes
 -----------


### PR DESCRIPTION
## Description

We will stop official support for Python3.8 shortly. In the meantime, we have trouble with it in the CI which is not worth dealing with anymore at this point.