### PR TITLE
Feat/cli/show all registries

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -14,6 +14,7 @@ New features
 Infrastructure / Support
 ----------------------
 * Updated dependencies [see `PR #1707 <https://www.github.com/FlexMeasures/flexmeasures/pull/1707>`_]
+* Include finished and canceled jobs in the overview printed by the CLI command ``flexmeasures jobs show-queues`` [see `PR #1712 <https://github.com/FlexMeasures/flexmeasures/pull/1712>`_]
 
 Bugfixes
 -----------

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -4,6 +4,10 @@
 FlexMeasures CLI Changelog
 **********************
 
+since v0.29.0 | October XX, 2024
+=================================
+* Include finished and canceled jobs in the overview printed by the CLI command ``flexmeasures jobs show-queues``.
+
 since v0.28.0 | September 10, 2025
 =================================
 * Removed command ``flexmeasures db-ops save`` and ``flexmeasures db-ops load`` for folder&file - base backup management.

--- a/flexmeasures/cli/jobs.py
+++ b/flexmeasures/cli/jobs.py
@@ -147,13 +147,13 @@ def show_queues():
     queue_data = [
         (
             q.name,
-            q.finished_job_registry.count,
-            q.started_job_registry.count,
             q.count,
             q.deferred_job_registry.count,
             q.scheduled_job_registry.count,
-            q.canceled_job_registry.count,
+            q.started_job_registry.count,
+            q.finished_job_registry.count,
             q.failed_job_registry.count,
+            q.canceled_job_registry.count,
         )
         for q in app.queues.values()
     ]
@@ -162,13 +162,13 @@ def show_queues():
             queue_data,
             headers=[
                 "Queue",
-                "Finished",
-                "Started",
-                "Queued",
-                "Deferred",
-                "Scheduled",
-                "Canceled",
-                "Failed",
+                "Queued jobs",
+                "Deferred jobs",
+                "Scheduled jobs",
+                "Started jobs",
+                "Finished jobs",
+                "Failed jobs",
+                "Canceled jobs",
             ],
         )
     )

--- a/flexmeasures/cli/jobs.py
+++ b/flexmeasures/cli/jobs.py
@@ -147,10 +147,12 @@ def show_queues():
     queue_data = [
         (
             q.name,
+            q.finished_job_registry.count,
             q.started_job_registry.count,
             q.count,
             q.deferred_job_registry.count,
             q.scheduled_job_registry.count,
+            q.canceled_job_registry.count,
             q.failed_job_registry.count,
         )
         for q in app.queues.values()
@@ -158,7 +160,16 @@ def show_queues():
     click.echo(
         tabulate(
             queue_data,
-            headers=["Queue", "Started", "Queued", "Deferred", "Scheduled", "Failed"],
+            headers=[
+                "Queue",
+                "Finished",
+                "Started",
+                "Queued",
+                "Deferred",
+                "Scheduled",
+                "Canceled",
+                "Failed",
+            ],
         )
     )
 


### PR DESCRIPTION
## Description

- [x] Add the last missing registries to show up when running `flexmeasures tasks show-queues`
- [x] Reorder so the registries appear in the same order as presented in RQ Dashboard
- [x] Added changelog item in `documentation/changelog.rst`
- [x] Added changelog item in `documentation/cli/change_log.rst`

## Look & Feel

```
Queue          Queued jobs    Deferred jobs    Scheduled jobs    Started jobs    Finished jobs    Failed jobs    Canceled jobs
-----------  -------------  ---------------  ----------------  --------------  ---------------  -------------  ---------------
forecasting              0                0                 0               0                0              0                0
scheduling               0                0                 0               0                7              1                0
```

## How to test

Run `flexmeasures tasks show-queues`.
...
