### PR TITLE
Integration of DBFlexmodelSchema(and its custom validators)

### DIFF
--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -545,6 +545,7 @@ class AssetAPI(FlaskView):
             flex_context=DBFlexContextSchema,
             flex_model=DBStorageFlexModelSchema,
         )
+
         for k, v in asset_data.items():
             if getattr(db_asset, k) == v:
                 continue

--- a/flexmeasures/data/schemas/generic_assets.py
+++ b/flexmeasures/data/schemas/generic_assets.py
@@ -176,6 +176,7 @@ class GenericAssetSchema(ma.SQLAlchemySchema):
     sensors = ma.Nested("SensorSchema", many=True, dump_only=True, only=("id", "name"))
     sensors_to_show = JSON(required=False)
     flex_context = JSON(required=False)
+    flex_model = JSON(required=False)
 
     class Meta:
         model = GenericAsset

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -403,7 +403,6 @@ class DBStorageFlexModelSchema(Schema):
 
     def _validate_field(self, data: dict, field_type: str, field: str, unit_validator):
         """Validate fields based on type and unit validator."""
-        print(f"Validating {field_type} field '{self.mapped_schema_keys[field]}'...")
         if isinstance(data[field], ur.Quantity):
             if not unit_validator(str(data[field].units)):
                 raise ValidationError(

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -381,8 +381,6 @@ class DBStorageFlexModelSchema(Schema):
     def _validate_power_fields(self, data: dict):
         """Validate power fields."""
         power_fields = [
-            "soc_gain",
-            "soc_usage",
             "power_capacity",
             "consumption_capacity",
             "production_capacity",

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -315,7 +315,7 @@ class DBStorageFlexModelSchema(Schema):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.mapped_schema_keys = {
-            field: self.declared_fields[field].data_key
+            field: (self.declared_fields[field].data_key or field)
             for field in self.declared_fields
         }
 

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -310,7 +310,7 @@ class DBStorageFlexModelSchema(Schema):
         validate=validate.Length(min=1),
     )
 
-    mapped_schema_keys: dict = {}
+    mapped_schema_keys: dict | None = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -328,6 +328,9 @@ class DBStorageFlexModelSchema(Schema):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # Initialize mapped_schema_keys to map field names to their data keys
+        # This is necessary for validation methods to access the correct data keys
+        # after the schema is declared.
         self.mapped_schema_keys = {
             field: (self.declared_fields[field].data_key or field)
             for field in self.declared_fields
@@ -374,6 +377,20 @@ class DBStorageFlexModelSchema(Schema):
         for field in energy_fields:
             if field in data:
                 self._validate_field(data, field, unit_validator=is_energy_unit)
+
+    def _validate_power_fields(self, data: dict):
+        """Validate power fields."""
+        power_fields = [
+            "soc_gain",
+            "soc_usage",
+            "power_capacity",
+            "consumption_capacity",
+            "production_capacity",
+        ]
+
+        for field in power_fields:
+            if field in data:
+                self._validate_field(data, field, unit_validator=is_power_unit)
 
     def _validate_array_fields(self, data: dict):
         """Validate power array fields."""

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -293,7 +293,7 @@ class DBStorageFlexModelSchema(Schema):
     """
 
     soc_min = VariableQuantityField(
-        to_unit="/MWh",
+        to_unit="MWh",
         data_key="soc-min",
         required=False,
         value_validator=validate.Range(min=0),
@@ -304,7 +304,7 @@ class DBStorageFlexModelSchema(Schema):
     )
 
     soc_gain = fields.List(
-        VariableQuantityField("/MW"),
+        VariableQuantityField("MW"),
         data_key="soc-gain",
         required=False,
         validate=validate.Length(min=1),

--- a/flexmeasures/ui/templates/assets/asset_flexmodel.html
+++ b/flexmeasures/ui/templates/assets/asset_flexmodel.html
@@ -188,6 +188,7 @@
                 }
             });
         }
+
         function setCardSensor(sensorId) {
             if (!activeCard()) {
                 showToast("Please select a field to set a sensor", "info");
@@ -266,6 +267,10 @@
             for (const [key, value] of Object.entries(data)) {
                 if (value === null) {
                     delete data[key];
+                } else if (Array.isArray(value) && value.length === 0) {
+                    delete data[key];
+                } else if (typeof value === 'object' && Object.keys(value).length === 0) {
+                    delete data[key];
                 }
             }
 
@@ -285,10 +290,10 @@
                 showToast(`Failed to update the flex model: ${errorMessage}`, "error");
 
                 // Revert to previous state
-                // const asset = await getAsset("{{ asset.id }}", false);
-                // const previousFlexContext = await processResourceRawJSON(assetFlexModelSchema, asset.flex_context);
-                // assetFlexContext = previousFlexContext;
-                // renderFlexModelForm();
+                const asset = await getAsset("{{ asset.id }}", false);
+                const previousFlexContext = Object.assign({}, assetFlexModelSchema, processResourceRawJSON(assetFlexModelSchema, '"{{ asset_flexmodel | safe}}"'));
+                setFlexModel(previousFlexContext);
+                renderFlexModelForm();
             } else {
                 showToast("Flex model updated successfully", "success");
             }


### PR DESCRIPTION
## Description

This PR contains the stable integration of the `DBFlexModelSchema` in the asset API to validate the `flex_model` field during updates.


## Look & Feel
None

## How to test

use the asset update API `http://localhost:5000/api/v3_0/assets/<asset_id>` to update an asset's flex model. You can use the data below for testing. Go to your DB and add this dummy data to the asset you want to update(make sure to change the sensor-id to what exists in your DB)

#### Dummy Data
```
{"soc-min": {"sensor": 10},
"prefer-charging-sooner": false,
"soc-gain": [{"sensor": 13}, "700 KRW/MWh"]}
```

## Further Improvements

None

## Related Items

This PR is a child of #1565 

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures