### PR TITLE
fix: use same timezone offsets for start and end 

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -29,6 +29,7 @@ Bugfixes
 -----------
 * Fixed usage of slow query for status page [see `PR #1638 <https://www.github.com/FlexMeasures/flexmeasures/pull/1638>`_]
 * Fix editing of public assets in the UI [see `PR #1636 <https://www.github.com/FlexMeasures/flexmeasures/pull/1636>`_]
+* Fix issue with :abbr:`DST (Daylight Saving Time)` transitions when processing variable quantities using the time series specification format, in flex-contexts and/or flex-models [see `PR #1681 <https://www.github.com/FlexMeasures/flexmeasures/pull/1681>`_]
 * Add audit log entries when creating sensors, assets and accounts via the CLI [see `PR #1623 <https://www.github.com/FlexMeasures/flexmeasures/pull/1623>`_]
 
 

--- a/flexmeasures/data/models/planning/tests/test_storage_utils.py
+++ b/flexmeasures/data/models/planning/tests/test_storage_utils.py
@@ -113,6 +113,36 @@ from flexmeasures.utils.unit_utils import ur
                 name="event_value",
             ),
         ),
+        # Test case 4: DST start (CET +01:00 -> CEST +02:00) — index in UTC, event in Europe/Amsterdam
+        (
+            pd.date_range(
+                "2024-03-30 23:00:00+00:00", periods=11, freq="15min", tz="UTC"
+            ),
+            [
+                {
+                    # Local event spans 00:00–00:30 Europe/Amsterdam on DST day.
+                    # In UTC, that is 23:00–23:15 the previous day.
+                    "value": 0.015,
+                    "start": pd.Timestamp(
+                        "2024-03-31 00:00:00+01:00", tz="Europe/Amsterdam"
+                    ),
+                    "end": pd.Timestamp(
+                        "2024-03-31 03:45:00+02:00", tz="Europe/Amsterdam"
+                    ),
+                }
+            ],
+            "dimensionless",
+            pd.Timedelta("15min"),
+            "first",
+            pd.Series(
+                # rest -> NaN
+                [0.015] * 11,
+                index=pd.date_range(
+                    "2024-03-30 23:00:00+00:00", periods=11, freq="15min", tz="UTC"
+                ),
+                name="event_value",
+            ),
+        ),
     ],
 )
 def test_process_time_series_segments(

--- a/flexmeasures/data/models/planning/tests/test_storage_utils.py
+++ b/flexmeasures/data/models/planning/tests/test_storage_utils.py
@@ -123,12 +123,8 @@ from flexmeasures.utils.unit_utils import ur
                     # Local event spans 00:00–00:30 Europe/Amsterdam on DST day.
                     # In UTC, that is 23:00–23:15 the previous day.
                     "value": 0.015,
-                    "start": pd.Timestamp(
-                        "2024-03-31 00:00:00+01:00", tz="Europe/Amsterdam"
-                    ),
-                    "end": pd.Timestamp(
-                        "2024-03-31 03:45:00+02:00", tz="Europe/Amsterdam"
-                    ),
+                    "start": pd.Timestamp("2024-03-31 00:00:00+01:00"),
+                    "end": pd.Timestamp("2024-03-31 03:45:00+02:00"),
                 }
             ],
             "dimensionless",

--- a/flexmeasures/data/models/planning/utils.py
+++ b/flexmeasures/data/models/planning/utils.py
@@ -438,6 +438,12 @@ def process_time_series_segments(
                 )
         start = event["start"]
         end = event["end"]
+        same_offset = start.utcoffset() == end.utcoffset()
+        # If start and end have different UTC offsets (like crossing DST),
+        # normalize them by converting to UTC.
+        if not same_offset:
+            start = start.tz_convert("UTC")
+            end = end.tz_convert("UTC")
         # Assign the value to the corresponding segment in the DataFrame
         time_series_segments.loc[start : end - resolution, segment] = value
 


### PR DESCRIPTION
## Description
To select a segment use same timezone offset and then assign a value to it. 