### PR TITLE
Test: Add forecasting config tests

### DIFF
--- a/flexmeasures/data/schemas/tests/test_forecasting.py
+++ b/flexmeasures/data/schemas/tests/test_forecasting.py
@@ -3,7 +3,10 @@ import pytest
 from marshmallow import ValidationError
 import pandas as pd
 
-from flexmeasures.data.schemas.forecasting.pipeline import ForecasterParametersSchema, TrainPredictPipelineConfigSchema
+from flexmeasures.data.schemas.forecasting.pipeline import (
+    ForecasterParametersSchema,
+    TrainPredictPipelineConfigSchema,
+)
 from flexmeasures.data.schemas.utils import kebab_to_snake
 
 


### PR DESCRIPTION
## Description

This PR add forecasting config `TrainPredictPipelineConfigSchema` testing in `test_forecasting.py`

### What changed

- Added 4 config-schema timing scenarios covering:
  1. `retrain-frequency` only (defaults + 12h retraining)
  2. `train-start` + `train-period` (3 days)
  3. `train-start` + `train-period` (20 days)
  4. end/default-driven behavior with custom `retrain-frequency` (3 days)

**Note:** `end_date` is commented out in the test config input because it's not yet in config

## How to test

`pytest flexmeasures/data/schemas/tests/test_forecasting.py::test_timing_parameters_of_forecaster_config_schema`


## Related Items
closes #1979 

---

#### Sign-off

<!--
We ask contributors outside the FlexMeasures organisation to sign off on their contribution.
Please mark the below fields with an [x].
-->

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
