### PR TITLE
feat: Cleanup of stale sensor references

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -21,6 +21,7 @@ New features
 * Separate the ``StorageScheduler``'s tie-breaking preference for a full :abbr:`SoC (state of charge)` from its reported energy costs [see `PR #2023 <https://www.github.com/FlexMeasures/flexmeasures/pull/2023>`_]
 * Improve asset graph hover interaction with a vertical ruler across subcharts, while keeping hover dots for easier visual tracking [see `PR #2079 <https://www.github.com/FlexMeasures/flexmeasures/pull/2079>`_]
 * Improve asset audit log messages for JSON field edits (especially ``sensors_to_show`` and nested flex-config values) [see `PR #2055 <https://www.github.com/FlexMeasures/flexmeasures/pull/2055>`_]
+* Clean up stale sensor references from ``flex-config`` and ``sensors_to_show`` when deleting a sensor, using JSONB queries to find affected assets before pruning those references [see `PR #2106 <https://www.github.com/FlexMeasures/flexmeasures/pull/2106>`_]
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -64,7 +64,7 @@ from flexmeasures.api.common.schemas.search import SearchFilterField
 from flexmeasures.data.schemas.scheduling import GetScheduleSchema
 from flexmeasures.data.schemas.units import UnitField
 from flexmeasures.data.services.sensors import get_sensor_stats
