### PR TITLE
Fix/UI/floating spinner

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -28,6 +28,7 @@ Bugfixes
 -----------
 * Changed 422 response for asset PATCH endpoint to the format also used elsewhere [see `PR #1722 <https://github.com/FlexMeasures/flexmeasures/pull/1722>`_]
 * Fix UI flex-context editor for flex-contexts with boolean fields (that were set through the API) [see `PR #1733 <https://www.github.com/FlexMeasures/flexmeasures/pull/1733>`_]
+* Fix floating spinner on asset graphs page [see `PR #1738 <https://www.github.com/FlexMeasures/flexmeasures/pull/1738>`_]
 * Make monitoring tasks & users robust against db issues [see `PR #1715 <https://www.github.com/FlexMeasures/flexmeasures/pull/1715>`_]
 
 

--- a/flexmeasures/ui/templates/assets/asset_graph.html
+++ b/flexmeasures/ui/templates/assets/asset_graph.html
@@ -66,7 +66,7 @@
    
         </div>
         <div class="col-md-8">
-            <div id="spinner">
+            <div id="spinner" class="spinner">
                 <i class="fa fa-spinner fa-pulse fa-3x fa-fw"></i>
                 <span class="sr-only">Loading...</span>
             </div>


### PR DESCRIPTION
## Description

- [x] Fix floating property of spinner on asset graphs page
- [x] Added changelog item in `documentation/changelog.rst`

## Look & Feel

Before this, we had a regression where the charts would jump slightly down while the spinner was visible.

