### PR TITLE
feat: speed up dict representations

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,6 +13,7 @@ New features
 -------------
 
 * Display KPIs for asset sensors with daily event resolution [see `PR #1608 <https://github.com/FlexMeasures/flexmeasures/pull/1608>`_ and `PR #1634 <https://github.com/FlexMeasures/flexmeasures/pull/1634>`_]
+* Faster data loading for the UI [see `PR #1647 <https://www.github.com/FlexMeasures/flexmeasures/pull/1647>`_]
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -517,7 +517,7 @@ def chart_for_multiple_sensors(
         # Set up field definition for sensor descriptions
         sensor_field_definition = FIELD_DEFINITIONS["sensor_description"].copy()
         sensor_field_definition["scale"] = dict(
-            domain=[sensor.to_dict()["description"] for sensor in row_sensors]
+            domain=[sensor.as_dict["description"] for sensor in row_sensors]
         )
 
         # Derive the unit that should be shown

--- a/flexmeasures/data/models/data_sources.py
+++ b/flexmeasures/data/models/data_sources.py
@@ -347,7 +347,8 @@ class DataSource(db.Model, tb.BeliefSourceDBMixin):
     def __str__(self) -> str:
         return self.description
 
-    def to_dict(self) -> dict:
+    @property
+    def as_dict(self) -> dict:
         model_incl_version = self.model if self.model else ""
         if self.model and self.version:
             model_incl_version += f" (v{self.version})"

--- a/flexmeasures/data/models/data_sources.py
+++ b/flexmeasures/data/models/data_sources.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from functools import cached_property
 from typing import TYPE_CHECKING, Any, ClassVar
 from sqlalchemy.ext.mutable import MutableDict
 
@@ -347,7 +348,7 @@ class DataSource(db.Model, tb.BeliefSourceDBMixin):
     def __str__(self) -> str:
         return self.description
 
-    @property
+    @cached_property
     def as_dict(self) -> dict:
         model_incl_version = self.model if self.model else ""
         if self.model and self.version:

--- a/flexmeasures/data/models/data_sources.py
+++ b/flexmeasures/data/models/data_sources.py
@@ -366,6 +366,9 @@ class DataSource(db.Model, tb.BeliefSourceDBMixin):
             description=self.description,
         )
 
+    def to_dict(self) -> dict:
+        return self.as_dict
+
     @staticmethod
     def hash_attributes(attributes: dict) -> str:
         return hashlib.sha256(json.dumps(attributes).encode("utf-8")).digest()

--- a/flexmeasures/data/models/data_sources.py
+++ b/flexmeasures/data/models/data_sources.py
@@ -367,6 +367,9 @@ class DataSource(db.Model, tb.BeliefSourceDBMixin):
         )
 
     def to_dict(self) -> dict:
+        current_app.logger.warning(
+            "DataSource().to_dict() is deprecated since v0.28.0 and should be replaced by the DataSource().as_dict property."
+        )
         return self.as_dict
 
     @staticmethod

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -739,8 +739,8 @@ class GenericAsset(db.Model, AuthModelMixin):
                 )
                 df["sensor"] = {}  # ensure the same columns as a non-empty frame
             df = df.reset_index()
-            df["source"] = df["source"].apply(lambda x: x.to_dict())
-            df["sensor"] = df["sensor"].apply(lambda x: x.to_dict())
+            df["source"] = df["source"].apply(lambda x: x.as_dict)
+            df["sensor"] = df["sensor"].apply(lambda x: x.as_dict)
             df["sensor_unit"] = df["sensor"].apply(lambda x: x["sensor_unit"])
             df["event_value"] = df.apply(
                 lambda row: (

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Type
 from datetime import datetime as datetime_type, timedelta
+from functools import cached_property
 import json
 from packaging.version import Version
 from flask import current_app
@@ -534,7 +535,7 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
     def __str__(self) -> str:
         return self.name
 
-    @property
+    @cached_property
     def as_dict(self) -> dict:
         parent_asset = db.session.execute(
             select(GenericAsset).filter_by(id=self.generic_asset.parent_asset_id)

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -401,8 +401,8 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
         if as_json:
             df = bdf.reset_index()
             df["sensor"] = self
-            df["sensor"] = df["sensor"].apply(lambda x: x.to_dict())
-            df["source"] = df["source"].apply(lambda x: x.to_dict())
+            df["sensor"] = df["sensor"].apply(lambda x: x.as_dict)
+            df["source"] = df["source"].apply(lambda x: x.as_dict)
             return df.to_json(orient="records")
         return bdf
 
@@ -534,7 +534,8 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
     def __str__(self) -> str:
         return self.name
 
-    def to_dict(self) -> dict:
+    @property
+    def as_dict(self) -> dict:
         parent_asset = db.session.execute(
             select(GenericAsset).filter_by(id=self.generic_asset.parent_asset_id)
         ).scalar_one_or_none()

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -549,6 +549,9 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
             + (f" ({parent_asset.name})" if parent_asset is not None else ""),
         )
 
+    def to_dict(self) -> dict:
+        return self.as_dict
+
     @classmethod
     def find_closest(
         cls, generic_asset_type_name: str, sensor_name: str, n: int = 1, **kwargs

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -550,6 +550,9 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
         )
 
     def to_dict(self) -> dict:
+        current_app.logger.warning(
+            "Sensor().to_dict() is deprecated since v0.28.0 and should be replaced by the Sensor().as_dict property."
+        )
         return self.as_dict
 
     @classmethod


### PR DESCRIPTION
## Description

- [x] The dict representation of sensor becomes a cached property of the object.
- [x] Likewise for sources. 
- [x] When determining the latest version, only get a dict representation of the unique sources.
- [x] Added changelog item in `documentation/changelog.rst`

<!--
For changelog entries, please take into account the intended audience.

In our main changelog:
- The 'New features' section targets API / CLI / UI users.
- The 'Infrastructure / Support' section targets plugin developers and hosts.

Finally, please note that the API and CLI keep additional changelogs:
- `documentation/api/changelog.rst`
- `documentation/cli/changelog.rst`
-->

## Look & Feel

<!--
This section can contain example pictures for the UI, Input/Output for the CLI, Request / Response for an API endpoint, etc.
-->

...

## How to test

Use the profiler for benchmarking speed of the endpoint to fetch chart data

## Further Improvements

- Maybe some overlap with #1645?

## Related Items

<!--
Mention if this PR closes an Issue or Project.
-->