-from flexmeasures.data.services.sensors import cleanup_sensor_references_in_assets
+from flexmeasures.data.services.sensors import delete_sensor as delete_sensor_and_data
 from flexmeasures.data.services.scheduling import (
     create_scheduling_job,
     get_data_source_for_job,
@@ -1349,20 +1349,8 @@ class SensorAPI(FlaskView):
             - Sensors
         """
 
-        """Delete time series data."""
-        db.session.execute(delete(TimedBelief).filter_by(sensor_id=sensor.id))
-
-        AssetAuditLog.add_record(
-            sensor.generic_asset, f"Deleted sensor '{sensor.name}': {sensor.id}"
-        )
-
         sensor_name = sensor.name
-        cleanup_sensor_references_in_assets(sensor.id)
-        AssetAuditLog.add_record(
-            sensor.generic_asset,
-            f"Deleted sensor '{sensor_name}': {id}",
-        )
-        db.session.execute(delete(Sensor).filter_by(id=sensor.id))
+        delete_sensor_and_data(sensor)
         db.session.commit()
         current_app.logger.info("Deleted sensor '%s'." % sensor_name)
         return {}, 204

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -64,6 +64,7 @@ from flexmeasures.api.common.schemas.search import SearchFilterField
 from flexmeasures.data.schemas.scheduling import GetScheduleSchema
 from flexmeasures.data.schemas.units import UnitField
 from flexmeasures.data.services.sensors import get_sensor_stats
+from flexmeasures.data.services.sensors import cleanup_sensor_references_in_assets
 from flexmeasures.data.services.scheduling import (
     create_scheduling_job,
     get_data_source_for_job,
@@ -1356,6 +1357,7 @@ class SensorAPI(FlaskView):
         )
 
         sensor_name = sensor.name
+        cleanup_sensor_references_in_assets(sensor.id)
         AssetAuditLog.add_record(
             sensor.generic_asset,
             f"Deleted sensor '{sensor_name}': {id}",

--- a/flexmeasures/api/v3_0/tests/test_sensors_api.py
+++ b/flexmeasures/api/v3_0/tests/test_sensors_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 import math
 import io
+import json
 
 from flask import url_for
 from sqlalchemy import select, func
@@ -536,6 +537,29 @@ def test_delete_a_sensor(client, setup_api_test_data, requesting_user, db):
     existing_sensor_id = existing_sensor.id
     sensor_count = db.session.scalar(select(func.count()).select_from(Sensor))
 
+    asset = existing_sensor.generic_asset
+    asset.flex_model = {
+        "soc-max": {"sensor": existing_sensor_id},
+        "static-limit": "10 kW",
+    }
+    asset.flex_context = {
+        "consumption-price": {"sensor": existing_sensor_id},
+        "inflexible-device-sensors": [existing_sensor_id],
+    }
+    asset.sensors_to_show = [
+        {"title": "Power", "plots": [{"sensor": existing_sensor_id}]},
+        existing_sensor_id,
+    ]
+    asset.sensors_to_show_as_kpis = [
+        {
+            "sensor": existing_sensor_id,
+            "title": "Temperature KPI",
+            "function": "sum",
+        }
+    ]
+    db.session.add(asset)
+    db.session.commit()
+
     delete_sensor_response = client.delete(
         url_for("SensorAPI:delete", id=existing_sensor_id),
     )
@@ -550,6 +574,16 @@ def test_delete_a_sensor(client, setup_api_test_data, requesting_user, db):
     )
     assert (
         db.session.scalar(select(func.count()).select_from(Sensor)) == sensor_count - 1
+    )
+
+    asset_after = db.session.get(GenericAsset, asset.id)
+    assert asset_after.flex_model.get("soc-max") is None
+    assert asset_after.flex_model.get("static-limit") == "10 kW"
+    assert asset_after.flex_context.get("consumption-price") is None
+    assert asset_after.flex_context.get("inflexible-device-sensors") == []
+    assert str(existing_sensor_id) not in json.dumps(asset_after.sensors_to_show)
+    assert str(existing_sensor_id) not in json.dumps(
+        asset_after.sensors_to_show_as_kpis
     )
 
     check_audit_log_event(

--- a/flexmeasures/api/v3_0/tests/test_sensors_api.py
+++ b/flexmeasures/api/v3_0/tests/test_sensors_api.py
@@ -600,19 +600,19 @@ def test_delete_a_sensor(client, setup_api_test_data, requesting_user, db):
     )
     check_audit_log_event(
         db=db,
-        event=f"Removed deleted sensor reference '{existing_sensor.name}': {existing_sensor.id} from flex-context.",
+        event=f"Removed sensor reference '{existing_sensor.name}': {existing_sensor.id} from flex-context (because sensor has been deleted).",
         user=requesting_user,
         asset=existing_sensor.generic_asset,
     )
     check_audit_log_event(
         db=db,
-        event=f"Removed deleted sensor reference '{existing_sensor.name}': {existing_sensor.id} from sensors-to-show.",
+        event=f"Removed sensor reference '{existing_sensor.name}': {existing_sensor.id} from sensors-to-show (because sensor has been deleted).",
         user=requesting_user,
         asset=existing_sensor.generic_asset,
     )
     check_audit_log_event(
         db=db,
-        event=f"Removed deleted sensor reference '{existing_sensor.name}': {existing_sensor.id} from sensors-to-show-as-kpis.",
+        event=f"Removed sensor reference '{existing_sensor.name}': {existing_sensor.id} from sensors-to-show-as-kpis (because sensor has been deleted).",
         user=requesting_user,
         asset=existing_sensor.generic_asset,
     )

--- a/flexmeasures/api/v3_0/tests/test_sensors_api.py
+++ b/flexmeasures/api/v3_0/tests/test_sensors_api.py
@@ -594,7 +594,7 @@ def test_delete_a_sensor(client, setup_api_test_data, requesting_user, db):
     )
     check_audit_log_event(
         db=db,
-        event=f"Removed deleted sensor reference '{existing_sensor.name}': {existing_sensor.id} from flex-model.",
+        event=f"Removed sensor reference '{existing_sensor.name}': {existing_sensor.id} from flex-model (because sensor has been deleted).",
         user=requesting_user,
         asset=existing_sensor.generic_asset,
     )

--- a/flexmeasures/api/v3_0/tests/test_sensors_api.py
+++ b/flexmeasures/api/v3_0/tests/test_sensors_api.py
@@ -592,6 +592,30 @@ def test_delete_a_sensor(client, setup_api_test_data, requesting_user, db):
         user=requesting_user,
         asset=existing_sensor.generic_asset,
     )
+    check_audit_log_event(
+        db=db,
+        event=f"Removed deleted sensor reference '{existing_sensor.name}': {existing_sensor.id} from flex-model.",
+        user=requesting_user,
+        asset=existing_sensor.generic_asset,
+    )
+    check_audit_log_event(
+        db=db,
+        event=f"Removed deleted sensor reference '{existing_sensor.name}': {existing_sensor.id} from flex-context.",
+        user=requesting_user,
+        asset=existing_sensor.generic_asset,
+    )
+    check_audit_log_event(
+        db=db,
+        event=f"Removed deleted sensor reference '{existing_sensor.name}': {existing_sensor.id} from sensors-to-show.",
+        user=requesting_user,
+        asset=existing_sensor.generic_asset,
+    )
+    check_audit_log_event(
+        db=db,
+        event=f"Removed deleted sensor reference '{existing_sensor.name}': {existing_sensor.id} from sensors-to-show-as-kpis.",
+        user=requesting_user,
+        asset=existing_sensor.generic_asset,
+    )
 
 
 @pytest.mark.parametrize(

--- a/flexmeasures/cli/data_delete.py
+++ b/flexmeasures/cli/data_delete.py
@@ -27,7 +27,7 @@ from flexmeasures.data.schemas import (
     SourceIdField,
 )
 from flexmeasures.data.services.users import find_user_by_email, delete_user
-from flexmeasures.data.services.sensors import cleanup_sensor_references_in_assets
+from flexmeasures.data.services.sensors import delete_sensor as delete_sensor_and_data
 from flexmeasures.cli.utils import (
     abort,
     done,
@@ -540,20 +540,17 @@ def delete_sensor(
     sensors: list[Sensor],
 ):
     """Delete sensors and their (time series) data."""
-    n = delete(TimedBelief).where(
-        TimedBelief.sensor_id.in_(sensor.id for sensor in sensors)
-    )
-    statements = []
-    for sensor in sensors:
-        statements.append(delete(Sensor).filter_by(id=sensor.id))
+    n_beliefs = db.session.execute(
+        select(func.count())
+        .select_from(TimedBelief)
+        .where(TimedBelief.sensor_id.in_([sensor.id for sensor in sensors]))
+    ).scalar_one()
     click.confirm(
-        f"Delete {', '.join(sensor.__repr__() for sensor in sensors)}, along with {n} beliefs?",
+        f"Delete {', '.join(sensor.__repr__() for sensor in sensors)}, along with {n_beliefs} beliefs?",
         abort=True,
     )
     for sensor in sensors:
-        cleanup_sensor_references_in_assets(sensor.id)
-    for statement in statements:
-        db.session.execute(statement)
+        delete_sensor_and_data(sensor)
     db.session.commit()
 
 

--- a/flexmeasures/cli/data_delete.py
+++ b/flexmeasures/cli/data_delete.py
@@ -27,6 +27,7 @@ from flexmeasures.data.schemas import (
     SourceIdField,
 )
 from flexmeasures.data.services.users import find_user_by_email, delete_user
+from flexmeasures.data.services.sensors import cleanup_sensor_references_in_assets
 from flexmeasures.cli.utils import (
     abort,
     done,
@@ -549,6 +550,8 @@ def delete_sensor(
         f"Delete {', '.join(sensor.__repr__() for sensor in sensors)}, along with {n} beliefs?",
         abort=True,
     )
+    for sensor in sensors:
+        cleanup_sensor_references_in_assets(sensor.id)
     for statement in statements:
         db.session.execute(statement)
     db.session.commit()

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -178,7 +178,9 @@ def _prune_sensors_to_show_as_kpis_refs(value, sensor_id: int):
     return cleaned, changed
 
 
-def cleanup_sensor_references_in_assets(sensor_id: int) -> int:
+def cleanup_sensor_references_in_assets(
+    sensor_id: int, sensor_name: str | None = None
+) -> int:
     """Remove references to a sensor in JSONB config fields across assets.
 
     Returns the number of updated assets.
@@ -254,6 +256,23 @@ def cleanup_sensor_references_in_assets(sensor_id: int) -> int:
         )
         if not changed:
             continue
