### PR TITLE
Refactor/remove existing beliefs

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -29,7 +29,6 @@ Infrastructure / Support
 * Upgraded some dependencies for security reasons [see `PR #2037 <https://www.github.com/FlexMeasures/flexmeasures/pull/2037>`_]
 * Remove unused ``dictdiffer`` dependency after replacing JSON audit-diff logic with internal formatting utilities [see `PR #2055 <https://www.github.com/FlexMeasures/flexmeasures/pull/2055>`_]
 * Upgraded dependencies, including sphinx from v8 to v9 [see `PR #2061 <https://www.github.com/FlexMeasures/flexmeasures/pull/2061>`_]
-* Prevent ``save_to_db`` from failing on saving duplicate beliefs in case ``FLEXMEASURES_ALLOW_DATA_OVERWRITE = False`` [see `PR #2059 <https://www.github.com/FlexMeasures/flexmeasures/pull/2059>`_]
 * Improve error logging for various exceptions [see `PR #2045 <https://www.github.com/FlexMeasures/flexmeasures/pull/2045>`_]
 * Update agent instructions and workflows to customize the primary entry point and to make the test environment used by agents and by the test workflow identical [see `PR #2066 <https://www.github.com/FlexMeasures/flexmeasures/pull/2066>`_, `PR #1998 <https://www.github.com/FlexMeasures/flexmeasures/pull/1998>`_ and `PR #2068 <https://www.github.com/FlexMeasures/flexmeasures/pull/2068>`_]
 * Filter out 404 (Not Found) errors from Sentry reports by default, configurable via ``FLEXMEASURES_DO_NOT_SEND_NOTFOUND_TO_SENTRY`` [see `PR #2071 <https://www.github.com/FlexMeasures/flexmeasures/pull/2071>`_]
@@ -46,6 +45,7 @@ Bugfixes
 * Fix regression in upsampling speed [see `PR #2060 <https://www.github.com/FlexMeasures/flexmeasures/pull/2060>`_]
 * Fix forecasting with multiple regressors in ``flexmeasures add forecasts`` by combining regressor time series as parallel components [see `PR #2088 <https://www.github.com/FlexMeasures/flexmeasures/pull/2088>`_]
 * Fix a bug where ``save_to_db`` could silently drop a changed belief when the prior beliefs in the database happened to be ordered by descending belief time [see `PR #2086 <https://www.github.com/FlexMeasures/flexmeasures/pull/2086>`_]
+* Prevent ``save_to_db`` from failing on saving duplicate beliefs in case ``FLEXMEASURES_ALLOW_DATA_OVERWRITE = False`` [see `PR #2059 <https://www.github.com/FlexMeasures/flexmeasures/pull/2059>`_ and `PR #2098 <https://www.github.com/FlexMeasures/flexmeasures/pull/2098>`_]
 * Fix :abbr:`DST (Daylight Saving Time)` bug in processing time series segments [see `PR #2069 <https://www.github.com/FlexMeasures/flexmeasures/pull/2069>`_]
 
 

--- a/flexmeasures/data/services/time_series.py
+++ b/flexmeasures/data/services/time_series.py
@@ -55,11 +55,13 @@ def aggregate_values(bdf_dict: dict[Any, tb.BeliefsDataFrame]) -> tb.BeliefsData
 
 
 def drop_unchanged_beliefs(bdf: tb.BeliefsDataFrame) -> tb.BeliefsDataFrame:
-    """Drop beliefs that are already stored in the database with an earlier belief time.
+    """Drop beliefs that are already stored in the database with an earlier or equal belief time.
 
     Also drop beliefs that are already in the data with an earlier belief time.
 
