### PR TITLE
make JS code more robust against initial vars not being ready

### DIFF
--- a/flexmeasures/ui/static/js/daterange-utils.js
+++ b/flexmeasures/ui/static/js/daterange-utils.js
@@ -183,3 +183,25 @@ export function computeSimulationRanges(startDate, endDate, minRes = "hour") {
         throw new Error(`Unsupported minimum resolution: ${minRes}`);
     }
 }
+
+/**
+ * Encode the query string of a relative URL to ensure proper URL encoding of special characters.
+ *
+ * This function preserves the base path and re-encodes the query string using URLSearchParams.
+ * It ensures that characters like `+` (often mistakenly interpreted as spaces in form submissions)
+ * are correctly encoded as `%2B`, along with other special characters like `:` and `&`.
+ *
+ * For example:
+ *   Input:  "path?date=2025-06-16T00:00:00+02:00"
+ *   Output: "path?date=2025-06-16T00%3A00%3A00%2B02%3A00"
+ *
+ * @param {string} rawUrl - A relative URL (e.g., "path?foo=bar&date=...").
+ * @returns {string} The same URL with the query string safely encoded.
+ */
+export function encodeUrlQuery(rawUrl) {
+    const [path, query] = rawUrl.split("?");
+    if (!query) return rawUrl;  // No query to encode
+
+    const params = new URLSearchParams(query);
+    return `${path}?${params.toString()}`;
+}

--- a/flexmeasures/ui/templates/assets/asset_graph.html
+++ b/flexmeasures/ui/templates/assets/asset_graph.html
@@ -91,16 +91,17 @@
                         }
 
                         $(window).ready(() => {
-                            picker.on('selected', (startDate, endDate) => {
-                                startDate = encodeURIComponent(toIsoString(startDate.toJSDate()));
-                                endDate = encodeURIComponent(toIsoString(endDate.toJSDate()));
-                                var base_url = window.location.href.split("?")[0];
-                                var new_url = `${base_url}?start_time=${startDate}&end_time=${endDate}`;
+                            if (picker) {
+                                picker.on('selected', (startDate, endDate) => {
+                                    startDate = encodeURIComponent(toIsoString(startDate.toJSDate()));
+                                    endDate = encodeURIComponent(toIsoString(endDate.toJSDate()));
+                                    var base_url = window.location.href.split("?")[0];
+                                    var new_url = `${base_url}?start_time=${startDate}&end_time=${endDate}`;
 
-                                // change current url without reloading the page
-                                window.history.pushState({}, null, new_url);
-                            });
-
+                                    // change current url without reloading the page
+                                    window.history.pushState({}, null, new_url);
+                                });
+                            }
                         });
 
                         function copyUrl(event) {

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -505,13 +505,6 @@
 
     var playBackDataLoadedForKnownDateRange = false;
 
-    const initialData = fetch(dataPath + '/chart_data?event_starts_after=' + '{{ event_starts_after }}' + '&event_ends_before=' + '{{ event_ends_before }}', {
-        method: "GET",
-        headers: {"Content-Type": "application/json"},
-        signal: signal,
-    })
-    .then(function(response) { return response.json(); });
-
     // Set session start and end
     {% if event_starts_after and event_ends_before %}
         var sessionStart = new Date('{{ event_starts_after }}');
@@ -658,6 +651,13 @@
             {% if event_starts_after and event_ends_before %}
                 // Initialize picker to the date selection specified in the session
                 $("#spinner").show();
+
+                const initialData = fetch(dataPath + '/chart_data?event_starts_after=' + '{{ event_starts_after }}' + '&event_ends_before=' + '{{ event_ends_before }}', {
+                    method: "GET",
+                    headers: {"Content-Type": "application/json"},
+                    signal: signal,
+                })
+                .then(function(response) { return response.json(); });
                 let fetchedInitialData = await Promise.all([
                     initialData,
                     embedAndLoad(chartSpecsPath + 'event_starts_after=' + '{{ event_starts_after }}' + '&event_ends_before=' + '{{ event_ends_before }}' + '&', elementId, datasetName, previousResult, sessionStart, sessionEnd),

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -725,6 +725,7 @@
                     var start_time = '{{event_starts_after}}';
                     var new_start_date = new Date(start_time);
                     picker.setDateRange(decodeURIComponent(toIsoString(new_start_date)), decodeURIComponent(toIsoString(new_end_date)));
+                    picker.gotoDate(new_end_date);
                 };
             });
         }

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -702,7 +702,7 @@
                     if (timerangeNotSetYet) {
                         // Initialize picker to the last 2 days of sensor data
                         var nearEnd = new Date(end)//.setDate(end.getDate() - 1);
-                        nearEnd.setDate(nearEnd.getDate() - 1);
+                        nearEnd.setDate(nearEnd.getDate() - 2);
                         var new_start_date = nearEnd;
                         var new_end_date = end;
                     } else {

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -703,11 +703,12 @@
                         // Initialize picker to the last 2 days of sensor data
                         var nearEnd = new Date(end)//.setDate(end.getDate() - 1);
                         nearEnd.setDate(nearEnd.getDate() - 1);
-                        picker.setDateRange(
-                            nearEnd,
-                            end,
-                        );
-                    } 
+                        var new_start_date = nearEnd;
+                        var new_end_date = end;
+                    } else {
+                        var new_start_date = new Date('{{ event_starts_after }}');
+                        var new_end_date = new Date('{{ event_ends_before }}');
+                    }
                     
                     // No use looking for data in years outside timerange of sensor data
                     picker.setOptions({
@@ -718,12 +719,8 @@
                     });
                     
                     // Persist the range on the datepicker UI so correct range is shown when the user opens the datepicker
