### PR TITLE
Fix: Statistics not working on source change.

### DIFF
--- a/flexmeasures/ui/static/js/flexmeasures.js
+++ b/flexmeasures/ui/static/js/flexmeasures.js
@@ -584,7 +584,7 @@ function loadSensorStats(sensor_id, event_start_time="", event_end_time="") {
                     event.preventDefault();
                     const selectedSourceKey = event.target.dataset.sourceKey;
                     dropdownButton.textContent = selectedSourceKey;
-                    updateStatsTable(data[selectedSourceKey]);
+                    updateStatsTable(data[selectedSourceKey], tableBody);
                 });
 
                 dropdownItem.appendChild(dropdownLink);


### PR DESCRIPTION
## Description

Fixed the JS error on statistics table update.

## Look & Feel

Nothing of a UI change.

...

## How to test

- Go to a sensor page.
- Change the source in the dropdown.
- Make sure the table updates with the change of the source.

...

## Further Improvements

---

...

## Related Items

Closes #1563 

...

---

#### Sign-off

<!--
We ask contributors outside the FlexMeasures organisation to sign off on their contribution.
Please mark the below fields with an [x].
-->

- [ ] I agree to contribute to the project under Apache 2 License. 
- [ ] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