+
+        changed_field_events = (
+            (changed_flex_model, "flex-model"),
+            (changed_flex_context, "flex-context"),
+            (changed_sensors_to_show, "sensors-to-show"),
+            (changed_sensors_to_show_as_kpis, "sensors-to-show-as-kpis"),
+        )
+        for field_changed, field_name in changed_field_events:
+            if not field_changed:
+                continue
+            sensor_label = (
+                f"'{sensor_name}': {sensor_id}" if sensor_name else str(sensor_id)
+            )
+            AssetAuditLog.add_record(
+                asset,
+                f"Removed deleted sensor reference {sensor_label} from {field_name}.",
+            )
 
         asset.flex_model = flex_model
         asset.flex_context = flex_context
@@ -853,7 +872,7 @@ def delete_sensor(sensor: Sensor):
     Creates an audit log.
     """
     sensor_name = sensor.name
-    cleanup_sensor_references_in_assets(sensor.id)
+    cleanup_sensor_references_in_assets(sensor.id, sensor.name)
     db.session.execute(delete(TimedBelief).filter_by(sensor_id=sensor.id))
     AssetAuditLog.add_record(
         sensor.generic_asset, f"Deleted sensor '{sensor_name}': {sensor.id}"

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -32,8 +32,36 @@ from flexmeasures.utils.time_utils import server_now
 _REMOVE = object()
 
 
-def _prune_flex_config_sensor_refs(value, sensor_id: int):
-    """Remove references to a sensor from flex_model/flex_context JSON values."""
+def _prune_flex_config_sensor_refs(
+    value: dict[str, Any] | list[Any] | int | str | None, sensor_id: int
+) -> tuple[dict[str, Any] | list[Any] | int | str | None | object, bool]:
+    """Recursively remove sensor references from nested flex_model/flex_context JSON structures.
+
+    This function handles deeply nested JSON objects and lists from flex_model and flex_context
+    JSONB columns. It scans for sensor references in two forms:
+    - Direct objects: {"sensor": sensor_id_to_remove}
+    - Lists: [sensor_id_to_remove, ...] in "inflexible-device-sensors" keys
+
+    Args:
+        value: A JSON-like value (dict, list, int, str, None) from flex_model/flex_context.
+               Can be arbitrarily nested.
+        sensor_id: The ID of the sensor to remove references to.
+
+    Returns:
+        A tuple (pruned_value, changed):
+        - pruned_value: The value with sensor references removed. Can be:
+            - `_REMOVE` (sentinel object): Remove this entire entry from parent
+            - A pruned dict/list/scalar: The value with refs removed
+        - changed (bool): True if any references were actually removed.
+
+    Example:
+        >>> value = {"soc-max": {"sensor": 42}, "limit": "10 kW"}
+        >>> pruned, did_change = _prune_flex_config_sensor_refs(value, sensor_id=42)
+        >>> pruned
+        {"limit": "10 kW"}  # soc-max removed entirely
+        >>> did_change
+        True
+    """
     if isinstance(value, dict):
         # Direct sensor reference object (for example {"sensor": 12})
         if set(value.keys()) == {"sensor"} and value.get("sensor") == sensor_id:
@@ -72,8 +100,34 @@ def _prune_flex_config_sensor_refs(value, sensor_id: int):
     return value, False
 
 
-def _prune_sensors_to_show_refs(value, sensor_id: int):
-    """Remove references to a sensor from sensors_to_show JSON values."""
+def _prune_sensors_to_show_refs(
+    value: list[Any] | None, sensor_id: int
+) -> tuple[list[Any] | None, bool]:
+    """Remove sensor references from sensors_to_show JSON list.
+
+    This function handles sensors_to_show lists which support multiple entry formats:
+    - Bare sensor IDs: [42, 43, ...]
+    - Grouped sensor IDs: [42, [43, 44], ...] (nested lists)
+    - Dict entries: [{"sensor": 42, ...}, ...] (delegated to _prune_sensors_to_show_entry)
+
+    Args:
+        value: The sensors_to_show JSON list (or None). Each entry can be an int, list of ints, or dict.
+        sensor_id: The ID of the sensor to remove references to.
+
+    Returns:
+        A tuple (pruned_list, changed):
+        - pruned_list: The list with sensor references removed (or empty lists filtered out).
+                       Returns None/value unchanged if input is not a list.
+        - changed (bool): True if any references were actually removed.
+
+    Example:
+        >>> value = [42, [43, 42], {"sensor": 42}]
+        >>> pruned, did_change = _prune_sensors_to_show_refs(value, sensor_id=42)
+        >>> pruned
+        [[43]]  # bare 42 removed, 42 from group removed (empty group filtered), dict removed
+        >>> did_change
+        True
+    """
     if not isinstance(value, list):
         return value, False
 
@@ -111,8 +165,33 @@ def _prune_sensors_to_show_refs(value, sensor_id: int):
     return cleaned, changed
 
 
-def _prune_sensors_to_show_entry(entry: dict[str, Any], sensor_id: int):
-    """Prune one dict entry from sensors_to_show and report if it changed."""
+def _prune_sensors_to_show_entry(
+    entry: dict[str, Any], sensor_id: int
+) -> tuple[dict[str, Any] | object, bool]:
+    """Remove sensor references from a single sensors_to_show dict entry.
+
+    Handles three field types within a dict entry:
+    - "sensor": Direct sensor ID reference → remove if matches
+    - "sensors": List of sensor IDs → filter out matching IDs
+    - "plots": List of plot dicts, each may contain "sensor" or "sensors" → recurse
+
+    Args:
+        entry: A dict from the sensors_to_show list (e.g., {"sensor": 42, "title": "..."}).
+        sensor_id: The ID of the sensor to remove references to.
+
+    Returns:
+        A tuple (pruned_entry, changed):
+        - pruned_entry: Can be:
+            - `_REMOVE`: Remove this entire entry from parent list
+            - Modified entry dict: The entry with refs removed
+        - changed (bool): True if any references were removed.
+
+    Example:
+        >>> entry = {"sensor": 42, "title": "Power"}
+        >>> pruned, did_change = _prune_sensors_to_show_entry(entry, sensor_id=42)
+        >>> pruned
+        _REMOVE  # entire entry removed
+    """
     if "sensor" in entry:
         if entry.get("sensor") == sensor_id:
             return _REMOVE, True
@@ -159,8 +238,33 @@ def _prune_sensors_to_show_entry(entry: dict[str, Any], sensor_id: int):
     return entry, False
 
 
-def _prune_sensors_to_show_as_kpis_refs(value, sensor_id: int):
-    """Remove references to a sensor from sensors_to_show_as_kpis JSON values."""
+def _prune_sensors_to_show_as_kpis_refs(
+    value: list[Any] | None, sensor_id: int
+) -> tuple[list[Any] | None, bool]:
+    """Remove sensor references from sensors_to_show_as_kpis JSON list.
+
+    This function handles sensors_to_show_as_kpis lists which support:
+    - Bare sensor IDs: [42, 43, ...]
+    - Dict entries: [{"sensor": 42, "title": "...", "function": "sum"}, ...]
+
+    Args:
+        value: The sensors_to_show_as_kpis JSON list (or None). Each entry is an int or dict.
+        sensor_id: The ID of the sensor to remove references to.
+
+    Returns:
+        A tuple (pruned_list, changed):
+        - pruned_list: The list with sensor references removed.
+                       Returns None/value unchanged if input is not a list.
+        - changed (bool): True if any references were actually removed.
+
+    Example:
+        >>> value = [42, {"sensor": 42, "title": "Temp KPI", "function": "sum"}]
+        >>> pruned, did_change = _prune_sensors_to_show_as_kpis_refs(value, sensor_id=42)
+        >>> pruned
+        []  # all entries removed
+        >>> did_change
+        True
+    """
     if not isinstance(value, list):
         return value, False
 

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -58,7 +58,7 @@ def _prune_flex_config_sensor_refs(
         >>> value = {"soc-max": {"sensor": 42}, "limit": "10 kW"}
         >>> pruned, did_change = _prune_flex_config_sensor_refs(value, sensor_id=42)
         >>> pruned
-        {"limit": "10 kW"}  # soc-max removed entirely
+        {'limit': '10 kW'}
         >>> did_change
         True
     """
