### PR TITLE
fix: some audit logs about sensor events were not committed to db correctly

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -19,6 +19,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
+* Fix two audit logs in the sensor API, which were not committed to db [see `PR #1721 <https://github.com/FlexMeasures/flexmeasures/pull/1721>`_]
 
 
 v0.28.1 | September 18, 2025

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -883,11 +883,11 @@ class SensorAPI(FlaskView):
         """
         sensor = Sensor(**sensor_data)
         db.session.add(sensor)
-        db.session.commit()
 
         AssetAuditLog.add_record(
             sensor.generic_asset, f"Created sensor '{sensor.name}': {sensor.id}"
         )
+        db.session.commit()
 
         return sensor_schema.dump(sensor), 201
 
@@ -1015,12 +1015,11 @@ class SensorAPI(FlaskView):
         :status 422: UNPROCESSABLE_ENTITY
         """
         db.session.execute(delete(TimedBelief).filter_by(sensor_id=sensor.id))
-        db.session.commit()
-
         AssetAuditLog.add_record(
             sensor.generic_asset,
             f"Deleted data for sensor '{sensor.name}': {sensor.id}",
         )
+        db.session.commit()
 
         return {}, 204
 

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -883,7 +883,7 @@ class SensorAPI(FlaskView):
         """
         sensor = Sensor(**sensor_data)
         db.session.add(sensor)
-
+        db.session.flush()
         AssetAuditLog.add_record(
             sensor.generic_asset, f"Created sensor '{sensor.name}': {sensor.id}"
         )


### PR DESCRIPTION
## Description

Two audit logs were created but not committed. This PR fixes that.

- [x] fix order
- [x] Added changelog item in `documentation/changelog.rst`

