### PR TITLE
Chore/fix CI for pint v25

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -62,8 +62,11 @@ jobs:
         run: pytest flexmeasures/data/schemas --doctest-modules --ignore flexmeasures/data/schemas/tests
       - name: Run all doctests in the ui/utils subpackage
         run: pytest flexmeasures/ui --doctest-modules --ignore flexmeasures/ui/tests
-      - name: Run all doctests in the utils subpackage
-        run: pytest flexmeasures/utils --doctest-modules --ignore flexmeasures/utils/tests
+      - name: Run all doctests in the utils subpackage (except find_smallest_common_unit)
+        run: pytest flexmeasures/utils --doctest-modules --ignore flexmeasures/utils/tests -k "not find_smallest_common_unit"
+      - name: Run doctest for find_smallest_common_unit (only on 3.11+)
+        if: ${{ matrix.py_version >= '3.11' }}
+        run: pytest flexmeasures/utils/unit_utils.py --doctest-modules -k "find_smallest_common_unit"
       - name: Run all tests except those marked to be skipped by GitHub AND record coverage
         run: pytest -v -m "not skip_github" --cov=flexmeasures --cov-branch --cov-report=lcov
       - name: Coveralls

--- a/flexmeasures/utils/unit_utils.py
+++ b/flexmeasures/utils/unit_utils.py
@@ -96,8 +96,8 @@ def find_smallest_common_unit(units: list[str]) -> tuple[str, dict[str, float]]:
     ('W', {'MW': 1000000.0, 'kW': 1000.0, 'W': 1.0})
     >>> find_smallest_common_unit(["kEUR", "EUR"])
     ('EUR', {'kEUR': 1000.0, 'EUR': 1.0})
-    >>> find_smallest_common_unit(["cEUR/kWh", "EUR/MWh"])  # NB: has a floating point error
-    ('EUR/MWh', {'cEUR/kWh': 10.000000000000002, 'EUR/MWh': 1.0})
+    >>> find_smallest_common_unit(["cEUR/kWh", "EUR/MWh"])
+    ('EUR/MWh', {'cEUR/kWh': 10.0, 'EUR/MWh': 1.0})
     >>> find_smallest_common_unit(["%", "dimensionless"])
     ('%', {'%': 1.0, 'dimensionless': 100.0})
     >>> find_smallest_common_unit(["%", ""])


### PR DESCRIPTION
## Description

- [x] Fixed failing test for `pint==25` (no more floating point error)
- [x] Stop testing a particular test for Python < 3.11 (which would install an older pint version that still has the floating point error; I researched conditional doctest statements, but it's too cumbersome)
- [ ] Added changelog item in `documentation/changelog.rst`
