### PR TITLE
Implement 2FA with Email

### DIFF
--- a/flexmeasures/data/migrations/versions/0f64e22d6b9e_add_tf_totp_secret_column.py
+++ b/flexmeasures/data/migrations/versions/0f64e22d6b9e_add_tf_totp_secret_column.py
@@ -8,6 +8,8 @@ Create Date: 2025-06-23 23:46:19.461406
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.orm import Session
+from passlib.totp import TOTP
 
 # revision identifiers, used by Alembic.
 revision = "0f64e22d6b9e"
@@ -17,9 +19,12 @@ depends_on = None
 
 
 def upgrade():
+    # Add the columns first
     with op.batch_alter_table("fm_user", schema=None) as batch_op:
         batch_op.add_column(
-            sa.Column("tf_totp_secret", sa.String(length=255), nullable=True)
+            sa.Column(
+                "tf_totp_secret", sa.Text(), nullable=True
+            )  # Using Text to store JSON
         )
         batch_op.add_column(
             sa.Column(
@@ -28,7 +33,35 @@ def upgrade():
                 nullable=True,
                 server_default="email",
             )
-        )  # Adding a default value of 'email' cos we are working with email for now.
+        )
+
+    # Get the table metadata for SQLAlchemy
+    bind = op.get_bind()
+    session = Session(bind=bind)
+    fm_user = sa.Table(
+        "fm_user",
+        sa.MetaData(),
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("email", sa.String(255)),
+        sa.Column("tf_totp_secret", sa.Text()),
+        autoload_with=bind,
+    )
+
+    # Generate unique TOTP config for each user
+    for user in session.execute(sa.select(fm_user)):
+        # Generate a new TOTP config using passlib
+        totp = TOTP.new()
+        json_config = totp.to_json()
+
+        # Update the user record with the JSON config
+        session.execute(
+            fm_user.update()
+            .where(fm_user.c.id == user.id)
+            .values(tf_totp_secret=json_config)
+        )
+
+    # Commit changes
+    session.commit()
 
 
 def downgrade():

