### PR TITLE
Fix: wrong ID type for fetching a schedule via OpenAPI

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -41,6 +41,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
+* Fix the Swagger endpoint for fetching a schedule [see `PR #2109 <https://www.github.com/FlexMeasures/flexmeasures/pull/2109>`_]
 
 
 v0.31.3 | April 11, 2026

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -889,7 +889,7 @@ class SensorAPI(FlaskView):
               description: ID of the sensor for which to retrieve the schedule.
               example: 5
               schema:
-                type: int
+                type: integer
             - in: path
               name: uuid
               required: true

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -1006,7 +1006,11 @@ class GetScheduleSchema(Schema):
 
         if unit is None:
             data["unit"] = sensor.unit
-        elif unit != sensor.unit and not units_are_convertible(sensor.unit, unit):
+        elif unit != sensor.unit and not units_are_convertible(
+            sensor.unit,
+            unit,
+            duration_known=True if sensor.event_resolution != timedelta(0) else False,
+        ):
             raise ValidationError(
                 f"Incompatible units: {sensor.unit} cannot be converted to {unit}.",
                 field_name="unit",

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -672,7 +672,7 @@
             "description": "ID of the sensor for which to retrieve the schedule.",
             "example": 5,
             "schema": {
-              "type": "int"
+              "type": "integer"
             }
           },
           {

--- a/tests/documentation/test_openapi_spec.py
+++ b/tests/documentation/test_openapi_spec.py
@@ -1,0 +1,60 @@
+"""Tests for the static OpenAPI specification file."""
+
+import json
+from pathlib import Path
+
+
+OPENAPI_SPEC_PATH = Path("flexmeasures/ui/static/openapi-specs.json")
+
+# Python type names that are commonly confused with their JSON Schema equivalents.
+# Keyed by the wrong value, valued by the correct replacement.
+PYTHON_TYPE_ALIASES = {
+    "int": "integer",
+    "float": "number",
+    "bool": "boolean",
+    "dict": "object",
+    "list": "array",
+    "str": "string",
+    "bytes": "string",
+    "tuple": "array",
+}
+
+
+def _collect_type_values(node, path=""):
+    """Yield (json_path, type_value) for every 'type' key found anywhere in *node*."""
+    if isinstance(node, dict):
+        if "type" in node:
+            yield path + ".type", node["type"]
+        for key, value in node.items():
+            yield from _collect_type_values(value, path + f".{key}")
+    elif isinstance(node, list):
+        for i, item in enumerate(node):
+            yield from _collect_type_values(item, path + f"[{i}]")
+
+
+def test_openapi_spec_schema_types_are_not_python_aliases():
+    """No 'type' declaration in openapi-specs.json may use a Python type alias.
+
+    Catches typos that silently break Swagger UI field rendering,
+    such as ``type: int`` (Python) instead of ``type: integer`` (JSON Schema).
+    See: https://swagger.io/docs/specification/data-models/data-types/
+    """
+    spec = json.loads(OPENAPI_SPEC_PATH.read_text())
+
+    invalid = []
+    for json_path, type_value in _collect_type_values(spec):
+        # type can be a string or a list of strings (OpenAPI 3.1 nullable shorthand).
+        # Non-string values (e.g. nested schema objects) are skipped.
+        type_values = type_value if isinstance(type_value, list) else [type_value]
+        for tv in type_values:
+            if isinstance(tv, str) and tv in PYTHON_TYPE_ALIASES:
+                invalid.append((json_path, tv, PYTHON_TYPE_ALIASES[tv]))
+
+    assert not invalid, (
+        "The following 'type' values in openapi-specs.json use Python type aliases "
+        "instead of JSON Schema types:\n\n"
+        + "\n".join(
+            f"  {path!r}: {wrong!r}  (use {correct!r} instead)"
+            for path, wrong, correct in invalid
+        )
+    )


### PR DESCRIPTION
## Description

- [x] Fix the sensor ID type annotation for the endpoint to fetch a schedule
- [x] Prevent server `ZeroDivisionError` on converting kWh instantaneous sensor data to kW, and instead return `ValidationError`.
- [x] Added changelog item in `documentation/changelog.rst`


## Look & Feel

No longer shows:

```
Please correct the following validation errors and try again.  
For 'id': Required field is not provided. 
```

## How to test

- Regression test added: `pytest -k test_openapi_spec_schema_types_are_not_python_aliases`
- For the `ZeroDivisionError` fetch the schedule from a kWh instantaneous sensor and try setting kW as the unit (for instance, in Swagger).

## Further Improvements

<!--
Potential improvements to be done in the same PR or follow-up Issues/Discussions/PRs.
-->

...

## Related Items

<!--
Mention if this PR closes an Issue or Project.
-->
