### PR TITLE
fix: correctly pass as_job param in forecasting parameters

### DIFF
--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -1170,7 +1170,6 @@ def add_holidays(
 )
 @with_appcontext
 def train_predict_pipeline(
-    as_job,
     forecaster_class: str,
     source: DataSource | None = None,
     config_file: TextIOBase | None = None,
@@ -1249,7 +1248,7 @@ def train_predict_pipeline(
     )
 
     try:
-        forecaster.compute(as_job=as_job, parameters=parameters)
+        forecaster.compute(parameters=parameters)
 
     except Exception as e:
         click.echo(f"Error running Train-Predict Pipeline: {str(e)}")


### PR DESCRIPTION
## Description:

This PR removes the explicit `as_job` argument from the `train_predict_pipeline` CLI command and stops passing it directly to `forecaster.compute()`.
Instead, `as_job` is now forwarded through `**kwargs` into the `parameters` dictionary, where it is validated and handled by ` ForecasterParametersSchema`.

This ensures consistent job-triggering.


## How to test

Running the forecasting CLI command with `--as-job` should enqueue the forecasting task onto the forecasting queue:

```bash
flexmeasures add forecasts \
  --sensor 276992 \
  --train-start 2026-01-01T00:00:00+01:00 \
  --from-date 2026-01-15T00:00:00+01:00 \
  --to-date 2026-01-16T00:00:00+01:00 \
  --max-forecast-horizon PT24H \
  --forecast-frequency PT4H \
  --ensure-positive \
  --model-save-dir forecaster_models \
  --as-job
```

#### Sign-off

<!--
We ask contributors outside the FlexMeasures organisation to sign off on their contribution.
Please mark the below fields with an [x].
-->

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures