### PR TITLE
Always enable RQ embedded scheduler in flexmeasures jobs run-worker

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -62,6 +62,7 @@ Infrastructure / Support
 Bugfixes
 -----------
 * Fix the Swagger endpoint for fetching a schedule [see `PR #2109 <https://www.github.com/FlexMeasures/flexmeasures/pull/2109>`_]
+* Run ``flexmeasures jobs run-worker`` with RQ's embedded scheduler always on so jobs created with ``enqueue_in`` are promoted from the scheduled registry when due [see `issue #2105 <https://github.com/FlexMeasures/flexmeasures/issues/2105>`_]
 
 
 v0.31.3 | April 11, 2026

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,6 +13,7 @@ New features
 Infrastructure / Support
 ----------------------
 * Upgraded dependencies [see `PR #2114 <https://www.github.com/FlexMeasures/flexmeasures/pull/2114>`_]
+* Run ``flexmeasures jobs run-worker`` with RQ's embedded scheduler on by default so jobs created with ``enqueue_in`` are promoted from the scheduled registry when due; pass ``--without-scheduler`` to disable [see `PR #2112 <https://www.github.com/FlexMeasures/flexmeasures/pull/2112>`_]
 
 Bugfixes
 -----------
@@ -62,7 +63,6 @@ Infrastructure / Support
 Bugfixes
 -----------
 * Fix the Swagger endpoint for fetching a schedule [see `PR #2109 <https://www.github.com/FlexMeasures/flexmeasures/pull/2109>`_]
-* Run ``flexmeasures jobs run-worker`` with RQ's embedded scheduler always on so jobs created with ``enqueue_in`` are promoted from the scheduled registry when due [see `issue #2105 <https://github.com/FlexMeasures/flexmeasures/issues/2105>`_]
 
 
 v0.31.3 | April 11, 2026

--- a/flexmeasures/cli/jobs.py
+++ b/flexmeasures/cli/jobs.py
@@ -358,9 +358,10 @@ def run_worker(queue: str, name: str | None):
     )
     for q in q_list:
         click.echo("Running against %s on %s" % (q, q.connection))
+    click.echo("RQ embedded scheduler: on (enqueue_in jobs)")
     click.echo("=========================================================\n")
 
-    worker.work()
+    worker.work(with_scheduler=True)
 
 
 @fm_jobs.command("show-queues")

--- a/flexmeasures/cli/jobs.py
+++ b/flexmeasures/cli/jobs.py
@@ -104,7 +104,6 @@ def stats(window: int):
     L_i = []
     rows = []
     for queue_name, rq_queue in app.queues.items():
-
         # Lq = current queue length
         Lq = rq_queue.count
 
@@ -162,7 +161,9 @@ def stats(window: int):
         **(
             MsgStyle.SUCCESS
             if rho_system < 0.68
-            else MsgStyle.WARN if rho_system < 0.95 else MsgStyle.ERROR
+            else MsgStyle.WARN
+            if rho_system < 0.95
+            else MsgStyle.ERROR
         ),
     )
     click.echo(tabulate(rows, headers=headers, tablefmt="simple"))
@@ -300,7 +301,16 @@ def run_job(job_id: str):
     required=False,
     help="Give your worker a recognizable name. Defaults to random string. Defaults to fm-worker-<randomstring>",
 )
-def run_worker(queue: str, name: str | None):
+@click.option(
+    "--with-scheduler/--without-scheduler",
+    "with_scheduler",
+    default=True,
+    help=(
+        "Enable RQ's embedded scheduler so jobs queued with enqueue_in run when due. "
+        "Default: enabled. Use --without-scheduler to disable."
+    ),
+)
+def run_worker(queue: str, name: str | None, with_scheduler: bool):
     """
     Start a worker process for forecasting and/or scheduling jobs.
 
@@ -358,10 +368,13 @@ def run_worker(queue: str, name: str | None):
     )
     for q in q_list:
         click.echo("Running against %s on %s" % (q, q.connection))
-    click.echo("RQ embedded scheduler: on (enqueue_in jobs)")
+    click.echo(
+        "RQ embedded scheduler: %s (enqueue_in jobs)"
+        % ("on" if with_scheduler else "off")
+    )
     click.echo("=========================================================\n")
 
-    worker.work(with_scheduler=True)
+    worker.work(with_scheduler=with_scheduler)
 
 
 @fm_jobs.command("show-queues")

--- a/flexmeasures/cli/jobs.py
+++ b/flexmeasures/cli/jobs.py
@@ -161,9 +161,7 @@ def stats(window: int):
         **(
             MsgStyle.SUCCESS
             if rho_system < 0.68
-            else MsgStyle.WARN
-            if rho_system < 0.95
-            else MsgStyle.ERROR
+            else MsgStyle.WARN if rho_system < 0.95 else MsgStyle.ERROR
         ),
     )
     click.echo(tabulate(rows, headers=headers, tablefmt="simple"))


### PR DESCRIPTION
## Summary
- Call `Worker.work(with_scheduler=True)` so jobs queued with `enqueue_in` are promoted from the scheduled registry when due (RQ default is not to run the embedded scheduler).
- Log a clear startup line: `RQ embedded scheduler: on (enqueue_in jobs)`.
- Changelog: add v0.32.0 bugfix note for issue #2105.

## Context
Closes https://github.com/FlexMeasures/flexmeasures/issues/2105

Made with [Cursor](https://cursor.com)