### PR TITLE
Feat/delete unchanged beliefs within period

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -11,6 +11,7 @@ v0.29.0 | October XX, 2025
 New features
 -------------
 * Allow ``PandasReporter`` configurations to skip a transformation in case any of the transformation ``args`` or ``kwargs`` is missing all data [see `PR #1717 <https://www.github.com/FlexMeasures/flexmeasures/pull/1717>`_]
+* The ``flexmeasures delete unchanged-beliefs`` CLI command now supports limiting the action to a given period [see `PR #1720 <https://www.github.com/FlexMeasures/flexmeasures/pull/1720>`_]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -7,6 +7,7 @@ FlexMeasures CLI Changelog
 since v0.29.0 | October XX, 2024
 =================================
 * Include finished and canceled jobs in the overview printed by the CLI command ``flexmeasures jobs show-queues``.
+* The ``flexmeasures delete unchanged-beliefs`` CLI command now supports limiting the action to a given period.
 
 since v0.28.0 | September 10, 2025
 =================================

--- a/flexmeasures/cli/data_delete.py
+++ b/flexmeasures/cli/data_delete.py
@@ -307,6 +307,9 @@ def delete_beliefs(  # noqa: C901
     # Prompt based on count of query
     num_beliefs_up_for_deletion = db.session.scalar(select(func.count()).select_from(q))
     # repr(entity) includes the IDs, which matters for the confirmation prompt
+    if num_beliefs_up_for_deletion == 0:
+        done("0 unchanged beliefs found.")
+        return
     if sensors:
         prompt = f"Delete all {num_beliefs_up_for_deletion} beliefs on {join_words_into_a_list([repr(sensor) for sensor in sensors])}?"
     elif generic_assets:

--- a/flexmeasures/cli/data_delete.py
+++ b/flexmeasures/cli/data_delete.py
@@ -388,7 +388,7 @@ def delete_unchanged_beliefs(
         q = q.filter(TimedBelief.event_start >= start)
     if end:
         q = q.join(Sensor, TimedBelief.sensor_id == Sensor.id)
-        q = q.filter(TimedBelief.event_start + Sensor.event_resolution <= end)
+        q = q.filter(TimedBelief.event_start <= end - Sensor.event_resolution)
     num_beliefs_before = db.session.scalar(select(func.count()).select_from(q))
     unchanged_queries = []
     num_forecasts_up_for_deletion = 0

--- a/flexmeasures/cli/data_delete.py
+++ b/flexmeasures/cli/data_delete.py
@@ -308,7 +308,7 @@ def delete_beliefs(  # noqa: C901
     num_beliefs_up_for_deletion = db.session.scalar(select(func.count()).select_from(q))
     # repr(entity) includes the IDs, which matters for the confirmation prompt
     if num_beliefs_up_for_deletion == 0:
-        done("0 unchanged beliefs found.")
+        done("0 beliefs found.")
         return
     if sensors:
         prompt = f"Delete all {num_beliefs_up_for_deletion} beliefs on {join_words_into_a_list([repr(sensor) for sensor in sensors])}?"
@@ -426,6 +426,9 @@ def delete_unchanged_beliefs(
     num_beliefs_up_for_deletion = (
         num_forecasts_up_for_deletion + num_measurements_up_for_deletion
     )
+    if num_beliefs_up_for_deletion == 0:
+        done("0 unchanged beliefs found.")
+        return
     prompt = f"Delete {num_beliefs_up_for_deletion} unchanged beliefs ({num_measurements_up_for_deletion} measurements and {num_forecasts_up_for_deletion} forecasts) out of {num_beliefs_before} beliefs?"
     click.confirm(prompt, abort=True)
 

--- a/flexmeasures/cli/data_delete.py
+++ b/flexmeasures/cli/data_delete.py
@@ -385,9 +385,10 @@ def delete_unchanged_beliefs(
             abort(f"Failed to delete any beliefs: no sensor found with id {sensor_id}.")
         q = q.filter_by(sensor_id=sensor.id)
     if start:
-        q = q.filter(TimedBelief.event_start >= start.isoformat())
+        q = q.filter(TimedBelief.event_start >= start)
     if end:
-        q = q.filter(TimedBelief.event_start < end.isoformat())
+        q = q.join(Sensor, TimedBelief.sensor_id == Sensor.id)
+        q = q.filter(TimedBelief.event_start + Sensor.event_resolution <= end)
     num_beliefs_before = db.session.scalar(select(func.count()).select_from(q))
     unchanged_queries = []
     num_forecasts_up_for_deletion = 0


### PR DESCRIPTION
## Description

- [x] `flexmeasures delete unchanged-beliefs` sports setting a period
- [x] Added changelog item in `documentation/changelog.rst`
- [x] Added CLI changelog item in `documentation/cli/changelog.rst`

## Look & Feel

- `--start` and `--end` parameters, similar to those used in `flexmeasures delete beliefs`

## How to test

For instance, using:

```
flexmeasures delete unchanged-beliefs --start 2025-08-01T00:00+02 --end 2025-08-02T00:00+02
flexmeasures delete unchanged-beliefs --sensor <id> --start 2025-08-01T00:00+02 --end 2025-08-02T00:00+02
```

## Related Items

- Found this useful when cleaning up reporter-generated data (retail prices)
