### PR TITLE
Floor event start

### DIFF
--- a/flexmeasures/api/common/schemas/sensor_data.py
+++ b/flexmeasures/api/common/schemas/sensor_data.py
@@ -303,7 +303,7 @@ class PostSensorDataSchema(SensorDataDescriptionSchema):
             )
 
     @post_load()
-    def post_load_sequence(self, data: dict, **kwargs) -> BeliefsDataFrame:
+    def post_load_sequence(self, data: dict, **kwargs) -> dict[str, BeliefsDataFrame]:
         """
         If needed, upsample and convert units, then deserialize to a BeliefsDataFrame.
         Returns a dict with the BDF in it, as that is expected by webargs when used with as_kwargs=True.

--- a/flexmeasures/api/common/schemas/sensor_data.py
+++ b/flexmeasures/api/common/schemas/sensor_data.py
@@ -381,7 +381,12 @@ class PostSensorDataSchema(SensorDataDescriptionSchema):
             event_resolution=inferred_resolution,
             **belief_timing,
         )
-        resampled_bdf = bdf.resample_events(sensor.event_resolution)
+        try:
+            resampled_bdf = bdf.resample_events(sensor.event_resolution)
+        except NotImplementedError:
+            raise ValidationError(
+                f"Resolution of {inferred_resolution} is incompatible with the sensor's required resolution of {sensor.event_resolution}."
+            )
         return resampled_bdf
 
 

--- a/flexmeasures/api/common/schemas/sensor_data.py
+++ b/flexmeasures/api/common/schemas/sensor_data.py
@@ -268,28 +268,6 @@ class PostSensorDataSchema(SensorDataDescriptionSchema):
             )
 
     @validates_schema
-    def check_resolution_compatibility_of_sensor_data(self, data, **kwargs):
-        """Ensure event frequency is compatible with the sensor's event resolution.
-
-        For a sensor recording instantaneous values, any event frequency is compatible.
-        For a sensor recording non-instantaneous values, the event frequency must fit the sensor's event resolution.
-        Currently, only upsampling is supported (e.g. converting hourly events to 15-minute events).
-        """
-        required_resolution = data["sensor"].event_resolution
-
-        if required_resolution == timedelta(hours=0):
-            # For instantaneous sensors, any event frequency is compatible
-            return
-
-        # The event frequency is inferred by assuming sequential, equidistant values within a time interval.
-        # The event resolution is assumed to be equal to the event frequency.
-        inferred_resolution = data["duration"] / len(data["values"])
-        if inferred_resolution % required_resolution != timedelta(hours=0):
-            raise ValidationError(
-                f"Resolution of {inferred_resolution} is incompatible with the sensor's required resolution of {required_resolution}."
-            )
-
-    @validates_schema
     def check_multiple_instantenous_values(self, data, **kwargs):
         """Ensure that we are not getting multiple instantaneous values that overlap.
         That is, two values spanning the same moment (a zero duration).
