### PR TITLE
Fix/asset context page bugs

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -15,6 +15,7 @@ Infrastructure / Support
 Bugfixes
 -----------
 * Return a clear validation error (instead of a server ZeroDivisionError) when posting instantaneous (0-minute) data to non-instantaneous sensors via ``[POST] /sensors/(id)/data`` [see `PR #2116 <https://www.github.com/FlexMeasures/flexmeasures/pull/2116>`_]
+* Fix asset context page for asset names containing apostrophes [see `PR #2117 <https://www.github.com/FlexMeasures/flexmeasures/pull/2117>`_]
 
 
 v0.32.0 | April 15, 2026

--- a/flexmeasures/ui/templates/_macros.html
+++ b/flexmeasures/ui/templates/_macros.html
@@ -8,7 +8,7 @@
   window.onload = function(){
 
   let assets = {{ assets | safe }};
-  let currentAssetName = '{{ current_asset_name | safe}}';
+  let currentAssetName = {{ current_asset_name | tojson }};
 
   {# Vega Spec adapted from https://stackoverflow.com/a/76300309 #}
 

--- a/flexmeasures/ui/templates/assets/asset_context.html
+++ b/flexmeasures/ui/templates/assets/asset_context.html
@@ -2,7 +2,7 @@
 
 {% set active_page = "assets" %}
 
-{% block title %} {{ asset.name }} - Scenario {% endblock %}
+{% block title %} {{ asset.name }} {% endblock %}
 
 {% block divs %}
 

--- a/flexmeasures/ui/templates/assets/asset_context.html
+++ b/flexmeasures/ui/templates/assets/asset_context.html
@@ -31,10 +31,6 @@
                     <p>Type: {{ asset.generic_asset_type.name.split('.')[-1] | title }}</p>
                 </div>
                 <div class="col-sm-3">
-                    {% if can_delete %}
-                    <button type="button" class="btn delete-button"
-                        onClick="delete_asset(event, {{ asset.id }}, '{{ asset.name }}')">Delete Scenario</button>
-                    {% endif %}
                     <!-- Tabs for toggling content -->
                     <div class="tabs-container">
                         <ul class="nav nav-tabs">

--- a/flexmeasures/ui/templates/assets/asset_context.html
+++ b/flexmeasures/ui/templates/assets/asset_context.html
@@ -208,7 +208,7 @@
 <script>
     function openSensorsModal() {
         const sensors = {{ current_asset_sensors | safe }};
-        document.getElementById("modalTitle").innerText = "Sensors for " + '{{ asset.name }}';
+        document.getElementById("modalTitle").innerText = "Sensors for " + {{ asset.name | tojson }};
         let tableHead = document.getElementById("modalTableHead");
         let tableBody = document.getElementById("modalTableBody");
 


### PR DESCRIPTION
## Description

- [x] Fix asset context page for asset names with an apostrophe (incl. a broken structure diagram)
- [x] Stop showing 'scenario' in the asset context page title
- [x] Added changelog item in `documentation/changelog.rst`

## Look & Feel

<!--
This section can contain example pictures for the UI, Input/Output for the CLI, Request / Response for an API endpoint, etc.
-->

...

## How to test

<!--
Steps to test it or name of the tests functions.

The library [flexmeasures-client](https://github.com/FlexMeasures/flexmeasures-client/) can be useful to showcase new features.
For example, it can be used to set some example data to be used in a new UI feature.
-->

...

## Further Improvements

<!--
Potential improvements to be done in the same PR or follow-up Issues/Discussions/PRs.
-->

...

## Related Items

<!--
Mention if this PR closes an Issue or Project.
-->

...
