### PR TITLE
Fix Asset API sorting test expectations

### DIFF
--- a/flexmeasures/api/v3_0/tests/test_assets_api.py
+++ b/flexmeasures/api/v3_0/tests/test_assets_api.py
@@ -96,7 +96,7 @@ def test_get_asset_nonaccount_access(
             False,
             "name",
             "asc",
-            "incineration line",
+            "Test wind turbine",
         ),
         (
             "test_admin_user@seita.nl",
@@ -105,7 +105,7 @@ def test_get_asset_nonaccount_access(
             False,
             "name",
             "desc",
-            "Test wind turbine",
+            "incineration line",
         ),
         ("test_consultant@seita.nl", "ConsultancyClient", 1, False, None, None, None),
         ("test_admin_user@seita.nl", "Prosumer", 1, True, None, None, None),


### PR DESCRIPTION
## Description

Fixes two failing tests in test_assets_api.py.
The API sorts asset names case-sensitively, but the tests assumed case-insensitive ordering. This PR updates the expected first asset values for:
 * sort_by="name", sort_dir="asc"
 * sort_by="name", sort_dir="desc"
 
No changes to API logic.


## How to test

Run `pytest -k  test_get_assets  `

---

#### Sign-off

<!--
We ask contributors outside the FlexMeasures organisation to sign off on their contribution.
Please mark the below fields with an [x].
-->

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
