### PR TITLE
Feat/`belief_horizon` in `AggregatorReporter`

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -21,6 +21,7 @@ Infrastructure / Support
 * Migrate data for the ``flex-model`` of an asset to a dedicated column in the database table for assets [see `PR #1429 <https://github.com/FlexMeasures/flexmeasures/pull/1429>`_]
 * Updated dependencies [see `PR #1707 <https://www.github.com/FlexMeasures/flexmeasures/pull/1707>`_]
 * Upgraded Docker Image Ubuntu 24, which uses Python 3.12 [see `PR #1723 <https://www.github.com/FlexMeasures/flexmeasures/pull/1723>`_]
+* Support saving beliefs with a ``belief_horizon`` in the ``AggregatorReporter`` [see `PR #1735 <https://www.github.com/FlexMeasures/flexmeasures/pull/1735>`_]
 * Include finished and canceled jobs in the overview printed by the CLI command ``flexmeasures jobs show-queues`` [see `PR #1712 <https://github.com/FlexMeasures/flexmeasures/pull/1712>`_]
 * Improved flex-context modal UI and UI-backend functionalities&structure [see `PR #1704 <https://github.com/FlexMeasures/flexmeasures/pull/1704>`_]
 

--- a/flexmeasures/data/models/reporting/aggregator.py
+++ b/flexmeasures/data/models/reporting/aggregator.py
@@ -35,6 +35,7 @@ class AggregatorReporter(Reporter):
         output: list[dict[str, Any]],
         resolution: timedelta | None = None,
         belief_time: datetime | None = None,
+        belief_horizon: timedelta | None = None,
     ) -> list[dict[str, Any]]:
         """
         This method merges all the BeliefDataFrames into a single one, dropping
@@ -47,7 +48,7 @@ class AggregatorReporter(Reporter):
 
         dataframes = []
 
-        if belief_time is None:
+        if belief_time is None and belief_horizon is None:
             belief_time = server_now()
 
         for input_description in input:
@@ -66,6 +67,7 @@ class AggregatorReporter(Reporter):
                 event_ends_before=end,
                 resolution=resolution,
                 beliefs_before=belief_time,
+                horizons_at_most=belief_horizon,
                 source=source,
                 one_deterministic_belief_per_event=True,
                 **input_description,
@@ -115,14 +117,19 @@ class AggregatorReporter(Reporter):
 
         # convert BeliefsSeries into a BeliefsDataFrame
         output_df = output_df.to_frame("event_value")
-        output_df["belief_time"] = belief_time
+        if belief_time is not None:
+            belief_col = "belief_time"
+            output_df[belief_col] = belief_time
+        elif belief_horizon is not None:
+            belief_col = "belief_horizon"
+            output_df[belief_col] = belief_horizon
         output_df["cumulative_probability"] = 0.5
         output_df["source"] = self.data_source
         output_df.sensor = output[0]["sensor"]
         output_df.event_resolution = output[0]["sensor"].event_resolution
 
         output_df = output_df.set_index(
-            ["belief_time", "source", "cumulative_probability"], append=True
+            [belief_col, "source", "cumulative_probability"], append=True
         )
 
         return [


### PR DESCRIPTION
## Description

- [x] Just like the `PandasReporter` already did, the `AggregatorReporter` now supports setting a `belief_horizon`. You can use this to do "live reporting", where each aggregate value is recorded as if it was measured straight after each event.
- [x] Added changelog item in `documentation/changelog.rst`

## Look & Feel

Used in the HEMS tutorial (https://github.com/FlexMeasures/flexmeasures-client/pull/134) to see live aggregate power values in the replay.
