### PR TITLE
inject parent asset Id in error-induced asset form reload

### DIFF
--- a/flexmeasures/ui/views/assets/views.py
+++ b/flexmeasures/ui/views/assets/views.py
@@ -267,6 +267,7 @@ class AssetCrudUI(FlaskView):
                     "assets/asset_new.html",
                     asset_form=asset_form,
                     msg=msg,
+                    parent_asset_id=asset_form.parent_asset_id.data,
                     map_center=get_center_location_of_assets(user=current_user),
                     mapboxAccessToken=current_app.config.get("MAPBOX_ACCESS_TOKEN", ""),
                 )


### PR DESCRIPTION
## Description

Fix a few grievances when creating child-assets, or asset creation in general

Closes #1603

- [ ] see checklist on issue
- [ ] Added changelog item in `documentation/changelog.rst`

## Look & Feel

Avoids unpleasant errors, adds buttons: TODO
...

## How to test

Create sub-assets through various means and make various errors (leaving off the asset type for instance) - expect graceful behavior.