### PR TITLE
Fix/serialized job description metadata

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -19,7 +19,7 @@ New features
 * New API endpoint `[POST] /assets/(id)/schedules/trigger <api/v3_0.html#post--api-v3_0-assets-(id)-schedules-trigger>`_ to schedule a site with multiple flexible devices [see `PR #1065 <https://github.com/FlexMeasures/flexmeasures/pull/1065/>`_]
 * Add form to upload sensor data to the database [see `PR #1481 <https://github.com/FlexMeasures/flexmeasures/pull/1481>`_, `PR #1573 <https://github.com/FlexMeasures/flexmeasures/pull/1573>`_, `PR #1583 <https://github.com/FlexMeasures/flexmeasures/pull/1583>`_, `PR #1585 <https://github.com/FlexMeasures/flexmeasures/pull/1585>`_ and `PR #1590 <https://github.com/FlexMeasures/flexmeasures/pull/1590>`_]
 * Allow editing users in the UI [see `PR #1502 <https://github.com/FlexMeasures/flexmeasures/pull/1502>`_]
-* Scheduling job descriptions on the tasks page (RQ Dashboard) shows the whole flex-model and flex-context, including any server-side configuration of e.g. capacities [see `PR #1579 <https://github.com/FlexMeasures/flexmeasures/pull/1579>`_]
+* Scheduling job descriptions on the tasks page (RQ Dashboard) shows the whole flex-model and flex-context, including any server-side configuration of e.g. capacities [see `PR #1579 <https://github.com/FlexMeasures/flexmeasures/pull/1579>`_ and `PR #1601 <https://github.com/FlexMeasures/flexmeasures/pull/1601>`_]
 * Smarter date range navigation [see `PR #1531 <https://github.com/FlexMeasures/flexmeasures/pull/1531>`_]
 * Smarter toast notifications [see `PR #1530 <https://github.com/FlexMeasures/flexmeasures/pull/1530>`_]
 * Move various warnings to toast notifications [see `PR #1529 <https://github.com/FlexMeasures/flexmeasures/pull/1529>`_]

--- a/flexmeasures/data/services/scheduling.py
+++ b/flexmeasures/data/services/scheduling.py
@@ -15,8 +15,9 @@ from copy import deepcopy
 from traceback import print_tb
 
 
-from flask import current_app
 import click
+from flask import current_app
+from isodate import duration_isoformat
 from rq import get_current_job, Callback
 from rq.exceptions import InvalidJobOperation
 from rq.job import Job
@@ -262,13 +263,22 @@ def create_scheduling_job(
     job.meta["asset_or_sensor"] = asset_or_sensor
     job.meta["scheduler_kwargs"] = scheduler_kwargs
 
-    # Serialize start and end
+    # Serialize start, end, resolution and belief_time
     job.meta["scheduler_kwargs"]["start"] = job.meta["scheduler_kwargs"][
         "start"
     ].isoformat()
     job.meta["scheduler_kwargs"]["end"] = job.meta["scheduler_kwargs"][
         "end"
     ].isoformat()
+    if job.meta.get("belief_time") is not None:
+        job.meta["scheduler_kwargs"]["belief_time"] = job.meta["scheduler_kwargs"][
+            "belief_time"
+        ].isoformat()
+
+    if job.meta.get("resolution") is not None:
+        job.meta["scheduler_kwargs"]["resolution"] = duration_isoformat(
+            job.meta["scheduler_kwargs"]["resolution"]
+        )
 
     job.save_meta()
 


### PR DESCRIPTION
## Description

- [x] Two more kwargs were not being serialized before being saved in the job metadata, which rq-dashboard crashed on
- [x] Added changelog item in `documentation/changelog.rst`

## Look & Feel

Job descriptions show again in RQ Dashboard.

