### PR TITLE
Fix: Duplicate call for chart_data.

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -42,7 +42,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
-* Prevent redundant second call to fetch chart data on page load and start replay button [see `PR #1586 <https://github.com/FlexMeasures/flexmeasures/pull/1586>`_]
+* Prevent redundant second call to fetch chart data on page load and start replay button [see `PR #1586 <https://github.com/FlexMeasures/flexmeasures/pull/1586>`_ and `PR #1596 <https://github.com/FlexMeasures/flexmeasures/pull/1596>`_]
 * On the asset context page, send the highest ancestor as site_asset (then the asset context view uses this to look up sensors for the flex-context) [see `PR #1581 <https://www.github.com/FlexMeasures/flexmeasures/pull/1581>`_]
 * Fix support for using 3-digit hex colors in account color scheme [see `PR #1569 <https://github.com/FlexMeasures/flexmeasures/pull/1569>`_]
 

--- a/flexmeasures/api/v3_0/tests/test_sensors_api.py
+++ b/flexmeasures/api/v3_0/tests/test_sensors_api.py
@@ -608,3 +608,92 @@ def test_fetch_sensor_stats(
 
     # Check stats cache works and stats query is executed only once
     assert counter1.count == counter2.count + 1
+
+
+@pytest.mark.parametrize(
+    "requesting_user",
+    ["test_admin_user@seita.nl"],
+    indirect=True,
+)
+def test_sensor_page(db, client, setup_api_test_data, requests_mock, requesting_user):
+    sensor = db.session.get(Sensor, 1)
+    sensor_page = client.get(
+        url_for(
+            "SensorUI:get",
+            id=sensor.id,
+            start_time="2022-10-01T00:00:00+02:00",
+            end_time="2022-10-02T00:00:00+02:00",
+        ),
+        follow_redirects=True,
+    )
+    assert sensor_page.status_code == 200
+    chart_query = {
+        "event_starts_before": "2022-10-01T00:00:00%2B02:00",
+        "event_ends_after": "2022-10-02T00:00:00%2B02:00",
+    }
+    chart_data_query = {
+        "event_starts_after": "2025-04-30T19:00:00.000Z",
+        "event_ends_before": "2025-05-15T19:00:00.000Z",
+        "dataset_name": "asset_12561",
+        "combine_legend": "false",
+        "width": "container",
+        "include_sensor_annotations": "false",
+        "include_asset_annotations": "false",
+        "chart_type": "chart_for_multiple_sensors",
+    }
+    chat_response = client.get(
+        url_for("AssetAPI:get_chart", id=sensor.generic_asset_id),
+        query_string=chart_query,
+    )
+    print("chart response: %s" % chat_response.json)
+    assert chat_response.status_code == 200
+
+    chat_data_response = client.get(
+        url_for("AssetAPI:get_chart_data", id=sensor.generic_asset_id),
+        query_string=chart_data_query,
+    )
+    print("chart data response: %s" % chat_data_response.json)
+    assert chat_data_response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "args, error",
+    [
+        (
+            {"start_time": "2022-10-01T00:00:00+02:00"},
+            "Both start_time and end_time must be provided together.",
+        ),
+        (
+            {"end_time": "2022-10-01T00:00:00+02:00"},
+            "Both start_time and end_time must be provided together.",
+        ),
+        (
+            {
+                "start_time": "2022-10-01T00:00:00+02:00",
+                "end_time": "2022-10-01T00:00:00+02:00",
+            },
+            "start_time must be before end_time.",
+        ),
+        (
+            {
+                "start_time": "2022-10-01T00:00:00",
+                "end_time": "2022-10-02T00:00:00+02:00",
+            },
+            "Not a valid aware datetime",
+        ),
+    ],
+)
+def test_sensor_page_dates_validation(
+    db, client, setup_api_test_data, requests_mock, args, error
+):
+    sensor = db.session.get(Sensor, 1)
+    sensor_page = client.get(
+        url_for(
+            "SensorUI:get",
+            id=sensor.id,
+            **args,
+        ),
+        follow_redirects=True,
+    )
+    assert error.encode() in sensor_page.data
+    assert "UNPROCESSABLE_ENTITY".encode() in sensor_page.data

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -353,7 +353,7 @@
 
                 // Reload daterange
                 embedAndLoad(chartSpecsPath + 'event_starts_after=' + storeStartDate.toISOString() + '&event_ends_before=' + storeEndDate.toISOString() + '&', elementId, datasetName, previousResult, storeStartDate, storeEndDate)
-                vegaView.change(datasetName, vega.changeset().remove(vega.truthy).insert(previousResult)).resize().run();
+                vegaView.change(datasetName, vega.changeset().remove(vega.truthy).insert(previousResult.data)).resize().run();
             });
         }
     });
