### PR TITLE
chore: update PR template to hide contributor notes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,36 +1,67 @@
 ## Description
 
+<!--
 Summary of the changes introduced in this PR. Try to use bullet points as much as possible.
+-->
 
 - [ ] ...
 - [ ] Added changelog item in `documentation/changelog.rst`
 
 <!--
-Note regarding our changelog:
+For changelog entries, please take into account the intended audience.
+
+In our main changelog:
 - The 'New features' section targets API / CLI / UI users.
 - The 'Infrastructure / Support' section targets plugin developers and hosts.
+
+Finally, please note that the API and CLI keep additional changelogs:
+- `documentation/api/changelog.rst`
+- `documentation/cli/changelog.rst`
 -->
 
 ## Look & Feel
 
-This section can contain example pictures for UI, Input/Output for CLI, Request / Response for API endpoint, etc.
+<!--
+This section can contain example pictures for the UI, Input/Output for the CLI, Request / Response for an API endpoint, etc.
+-->
+
+...
 
 ## How to test
 
+<!--
 Steps to test it or name of the tests functions.
 
-The library [flexmeasures-client](https://github.com/FlexMeasures/flexmeasures-client/) can be useful to showcase new features. For example,
-it can be used to set some example data to be used in a new UI feature.
+The library [flexmeasures-client](https://github.com/FlexMeasures/flexmeasures-client/) can be useful to showcase new features.
+For example, it can be used to set some example data to be used in a new UI feature.
+-->
+
+...
 
 ## Further Improvements
 
+<!--
 Potential improvements to be done in the same PR or follow-up Issues/Discussions/PRs.
+-->
+
+...
 
 ## Related Items
 
+<!--
 Mention if this PR closes an Issue or Project.
+-->
+
+...
 
 ---
+
+#### Sign-off
+
+<!--
+We ask contributors outside the FlexMeasures organisation to sign off on their contribution.
+Please mark the below fields with an [x].
+-->
 
 - [ ] I agree to contribute to the project under Apache 2 License. 
 - [ ] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures


### PR DESCRIPTION
## Description

- [x] Update PR template so that the notes intended for the contributor don't show up by default; this is intended to save some of the reviewer's time
- [ ] Added changelog item in `documentation/changelog.rst`

## Look & Feel

![image](https://github.com/user-attachments/assets/1be7f02b-c190-49a6-89a0-40ac4c45f5a6)

## Further Improvements

- @nhoening Should we check the sign-off boxes by default?
