### PR TITLE
feat: support storing the aggregate power schedule

### DIFF
--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -1257,11 +1257,17 @@ class StorageScheduler(MetaStorageScheduler):
             for d, sensor in enumerate(sensors)
             if sensor is not None
         }
+        # Obtain the aggregate power schedule, too, if the flex-context states the associated sensor
+        aggregate_power_sensor = self.flex_context.get("aggregate_power", None)
+        if isinstance(aggregate_power_sensor, Sensor):
+            storage_schedule[aggregate_power_sensor] = pd.concat(
+                ems_schedule, axis=1
+            ).sum(axis=1)
 
         # Convert each device schedule to the unit of the device's power sensor
         storage_schedule = {
             sensor: convert_units(storage_schedule[sensor], "MW", sensor.unit)
-            for sensor in sensors
+            for sensor in storage_schedule.keys()
             if sensor is not None
         }
 
@@ -1298,7 +1304,7 @@ class StorageScheduler(MetaStorageScheduler):
                 sensor: storage_schedule[sensor]
                 .resample(sensor.event_resolution)
                 .mean()
-                for sensor in sensors
+                for sensor in storage_schedule.keys()
                 if sensor is not None
             }
 
@@ -1306,7 +1312,7 @@ class StorageScheduler(MetaStorageScheduler):
         if self.round_to_decimals:
             storage_schedule = {
                 sensor: storage_schedule[sensor].round(self.round_to_decimals)
-                for sensor in sensors
+                for sensor in storage_schedule.keys()
                 if sensor is not None
             }
             soc_schedule = {
@@ -1322,7 +1328,7 @@ class StorageScheduler(MetaStorageScheduler):
                     "data": storage_schedule[sensor],
                     "unit": sensor.unit,
                 }
-                for sensor in sensors
+                for sensor in storage_schedule.keys()
                 if sensor is not None
             ]
             commitment_costs = [

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -153,6 +153,11 @@ class FlexContextSchema(Schema):
     inflexible_device_sensors = fields.List(
         SensorIdField(), data_key="inflexible-device-sensors"
     )
+    aggregate_power = VariableQuantityField(
+        to_unit="MW",
+        data_key="aggregate-power",
+        required=False,
+    )
 
     def set_default_breach_prices(
         self, data: dict, fields: list[str], price: ur.Quantity


### PR DESCRIPTION
Work in progress.

## Description

This PR adds a new flex-context field that allows users to record the aggregate power schedule on a sensor, but it needs a bit more thinking how this would play in a user-friendly way with user-defined asset trees. In particular, I envision that the field might end up moving to the flex-model instead.

- [ ] ...
- [ ] Added changelog item in `documentation/changelog.rst`


## Look & Feel

<!--
This section can contain example pictures for the UI, Input/Output for the CLI, Request / Response for an API endpoint, etc.
-->

...

## How to test

<!--
Steps to test it or name of the tests functions.

The library [flexmeasures-client](https://github.com/FlexMeasures/flexmeasures-client/) can be useful to showcase new features.
For example, it can be used to set some example data to be used in a new UI feature.
-->

...

## Further Improvements

<!--
Potential improvements to be done in the same PR or follow-up Issues/Discussions/PRs.
-->

...

## Related Items

<!--
Mention if this PR closes an Issue or Project.
-->

...
