### PR TITLE
Fix/UI flex context editor with boolean fields

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -27,6 +27,7 @@ Infrastructure / Support
 Bugfixes
 -----------
 * Changed 422 response for asset PATCH endpoint to the format also used elsewhere [see `PR #1722 <https://github.com/FlexMeasures/flexmeasures/pull/1722>`_]
+* Fix UI flex-context editor for flex-contexts with boolean fields (that were set through the API) [see `PR #1733 <https://www.github.com/FlexMeasures/flexmeasures/pull/1733>`_]
 * Make monitoring tasks & users robust against db issues [see `PR #1715 <https://www.github.com/FlexMeasures/flexmeasures/pull/1715>`_]
 
 

--- a/flexmeasures/ui/static/js/ui-utils.js
+++ b/flexmeasures/ui/static/js/ui-utils.js
@@ -59,6 +59,9 @@ export function processResourceRawJSON(schema, rawJSON) {
     let processedJSON = rawJSON.replace(/'/g, '"');
     // change None to null
     processedJSON = processedJSON.replace(/None/g, 'null');
+    // change True to true and False to false
+    processedJSON = processedJSON.replace('True', 'true');
+    processedJSON = processedJSON.replace('False', 'false');
     // update the assetFlexModel fields
     processedJSON = JSON.parse(processedJSON);
 


### PR DESCRIPTION
## Description

- [x] Boolean flex-context fields (those dealing with constraint relaxations) no longer prevent the flex-context UI editor from loading
- [x] Added changelog item in `documentation/changelog.rst`
