### PR TITLE
fix: get rid RuntimeWarning: '<' not supported between instances

### DIFF
--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -43,10 +43,11 @@ from flexmeasures.data.models.data_sources import DataSource
 from flexmeasures.data.models.generic_assets import GenericAsset
 from flexmeasures.data.models.validation_utils import check_required_attributes
 from flexmeasures.data.queries.sensors import query_sensors_by_proximity
+from flexmeasures.utils.temp_coding_utils import OrderByIdMixin
 from flexmeasures.utils.geo_utils import parse_lat_lng
 
 
-class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
+class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin, OrderByIdMixin):
     """A sensor measures events."""
 
     attributes = db.Column(MutableDict.as_mutable(db.JSON), nullable=False, default={})

--- a/flexmeasures/utils/temp_coding_utils.py
+++ b/flexmeasures/utils/temp_coding_utils.py
@@ -1,0 +1,45 @@
+"""Temporary module which should move into coding_utils.py after get_downsample_function_and_value moves out of there."""
+
+from functools import total_ordering
+
+
+@total_ordering
+class OrderByIdMixin:
+    """
+    Mixin class that adds rich comparison and hashing methods based on an ``id`` attribute.
+
+    Classes inheriting from this mixin must define an ``id`` property or attribute
+    that is an ``int`` or otherwise supports comparison and hashing.
+    """
+
+    def __eq__(self, other):
+        """
+        Return True if the ``id`` of both instances is equal.
+
+        :param other: Another instance to compare.
+        :return: True if ``self.id == other.id``, else False.
+        """
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self.id == other.id
+
+    def __lt__(self, other):
+        """
+        Return True if this instance's ``id`` is less than the other's.
+
+        :param other: Another instance to compare.
+        :return: True if ``self.id < other.id``, else False.
+        """
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self.id < other.id
+
+    def __hash__(self):
+        """
+        Return a hash based on the ``id`` attribute.
+
+        This allows instances to be used in sets and as dictionary keys.
+
+        :return: Hash value.
+        """
+        return hash(self.id)


### PR DESCRIPTION
## Description

- [x] fix: get rid RuntimeWarning: '<' not supported between instances) of 'Sensor' and 'Sensor', sort order is undefined for incomparable objects.
- [x] Let `Sensor` objects be used as dict keys by making them hashable.
- [ ] Added changelog item in `documentation/changelog.rst`

## Look & Feel

Just gets rid of log statements like:
```
flexmeasures/data/models/generic_assets.py:723: RuntimeWarning: '<' not supported between instances of 'Sensor' and 'Sensor', sort order is undefined for incomparable objects.
  df = pd.concat(df_dict.values())
```

## How to test

Check the logs when visiting an asset chart page with multiple sensors.

## Further Improvements

- Potentially, we could apply the mixing to the `GenericAsset` class, too. However, I haven't encountered this issue in the logs for assets, so I don't see the direct need.

## Related Items

- Waiting for #1634 so I can move the new util class to a better place without getting a circular import error.