@@ -308,7 +286,6 @@ class PostSensorDataSchema(SensorDataDescriptionSchema):
         If needed, upsample and convert units, then deserialize to a BeliefsDataFrame.
         Returns a dict with the BDF in it, as that is expected by webargs when used with as_kwargs=True.
         """
-        data = self.possibly_upsample_values(data)
         data = self.possibly_convert_units(data)
         bdf = self.load_bdf(data)
 
@@ -371,6 +348,7 @@ class PostSensorDataSchema(SensorDataDescriptionSchema):
         event_resolution = sensor_data["duration"] / num_values
         start = sensor_data["start"]
         sensor = sensor_data["sensor"]
+        inferred_resolution = sensor_data["duration"] / len(sensor_data["values"])
 
         if frequency := sensor.get_attribute("frequency"):
             start = pd.Timestamp(start).round(frequency)
@@ -396,12 +374,15 @@ class PostSensorDataSchema(SensorDataDescriptionSchema):
             belief_timing["belief_horizon"] = sensor_data["horizon"]
         else:
             belief_timing["belief_time"] = server_now()
-        return BeliefsDataFrame(
+        bdf = BeliefsDataFrame(
             s,
             source=source,
             sensor=sensor_data["sensor"],
+            event_resolution=inferred_resolution,
             **belief_timing,
         )
+        resampled_bdf = bdf.resample_events(sensor.event_resolution)
+        return resampled_bdf
 
 
 class GetSensorDataSchemaEntityAddress(GetSensorDataSchema):

--- a/flexmeasures/api/common/schemas/tests/test_sensor_data_schema.py
+++ b/flexmeasures/api/common/schemas/tests/test_sensor_data_schema.py
@@ -487,7 +487,7 @@ def test_build_asset_jobs_data(db, app, add_battery_assets):
 @pytest.mark.parametrize(
     "deserialization_input, exp_length, exp_deserialization_output",
     [
-        # A single 2-hour event (spanning 3 wall-clock hours) is deserialized to a BeliefsDataFrame, to be recorded on a 1-hour sensor
+        # # A single 2-hour event (spanning 3 wall-clock hours) is deserialized to a BeliefsDataFrame, to be recorded on a 1-hour sensor
         (
             {
                 "sensor": "epex_da",  # name is used to look up the corresponding sensor ID
@@ -497,6 +497,30 @@ def test_build_asset_jobs_data(db, app, add_battery_assets):
                 "unit": "EUR/kWh",
             },
             2,
+            {},
+        ),
+        # One 5-minute event (spanning 2 wall-clock hours) is deserialized to a BeliefsDataFrame, to be recorded on a 1-hour sensor
+        (
+            {
+                "sensor": "epex_da",  # name is used to look up the corresponding sensor ID
+                "start": "2025-11-21T10:58:40+01",
+                "duration": "PT5M",
+                "values": [1],
+                "unit": "EUR/kWh",
+            },
+            2,
+            {},
+        ),
+        # One 2-minute event (spanning 1 wall-clock hour) is deserialized to a BeliefsDataFrame, to be recorded on a 1-hour sensor
+        (
+            {
+                "sensor": "epex_da",  # name is used to look up the corresponding sensor ID
+                "start": "2025-11-21T10:58:00+01",
+                "duration": "PT2M",
+                "values": [1],
+                "unit": "EUR/kWh",
+            },
+            1,
             {},
         ),
         # Six 2-minute events (spanning 2 wall-clock hours) are deserialized to a BeliefsDataFrame, to be recorded on a 1-hour sensor

--- a/flexmeasures/api/v3_0/tests/test_sensor_data.py
+++ b/flexmeasures/api/v3_0/tests/test_sensor_data.py
@@ -145,12 +145,6 @@ def test_post_sensor_data_bad_auth(
     "request_field, new_value, error_field, error_text",
     [
         ("start", "2021-06-07T00:00:00", "start", "Not a valid aware datetime"),
-        (
-            "duration",
-            "PT30M",
-            "_schema",
-            "Resolution of 0:05:00 is incompatible",
-        ),  # downsampling not supported
         ("unit", "m", "_schema", "Required unit"),
         ("type", "GetSensorDataRequest", "type", "Must be one of"),
     ],

--- a/flexmeasures/api/v3_0/tests/test_sensor_data_fresh_db.py
+++ b/flexmeasures/api/v3_0/tests/test_sensor_data_fresh_db.py
@@ -31,12 +31,12 @@ from flexmeasures.data.models.time_series import TimedBelief
         ),  # upsample from single value for 1-hour interval, sent as float rather than list of floats
         (
             4,
-            0,
+            6,
             "m³/h",
             False,
-            None,
+            -11.28,
             False,
-            422,
+            200,
         ),  # failed to resample from 15-min intervals to 10-min intervals
         (
             10,


### PR DESCRIPTION
## Description

Testing expectations for converting incoming time series data to a BeliefsDataFrame to be recorded on a sensor.

<!--
Summary of the changes introduced in this PR. Try to use bullet points as much as possible.
-->

- [ ] ...
- [ ] Requires https://github.com/SeitaBV/timely-beliefs/pull/212
- [ ] Added changelog item in `documentation/changelog.rst`

<!--
For changelog entries, please take into account the intended audience.

In our main changelog:
- The 'New features' section targets API / CLI / UI users.
- The 'Infrastructure / Support' section targets plugin developers and hosts.

Finally, please note that the API and CLI keep additional changelogs:
- `documentation/api/changelog.rst`
- `documentation/cli/changelog.rst`
-->

## Look & Feel

<!--
This section can contain example pictures for the UI, Input/Output for the CLI, Request / Response for an API endpoint, etc.
-->

...

## How to test

<!--
Steps to test it or name of the tests functions.

The library [flexmeasures-client](https://github.com/FlexMeasures/flexmeasures-client/) can be useful to showcase new features.
For example, it can be used to set some example data to be used in a new UI feature.
-->

...

## Further Improvements

<!--
Potential improvements to be done in the same PR or follow-up Issues/Discussions/PRs.
-->

...

## Related Items

<!--
Mention if this PR closes an Issue or Project.
-->

...

---

#### Sign-off

<!--
We ask contributors outside the FlexMeasures organisation to sign off on their contribution.
Please mark the below fields with an [x].
-->

- [ ] I agree to contribute to the project under Apache 2 License. 
- [ ] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