-                    var end_time = '{{event_ends_before}}';
-                    var new_end_date = new Date(end_time);
                     // Adjusting the date by subtracting one day to account for timezone discrepancies.
                     new_end_date.setDate(new_end_date.getDate() - 1);
-                    var start_time = '{{event_starts_after}}';
-                    var new_start_date = new Date(start_time);
                     picker.setDateRange(decodeURIComponent(toIsoString(new_start_date)), decodeURIComponent(toIsoString(new_end_date)));
                     picker.gotoDate(new_end_date);
                 };

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -305,7 +305,7 @@
 
     // Import local js (the FM version is used for cache-busting, causing the browser to fetch the updated version from the server)
     import { getUniqueValues, convertToCSV } from "{{ url_for('flexmeasures_ui.static', filename='js/data-utils.js') }}?v={{ flexmeasures_version }}";
-    import { subtract, computeSimulationRanges, lastNMonths, countDSTTransitions, getOffsetBetweenTimezonesForDate } from "{{ url_for('flexmeasures_ui.static', filename='js/daterange-utils.js') }}?v={{ flexmeasures_version }}";
+    import { subtract, computeSimulationRanges, lastNMonths, countDSTTransitions, encodeUrlQuery, getOffsetBetweenTimezonesForDate } from "{{ url_for('flexmeasures_ui.static', filename='js/daterange-utils.js') }}?v={{ flexmeasures_version }}";
     import { partition, updateBeliefs, beliefTimedelta, setAbortableTimeout} from "{{ url_for('flexmeasures_ui.static', filename='js/replay-utils.js') }}?v={{ flexmeasures_version }}";
 
     let vegaView;
@@ -375,8 +375,8 @@
     }
 
     async function embedAndLoad(chartSpecsPath, elementId, datasetName, previousResult, startDate, endDate) {
-
-        await vegaEmbed('#'+elementId, chartSpecsPath + 'dataset_name=' + datasetName + '&combine_legend='+ combineLegend + '&width=container&include_sensor_annotations=false&include_asset_annotations=false&chart_type=' + chartType, {{ chart_options | safe }})
+        const url = encodeUrlQuery(chartSpecsPath + 'dataset_name=' + datasetName + '&combine_legend='+ combineLegend + '&width=container&include_sensor_annotations=false&include_asset_annotations=false&chart_type=' + chartType);
+        await vegaEmbed('#'+elementId, url, {{ chart_options | safe }})
         .then(function (result) {
 
             // Create a custom menu item for exporting to CSV

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -589,7 +589,7 @@
             $("#spinner").show();
             checkDSTTransitions(startDate, endDate)
             Promise.all([
-                (previousResult.start.getTime() === startDate.getTime() && previousResult.end.getTime() === endDate.getTime()) ? Promise.resolve(previousResult.data) :
+                (previousResult && previousResult.start.getTime() === startDate.getTime() && previousResult.end.getTime() === endDate.getTime()) ? Promise.resolve(previousResult.data) :
                 // Fetch time series data
                 fetch(dataPath + '/chart_data?event_starts_after=' + queryStartDate + '&event_ends_before=' + queryEndDate, {
                     method: "GET",


### PR DESCRIPTION
## Description

I noticed graph pages not loading data, resulting in a 422 error. start and end date were sent as `None` even if I set them in the URL of the graph page explicitly.

<img width="974" height="327" alt="Screenshot from 2025-07-16 16-11-23" src="https://github.com/user-attachments/assets/4e127001-daec-425f-9a07-c15c06118d1f" />

Not easy to reproduce... 

One thing I see I can do is to make sure we don't work with / access variables if they are not actually defined yet. During investigation, those errors also showed. After the checks in this PR were run, I did not encounter the 422 error again. But as I said, it is tricky to reliabily reproduce.