### PR TITLE
fix: do not use `squeeze` for a single row dataframe

### DIFF
--- a/flexmeasures/data/models/planning/utils.py
+++ b/flexmeasures/data/models/planning/utils.py
@@ -375,7 +375,12 @@ def get_series_from_quantity_or_sensor(
         )
         if as_instantaneous_events:
             bdf = bdf.resample_events(timedelta(0), boundary_policy=resolve_overlaps)
-        time_series = simplify_index(bdf).reindex(index).squeeze()
+        time_series = simplify_index(bdf).reindex(index)
+        time_series = pd.Series(
+            data=time_series.iloc[:, 0].values,
+            index=time_series.index,
+            name=time_series.columns[0],
+        )
         time_series = convert_units(
             time_series, variable_quantity.unit, unit, resolution
         )


### PR DESCRIPTION
## Description
This PR fixes an issue where `.squeeze()` was used on a DataFrame with a single column, which could result in a scalar if the DataFrame had only one row. This caused downstream errors when the expected output was a Series.


<!--
For changelog entries, please take into account the intended audience.

In our main changelog:
- The 'New features' section targets API / CLI / UI users.
- The 'Infrastructure / Support' section targets plugin developers and hosts.

Finally, please note that the API and CLI keep additional changelogs:
- `documentation/api/changelog.rst`
- `documentation/cli/changelog.rst`
-->

## Look & Feel

<!--
This section can contain example pictures for the UI, Input/Output for the CLI, Request / Response for an API endpoint, etc.
-->

...

## How to test
Without Fix:
```python
import pandas as pd

df = pd.DataFrame({"value": [42.5]}, index=[pd.Timestamp("2025-07-01 00:00")])

# Simulate .reindex() on a single timestamp
df = df.reindex([pd.Timestamp("2025-07-01 00:00")])

# Squeeze collapses to a scalar if only one row
result = df.squeeze()

print(type(result))  # <class 'float'>
print(result)
```

With Fix:
```python
import pandas as pd

df = pd.DataFrame({"value": [42.5]}, index=[pd.Timestamp("2025-07-01 00:00")])

# Simulate .reindex() on a single timestamp
df = df.reindex([pd.Timestamp("2025-07-01 00:00")])

# Convert to Series without squeeze
series = pd.Series(
    data=df.iloc[:, 0].values,
    index=df.index,
    name=df.columns[0]
)

print(type(series))  # <class 'pandas.core.series.Series'>
print(series)
```


#### Sign-off

<!--
We ask contributors outside the FlexMeasures organisation to sign off on their contribution.
Please mark the below fields with an [x].
-->

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
