### PR TITLE
Suppress Darts "Support for Torch based models not available" warning

### DIFF
--- a/flexmeasures/data/models/forecasting/__init__.py
+++ b/flexmeasures/data/models/forecasting/__init__.py
@@ -21,7 +21,7 @@ from flexmeasures.data.schemas.forecasting import ForecasterConfigSchema
 
 
 class SuppressTorchWarning(logging.Filter):
-    "Suppress specific Torch warnings from Darts library about model availability."
+    """Suppress specific Torch warnings from Darts library about model availability."""
 
     def filter(self, record):
         return "Support for Torch based models not available" not in record.getMessage()


### PR DESCRIPTION
## Description

- Added a logging filter to suppress the **"Support for Torch based models not available"** warning emitted by the Darts library.  
- This warning is unrelated to our current setup since our forecasting models use **LightGBM**, not Torch-based models.  
- The filter ensures only this specific message is hidden while keeping other Darts warnings visible.  

## How to test

1. Start FlexMeasures normally (`flexmeasures run` or any forecast workflow).  
2. Verify that the **Torch warning no longer appears** in logs.  
3. Confirm that other Darts logs and warnings still appear as expected.

---

#### Sign-off

- [x] I agree to contribute to the project under Apache 2 License.  
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures.
