### PR TITLE
Feat/improve error messages for bad `PandasReporter` configurations

### DIFF
--- a/flexmeasures/data/models/reporting/pandas_reporter.py
+++ b/flexmeasures/data/models/reporting/pandas_reporter.py
@@ -349,8 +349,12 @@ class PandasReporter(Reporter):
             if (_any_empty(args) or _any_empty(kwargs.values())) and skip_if_empty:
                 self.data[df_output] = self.data[df_input]
             else:
-                self.data[df_output] = getattr(self.data[df_input], method)(
-                    *args, **kwargs
-                )
+                try:
+                    self.data[df_output] = getattr(self.data[df_input], method)(
+                        *args, **kwargs
+                    )
+                except TypeError as exc:
+                    if "unhashable type" in str(exc) and method == "sum":
+                        raise TypeError("Maybe use 'add' instead of 'sum'") from exc
 
             previous_df = df_output

--- a/flexmeasures/data/models/reporting/pandas_reporter.py
+++ b/flexmeasures/data/models/reporting/pandas_reporter.py
@@ -355,6 +355,8 @@ class PandasReporter(Reporter):
                     )
                 except TypeError as exc:
                     if "unhashable type" in str(exc) and method == "sum":
-                        raise TypeError("Maybe use 'add' instead of 'sum'") from exc
+                        raise TypeError(
+                            "Consider using 'add' instead of 'sum' as the transformation method."
+                        ) from exc
 
             previous_df = df_output


### PR DESCRIPTION
Work in progress.

## Description

- [x] Catch `PandasReporter` configurations failing on using the `sum` method instead of the `add` method.
- [ ] Catch `PandasReporter` configurations failing on using the `product` method instead of the `multiply` method.
- [ ] Added changelog item in `documentation/changelog.rst`

## Look & Feel

<!--
This section can contain example pictures for the UI, Input/Output for the CLI, Request / Response for an API endpoint, etc.
-->

...

## How to test

<!--
Steps to test it or name of the tests functions.

The library [flexmeasures-client](https://github.com/FlexMeasures/flexmeasures-client/) can be useful to showcase new features.
For example, it can be used to set some example data to be used in a new UI feature.
-->

...

## Further Improvements

<!--
Potential improvements to be done in the same PR or follow-up Issues/Discussions/PRs.
-->

...

## Related Items

<!--
Mention if this PR closes an Issue or Project.
-->

...