@@ -404,11 +404,11 @@
             // result.view is the Vega View, chartSpecsPath is the original Vega-Lite specification
             vegaView = result.view;
             if (previousResult) {
-                checkSourceMasking(previousResult);
-                var slicedPreviousResult = previousResult.filter(item => {
+                checkSourceMasking(previousResult.data);
+                var slicedPreviousData = previousResult.data.filter(item => {
                     return item.event_start >= startDate.getTime() && item.event_start < endDate.getTime();
                 })
-                vegaView.change(datasetName, vega.changeset().remove(vega.truthy).insert(slicedPreviousResult)).resize().run();
+                vegaView.change(datasetName, vega.changeset().remove(vega.truthy).insert(slicedPreviousData)).resize().run();
             }
         });
     }
@@ -505,8 +505,6 @@
 
     var playBackDataLoadedForKnownDateRange = false;
 
-    var initialStartDate = new Date('{{ event_starts_after }}');
-    var initialEndDate = new Date('{{ event_ends_before }}');
     const initialData = fetch(dataPath + '/chart_data?event_starts_after=' + '{{ event_starts_after }}' + '&event_ends_before=' + '{{ event_ends_before }}', {
         method: "GET",
         headers: {"Content-Type": "application/json"},
@@ -591,19 +589,14 @@
             $("#spinner").show();
             checkDSTTransitions(startDate, endDate)
             Promise.all([
-                (initialStartDate.getTime() === startDate.getTime() && initialEndDate.getTime() === endDate.getTime()) ? Promise.resolve(previousResult) :
+                (previousResult.start.getTime() === startDate.getTime() && previousResult.end.getTime() === endDate.getTime()) ? Promise.resolve(previousResult.data) :
                 // Fetch time series data
                 fetch(dataPath + '/chart_data?event_starts_after=' + queryStartDate + '&event_ends_before=' + queryEndDate, {
                     method: "GET",
                     headers: {"Content-Type": "application/json"},
                     signal: signal,
                 })
-                .then(function(response) {
-                    // Update the initial start and end dates
-                    initialStartDate = startDate;
-                    initialEndDate = endDate;
-                    return response.json();
-                }),
+                .then(function(response) { return response.json(); }),
 
                 /**
                 // Fetch annotations
@@ -620,8 +613,12 @@
             ]).then(function(result) {
                 $("#spinner").hide();
                 vegaView.change(datasetName, vega.changeset().remove(vega.truthy).insert(result[0])).resize().run();
-                previousResult = result[0];
-                checkSourceMasking(previousResult);
+                previousResult = {
+                    start: startDate,
+                    end: endDate,
+                    data: result[0]
+                };
+                checkSourceMasking(previousResult.data);
                 playBackDataLoadedForKnownDateRange = false;
                 /**
                 vegaView.change(datasetName + '_annotations', vega.changeset().remove(vega.truthy).insert(result[1])).resize().run();
@@ -667,8 +664,14 @@
                 ]).then(function (result) {return result[0]}).catch(console.error);
                 $("#spinner").hide();
                 vegaView.change(datasetName, vega.changeset().remove(vega.truthy).insert(fetchedInitialData)).resize().run();
-                previousResult = fetchedInitialData;
-                checkSourceMasking(previousResult);
+                var sessionStart = new Date('{{ event_starts_after }}');
+                var sessionEnd = new Date('{{ event_ends_before }}');
+                previousResult = {
+                    start: sessionStart,
+                    end: sessionEnd,
+                    data: fetchedInitialData
+                };
+                checkSourceMasking(previousResult.data);
                 var timerangeNotSetYet = false
             {% else %}
                 var timerangeNotSetYet = true

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -505,6 +505,8 @@
 
     var playBackDataLoadedForKnownDateRange = false;
 
+    var initialStartDate = new Date('{{ event_starts_after }}');
+    var initialEndDate = new Date('{{ event_ends_before }}');
     const initialData = fetch(dataPath + '/chart_data?event_starts_after=' + '{{ event_starts_after }}' + '&event_ends_before=' + '{{ event_ends_before }}', {
         method: "GET",
         headers: {"Content-Type": "application/json"},
@@ -589,13 +591,19 @@
             $("#spinner").show();
             checkDSTTransitions(startDate, endDate)
             Promise.all([
+                (initialStartDate.getTime() === startDate.getTime() && initialEndDate.getTime() === endDate.getTime()) ? Promise.resolve(previousResult) :
                 // Fetch time series data
                 fetch(dataPath + '/chart_data?event_starts_after=' + queryStartDate + '&event_ends_before=' + queryEndDate, {
                     method: "GET",
                     headers: {"Content-Type": "application/json"},
                     signal: signal,
                 })
-                .then(function(response) { return response.json(); }),
+                .then(function(response) {
+                    // Update the initial start and end dates
+                    initialStartDate = startDate;
+                    initialEndDate = endDate;
+                    return response.json();
+                }),
 
                 /**
                 // Fetch annotations


### PR DESCRIPTION
## Description

Removed the second call to the chart_data endpoint on the sensors page.

## Look & Feel

- No UI changes.

## How to test

- Navigate to the sensors page and observe through network tab.
- The chart_data endpoint is being called once per request.

## Further Improvements

--

## Related Items

Closes #1558 

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures