### PR TITLE
New-style endpoints for sensor data, deprecating older ones

### DIFF
--- a/flexmeasures/api/common/schemas/sensor_data.py
+++ b/flexmeasures/api/common/schemas/sensor_data.py
@@ -73,6 +73,8 @@ class SensorDataDescriptionSchema(ma.Schema):
     Schema describing sensor data (specifically, the sensor and the timing of the data).
     """
 
+    # TODO: transition to SensorIdField
+    # The sensor field relies on entity addresses which are going to be faded out.
     sensor = SensorField(required=True, entity_type="sensor", fm_scheme="fm1")
     start = AwareDateTimeField(required=True, format="iso")
     duration = DurationField(required=True)
@@ -310,7 +312,10 @@ class PostSensorDataSchema(SensorDataDescriptionSchema):
             if any(h < timedelta(0) for h in bdf.belief_horizons):
                 raise ValidationError("Prognoses must lie in the future.")
 
-        return bdf
+        # return bdf
+        # Returning a dict with our value wrapped in there, as that is expected
+        # (not sure why using location_loader leads to this expectation ...)
+        return dict(bdf=bdf)
 
     @staticmethod
     def possibly_convert_units(data):


### PR DESCRIPTION
The existing API endpoints for sensors/data (POST and GET) are confusing, as the sensor is identified in the JSON, not the URL (sensors/(id)/data).

Here is a first tech spike on putting sensor Id in the URL, merging into JSON for schema consumption. I do not understand the `path_and_json` loader (I worked from an existing example) and there are some consequences in how the endpoint decorators receive further information. If a reviewer has more insights, let me know.

But this seems to work now.

I did it just for the POST endpoint for now. Includes how I would announce the deprecation of the existing style. (plus message in release notes)

Here is a client diff to use the new endpoint:

```
diff --git a/src/flexmeasures_client/client.py b/src/flexmeasures_client/client.py
index d05dc4d..4caa289 100644
--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -310,7 +310,7 @@ class FlexMeasuresClient:
         This function raises a ValueError when an unhandled status code is returned.
         """
         json_payload = dict(
-            sensor=f"{ENTITY_ADDRESS_PLACEHOLDER}.{sensor_id}",
+            #sensor=f"{ENTITY_ADDRESS_PLACEHOLDER}.{sensor_id}",
             start=pd.Timestamp(
                 start
             ).isoformat(),  # for example: 2021-10-13T00:00+02:00
@@ -322,7 +322,7 @@ class FlexMeasuresClient:
             json_payload["prior"] = prior
 
         _response, status = await self.request(
-            uri="sensors/data",
+            uri=f"sensors/{sensor_id}/data",
             json_payload=json_payload,
         )
 ```

