### PR TITLE
Chore/update Ubuntu and Python in Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,9 @@ WORKDIR /app
 COPY requirements /app/requirements
 
 # py dev tooling
-RUN python3 -m pip install --no-cache-dir --upgrade pip && python3 --version && \
-    pip3 install --no-cache-dir --upgrade setuptools && pip3 install highspy && \
+RUN python3 -m pip install --break-system-packages highspy && \
     PYV=$(python3 -c "import sys;t='{v[0]}.{v[1]}'.format(v=list(sys.version_info[:2]));sys.stdout.write(t)") && \
-    pip3 install --no-cache-dir -r requirements/$PYV/app.txt -r requirements/$PYV/dev.txt -r requirements/$PYV/test.txt
+    pip install --no-cache-dir --break-system-packages -r requirements/$PYV/app.txt -r requirements/$PYV/dev.txt -r requirements/$PYV/test.txt
 
 # Copy code and meta/config data
 COPY setup.* pyproject.toml .flaskenv wsgi.py /app/
@@ -23,7 +22,7 @@ COPY flexmeasures/ /app/flexmeasures
 RUN find . | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf
 COPY .git/ /app/.git
 
-RUN pip3 install --no-cache-dir .
+RUN pip3 install --no-cache-dir --break-system-packages .
 
 EXPOSE 5000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/ubuntu:22.04
+FROM amd64/ubuntu:24.04
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV LC_ALL C.UTF-8

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -15,6 +15,7 @@ New features
 Infrastructure / Support
 ----------------------
 * Updated dependencies [see `PR #1707 <https://www.github.com/FlexMeasures/flexmeasures/pull/1707>`_]
+* Upgraded Docker Image to Python 3.12 and Ubuntu 24 [see `PR #1723 <https://www.github.com/FlexMeasures/flexmeasures/pull/1723>`_]
 * Include finished and canceled jobs in the overview printed by the CLI command ``flexmeasures jobs show-queues`` [see `PR #1712 <https://github.com/FlexMeasures/flexmeasures/pull/1712>`_]
 
 Bugfixes


### PR DESCRIPTION
## Description

- [x] Move to Python 3.12 (from Python 3.10)
- [x] Added changelog item in `documentation/changelog.rst`

## How to test

```
docker compose build
docker run --rm -it flexmeasures-server bash
```
Inside the container:
```
python3 --version
```

## Further Improvements

- [ ] Move Dockerfile to installing a venv, to get rid of using the `--break-system-packages` option.
