### PR TITLE
Fix/nan datetimes in url

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -32,6 +32,7 @@ v0.27.3 | August XX, 2025
 
 Bugfixes
 -----------
+* Fix the time window in the UI from being replaced with :abbr:`NaN (not a number)` values when refreshing the asset graphs page [see `PR #1667 <https://github.com/FlexMeasures/flexmeasures/pull/1667>`_]
 * Fix scheduling storage devices within a single time step [see `PR #1619 <https://github.com/FlexMeasures/flexmeasures/pull/1619>`_]
 
 

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -41,7 +41,7 @@ v0.27.2 | August 13, 2025
 
 Bugfixes
 -----------
-* Resolve issue where concatenating sensor data from updated reporters leads to a NaN source and crashing the asset chart page [see `PR #1660 <https://github.com/FlexMeasures/flexmeasures/pull/1660>`_]
+* Resolve issue where concatenating sensor data from updated reporters leads to a :abbr:`NaN (not a number)` source and crashing the asset graphs page [see `PR #1660 <https://github.com/FlexMeasures/flexmeasures/pull/1660>`_]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -27,7 +27,7 @@ Bugfixes
 * Fixed usage of slow query for status page [see `PR #1638 <https://www.github.com/FlexMeasures/flexmeasures/pull/1638>`_]
 
 
-v0.27.3 | August XX, 2025
+v0.27.3 | August 19, 2025
 ============================
 
 Bugfixes

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -564,10 +564,8 @@
             endDate.setDate(endDate.getDate() + 1);
 
             // Update current url without reloading the page
-            var urlStartDate = encodeURIComponent(toIsoString(startDate));
-            var urlEndDate = encodeURIComponent(toIsoString(endDate));
             var base_url = window.location.href.split("?")[0];
-            var new_url = `${base_url}?start_time=${urlStartDate}&end_time=${urlEndDate}`;
+            var new_url = `${base_url}?start_time=${toIsoString(startDate)}&end_time=${toIsoString(endDate)}`;
             window.history.pushState({}, null, new_url);
 
             storeStartDate = startDate;

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -564,8 +564,10 @@
             endDate.setDate(endDate.getDate() + 1);
 
             // Update current url without reloading the page
+            var urlStartDate = encodeURIComponent(toIsoString(startDate));
+            var urlEndDate = encodeURIComponent(toIsoString(endDate));
             var base_url = window.location.href.split("?")[0];
-            var new_url = `${base_url}?start_time=${toIsoString(startDate)}&end_time=${toIsoString(endDate)}`;
+            var new_url = `${base_url}?start_time=${urlStartDate}&end_time=${urlEndDate}`;
             window.history.pushState({}, null, new_url);
 
             storeStartDate = startDate;

--- a/flexmeasures/ui/utils/view_utils.py
+++ b/flexmeasures/ui/utils/view_utils.py
@@ -57,12 +57,18 @@ def render_flexmeasures_template(html_filename: str, **variables):
 
     # Use event_starts_after and event_ends_before from session if not given
     # and resolve url encoding issue for timezone offsets with plus sign
-    variables["event_starts_after"] = (
-        variables.get("event_starts_after") or session.get("event_starts_after")
-    ).replace(" ", "+")
-    variables["event_ends_before"] = (
-        variables.get("event_ends_before") or session.get("event_ends_before")
-    ).replace(" ", "+")
+    event_starts_after = variables.get("event_starts_after") or session.get(
+        "event_starts_after"
+    )
+    event_ends_before = variables.get("event_ends_before") or session.get(
+        "event_ends_before"
+    )
+    if isinstance(event_starts_after, str):
+        event_starts_after = event_starts_after.replace(" ", "+")
+    if isinstance(event_ends_before, str):
+        event_ends_before = event_ends_before.replace(" ", "+")
+    variables["event_starts_after"] = event_starts_after
+    variables["event_ends_before"] = event_ends_before
 
     variables["chart_type"] = session.get("chart_type", "bar_chart")
 

--- a/flexmeasures/ui/utils/view_utils.py
+++ b/flexmeasures/ui/utils/view_utils.py
@@ -55,7 +55,8 @@ def render_flexmeasures_template(html_filename: str, **variables):
     ):
         variables["documentation_exists"] = True
 
-    # use event_starts_after and event_ends_before from session if not given
+    # Use event_starts_after and event_ends_before from session if not given
+    # and resolve url encoding issue for timezone offsets with plus sign
     variables["event_starts_after"] = (
         variables.get("event_starts_after") or session.get("event_starts_after")
     ).replace(" ", "+")

--- a/flexmeasures/ui/utils/view_utils.py
+++ b/flexmeasures/ui/utils/view_utils.py
@@ -57,18 +57,11 @@ def render_flexmeasures_template(html_filename: str, **variables):
 
     # Use event_starts_after and event_ends_before from session if not given
     # and resolve url encoding issue for timezone offsets with plus sign
-    event_starts_after = variables.get("event_starts_after") or session.get(
-        "event_starts_after"
-    )
-    event_ends_before = variables.get("event_ends_before") or session.get(
-        "event_ends_before"
-    )
-    if isinstance(event_starts_after, str):
-        event_starts_after = event_starts_after.replace(" ", "+")
-    if isinstance(event_ends_before, str):
-        event_ends_before = event_ends_before.replace(" ", "+")
-    variables["event_starts_after"] = event_starts_after
-    variables["event_ends_before"] = event_ends_before
+    for key in ["event_starts_after", "event_ends_before"]:
+        value = variables.get(key) or session.get(key)
+        if isinstance(value, str):
+            value = value.replace(" ", "+")
+        variables[key] = value
 
     variables["chart_type"] = session.get("chart_type", "bar_chart")
 

--- a/flexmeasures/ui/utils/view_utils.py
+++ b/flexmeasures/ui/utils/view_utils.py
@@ -56,12 +56,12 @@ def render_flexmeasures_template(html_filename: str, **variables):
         variables["documentation_exists"] = True
 
     # use event_starts_after and event_ends_before from session if not given
-    variables["event_starts_after"] = variables.get(
-        "event_starts_after"
-    ) or session.get("event_starts_after")
-    variables["event_ends_before"] = variables.get("event_ends_before") or session.get(
-        "event_ends_before"
-    )
+    variables["event_starts_after"] = (
+        variables.get("event_starts_after") or session.get("event_starts_after")
+    ).replace(" ", "+")
+    variables["event_ends_before"] = (
+        variables.get("event_ends_before") or session.get("event_ends_before")
+    ).replace(" ", "+")
 
     variables["chart_type"] = session.get("chart_type", "bar_chart")
 


### PR DESCRIPTION
## Description

- [x] Fix regression from v0.27.2 where refreshing the asset charts page caused the datetimes in the url to be replaced with NaN values, due to a url encoding issue with plus signs in the timezone offset (fortunately, this only affected half the planet)
- [x] Added changelog item in `documentation/changelog.rst`

## Look & Feel

- Refreshing the asset charts page doesn't cause a problem any more
- Dates in the url query parameters remain human friendly (instead of being url encoded)
