### PR TITLE
Feat: Human-friendly times in sensor statistics

### DIFF
--- a/flexmeasures/ui/static/js/flexmeasures.js
+++ b/flexmeasures/ui/static/js/flexmeasures.js
@@ -484,6 +484,80 @@ function getTimeAgo(timestamp) {
     }
 }
 
+// Renders a date in the local timezone, including day of the week.
+// e.g. "Fri, 22 May 2020"
+const dateFormatter = new Intl.DateTimeFormat(
+  [], {"year": "numeric", "month": "long", "day": "numeric"}
+)
+
+// Renders an HH:MM time in the local timezone, including timezone info.
+// e.g. "12:17 BST"
+const timeFormatter = new Intl.DateTimeFormat(
+  [], {"hour": "numeric", "minute": "numeric", "timeZoneName": "short"}
+)
+
+/** Given an ISO 8601 date string, render it as a more friendly date
+ *  in the user's timezone.
+ * 
+ *  Examples:
+ *  - "today @ 12:00 BST"
+ *  - "yesterday @ 11:00 CST"
+ *  - "Fri, 22 May 2020 @ 10:00 PST"
+ */
+function getHumanFriendlyDateString(iso8601_date_string) {
+  const date = new Date(Date.parse(iso8601_date_string));
+
+  // When are today and yesterday?
+  const today = new Date();
+  const yesterday = new Date().setDate(today.getDate() - 1);
+
+  // We have to compare the *formatted* dates rather than the actual dates --
+  // for example, if the UTC date and the localised date fall on either side
+  // of midnight.
+  if (dateFormatter.format(date) == dateFormatter.format(today)) {
+    return "today @ " + timeFormatter.format(date);
+  } else if (dateFormatter.format(date) == dateFormatter.format(yesterday)) {
+    return "yesterday @ " + timeFormatter.format(date);
+  } else {
+    return dateFormatter.format(date) + " @ " + timeFormatter.format(date);
+  }
+}
+
+/** Given an ISO 8601 date string, render a human-friendly description
+ *  of how long ago it was, if recent.
+ *
+ *  Examples:
+ *  - "just now"
+ *  - "10 seconds ago"
+ *  - "20 minutes ago"
+ * 
+ * If longer ago than 24 hours, let getHumanFriendlyDateString take over.
+ */
+function getHumanFriendlyDeltaOrTimeStr(iso8601_date_string) {
+  const date = new Date(Date.parse(iso8601_date_string));
+  const now = new Date();
+
+  const deltaMilliseconds = now - date;
+  const deltaSeconds = Math.floor(deltaMilliseconds / 1000);
+  const deltaMinutes = Math.floor(deltaSeconds / 60);
+  const deltaHours = Math.floor(deltaMinutes / 60);
+
+  if (deltaSeconds < 5) {
+    return "just now";
+  } else if (deltaSeconds < 60) {
+    return deltaSeconds + " seconds ago";
+  } else if (deltaMinutes == 1) {
+    return "1 minute ago";
+  } else if (deltaMinutes < 60) {
+    return deltaMinutes + " minutes ago";
+  } else if (deltaHours == 1) {
+    return "> 1 hour ago";
+  } else if (deltaHours < 24) {
+    return "> " + deltaHours + " hours ago";
+  } else {
+    return getHumanFriendlyDateString(iso8601_date_string);
+  }
+}
 
 // Function to return a loading row for a table
 function getLoadingRow(id="loading-row") {
@@ -523,16 +597,23 @@ function updateStatsTable(stats, tableBody) {
     Object.entries(stats).forEach(([key, val]) => {
         const row = document.createElement('tr');
         const keyCell = document.createElement('th');
+        var valueTitle = "";
         const valueCell = document.createElement('td');
 
         keyCell.textContent = key;
         // Round value to 2 decimal points if it's a number
         if (typeof val === 'number' & key != 'Number of values') {
             valueCell.textContent = val.toFixed(4);
+        } else if (typeof val === 'string' & (key.includes("First") | key.includes("Last"))) {
+            valueCell.textContent = getHumanFriendlyDeltaOrTimeStr(val);
+            valueTitle = val;
         } else {
             valueCell.textContent = val;
         }
 
+        if (valueTitle !== ""){
+            valueCell.setAttribute("title", valueTitle);
+        }
         row.appendChild(keyCell);
         row.appendChild(valueCell);
         tableBody.appendChild(row);


### PR DESCRIPTION
## Description

The times in the stats were hard to read. I preserved them in tooltip (title), but now they usually show time deltas or dates that read easier. We get the keys and values via Ajax call as-is from the API, so I needed JS to make the strings friendly.

- [x] Make times human-friendly
- [ ] Added changelog item in `documentation/changelog.rst`


## Look & Feel

<img width="546" height="514" alt="Screenshot from 2025-07-26 23-44-45" src="https://github.com/user-attachments/assets/4fdfe79f-6709-4f35-b159-1b3609721988" />
<img width="546" height="519" alt="Screenshot from 2025-07-26 23-42-04" src="https://github.com/user-attachments/assets/1147bd35-034a-4780-9011-9b821284487d" />


## How to test

Upload sensor data or browse existing sensors.