-    Quite useful function to prevent cluttering up your database with beliefs that remain unchanged over time.
+    Quite useful function to prevent cluttering up your database with beliefs that remain
+    unchanged over time, and to prevent duplicate key violations when re-running forecasters
+    or reporters with identical data.
     """
     if bdf.empty:
         return bdf
@@ -112,13 +114,6 @@ def drop_unchanged_beliefs(bdf: tb.BeliefsDataFrame) -> tb.BeliefsDataFrame:
     if bdf_db.empty:
         return bdf
 
-    # Remove beliefs that already exist in the database to prevent duplicate key violations
-    bdf = bdf.groupby(level="source", group_keys=False).apply(
-        remove_existing_beliefs, bdf_db=bdf_db
-    )
-    if bdf.empty:
-        return bdf
-
     return (
         bdf.convert_index_from_belief_horizon_to_time()
         .groupby(
@@ -134,10 +129,19 @@ def _drop_unchanged_beliefs_compared_to_db(
     bdf: tb.BeliefsDataFrame,
     bdf_db: tb.BeliefsDataFrame,
 ) -> tb.BeliefsDataFrame:
-    """Drop beliefs that are already stored in the database with an earlier belief time.
+    """Drop beliefs that are already stored in the database with an earlier or equal belief time.
 
     Assumes a BeliefsDataFrame with a unique belief time and unique source,
     and either all ex-ante beliefs or all ex-post beliefs.
+
+    Handles two cases:
+
+    1. **Unchanged belief** — the candidate value matches the most recent prior belief in the DB
+       (belief_time strictly earlier than the candidate): the candidate is dropped to avoid
+       cluttering the database with redundant history.
+    2. **Exact duplicate** — a belief with the exact same belief_time already exists in the DB
+       with the same value: the candidate is dropped to prevent duplicate key violations, which
+       is particularly useful when re-running forecasters or reporters with identical data.
 
     It is preferable to call the public function drop_unchanged_beliefs instead.
     """
@@ -149,7 +153,7 @@ def _drop_unchanged_beliefs_compared_to_db(
     # Use .max() rather than searchsorted: the result is correct regardless of
     # whether bdf_db happens to be sorted ascending or descending by belief_time.
     most_recent_bt = bdf_db_from_source.belief_times[
-        bdf_db_from_source.belief_times < belief_time
+        bdf_db_from_source.belief_times <= belief_time
     ].max()
     if pd.isna(most_recent_bt):
         # No earlier belief time in db
@@ -175,62 +179,3 @@ def _drop_unchanged_beliefs_compared_to_db(
         ["event_start", "belief_time", "source", "cumulative_probability"]
     )
     return bdf
-
-
-def remove_existing_beliefs(
-    bdf: tb.BeliefsDataFrame, bdf_db: tb.BeliefsDataFrame
-) -> tb.BeliefsDataFrame:
-    """Remove beliefs that already exist in the database from the given BeliefsDataFrame.
-
-    This function filters out beliefs that are already stored in the database,
-    proactively preventing unique constraint violations,
-    for example, when re-running forecasters or reporters.
-
-    The function assumes the input BeliefsDataFrame has a unique source.
-    It compares beliefs based on their event start time, belief horizon, and value,
-    and removes any beliefs found in the database.
-
-    :param bdf:     BeliefsDataFrame to filter. Must contain beliefs with a single unique source.
-    :param bdf_db:  BeliefsDataFrame containing beliefs from the database.
-
-    :returns:       Filtered BeliefsDataFrame with existing beliefs removed.
-                    Returns an empty BeliefsDataFrame if all beliefs already exist in the database.
-    """
-
-    # Filter bdf_db by the unique source in bdf
-    source = bdf.lineage.sources[0]
-    bdf_db_from_source = bdf_db[bdf_db.sources == source]
-
-    if bdf.empty or bdf_db_from_source.empty:
-        return bdf
-
-    # Create a set of (event_start, belief_horizon, value) tuples for existing beliefs
-    existing_keys = set()
-    for idx, event_value in bdf_db_from_source.iterrows():
-        event_start = idx[0]  # event_start is first level of MultiIndex
-        belief_time = idx[1]  # belief_time is second level of MultiIndex
-        # Compute belief_horizon from belief_time and event_start
-        belief_horizon = event_start - belief_time
-        existing_keys.add((event_start, belief_horizon, float(event_value)))
-
-    # Create a set of indices to keep (rows that DON'T exist in database)
-    indices_to_keep = []
-
-    for idx, event_value in bdf.iterrows():
-        event_start = idx[0]  # event_start is first level of MultiIndex
-        belief_time = idx[1]  # belief_time is second level of MultiIndex
-        # Compute belief_horizon from belief_time and event_start
-        belief_horizon = event_start - belief_time
-        key = (event_start, belief_horizon, float(event_value))
-
-        if key not in existing_keys:
-            indices_to_keep.append(idx)
-
-    if not indices_to_keep:
-        # All beliefs exist, return empty with proper structure
-        return bdf.iloc[0:0]
-
-    # Filter BeliefsDataFrame to keep only new beliefs
-    bdf_filtered = bdf.loc[indices_to_keep]
-
-    return bdf_filtered


### PR DESCRIPTION
## Description

- [x] Move #2059 from v0.32.0 to v0.31.3
- [x] Refactor to make `remove_existing_beliefs` obsolete
- [x] Added changelog item in `documentation/changelog.rst`

## Look & Feel



## How to test

The removal of duplicate beliefs enjoys test coverage from #2059.

