### PR TITLE
feat: consolidate filters within FlexMeasures' `TimedBelief.search`

### DIFF
--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -371,7 +371,7 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin):
         :param use_latest_version_per_event: only return the belief from the latest version of a source, for each event
         :param most_recent_beliefs_only: only return the most recent beliefs for each event from each source (minimum belief horizon). Defaults to True.
         :param most_recent_events_only: only return (post knowledge time) beliefs for the most recent event (maximum event start). Defaults to False.
-        :param most_recent_only: only return a single belief, the most recent from the most recent event. Fastest method if you only need one. Defaults to False. To use, also set most_recent_beliefs_only=False. Use with care when data uses cumulative probability (more than one belief per event_start and horizon).
+        :param most_recent_only: only return a single belief, the most recent from the most recent event. Fastest method if you only need one. Defaults to False. Setting this to True will turn off usage of most_recent_beliefs_only and most_recent_events_only. Use with care when data uses cumulative probability (more than one belief per event_start and horizon).
         :param one_deterministic_belief_per_event: only return a single value per event (no probabilistic distribution and only 1 source)
         :param one_deterministic_belief_per_event_per_source: only return a single value per event per source (no probabilistic distribution)
         :param as_json: return beliefs in JSON format (e.g. for use in charts) rather than as BeliefsDataFrame

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -765,6 +765,15 @@ class TimedBelief(db.Model, tb.TimedBeliefDBMixin):
         )
         custom_join_targets = [] if parsed_sources else [DataSource]
 
+        # Consolidate the two most-recent-X approaches
+        if most_recent_only:
+            most_recent_filters = dict(most_recent_only=most_recent_only)
+        else:
+            most_recent_filters = dict(
+                most_recent_beliefs_only=most_recent_beliefs_only,
+                most_recent_events_only=most_recent_events_only,
+            )
+
         bdf_dict = {}
         for sensor in sensors:
             bdf = cls.search_session(
@@ -778,9 +787,7 @@ class TimedBelief(db.Model, tb.TimedBeliefDBMixin):
                 horizons_at_least=horizons_at_least,
                 horizons_at_most=horizons_at_most,
                 source=parsed_sources,
-                most_recent_beliefs_only=most_recent_beliefs_only,
-                most_recent_events_only=most_recent_events_only,
-                most_recent_only=most_recent_only,
+                **most_recent_filters,
                 custom_filter_criteria=source_criteria,
                 custom_join_targets=custom_join_targets,
             )

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -77,7 +77,6 @@ def _get_sensor_bdfs_by_source_type(
         bdf = TimedBelief.search(
             sensors=sensor,
             most_recent_only=True,
-            most_recent_beliefs_only=False,
             source_types=[source_type],
             **staleness_search,
         )


### PR DESCRIPTION
## Description

Attempt to remedy the situation where the desired behaviour to fetch the latest belief about the latest event requires a confusing set of search filters.
