### PR TITLE
Fix/serialize and deserialize scheduler kwargs kept in `job.meta`

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -27,6 +27,14 @@ Bugfixes
 * Fixed usage of slow query for status page [see `PR #1638 <https://www.github.com/FlexMeasures/flexmeasures/pull/1638>`_]
 
 
+v0.27.4 | August XX, 2025
+============================
+
+Bugfixes
+-----------
+* Show job information again on the job page on rq-dashboard, for scheduling jobs that set a specific ``belief_time`` and/or ``resolution`` [see `PR #1670 <https://github.com/FlexMeasures/flexmeasures/pull/1670>`_]
+
+
 v0.27.3 | August 19, 2025
 ============================
 

--- a/flexmeasures/data/services/scheduling.py
+++ b/flexmeasures/data/services/scheduling.py
@@ -125,6 +125,7 @@ def trigger_optional_fallback(job, connection, type, value, traceback):
         scheduler_kwargs = job.meta["scheduler_kwargs"]
 
         # Deserialize start, end, resolution and belief_time
+        # Workaround for https://github.com/Parallels/rq-dashboard/issues/510
         timezone = "UTC"
         if hasattr(asset_or_sensor, "timezone"):
             timezone = asset_or_sensor.timezone
@@ -272,6 +273,7 @@ def create_scheduling_job(
     job.meta["scheduler_kwargs"] = scheduler_kwargs
 
     # Serialize start, end, resolution and belief_time
+    # Workaround for https://github.com/Parallels/rq-dashboard/issues/510
     job.meta["scheduler_kwargs"]["start"] = job.meta["scheduler_kwargs"][
         "start"
     ].isoformat()

--- a/flexmeasures/data/services/scheduling.py
+++ b/flexmeasures/data/services/scheduling.py
@@ -134,6 +134,14 @@ def trigger_optional_fallback(job, connection, type, value, traceback):
         scheduler_kwargs["end"] = pd.Timestamp(scheduler_kwargs["end"]).tz_convert(
             timezone
         )
+        if "belief_time" in scheduler_kwargs:
+            scheduler_kwargs["belief_time"] = pd.Timestamp(
+                scheduler_kwargs["belief_time"]
+            ).tz_convert(timezone)
+        if "resolution" in scheduler_kwargs:
+            scheduler_kwargs["resolution"] = pd.Timedelta(
+                scheduler_kwargs["resolution"]
+            )
 
         if ("scheduler_specs" in job.kwargs) and (
             job.kwargs["scheduler_specs"] is not None

--- a/flexmeasures/data/services/scheduling.py
+++ b/flexmeasures/data/services/scheduling.py
@@ -270,12 +270,12 @@ def create_scheduling_job(
     job.meta["scheduler_kwargs"]["end"] = job.meta["scheduler_kwargs"][
         "end"
     ].isoformat()
-    if job.meta.get("belief_time") is not None:
+    if job.meta["scheduler_kwargs"].get("belief_time") is not None:
         job.meta["scheduler_kwargs"]["belief_time"] = job.meta["scheduler_kwargs"][
             "belief_time"
         ].isoformat()
 
-    if job.meta.get("resolution") is not None:
+    if job.meta["scheduler_kwargs"].get("resolution") is not None:
         job.meta["scheduler_kwargs"]["resolution"] = duration_isoformat(
             job.meta["scheduler_kwargs"]["resolution"]
         )

--- a/flexmeasures/data/services/scheduling.py
+++ b/flexmeasures/data/services/scheduling.py
@@ -134,11 +134,11 @@ def trigger_optional_fallback(job, connection, type, value, traceback):
         scheduler_kwargs["end"] = pd.Timestamp(scheduler_kwargs["end"]).tz_convert(
             timezone
         )
-        if "belief_time" in scheduler_kwargs:
+        if isinstance(scheduler_kwargs.get("belief_time"), str):
             scheduler_kwargs["belief_time"] = pd.Timestamp(
                 scheduler_kwargs["belief_time"]
             ).tz_convert(timezone)
-        if "resolution" in scheduler_kwargs:
+        if isinstance(scheduler_kwargs.get("resolution"), str):
             scheduler_kwargs["resolution"] = pd.Timedelta(
                 scheduler_kwargs["resolution"]
             )

--- a/flexmeasures/data/services/scheduling.py
+++ b/flexmeasures/data/services/scheduling.py
@@ -124,7 +124,7 @@ def trigger_optional_fallback(job, connection, type, value, traceback):
 
         scheduler_kwargs = job.meta["scheduler_kwargs"]
 
-        # Deserialize start and end
+        # Deserialize start, end, resolution and belief_time
         timezone = "UTC"
         if hasattr(asset_or_sensor, "timezone"):
             timezone = asset_or_sensor.timezone


### PR DESCRIPTION
## Description

- [x] Fixes a mistake in serializing scheduler kwargs to be saved in `job.meta`, which prevented the job page from showing for jobs that set a specific `resolution` (or `belief_time`)
- [x] Also deserializes the `belief_time` and `resolution` in case a fallback job needs to be created, where its `scheduler_kwargs` are taken from the `job.meta`.
- [x] Added changelog item in `documentation/changelog.rst`

## How to test

Click on any job in rq-dashboard. You should see its kwargs and some other info.

## Further Improvements

I consider this PR a workaround and have now suggested a more thorough fix hinging on a desired feature in rq-dashboard to configure a custom `JSONSerializer` for job metadata: https://github.com/Parallels/rq-dashboard/issues/510

## Related Items

Previous PRs aimed at letting the job page show again:

- Fixed the page only for scheduling jobs without `resolution` or `belief_time`: #1526
- Attempted to fix the page for other jobs, too, but had a bug that this PR fixes: #1601

