### PR TITLE
docs: OpenAPI/SwaggerUI

### DIFF
--- a/flexmeasures/api/v3_0/__init__.py
+++ b/flexmeasures/api/v3_0/__init__.py
@@ -3,6 +3,12 @@ FlexMeasures API v3
 """
 
 from flask import Flask
+import json
+
+from apispec import APISpec
+from apispec.ext.marshmallow import MarshmallowPlugin
+from apispec_webframeworks.flask import FlaskPlugin
+from flask_swagger_ui import get_swaggerui_blueprint
 
 from flexmeasures.api.v3_0.sensors import SensorAPI
 from flexmeasures.api.v3_0.accounts import AccountAPI
@@ -24,3 +30,57 @@ def register_at(app: Flask):
     AssetTypesAPI.register(app, route_prefix=v3_0_api_prefix)
     HealthAPI.register(app, route_prefix=v3_0_api_prefix)
     ServicesAPI.register(app)
+
+    register_swagger_ui(app)
+
+
+def create_openapi_specs(app: Flask):
+    """ """
+    spec = APISpec(
+        title="FlexMeasures",
+        version="0.28.0",  # TODO: dynamic
+        openapi_version="3.0.2",  # TODO: newest is 3.1.0
+        plugins=[FlaskPlugin(), MarshmallowPlugin()],
+    )
+    api_key_scheme = {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization",
+    }  # TODO: should we stop making this configurable?
+    spec.components.security_scheme("ApiKeyAuth", api_key_scheme)
+
+    with app.test_request_context():
+        for resource_name in ["SensorAPI"]:  # TODO: list others
+            # endpoints:dict = [{ep_name: ep} for ep, ep_name in app.view_functions if ep_name.starts_with(resource_name)]
+            # print(endpoints)
+            spec.path(
+                view=app.view_functions["SensorAPI:fetch_one"]
+            )  # TODO: get all views from the registered routes
+
+    spec_out = json.dumps(spec.to_dict(), indent=2)
+    print(spec_out)
+
+
+def register_swagger_ui(app: Flask):
+    """
+    Register the Swagger UI blueprint to view the OpenAPI specs.
+    """
+    SWAGGER_URL = "/api/docs"  # URL for exposing Swagger UI (without trailing '/')
+    API_URL = "/ui/static/openapi-specs.json"
+
+    # Call factory function to create our blueprint
+    swaggerui_blueprint = get_swaggerui_blueprint(
+        SWAGGER_URL,  # Swagger UI static files will be mapped to '{SWAGGER_URL}/dist/'
+        API_URL,
+        config={"app_name": "FlexMeasures"},  # Swagger UI config overrides
+        # oauth_config={  # OAuth config. See https://github.com/swagger-api/swagger-ui#oauth2-configuration .
+        #    'clientId': "your-client-id",
+        #    'clientSecret': "your-client-secret-if-required",
+        #    'realm': "your-realms",
+        #    'appName': "your-app-name",
+        #    'scopeSeparator': " ",
+        #    'additionalQueryStringParams': {'test': "hello"}
+        # }
+    )
+
+    app.register_blueprint(swaggerui_blueprint)

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -43,9 +43,10 @@ from flexmeasures.data.models.user import Account
 from flexmeasures.data.models.generic_assets import GenericAsset
 from flexmeasures.data.models.time_series import Sensor, TimedBelief
 from flexmeasures.data.queries.utils import simplify_index
-from flexmeasures.data.schemas.sensors import (
+from flexmeasures.data.schemas.sensors import (  # noqa F401
     SensorSchema,
     SensorIdField,
+    SensorId,
     SensorDataFileSchema,
 )
 from flexmeasures.data.schemas.times import AwareDateTimeField, PlanningDurationField
@@ -798,35 +799,32 @@ class SensorAPI(FlaskView):
     @use_kwargs({"sensor": SensorIdField(data_key="id")}, location="path")
     @permission_required_for_context("read", ctx_arg_name="sensor")
     @as_json
-    def fetch_one(self, id, sensor):
+    def fetch_one(self, id, sensor: Sensor):
         """Fetch a given sensor.
