### PR TITLE
Removed the duplicate call for chart_data endpoint.

### DIFF
--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -586,14 +586,7 @@
             $("#spinner").show();
             checkDSTTransitions(startDate, endDate)
             Promise.all([
-                // Fetch time series data
-                fetch(dataPath + '/chart_data?event_starts_after=' + queryStartDate + '&event_ends_before=' + queryEndDate, {
-                    method: "GET",
-                    headers: {"Content-Type": "application/json"},
-                    signal: signal,
-                })
-                .then(function(response) { return response.json(); }),
-
+                initialData,
                 /**
                 // Fetch annotations
                 fetch(dataPath + '/chart_annotations?event_starts_after=' + queryStartDate + '&event_ends_before=' + queryEndDate, {


### PR DESCRIPTION
## Description

Removed the second call to the chart_data endpoint on the sensors page.

## Look & Feel

- Does not involve UI change.

## How to test

- Navigate to the sensors page and observe through network tab.
- The chart_data endpoint is being called once per request.

## Further Improvements

--

## Related Items

Closes #1558 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
