### PR TITLE
Style/asset context

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,6 +13,7 @@ New features
 * New CLI command for scheduling, with full flex-context and flex-model support as well as the option to set your scheduler class [see `PR #1713 <https://github.com/FlexMeasures/flexmeasures/pull/1713>`_]
 * Added a UI editor (form modal) to edit an asset's flex-model [see `PR #1429 <https://github.com/FlexMeasures/flexmeasures/pull/1429>`_ and `PR #1565 <https://github.com/FlexMeasures/flexmeasures/pull/1565>`_]
 * Full coverage of flex-context fields in the UI editor [see `PR #1689 <https://www.github.com/FlexMeasures/flexmeasures/pull/1689>`_]
+* Touch up asset context page [see `PR #1732 <https://www.github.com/FlexMeasures/flexmeasures/pull/1732>`_]
 * Allow ``PandasReporter`` configurations to skip a transformation in case any of the transformation ``args`` or ``kwargs`` is missing all data [see `PR #1717 <https://www.github.com/FlexMeasures/flexmeasures/pull/1717>`_]
 * The ``flexmeasures delete unchanged-beliefs`` CLI command now supports limiting the action to a given period [see `PR #1720 <https://www.github.com/FlexMeasures/flexmeasures/pull/1720>`_]
 

--- a/flexmeasures/ui/templates/_macros.html
+++ b/flexmeasures/ui/templates/_macros.html
@@ -154,7 +154,7 @@ treeSpecs = {
               "fill": {
                 "signal": "parent.name === currentAssetName ? 'black' : parent.name === 'Add asset' ? 'white' : 'darkblue'"
               },
-              "limit": {"signal": "scaledNodeWidth-scaledLimit"},
+              "limit": {"signal": "scaledNodeWidth-scaledLimit - (scaledNodeWidth * 0.15)"},
               "font": {"value": "Calibri"},
               "href": {"signal": "datum.link"},
               "tooltip": {"signal": "parent.tooltip"}

--- a/flexmeasures/ui/templates/_macros.html
+++ b/flexmeasures/ui/templates/_macros.html
@@ -123,7 +123,7 @@ treeSpecs = {
             "signal": "datum.name === currentAssetName ? scaledNodeHeight * 1.1 : scaledNodeHeight"
           },
           "fill": {
-            "signal": "datum.name === currentAssetName ? 'gold' : datum.name === 'Add Child Asset' ? 'green' : 'lightblue'"
+            "signal": "datum.name === currentAssetName ? 'gold' : datum.name === 'Add asset' ? 'green' : 'lightblue'"
           },
           "stroke": {
             "signal": "datum.name === currentAssetName ? 'darkorange' : 'black'"
@@ -152,7 +152,7 @@ treeSpecs = {
                 "signal": "datum.name === currentAssetName ? scaledFont13 * 1.5 : scaledFont13"
               },
               "fill": {
-                "signal": "parent.name === currentAssetName ? 'black' : parent.name === 'Add Child Asset' ? 'white' : 'darkblue'"
+                "signal": "parent.name === currentAssetName ? 'black' : parent.name === 'Add asset' ? 'white' : 'darkblue'"
               },
               "limit": {"signal": "scaledNodeWidth-scaledLimit"},
               "font": {"value": "Calibri"},

--- a/flexmeasures/ui/templates/_macros.html
+++ b/flexmeasures/ui/templates/_macros.html
@@ -162,17 +162,17 @@ treeSpecs = {
           }
         },
         {
-    "type": "image",
-    "encode": {
-      "update": {
-        "x": {"signal": "-(scaledNodeWidth * 0.001)"},
-        "y": {"signal": "-(scaledNodeHeight * 0.001)"},
-        "width": {"signal": "scaledNodeWidth * 0.002"},
-        "height": {"signal": "scaledNodeHeight * 0.002"},
-        "url": {"signal": "parent.icon"}
-      }
-    }
-  },
+          "type": "image",
+          "encode": {
+            "update": {
+              "x": {"signal": "-(scaledNodeWidth * 0.001)"},
+              "y": {"signal": "-(scaledNodeHeight * 0.001)"},
+              "width": {"signal": "scaledNodeWidth * 0.002"},
+              "height": {"signal": "scaledNodeHeight * 0.002"},
+              "url": {"signal": "parent.icon"}
+            }
+          }
+        },
       ]
     }
   ]