@@ -124,7 +124,7 @@ def _prune_sensors_to_show_refs(
         >>> value = [42, [43, 42], {"sensor": 42}]
         >>> pruned, did_change = _prune_sensors_to_show_refs(value, sensor_id=42)
         >>> pruned
-        [[43]]  # bare 42 removed, 42 from group removed (empty group filtered), dict removed
+        [[43]]
         >>> did_change
         True
     """
@@ -189,8 +189,8 @@ def _prune_sensors_to_show_entry(
     Example:
         >>> entry = {"sensor": 42, "title": "Power"}
         >>> pruned, did_change = _prune_sensors_to_show_entry(entry, sensor_id=42)
-        >>> pruned
-        _REMOVE  # entire entry removed
+        >>> pruned is _REMOVE
+        True
     """
     if "sensor" in entry:
         if entry.get("sensor") == sensor_id:
@@ -261,7 +261,7 @@ def _prune_sensors_to_show_as_kpis_refs(
         >>> value = [42, {"sensor": 42, "title": "Temp KPI", "function": "sum"}]
         >>> pruned, did_change = _prune_sensors_to_show_as_kpis_refs(value, sensor_id=42)
         >>> pruned
-        []  # all entries removed
+        []
         >>> did_change
         True
     """

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import json
+import time
 import hashlib
 from datetime import datetime, timedelta
 from typing import Any
 from flask import current_app
+from sqlalchemy import delete
 
 from isodate import duration_isoformat
-import time
 from timely_beliefs import BeliefsDataFrame
 import pandas as pd
 
@@ -21,6 +22,7 @@ import sqlalchemy as sa
 
 from flexmeasures.data import db
 from flexmeasures import Sensor, Account, Asset
+from flexmeasures.data.models.audit_log import AssetAuditLog
 from flexmeasures.data.models.data_sources import DataSource, DEFAULT_DATASOURCE_TYPES
 from flexmeasures.data.models.generic_assets import GenericAsset
 from flexmeasures.data.schemas.reporting import StatusSchema
@@ -841,3 +843,20 @@ def get_sensor_stats(
         _sensor_stats_cache[key] = result
 
     return result
+
+
+def delete_sensor(sensor: Sensor):
+    """Delete a sensor and all its time series data.
+
+    Does not commit the session.
+    Cleans up sensor references in asset JSONB fields.
+    Creates an audit log.
+    """
+    sensor_name = sensor.name
+    cleanup_sensor_references_in_assets(sensor.id)
+    db.session.execute(delete(TimedBelief).filter_by(sensor_id=sensor.id))
+    AssetAuditLog.add_record(
+        sensor.generic_asset, f"Deleted sensor '{sensor_name}': {sensor.id}"
+    )
+    db.session.execute(delete(Sensor).filter_by(id=sensor.id))
+    current_app.logger.info("Deleted sensor '%s'." % sensor_name)

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import hashlib
 from datetime import datetime, timedelta
+from typing import Any
 from flask import current_app
 
 from isodate import duration_isoformat
@@ -24,6 +25,245 @@ from flexmeasures.data.models.data_sources import DataSource, DEFAULT_DATASOURCE
 from flexmeasures.data.models.generic_assets import GenericAsset
 from flexmeasures.data.schemas.reporting import StatusSchema
 from flexmeasures.utils.time_utils import server_now
+
+
+_REMOVE = object()
+
+
+def _prune_flex_config_sensor_refs(value, sensor_id: int):
+    """Remove references to a sensor from flex_model/flex_context JSON values."""
+    if isinstance(value, dict):
+        # Direct sensor reference object (for example {"sensor": 12})
+        if set(value.keys()) == {"sensor"} and value.get("sensor") == sensor_id:
+            return _REMOVE, True
+
+        changed = False
+        pruned_dict: dict[str, Any] = {}
+        for k, v in value.items():
+            if k == "inflexible-device-sensors" and isinstance(v, list):
+                new_list = [entry for entry in v if entry != sensor_id]
+                if len(new_list) != len(v):
+                    changed = True
+                pruned_dict[k] = new_list
+                continue
+
+            new_v, was_changed = _prune_flex_config_sensor_refs(v, sensor_id)
+            changed = changed or was_changed
+            if new_v is _REMOVE:
+                changed = True
+                continue
+            pruned_dict[k] = new_v
+        return pruned_dict, changed
+
+    if isinstance(value, list):
+        changed = False
+        pruned_list: list[Any] = []
+        for item in value:
+            new_item, was_changed = _prune_flex_config_sensor_refs(item, sensor_id)
+            changed = changed or was_changed
+            if new_item is _REMOVE:
+                changed = True
+                continue
+            pruned_list.append(new_item)
+        return pruned_list, changed
+
+    return value, False
+
+
+def _prune_sensors_to_show_refs(value, sensor_id: int):
+    """Remove references to a sensor from sensors_to_show JSON values."""
+    if not isinstance(value, list):
+        return value, False
+
+    changed = False
+    cleaned: list[Any] = []
+
+    for entry in value:
+        if isinstance(entry, int):
+            if entry == sensor_id:
+                changed = True
+                continue
+            cleaned.append(entry)
+            continue
+
+        if isinstance(entry, list):
+            new_group = [sid for sid in entry if sid != sensor_id]
+            if len(new_group) != len(entry):
+                changed = True
+            if new_group:
+                cleaned.append(new_group)
+            else:
+                changed = True
+            continue
+
+        if isinstance(entry, dict):
+            pruned_entry, entry_changed = _prune_sensors_to_show_entry(entry, sensor_id)
+            changed = changed or entry_changed
+            if pruned_entry is _REMOVE:
+                continue
+            cleaned.append(pruned_entry)
+            continue
+
+        cleaned.append(entry)
+
+    return cleaned, changed
+
+
+def _prune_sensors_to_show_entry(entry: dict[str, Any], sensor_id: int):
+    """Prune one dict entry from sensors_to_show and report if it changed."""
+    if "sensor" in entry:
+        if entry.get("sensor") == sensor_id:
+            return _REMOVE, True
+        return entry, False
+
+    if "sensors" in entry and isinstance(entry["sensors"], list):
+        new_sensors = [sid for sid in entry["sensors"] if sid != sensor_id]
+        changed = len(new_sensors) != len(entry["sensors"])
+        if not new_sensors:
+            return _REMOVE, True
+        copied = dict(entry)
+        copied["sensors"] = new_sensors
+        return copied, changed
+
+    if "plots" in entry and isinstance(entry["plots"], list):
+        changed = False
+        new_plots: list[Any] = []
+        for plot in entry["plots"]:
+            if not isinstance(plot, dict):
+                new_plots.append(plot)
+                continue
+            if plot.get("sensor") == sensor_id:
+                changed = True
+                continue
+            if "sensors" in plot and isinstance(plot["sensors"], list):
+                new_sensors = [sid for sid in plot["sensors"] if sid != sensor_id]
+                if len(new_sensors) != len(plot["sensors"]):
+                    changed = True
+                if not new_sensors:
+                    changed = True
+                    continue
+                copied_plot = dict(plot)
+                copied_plot["sensors"] = new_sensors
+                new_plots.append(copied_plot)
+            else:
+                new_plots.append(plot)
+
+        if not new_plots:
+            return _REMOVE, True
+        copied = dict(entry)
+        copied["plots"] = new_plots
+        return copied, changed
+
+    return entry, False
+
+
+def _prune_sensors_to_show_as_kpis_refs(value, sensor_id: int):
+    """Remove references to a sensor from sensors_to_show_as_kpis JSON values."""
+    if not isinstance(value, list):
+        return value, False
+
+    changed = False
+    cleaned: list[Any] = []
+    for entry in value:
+        if isinstance(entry, int) and entry == sensor_id:
+            changed = True
+            continue
+        if isinstance(entry, dict) and entry.get("sensor") == sensor_id:
+            changed = True
+            continue
+        cleaned.append(entry)
+
+    return cleaned, changed
+
+
+def cleanup_sensor_references_in_assets(sensor_id: int) -> int:
+    """Remove references to a sensor in JSONB config fields across assets.
+
+    Returns the number of updated assets.
+    """
+
+    if db.engine.dialect.name == "postgresql":
+        vars_json = sa.func.jsonb_build_object("sid", sensor_id)
+        candidates = db.session.scalars(
+            sa.select(GenericAsset).where(
+                sa.or_(
+                    sa.func.jsonb_path_exists(
+                        GenericAsset.flex_model,
+                        "$.**.sensor ? (@ == $sid)",
+                        vars_json,
+                    ),
+                    sa.func.jsonb_path_exists(
+                        GenericAsset.flex_context,
+                        "$.**.sensor ? (@ == $sid)",
+                        vars_json,
+                    ),
+                    sa.func.jsonb_path_exists(
+                        GenericAsset.flex_context,
+                        '$."inflexible-device-sensors"[*] ? (@ == $sid)',
+                        vars_json,
+                    ),
+                    sa.func.jsonb_path_exists(
+                        GenericAsset.sensors_to_show,
+                        "$.**.sensor ? (@ == $sid)",
+                        vars_json,
+                    ),
+                    sa.func.jsonb_path_exists(
+                        GenericAsset.sensors_to_show,
+                        "$.**.sensors[*] ? (@ == $sid)",
+                        vars_json,
+                    ),
+                    sa.func.jsonb_path_exists(
+                        GenericAsset.sensors_to_show,
+                        "$[*] ? (@ == $sid)",
+                        vars_json,
+                    ),
+                    sa.func.jsonb_path_exists(
+                        GenericAsset.sensors_to_show_as_kpis,
+                        "$.**.sensor ? (@ == $sid)",
+                        vars_json,
+                    ),
+                )
+            )
+        ).all()
+    else:
+        candidates = db.session.scalars(sa.select(GenericAsset)).all()
+
+    changed_assets = 0
+    for asset in candidates:
+        flex_model, changed_flex_model = _prune_flex_config_sensor_refs(
+            asset.flex_model, sensor_id
+        )
+        flex_context, changed_flex_context = _prune_flex_config_sensor_refs(
+            asset.flex_context, sensor_id
+        )
+        sensors_to_show, changed_sensors_to_show = _prune_sensors_to_show_refs(
+            asset.sensors_to_show, sensor_id
+        )
+        sensors_to_show_as_kpis, changed_sensors_to_show_as_kpis = (
+            _prune_sensors_to_show_as_kpis_refs(
+                asset.sensors_to_show_as_kpis, sensor_id
+            )
+        )
+
+        changed = any(
+            (
+                changed_flex_model,
+                changed_flex_context,
+                changed_sensors_to_show,
+                changed_sensors_to_show_as_kpis,
+            )
+        )
+        if not changed:
+            continue
+
+        asset.flex_model = flex_model
+        asset.flex_context = flex_context
+        asset.sensors_to_show = sensors_to_show
+        asset.sensors_to_show_as_kpis = sensors_to_show_as_kpis
+        db.session.add(asset)
+        changed_assets += 1
+
+    return changed_assets
 
 
 def get_sensors(

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -335,16 +335,16 @@ def cleanup_sensor_references_in_assets(
 
     changed_assets = 0
     for asset in candidates:
-        flex_model, changed_flex_model = _prune_flex_config_sensor_refs(
+        flex_model, flex_model_was_updated = _prune_flex_config_sensor_refs(
             asset.flex_model, sensor_id
         )
-        flex_context, changed_flex_context = _prune_flex_config_sensor_refs(
+        flex_context, flex_context_was_updated = _prune_flex_config_sensor_refs(
             asset.flex_context, sensor_id
         )
-        sensors_to_show, changed_sensors_to_show = _prune_sensors_to_show_refs(
+        sensors_to_show, sensors_to_show_was_updated = _prune_sensors_to_show_refs(
             asset.sensors_to_show, sensor_id
         )
-        sensors_to_show_as_kpis, changed_sensors_to_show_as_kpis = (
+        sensors_to_show_as_kpis, sensors_to_show_as_kpis_was_updated = (
             _prune_sensors_to_show_as_kpis_refs(
                 asset.sensors_to_show_as_kpis, sensor_id
             )
@@ -352,20 +352,20 @@ def cleanup_sensor_references_in_assets(
 
         changed = any(
             (
-                changed_flex_model,
-                changed_flex_context,
-                changed_sensors_to_show,
-                changed_sensors_to_show_as_kpis,
+                flex_model_was_updated,
+                flex_context_was_updated,
+                sensors_to_show_was_updated,
+                sensors_to_show_as_kpis_was_updated,
             )
         )
         if not changed:
             continue
 
         changed_field_events = (
-            (changed_flex_model, "flex-model"),
-            (changed_flex_context, "flex-context"),
-            (changed_sensors_to_show, "sensors-to-show"),
-            (changed_sensors_to_show_as_kpis, "sensors-to-show-as-kpis"),
+            (flex_model_was_updated, "flex-model"),
+            (flex_context_was_updated, "flex-context"),
+            (sensors_to_show_was_updated, "sensors-to-show"),
+            (sensors_to_show_as_kpis_was_updated, "sensors-to-show-as-kpis"),
         )
         for field_changed, field_name in changed_field_events:
             if not field_changed:

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -182,51 +182,48 @@ def cleanup_sensor_references_in_assets(sensor_id: int) -> int:
     Returns the number of updated assets.
     """
 
-    if db.engine.dialect.name == "postgresql":
-        vars_json = sa.func.jsonb_build_object("sid", sensor_id)
-        candidates = db.session.scalars(
-            sa.select(GenericAsset).where(
-                sa.or_(
-                    sa.func.jsonb_path_exists(
-                        GenericAsset.flex_model,
-                        "$.**.sensor ? (@ == $sid)",
-                        vars_json,
-                    ),
-                    sa.func.jsonb_path_exists(
-                        GenericAsset.flex_context,
-                        "$.**.sensor ? (@ == $sid)",
-                        vars_json,
-                    ),
-                    sa.func.jsonb_path_exists(
-                        GenericAsset.flex_context,
-                        '$."inflexible-device-sensors"[*] ? (@ == $sid)',
-                        vars_json,
-                    ),
-                    sa.func.jsonb_path_exists(
-                        GenericAsset.sensors_to_show,
-                        "$.**.sensor ? (@ == $sid)",
-                        vars_json,
-                    ),
-                    sa.func.jsonb_path_exists(
-                        GenericAsset.sensors_to_show,
-                        "$.**.sensors[*] ? (@ == $sid)",
-                        vars_json,
-                    ),
-                    sa.func.jsonb_path_exists(
-                        GenericAsset.sensors_to_show,
-                        "$[*] ? (@ == $sid)",
-                        vars_json,
-                    ),
-                    sa.func.jsonb_path_exists(
-                        GenericAsset.sensors_to_show_as_kpis,
-                        "$.**.sensor ? (@ == $sid)",
-                        vars_json,
-                    ),
-                )
+    vars_json = sa.func.jsonb_build_object("sid", sensor_id)
+    candidates = db.session.scalars(
+        sa.select(GenericAsset).where(
+            sa.or_(
+                sa.func.jsonb_path_exists(
+                    GenericAsset.flex_model,
+                    "$.**.sensor ? (@ == $sid)",
+                    vars_json,
+                ),
+                sa.func.jsonb_path_exists(
+                    GenericAsset.flex_context,
+                    "$.**.sensor ? (@ == $sid)",
+                    vars_json,
+                ),
+                sa.func.jsonb_path_exists(
+                    GenericAsset.flex_context,
+                    '$."inflexible-device-sensors"[*] ? (@ == $sid)',
+                    vars_json,
+                ),
+                sa.func.jsonb_path_exists(
+                    GenericAsset.sensors_to_show,
+                    "$.**.sensor ? (@ == $sid)",
+                    vars_json,
+                ),
+                sa.func.jsonb_path_exists(
+                    GenericAsset.sensors_to_show,
+                    "$.**.sensors[*] ? (@ == $sid)",
+                    vars_json,
+                ),
+                sa.func.jsonb_path_exists(
+                    GenericAsset.sensors_to_show,
+                    "$[*] ? (@ == $sid)",
+                    vars_json,
+                ),
+                sa.func.jsonb_path_exists(
+                    GenericAsset.sensors_to_show_as_kpis,
+                    "$.**.sensor ? (@ == $sid)",
+                    vars_json,
+                ),
             )
-        ).all()
-    else:
-        candidates = db.session.scalars(sa.select(GenericAsset)).all()
+        )
+    ).all()
 
     changed_assets = 0
     for asset in candidates:

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -271,7 +271,7 @@ def cleanup_sensor_references_in_assets(
             )
             AssetAuditLog.add_record(
                 asset,
-                f"Removed deleted sensor reference {sensor_label} from {field_name}.",
+                f"Removed sensor reference {sensor_label} from {field_name} (because sensor has been deleted).",
             )
 
         asset.flex_model = flex_model

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -4795,6 +4795,9 @@
             ],
             "maxLength": 255
           },
+          "attributes": {
+            "default": "{}"
+          },
           "account_roles": {
             "type": "array",
             "items": {
@@ -5523,6 +5526,9 @@
               "null"
             ],
             "maxLength": 255
+          },
+          "attributes": {
+            "default": "{}"
           },
           "account_roles": {
             "type": "array",


### PR DESCRIPTION
## Description

This PR implements a cleanup feature used to clean up sensor references on delete. Now, if a sensor is deleted, all its references in flex-config and sensors_to_show are deleted as well.

## Look & Feel

None

## How to test

1. Look for or intentionally add a sensor to any of the options (flex-config or sensors to show)
2. Delete that sensor, and confirm that its references are cleared in any of the above options you placed it in.

## Further Improvements
None

## Related Items

This PR closes #2099

#### Sign-off

<!--
We ask contributors outside the FlexMeasures organisation to sign off on their contribution.
Please mark the below fields with an [x].
-->

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
