### PR TITLE
fix: status page query performance

### DIFF
--- a/flexmeasures/data/migrations/versions/b8f3cda5e023_correct_order_in_index_for_single_most_.py
+++ b/flexmeasures/data/migrations/versions/b8f3cda5e023_correct_order_in_index_for_single_most_.py
@@ -1,0 +1,44 @@
+"""better order in index for single most recent event
+
+Revision ID: b8f3cda5e023
+Revises: b526da466b74
+Create Date: 2025-07-30 12:28:03.489985
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "b8f3cda5e023"
+down_revision = "b526da466b74"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """
+    Re-create the index with correct order
+    """
+    with op.batch_alter_table("timed_belief", schema=None) as batch_op:
+        batch_op.drop_index("timed_belief_search_session_singleevent_idx")
+    with op.batch_alter_table("timed_belief", schema=None) as batch_op:
+        batch_op.create_index(
+            "timed_belief_search_session_singleevent_idx",
+            ["sensor_id", "event_start"],
+            unique=False,
+        )
+
+
+def downgrade():
+    """
+    Re-create the original index
+    """
+    with op.batch_alter_table("timed_belief", schema=None) as batch_op:
+        batch_op.drop_index("timed_belief_search_session_singleevent_idx")
+    with op.batch_alter_table("timed_belief", schema=None) as batch_op:
+        batch_op.create_index(
+            "timed_belief_search_session_singleevent_idx",
+            ["event_start", "sensor_id"],
+            unique=False,
+        )

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -76,7 +76,8 @@ def _get_sensor_bdfs_by_source_type(
     for source_type in ("demo script", "user", "forecaster", "scheduler", "reporter"):
         bdf = TimedBelief.search(
             sensors=sensor,
-            most_recent_events_only=True,
+            most_recent_only=True,
+            most_recent_beliefs_only=False,
             source_types=[source_type],
             **staleness_search,
         )


### PR DESCRIPTION
## Description

Closes #1462

The index could have been better, but actually the largest miss was that we did not use the search functionality in the intended manner. This PR fixes the parameter, and also applies a better order to the index.

- [x] Fix search params
- [x] Improve index order (first sensor_id, which narrows it down better than event_start, but it also comes first, see example below)
- [ ] Added changelog item in `documentation/changelog.rst`

This is the query (once the params are used correctly):

```sql
SELECT timed_belief.event_start,
       timed_belief.belief_horizon,
       timed_belief.source_id,
       timed_belief.cumulative_probability,
       timed_belief.event_value
FROM timed_belief
JOIN data_source ON data_source.id = timed_belief.source_id
WHERE timed_belief.sensor_id = %(sensor_id_1)s
  AND timed_belief.event_start - timed_belief.belief_horizon <= %(param_1)s
  AND data_source.type IN (__[POSTCOMPILE_type_1])
ORDER BY timed_belief.event_start DESC,
         timed_belief.belief_horizon ASC
LIMIT %(param_2)s
```

LIMIT is simply 1.

I played with adding `source_id` to the index, but that did not change anything.

## How to test

Call the status page for an asset with multiple sensors. 
If there is a sensor which comprises more than 20% of the beliefs table, beware that postgres decides it's not worth using the index.

I tested by calling the page, and looking at response times for the different /sensor/(id)/status calls in the dev console.
The before/after effects shed multiple seconds for me, and sensors with not a lot of share of the table come in under 1s now (full roundtrip).


## Further Improvements

The more I test indexes, I'm less sure which one is really helping.

In the end, we should go deeper and use EXPLAIN

