### PR TITLE
Potential fix for code scanning alert no. 10: Reflected server-side cross-site scripting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,10 @@ HIGHS_DIR = "../HiGHS"
 
 # Note: use tabs
 # actions which are virtual, i.e. not a script
-.PHONY: install install-for-dev install-for-test install-deps install-flexmeasures run-local test freeze-deps upgrade-deps update-docs update-docs-pdf show-file-space show-data-model clean-db cli-autocomplete build-highs-macos install-highs-macos
+.PHONY: install install-for-dev install-for-test install-deps install-flexmeasures test freeze-deps upgrade-deps update-docs update-docs-pdf show-file-space show-data-model clean-db cli-autocomplete build-highs-macos install-highs-macos
 
 
 # ---- Development ---
-
-run-local:
-	python run-local.py
 
 test:
 	make install-for-test

--- a/documentation/dev/setup-and-guidelines.rst
+++ b/documentation/dev/setup-and-guidelines.rst
@@ -129,14 +129,6 @@ Now, to start the web application, you can run:
 
     $ flexmeasures run
 
-
-Or:
-
-.. code-block:: bash
-
-    $ python run-local.py
-
-
 And access the server at http://localhost:5000
 
 If you added a toy account, you could log in with `toy-user@flexmeasures.io`, password `toy-password`.

--- a/flexmeasures/api/__init__.py
+++ b/flexmeasures/api/__init__.py
@@ -3,6 +3,7 @@ FlexMeasures API routes and implementations.
 """
 
 from flask import Flask, Blueprint, request
+import html
 from flask_security.utils import verify_password
 from flask_json import as_json
 from flask_login import current_user
@@ -57,7 +58,7 @@ def request_auth_token():
             ).scalar_one_or_none()
             if not user:
                 return (
-                    {"errors": ["User with email '%s' does not exist" % email]},
+                    {"errors": ["User with email '%s' does not exist" % html.escape(email)]},
                     404,
                 )
 


### PR DESCRIPTION
Potential fix for [https://github.com/FlexMeasures/flexmeasures/security/code-scanning/10](https://github.com/FlexMeasures/flexmeasures/security/code-scanning/10)

To fix the issue, we need to sanitize the `email` parameter before including it in the response. The `html.escape()` function from Python's standard library can be used to escape special characters in the `email` string, ensuring that any potentially malicious input is neutralized. This change will not alter the functionality of the code but will make it secure against XSS attacks.

The fix involves:
1. Importing the `html` module if not already imported.
2. Escaping the `email` parameter using `html.escape()` before including it in the response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
