### PR TITLE
Fixed sensor page failing on getAssetKPIs.

### DIFF
--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -643,7 +643,9 @@
             {% if event_starts_after and event_ends_before %}
                 // Initialize picker to the date selection specified in the session
                 $("#spinner").show();
-                getAssetKPIs();
+                {% if active_subpage == "asset_graph" %}
+                    getAssetKPIs();
+                {% endif %}
                 const initialData = fetch(dataPath + '/chart_data?event_starts_after=' + '{{ event_starts_after }}' + '&event_ends_before=' + '{{ event_ends_before }}', {
                     method: "GET",
                     headers: {"Content-Type": "application/json"},


### PR DESCRIPTION
## Description
- [x] Fixed `getAccessKPIs` call on sensors page.

## Related Items

Closes [#1631](https://github.com/FlexMeasures/flexmeasures/issues/1631)

...

---

#### Sign-off

<!--
We ask contributors outside the FlexMeasures organisation to sign off on their contribution.
Please mark the below fields with an [x].
-->

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
