### PR TITLE
chore: pin pint <0.25

### DIFF
--- a/requirements/app.in
+++ b/requirements/app.in
@@ -1,7 +1,8 @@
 pyyaml
 altair
 pandas
-pint>=0.19.1
+# <0.25 due to misbehaving floating point errors in doctest, see https://github.com/FlexMeasures/flexmeasures/pull/1668
+pint>=0.19.1,<0.25
 py-moneyed
 iso8601
 xlrd


### PR DESCRIPTION
## Description

- [x] Before upgrading `pint` to v0.25, pin it to fix inconsistent behaviour in our CI pipeline
- [ ] Added changelog item in `documentation/changelog.rst`
