### PR TITLE
Add if_exists=True to index drops in migration b8f3cda5e023

### DIFF
--- a/flexmeasures/data/migrations/versions/b8f3cda5e023_correct_order_in_index_for_single_most_.py
+++ b/flexmeasures/data/migrations/versions/b8f3cda5e023_correct_order_in_index_for_single_most_.py
@@ -21,7 +21,9 @@ def upgrade():
     Re-create the index with correct order
     """
     with op.batch_alter_table("timed_belief", schema=None) as batch_op:
-        batch_op.drop_index("timed_belief_search_session_singleevent_idx")
+        batch_op.drop_index(
+            "timed_belief_search_session_singleevent_idx", if_exists=True
+        )
     with op.batch_alter_table("timed_belief", schema=None) as batch_op:
         batch_op.create_index(
             "timed_belief_search_session_singleevent_idx",
@@ -35,7 +37,9 @@ def downgrade():
     Re-create the original index
     """
     with op.batch_alter_table("timed_belief", schema=None) as batch_op:
-        batch_op.drop_index("timed_belief_search_session_singleevent_idx")
+        batch_op.drop_index(
+            "timed_belief_search_session_singleevent_idx", if_exists=True
+        )
     with op.batch_alter_table("timed_belief", schema=None) as batch_op:
         batch_op.create_index(
             "timed_belief_search_session_singleevent_idx",


### PR DESCRIPTION
## Description
This PR makes index drops in `b8f3cda5e023_correct_order_in_index_for_single_most_.py` conditional by using `if_exists=True` in both `upgrade()` and `downgrade()`.

## How to test
Run the following commands on a test database.
* `flexmeasures db upgrade`
* `flexmeasures db downgrade`


- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
