### PR TITLE
chore: multiple flex assets

### DIFF
--- a/documentation/features/scheduling.rst
+++ b/documentation/features/scheduling.rst
@@ -347,7 +347,4 @@ Here are some thoughts on further innovation:
   You can always write your own scheduler (see :ref:`plugin_customization`).
   You then might want to add your own flex model, as well.
   FlexMeasures will let the scheduler decide which flexibility model is relevant and how it should be validated.
-- We also aim to model situations with more than one flexible asset, and that have different types of flexibility (e.g. EV charging and smart heating in the same site).
-  This is ongoing architecture design work, and therefore happens in development settings, until we are happy with the outcomes.
-  Thoughts welcome :)
 - Aggregating flexibility of a group of assets (e.g. a neighborhood) and optimizing its aggregated usage (e.g. for grid congestion support) is also an exciting direction for expansion.


### PR DESCRIPTION
You can trigger a schedule for an asset that controls multiple flexible devices by using the --flex-model option. The flex-model can be a list of dictionaries, where each dictionary specifies a sensor and its flexibility parameters.  This is how you can schedule multiple assets (represented as sensors) at once.

## Description

<!--
Summary of the changes introduced in this PR. Try to use bullet points as much as possible.
-->

- [ ] ...
- [ ] Added changelog item in `documentation/changelog.rst`

<!--
For changelog entries, please take into account the intended audience.

In our main changelog:
- The 'New features' section targets API / CLI / UI users.
- The 'Infrastructure / Support' section targets plugin developers and hosts.

Finally, please note that the API and CLI keep additional changelogs:
- `documentation/api/changelog.rst`
- `documentation/cli/changelog.rst`
-->

## Look & Feel

<!--
This section can contain example pictures for the UI, Input/Output for the CLI, Request / Response for an API endpoint, etc.
-->

...

## How to test

<!--
Steps to test it or name of the tests functions.

The library [flexmeasures-client](https://github.com/FlexMeasures/flexmeasures-client/) can be useful to showcase new features.
For example, it can be used to set some example data to be used in a new UI feature.
-->

...

## Further Improvements

<!--
Potential improvements to be done in the same PR or follow-up Issues/Discussions/PRs.
-->

...

## Related Items

<!--
Mention if this PR closes an Issue or Project.
-->

...

---

#### Sign-off

<!--
We ask contributors outside the FlexMeasures organisation to sign off on their contribution.
Please mark the below fields with an [x].
-->

- [ ] I agree to contribute to the project under Apache 2 License. 
- [ ] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
