### PR TITLE
Dev/reporter with empty data

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -10,6 +10,7 @@ v0.29.0 | October XX, 2025
 
 New features
 -------------
+* Allow ``PandasReporter`` configurations to skip a transformation in case any of the transformation ``args`` or ``kwargs`` is missing all data [see `PR #1717 <https://www.github.com/FlexMeasures/flexmeasures/pull/1717>`_]
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/data/models/reporting/pandas_reporter.py
+++ b/flexmeasures/data/models/reporting/pandas_reporter.py
@@ -319,6 +319,12 @@ class PandasReporter(Reporter):
             ],
         """
 
+        def _any_empty(objs):
+            for o in objs:
+                if isinstance(o, (pd.Series, pd.DataFrame)) and o.empty:
+                    return True
+            return False
+
         previous_df = None
 
         for _transformation in self._config.get("transformations"):
@@ -338,9 +344,11 @@ class PandasReporter(Reporter):
             )
 
             # Possibly skip transformation if dealing with an empty Series/DataFrame
-            # skip_if_empty = transformation.get("skip_if_empty", False)
-            # todo: if any of the args or kwargs are empty Series or DataFrame, and skip_if_empty, then `self.data[df_output] = self.data[df_input]`
+            skip_if_empty = transformation.get("skip_if_empty", False)
 
-            self.data[df_output] = getattr(self.data[df_input], method)(*args, **kwargs)
+            if (_any_empty(args) or _any_empty(kwargs.values())) and skip_if_empty:
+                self.data[df_output] = self.data[df_input]
+            else:
+                self.data[df_output] = getattr(self.data[df_input], method)(*args, **kwargs)
 
             previous_df = df_output

--- a/flexmeasures/data/models/reporting/pandas_reporter.py
+++ b/flexmeasures/data/models/reporting/pandas_reporter.py
@@ -349,6 +349,8 @@ class PandasReporter(Reporter):
             if (_any_empty(args) or _any_empty(kwargs.values())) and skip_if_empty:
                 self.data[df_output] = self.data[df_input]
             else:
-                self.data[df_output] = getattr(self.data[df_input], method)(*args, **kwargs)
+                self.data[df_output] = getattr(self.data[df_input], method)(
+                    *args, **kwargs
+                )
 
             previous_df = df_output

--- a/flexmeasures/data/models/reporting/pandas_reporter.py
+++ b/flexmeasures/data/models/reporting/pandas_reporter.py
@@ -336,6 +336,11 @@ class PandasReporter(Reporter):
             kwargs = self._process_pandas_kwargs(
                 transformation.get("kwargs", {}), method
             )
+
+            # Possibly skip transformation if dealing with an empty Series/DataFrame
+            # skip_if_empty = transformation.get("skip_if_empty", False)
+            # todo: if any of the args or kwargs are empty Series or DataFrame, and skip_if_empty, then `self.data[df_output] = self.data[df_input]`
+
             self.data[df_output] = getattr(self.data[df_input], method)(*args, **kwargs)
 
             previous_df = df_output

--- a/flexmeasures/data/models/reporting/tests/conftest.py
+++ b/flexmeasures/data/models/reporting/tests/conftest.py
@@ -204,6 +204,19 @@ def setup_dummy_data(db, app, generic_report):
                 )
             )
 
+    # add a day of extra data for sensor 1, but not for sensor 2
+    for sensor, source, value in zip([sensor1], [source1, source2], [1, -1]):
+        for t in range(24):
+            beliefs.append(
+                TimedBelief(
+                    event_start=datetime(2023, 5, 11, tzinfo=utc) + timedelta(hours=t),
+                    belief_horizon=timedelta(hours=24),
+                    event_value=value,
+                    sensor=sensor,
+                    source=source,
+                )
+            )
+
     # add simple data for testing DST transition
     for t in range(24 * 4):  # create data for 4 days
         # UTC+1 -> UTC+2

--- a/flexmeasures/data/models/reporting/tests/test_pandas_reporter.py
+++ b/flexmeasures/data/models/reporting/tests/test_pandas_reporter.py
@@ -159,7 +159,7 @@ def test_reporter_empty(setup_dummy_data):
         output=[dict(name="sensor_r", sensor=report_sensor)],
     )
 
-    assert not report[0]["data"].empty
+    assert not report[0]["data"].empty, "expected some output, given non-empty input"
 
     # compute report on dates with no data available
     report = reporter.compute(
@@ -173,7 +173,7 @@ def test_reporter_empty(setup_dummy_data):
         output=[dict(name="sensor_r", sensor=report_sensor)],
     )
 
-    assert report[0]["data"].empty
+    assert report[0]["data"].empty, "expected empty output, given empty input"
 
     # compute report on dates with partial data available (sensor_1 yes, sensor_2 no)
     report = reporter.compute(

--- a/flexmeasures/data/models/reporting/tests/test_pandas_reporter.py
+++ b/flexmeasures/data/models/reporting/tests/test_pandas_reporter.py
@@ -134,9 +134,16 @@ def test_reporter_empty(setup_dummy_data):
     s1, s2, s3, s4, report_sensor, daily_report_sensor = setup_dummy_data
 
     config = dict(
-        required_input=[{"name": "sensor_1"}],
-        required_output=[{"name": "sensor_1"}],
-        transformations=[],
+        required_input=[{"name": "sensor_1"}, {"name": "sensor_2"}],
+        required_output=[{"name": "sensor_r"}],
+        transformations=[
+            {
+                "df_input": "sensor_1",
+                "method": "add",
+                "args": ["@sensor_2"],
+                "df_output": "sensor_r",
+            }
+        ],
     )
 
     reporter = PandasReporter(config=config)
@@ -145,8 +152,11 @@ def test_reporter_empty(setup_dummy_data):
     report = reporter.compute(
         start=datetime(2023, 4, 10, tzinfo=utc),
         end=datetime(2023, 4, 10, 10, tzinfo=utc),
-        input=[dict(name="sensor_1", sensor=s1)],
-        output=[dict(name="sensor_1", sensor=report_sensor)],
+        input=[
+            dict(name="sensor_1", sensor=s1),
+            dict(name="sensor_2", sensor=s2),
+        ],
+        output=[dict(name="sensor_r", sensor=report_sensor)],
     )
 
     assert not report[0]["data"].empty
@@ -156,8 +166,11 @@ def test_reporter_empty(setup_dummy_data):
         sensor=report_sensor,
         start=datetime(2021, 4, 10, tzinfo=utc),
         end=datetime(2021, 4, 10, 10, tzinfo=utc),
-        input=[dict(name="sensor_1", sensor=s1)],
-        output=[dict(name="sensor_1", sensor=report_sensor)],
+        input=[
+            dict(name="sensor_1", sensor=s1),
+            dict(name="sensor_2", sensor=s2),
+        ],
+        output=[dict(name="sensor_r", sensor=report_sensor)],
     )
 
     assert report[0]["data"].empty

--- a/flexmeasures/data/models/reporting/tests/test_pandas_reporter.py
+++ b/flexmeasures/data/models/reporting/tests/test_pandas_reporter.py
@@ -171,7 +171,15 @@ def test_reporter_empty(setup_dummy_data):
 
     # compute report on date with partial data available (sensor_1 yes, sensor_2 no)
     report = compute_period(start=datetime(2023, 5, 11, tzinfo=utc))
-    assert report[0]["data"].empty
+    assert (
+        not report[0]["data"].empty and report[0]["data"].isna().all().all()
+    ), "expected NaN values"
+
+    config["transformations"][0]["skip_if_empty"] = True
+    # recompute report on date with partial data available (sensor_1 yes, sensor_2 no)
+    reporter = PandasReporter(config=config)
+    report = compute_period(start=datetime(2023, 5, 11, tzinfo=utc))
+    assert not report[0]["data"].empty, "expected sensor_1 values"
 
 
 def test_pandas_reporter_unit_conversion(app, setup_dummy_data):

--- a/flexmeasures/data/models/reporting/tests/test_pandas_reporter.py
+++ b/flexmeasures/data/models/reporting/tests/test_pandas_reporter.py
@@ -175,6 +175,20 @@ def test_reporter_empty(setup_dummy_data):
 
     assert report[0]["data"].empty
 
+    # compute report on dates with partial data available (sensor_1 yes, sensor_2 no)
+    report = reporter.compute(
+        sensor=report_sensor,
+        start=datetime(2023, 5, 11, tzinfo=utc),
+        end=datetime(2022, 5, 11, 10, tzinfo=utc),
+        input=[
+            dict(name="sensor_1", sensor=s1),
+            dict(name="sensor_2", sensor=s2),
+        ],
+        output=[dict(name="sensor_r", sensor=report_sensor)],
+    )
+
+    assert report[0]["data"].empty
+
 
 def test_pandas_reporter_unit_conversion(app, setup_dummy_data):
     """

--- a/flexmeasures/data/schemas/reporting/pandas_reporter.py
+++ b/flexmeasures/data/schemas/reporting/pandas_reporter.py
@@ -23,6 +23,7 @@ class PandasMethodCall(Schema):
     method = fields.Str(required=True)
     args = fields.List(fields.Raw())
     kwargs = fields.Dict()
+    skip_if_empty = fields.Bool()
 
     @validates_schema
     def validate_method_call(self, data, **kwargs):


### PR DESCRIPTION
## Description

- [x] Extend test
- [x] Transformations support a `skip_if_empty` argument
- [x] Added changelog item in `documentation/changelog.rst`

## Look & Feel

Example transformation:

```yaml
transformations:
  - df_input: sensor_1
    method: add
    skip_if_empty: true
    args:
      - '@sensor_2'
    df_output: sensor_3
```

## How to test

`pytest -k test_reporter_empty`

## Further improvements

- [x] Extend reporter documentation -> moved to sub-task of https://github.com/FlexMeasures/flexmeasures/issues/828