-
-        .. :quickref: Sensor; Get a sensor
-
-        This endpoint gets a sensor.
-
-        **Example response**
-
-        .. sourcecode:: json
-
-            {
-                "name": "some gas sensor",
-                "unit": "m³/h",
-                "entity_address": "ea1.2023-08.localhost:fm1.1",
-                "event_resolution": "PT10M",
-                "generic_asset_id": 4,
-                "timezone": "UTC",
-                "id": 2
-            }
-
-        :reqheader Authorization: The authentication token
-        :reqheader Content-Type: application/json
-        :resheader Content-Type: application/json
-        :status 200: PROCESSED
-        :status 400: INVALID_REQUEST, REQUIRED_INFO_MISSING, UNEXPECTED_PARAMS
-        :status 401: UNAUTHORIZED
-        :status 403: INVALID_SENDER
-        :status 422: UNPROCESSABLE_ENTITY
+        ---
+        get:
+          description: Fetch a given sensor.
+          security:
+            - ApiKeyAuth: []
+          parameters:
+            - in: path
+              name: id
+              description: ID of the sensor to fetch.
+              schema: SensorId
+          responses:
+            200:
+              description: One Sensor
+              content:
+                application/json:
+                  schema: SensorSchema
+            400:
+              description: INVALID_REQUEST, REQUIRED_INFO_MISSING, UNEXPECTED_PARAMS
+            401:
+              description: UNAUTHORIZED
+            403:
+              description: INVALID_SENDER
+            422:
+              description: UNPROCESSABLE_ENTITY
         """
 
         return sensor_schema.dump(sensor), 200

--- a/flexmeasures/app.py
+++ b/flexmeasures/app.py
@@ -224,7 +224,9 @@ def create(  # noqa C901
 
     @app.teardown_request
     def teardown_request(exception=None):
-        if app.config.get("FLEXMEASURES_PROFILE_REQUESTS", False):
+        if app.config.get("FLEXMEASURES_PROFILE_REQUESTS", False) and hasattr(
+            g, "start"
+        ):
             diff = time.time() - g.start
             if all([kw not in request.url for kw in ["/static", "favicon.ico"]]):
                 app.logger.info(

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -267,6 +267,10 @@ class SensorIdField(MarshmallowClickMixin, fields.Int):
         return sensor.id
 
 
+class SensorId(Schema):
+    id = SensorIdField(required=True)
+
+
 class VariableQuantityField(MarshmallowClickMixin, fields.Field):
     def __init__(
         self,

--- a/flexmeasures/utils/generate_open_api_specs.py
+++ b/flexmeasures/utils/generate_open_api_specs.py
@@ -1,0 +1,5 @@
+from flexmeasures.app import create
+from flexmeasures.api.v3_0 import create_openapi_specs
+
+app = create()
+create_openapi_specs(app)


### PR DESCRIPTION
## Description

We want to offer our API docs in the OpenAPI/Swagger way for developers.
This PR use ApiDoc to create the JSON, and flask-swagger-ui to show the interactive docs

- [x] Make first roundtrip work for one endpoint
- [ ] ...
- [ ] Added changelog item in `documentation/changelog.rst`


<img width="1150" height="803" alt="Screenshot from 2025-09-09 14-17-28" src="https://github.com/user-attachments/assets/7c66e77e-7696-4f3f-aeaa-2f86568e12d1" />


## Look & Feel

At this point, the following steps are needed (update this when we have automated things better):

- Run `python flexmeasures/utils/generate_open_api_specs.py`
- Copy the output into `flexmeasures/ui/static/openapi-specs.json`
- Restart FlexMeasures
- Visit http://localhost:5000/api/docs

## How to test

In the end, going to http://localhost:5000/api/docs/ and trying the API out from there should work and be complete.

## Further Improvements

The swagger docs will be shipped with each instance of FlexMeasures.
- we could link to it from the menu
- we could think about updating the JSON every time it starts up
- maybe it should move to http://localhost:5000/api/v3_0/docs

Also, our inline API docs we make with Sphinx could be based on Marshmallow and OpenAPI. Here are two nice UIs:
- https://sphinxcontrib-redoc.readthedocs.io/en/stable/
- https://sphinxcontrib-openapi.readthedocs.io/

## Related Items

Closes #17