--- a/flexmeasures/ui/templates/_macros.html
+++ b/flexmeasures/ui/templates/_macros.html
@@ -20,7 +20,7 @@ treeSpecs = {
   "padding": 0,
   "autosize": {"type": "fit", "resize": false},
   "signals": [
-    {"name": "nodeWidth", "value": 190},
+    {"name": "nodeWidth", "value": 240},
     {"name": "nodeHeight", "value": 40},
     {"name": "verticalNodeGap", "value": 10},
     {"name": "horizontalNodeGap", "value": 60},
@@ -29,7 +29,7 @@ treeSpecs = {
       "name": "scaledNodeHeight",
       "update": "abs(nodeHeight/ max(span(ydom),height))*height"
     },
-    {"name": "scaledNodeWidth", "update": "(nodeWidth/ span(xdom))*width"},
+    {"name": "scaledNodeWidth", "update": "(nodeWidth / span(xdom)) * width"},
     {"name": "xrange", "update": "[0, width]"},
     {"name": "yrange", "update": "[0, height]"},
     {"name": "scaledFont13", "update": "(30/ span(xdom))*width"},
@@ -52,7 +52,7 @@ treeSpecs = {
         {
           "type": "tree",
           "method": "tidy",
-          "size": [{"signal": "nodeHeight *0.1"},
+          "size": [{"signal": "nodeHeight * 0.1"},
                    {"signal": "width"}
           ],
           "separation": {"signal": "true"},
@@ -143,18 +143,18 @@ treeSpecs = {
           "name": "name",
           "encode": {
             "update": {
-              "x": {"signal": "(5/ span(xdom))*width + (scaledNodeWidth * 0.15)"}, 
+              "x": {"signal": "(5/ span(xdom))*width + (scaledNodeWidth * 0.2)"},
               "y": {"signal": "(5/ span(xdom))*width + (scaledNodeHeight * 0.15)"},
               "fontWeight": {"value": "bold"},
-              "baseline": {"value": "top"},
+              "baseline": {"value": "line-top"},
               "text": {"signal": "parent.name"},
               "fontSize": {
-                "signal": "datum.name === currentAssetName ? scaledFont13 * 1.5 : scaledFont13"
+                "signal": "datum.name === currentAssetName ? scaledFont13 * 1.4 : scaledFont13"
               },
               "fill": {
                 "signal": "parent.name === currentAssetName ? 'black' : parent.name === 'Add asset' ? 'white' : 'darkblue'"
               },
-              "limit": {"signal": "scaledNodeWidth-scaledLimit - (scaledNodeWidth * 0.15)"},
+              "limit": {"signal": "scaledNodeWidth-scaledLimit * 0.9 - (scaledNodeWidth * 0.2)"},
               "font": {"value": "Calibri"},
               "href": {"signal": "datum.link"},
               "tooltip": {"signal": "parent.tooltip"}
@@ -169,6 +169,7 @@ treeSpecs = {
               "y": {"signal": "-(scaledNodeHeight * 0.001)"},
               "width": {"signal": "scaledNodeWidth * 0.002"},
               "height": {"signal": "scaledNodeHeight * 0.002"},
+              "baseline": {"value": "line-top"},
               "url": {"signal": "parent.icon"}
             }
           }

--- a/flexmeasures/ui/views/assets/utils.py
+++ b/flexmeasures/ui/views/assets/utils.py
@@ -149,7 +149,7 @@ def add_child_asset(asset: Asset, assets: list) -> list:
     """
     # Add Extra node to the current asset
     new_child_asset = {
-        "name": "Add Child Asset",
+        "name": "Add asset",
         "id": "new",
         "asset_type": asset.generic_asset_type.name,
         "link": url_for("AssetCrudUI:post", id="new", parent_asset_id=asset.id),


### PR DESCRIPTION
## Description

- [x] No more overflowing texts in nodes
- [x] **Add asset** node fully legible
- [x] More of each asset name visible
- [x] Added changelog item in `documentation/changelog.rst`

## Look & Feel

Before:

<img width="440" height="672" alt="image" src="https://github.com/user-attachments/assets/43c1ac72-60ae-4f81-847e-3b4e9e8f5e76" />

After:

<img width="389" height="684" alt="image" src="https://github.com/user-attachments/assets/600739f7-30ae-4711-af29-28ef3d46da53" />

## How to test

Please test on various asset trees!

## Further Improvements

Discussion out of scope. Just scratching an itch here.