--- a/flexmeasures/data/migrations/versions/0f64e22d6b9e_add_tf_totp_secret_column.py
+++ b/flexmeasures/data/migrations/versions/0f64e22d6b9e_add_tf_totp_secret_column.py
@@ -1,0 +1,37 @@
+"""Add tf_totp_secret column
+
+Revision ID: 0f64e22d6b9e
+Revises: ece7fb4207ed
+Create Date: 2025-06-23 23:46:19.461406
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0f64e22d6b9e"
+down_revision = "ece7fb4207ed"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("fm_user", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("tf_totp_secret", sa.String(length=255), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column(
+                "tf_primary_method",
+                sa.String(length=255),
+                nullable=True,
+                server_default="email",
+            )
+        )  # Adding a default value of 'email' cos we are working with email for now.
+
+
+def downgrade():
+    with op.batch_alter_table("fm_user", schema=None) as batch_op:
+        batch_op.drop_column("tf_totp_secret")
+        batch_op.drop_column("tf_primary_method")

--- a/flexmeasures/data/models/user.py
+++ b/flexmeasures/data/models/user.py
@@ -251,6 +251,9 @@ class User(db.Model, UserMixin, AuthModelMixin):
     # How often have they logged in?
     login_count = Column(Integer)
     active = Column(Boolean())
+
+    tf_totp_secret = db.Column(db.String(255), nullable=True)
+    tf_primary_method = db.Column(db.String(255), nullable=True, default="email")
     # Faster token checking
     fs_uniquifier = Column(String(64), unique=True, nullable=False)
     timezone = Column(String(255), default="Europe/Amsterdam")

--- a/flexmeasures/templates/security/_macros.html
+++ b/flexmeasures/templates/security/_macros.html
@@ -1,0 +1,21 @@
+{% macro render_field_with_errors(field) %}
+  <div class="fs-div" id="{{ field.id|default('fs-field') }}">
+    {{ field.label }} {{ field(**kwargs)|safe }}
+    {% if field.errors %}
+        <div class="mt-2">
+            <ul class="list-unstyled mb-0">
+            {% for error in field.errors %}
+                <li class="text-danger small d-flex align-items-center gap-2">
+                <i class="fa fa-exclamation-triangle"></i>
+                {{ error }}
+                </li>
+            {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+  </div>
+{% endmacro %}
+
+{% macro render_field(field) %}
+    <div class="fs-div mt-2" id="{{ field.id|default('fs-field') }}">{{ field(**kwargs)|safe }}</div>
+{% endmacro %}

--- a/flexmeasures/ui/templates/admin/two_factor_verify_code.html
+++ b/flexmeasures/ui/templates/admin/two_factor_verify_code.html
@@ -18,7 +18,7 @@
         </div>
 
         <div class="row">
-            <div class="col-lg-6">
+            <div class="col-lg-4">
                 <div class="card">
                     <div class="login-form">
                         <h1>{{ _fsdomain("Two-factor Authentication") }}</h1>
@@ -98,7 +98,7 @@
                     {% endblock teaser %}
                 </div>
             </div>
-            <div class="col-lg-2"></div>
+            <div class="col-lg-4"></div>
         </div>
     </div>
 {% endblock divs %}

--- a/flexmeasures/ui/templates/admin/two_factor_verify_code.html
+++ b/flexmeasures/ui/templates/admin/two_factor_verify_code.html
@@ -1,0 +1,104 @@
+{% extends "base.html" %}
+
+{% set active_page = "logged-in-user" %}
+
+{% block title %} Please log in {% endblock %}
+
+{% from "security/_macros.html" import render_field_with_errors, render_field %}
+
+{% block divs %}
+    <div class="container-fluid">
+        <div class="row" style="text-align: center; padding-bottom: 30px;">
+            <div class="col-md-12">
+                {% block platform_title %}
+                <h1>The FlexMeasures Platform</h1>
+                {% endblock platform_title %}
+                {% include "security/_messages.html" %}
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-lg-6">
+                <div class="card">
+                    <div class="login-form">
+                        <h1>{{ _fsdomain("Two-factor Authentication") }}</h1>
+                        <h6>{{ _fsdomain("Please enter your authentication code generated via: %(method)s", method=chosen_method) }}</h6>
+                        <form action="{{ url_for_security('two_factor_token_validation') }}" method="post" name="two_factor_verify_code_form">
+                            {{ two_factor_verify_code_form.hidden_tag() }}
+                            {{ render_field_with_errors(two_factor_verify_code_form.code, placeholder=_fsdomain("enter numeric code")) }}
+                            {{ render_field(two_factor_verify_code_form.submit) }}
+                        </form>
+                        <!-- Add link to Login / Password reset -->
+                        <form action="/login" method="get">
+                            <button class="btn btn-sm btn-responsive btn-link" type="submit">Back to login</button>
+                        </form>
+                        <form action="/reset" method="get">
+                            <button class="btn btn-sm btn-responsive btn-link" type="submit">Forgot password?</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-4">
+                <div class="card">
+                    {% block teaser %}
+                    <div class="carousel-container">
+                        <div id="myCarousel" class="carousel slide" data-bs-ride="carousel">
+
+                            <!-- Indicators -->
+                            <div class="carousel-indicators">
+                                <button type="button" data-bs-target="#myCarousel" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
+                                <button type="button" data-bs-target="#myCarousel" data-bs-slide-to="1" aria-label="Slide 2"></button>
+                                <button type="button" data-bs-target="#myCarousel" data-bs-slide-to="2" aria-label="Slide 3"></button>
+                            </div>
+
+                            <!-- Wrapper for slides -->
+                            <div class="carousel-inner">
+                                <div class="carousel-item active">
+                                    <img src="ui/static/images/flexmeasures-preview.jpg"
+                                        alt="The FlexMeasures platform on a laptop."
+                                        title="FlexMeasures provides in-depth analytics of flexibility in your portfolio."
+                                    >
+                                    <div class="carousel-caption">
+                                        In-depth analytics of flexibility in your portfolio.
+                                    </div>
+                                </div>
+
+                                <div class="carousel-item">
+                                    <img src="ui/static/images/tj-k-349056-unsplash.jpg"
+                                        alt="A landscape with wind farms."
+                                        title="FlexMeasures helps to forecast costs and revenues with precision."
+                                    >
+                                    <div class="carousel-caption">
+                                        Costs and revenues forecast with precision.
+                                    </div>
+                                </div>
+
+                                <div class="carousel-item">
+                                    <img src="ui/static/images/chase-lewis-506404-unsplash.jpg"
+                                        alt="A tesla charging station."
+                                        title="FlexMeasures provides charging strategies that help balance the grid."
+                                    >
+                                    <div class="carousel-caption">
+                                        Charging strategies that help balance the grid.
+                                    </div>
+                                </div>
+                            </div>
+
+                            <!-- Left and right controls -->
+                            <button class="carousel-control-prev" type="button" data-bs-target="#myCarousel" data-bs-slide="prev">
+                                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                                <span class="visually-hidden">Previous</span>
+                            </button>
+                            <button class="carousel-control-next" type="button" data-bs-target="#myCarousel" data-bs-slide="next">
+                                <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                                <span class="visually-hidden">Next</span>
+                            </button>
+                        </div>
+                    </div>
+                    {% endblock teaser %}
+                </div>
+            </div>
+            <div class="col-lg-2"></div>
+        </div>
+    </div>
+{% endblock divs %}

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -68,7 +68,7 @@ class Config(object):
     # Two Factor Authentication
     SECURITY_TWO_FACTOR_ENABLED_METHODS = ["email"]  # 'authenticator' can be added
     SECURITY_TWO_FACTOR = True
-    TOTP_SECRETS = {"1": "TjQ9Qa31VOrfEzuPy4VHQWPCTmRzCnFzMKLxXYiZu9B"}
+    TOTP_SECRETS = {"1": "e36a68b22752f8a992512c7221c8db2078895819f954e066"}
     TOTP_ISSUER = "FlexMeasures"
     SECURITY_TWO_FACTOR_ALWAYS_VALIDATE = (
         True  # False if you want to skip validation for testing
@@ -233,6 +233,8 @@ class TestingConfig(Config):
     FLEXMEASURES_PLANNING_HORIZON: timedelta = timedelta(
         hours=2 * 24
     )  # if more than 2 days, consider setting up more days of price data for tests
+
+    SECURITY_TWO_FACTOR = False  # disable 2FA
 
 
 class DocumentationConfig(Config):

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -65,6 +65,19 @@ class Config(object):
     SECURITY_TRACKABLE: bool = False  # this is more in line with modern privacy law
     SECURITY_PASSWORD_SALT: str | None = None
 
+    # Two Factor Authentication
+    SECURITY_TWO_FACTOR_ENABLED_METHODS = ["email"]  # 'authenticator' can be added
+    SECURITY_TWO_FACTOR = True
+    TOTP_SECRETS = {"1": "TjQ9Qa31VOrfEzuPy4VHQWPCTmRzCnFzMKLxXYiZu9B"}
+    TOTP_ISSUER = "FlexMeasures"
+    SECURITY_TWO_FACTOR_ALWAYS_VALIDATE = (
+        True  # False if you want to skip validation for testing
+    )
+    SECURITY_TWO_FACTOR_LOGIN_VALIDITY = (
+        "1 week"  # Add this setting to validate 2FA for some time.
+    )
+    SECURITY_TWO_FACTOR_VERIFY_CODE_TEMPLATE = "admin/two_factor_verify_code.html"
+
     # Allowed cross-origins. Set to "*" to allow all. For development (e.g. javascript on localhost) you might use "null" here
     CORS_ORIGINS: list[str] | str = []
     # this can be a dict with all possible options as value per regex, see https://flask-cors.readthedocs.io/en/latest/configuration.html


### PR DESCRIPTION
## Description

Added logic to implement 2FA with Email. Following is the main changelist:
- Added configurations for 2FA.
- Added html file for 2FA.
- Added migration to add `tf_totp_secret` and `tf_primary_method` fields and add defaults.

## Look & Feel

![image](https://github.com/user-attachments/assets/69ed5bb0-dbd2-4ce8-ad11-376e7e63bb4d)

## How to test

Follow the following steps to test:
- Go to login page and add email and password.
- Click login.
- A new page will come asking for 2FA code.
- Enter code and click submit.
- You should be logged in now.

## Further Improvements

- Authenticator app setup.
- Rescue process.

## Related Items

Closes #1507 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
