### PR TITLE
Fix/3-digit hex colors

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -60,6 +60,8 @@ jobs:
         if: github.event_name == 'pull_request'
       - name: Run all doctests in the data/schemas subpackage
         run: pytest flexmeasures/data/schemas --doctest-modules --ignore flexmeasures/data/schemas/tests
+      - name: Run all doctests in the ui/utils subpackage
+        run: pytest flexmeasures/ui --doctest-modules --ignore flexmeasures/ui/tests
       - name: Run all doctests in the utils subpackage
         run: pytest flexmeasures/utils --doctest-modules --ignore flexmeasures/utils/tests
       - name: Run all tests except those marked to be skipped by GitHub AND record coverage

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -40,6 +40,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
+* Fix support for using 3-digit hex colors in account color scheme [see `PR #1569 <https://github.com/FlexMeasures/flexmeasures/pull/1569>`_]
 
 
 v0.26.1 | June 09, 2025

--- a/flexmeasures/ui/utils/color_defaults.py
+++ b/flexmeasures/ui/utils/color_defaults.py
@@ -49,6 +49,11 @@ def get_color_settings(account: Account | None) -> dict:
 
 def darken_color(hex_color: str, percentage: int) -> str:
     hex_color = hex_color.lstrip("#")
+
+    # Expand 3-digit hex to 6-digit
+    if len(hex_color) == 3:
+        hex_color = "".join([c * 2 for c in hex_color])
+
     r, g, b = int(hex_color[0:2], 16), int(hex_color[2:4], 16), int(hex_color[4:6], 16)
     r = int(r * (1 - percentage / 100))
     g = int(g * (1 - percentage / 100))
@@ -75,6 +80,11 @@ def lighten_color(hex_color: str, percentage: int) -> str:
         '#d4dde5'
     """
     hex_color = hex_color.lstrip("#")
+
+    # Expand 3-digit hex to 6-digit
+    if len(hex_color) == 3:
+        hex_color = "".join([c * 2 for c in hex_color])
+
     r, g, b = int(hex_color[0:2], 16), int(hex_color[2:4], 16), int(hex_color[4:6], 16)
     r = int(r + (255 - r) * percentage / 100)
     g = int(g + (255 - g) * percentage / 100)
@@ -84,5 +94,10 @@ def lighten_color(hex_color: str, percentage: int) -> str:
 
 def rgba_color(hex_color: str, alpha: float) -> str:
     hex_color = hex_color.lstrip("#")
+
+    # Expand 3-digit hex to 6-digit
+    if len(hex_color) == 3:
+        hex_color = "".join([c * 2 for c in hex_color])
+
     r, g, b = int(hex_color[0:2], 16), int(hex_color[2:4], 16), int(hex_color[4:6], 16)
     return f"rgba({r}, {g}, {b}, {alpha})"

--- a/flexmeasures/ui/utils/color_defaults.py
+++ b/flexmeasures/ui/utils/color_defaults.py
@@ -48,6 +48,23 @@ def get_color_settings(account: Account | None) -> dict:
 
 
 def darken_color(hex_color: str, percentage: int) -> str:
+    """Darkens a hex color by a given percentage towards black.
+
+    :param hex_color:   The hex color string (e.g. "#abc" or "#aabbcc").
+    :param percentage:  The percentage to darken the color (0-100).
+
+    :returns:           The darkened hex color string.
+
+    Examples:
+        >>> darken_color("#ffffff", 0)
+        '#ffffff'
+        >>> darken_color("#ffffff", 100)
+        '#000000'
+        >>> darken_color("#123456", 50)
+        '#091a2b'
+        >>> darken_color("#abc", 50)
+        '#555d66'
+    """
     hex_color = hex_color.lstrip("#")
     hex_color = ensure_6_digit_hex(hex_color)
 

--- a/flexmeasures/ui/utils/color_defaults.py
+++ b/flexmeasures/ui/utils/color_defaults.py
@@ -49,10 +49,7 @@ def get_color_settings(account: Account | None) -> dict:
 
 def darken_color(hex_color: str, percentage: int) -> str:
     hex_color = hex_color.lstrip("#")
-
-    # Expand 3-digit hex to 6-digit
-    if len(hex_color) == 3:
-        hex_color = "".join([c * 2 for c in hex_color])
+    hex_color = ensure_6_digit_hex(hex_color)
 
     r, g, b = int(hex_color[0:2], 16), int(hex_color[2:4], 16), int(hex_color[4:6], 16)
     r = int(r * (1 - percentage / 100))
@@ -80,10 +77,7 @@ def lighten_color(hex_color: str, percentage: int) -> str:
         '#d4dde5'
     """
     hex_color = hex_color.lstrip("#")
-
-    # Expand 3-digit hex to 6-digit
-    if len(hex_color) == 3:
-        hex_color = "".join([c * 2 for c in hex_color])
+    hex_color = ensure_6_digit_hex(hex_color)
 
     r, g, b = int(hex_color[0:2], 16), int(hex_color[2:4], 16), int(hex_color[4:6], 16)
     r = int(r + (255 - r) * percentage / 100)
@@ -94,10 +88,14 @@ def lighten_color(hex_color: str, percentage: int) -> str:
 
 def rgba_color(hex_color: str, alpha: float) -> str:
     hex_color = hex_color.lstrip("#")
-
-    # Expand 3-digit hex to 6-digit
-    if len(hex_color) == 3:
-        hex_color = "".join([c * 2 for c in hex_color])
+    hex_color = ensure_6_digit_hex(hex_color)
 
     r, g, b = int(hex_color[0:2], 16), int(hex_color[2:4], 16), int(hex_color[4:6], 16)
     return f"rgba({r}, {g}, {b}, {alpha})"
+
+
+def ensure_6_digit_hex(hex_color: str) -> str:
+    """Expand 3-digit hex to 6-digit."""
+    if len(hex_color) == 3:
+        hex_color = "".join([c * 2 for c in hex_color])
+    return hex_color

--- a/flexmeasures/ui/utils/color_defaults.py
+++ b/flexmeasures/ui/utils/color_defaults.py
@@ -57,6 +57,23 @@ def darken_color(hex_color: str, percentage: int) -> str:
 
 
 def lighten_color(hex_color: str, percentage: int) -> str:
+    """Lightens a hex color by a given percentage towards white.
+
+    :param hex_color:   The hex color string (e.g. "#abc" or "#aabbcc").
+    :param percentage:  The percentage to lighten the color (0-100).
+
+    :returns:           The lightened hex color string.
+
+    Examples:
+        >>> lighten_color("#000000", 0)
+        '#000000'
+        >>> lighten_color("#000000", 100)
+        '#ffffff'
+        >>> lighten_color("#123456", 50)
+        '#8899aa'
+        >>> lighten_color("#abc", 50)
+        '#d4dde5'
+    """
     hex_color = hex_color.lstrip("#")
     r, g, b = int(hex_color[0:2], 16), int(hex_color[2:4], 16), int(hex_color[4:6], 16)
     r = int(r + (255 - r) * percentage / 100)


### PR DESCRIPTION
## Description

This fixes the `vega` not loaded error observed by a user with a 3-digit hex color in their account's color scheme.

- [x] Add support for 3-digit hex colors in account color scheme
- [x] Added changelog item in `documentation/changelog.rst`

## Look & Feel

![image](https://github.com/user-attachments/assets/b6c240aa-711a-4b83-81d8-11f912fe6b31)

## How to test

- Added doctests

## Further Improvements

- [x] The AccountSchema already validated the hex colors set by the user, and already explicitly supported both 3- and 6-digit hex values.

## Related Items

- Closes #1554.
