### PR TITLE
fix: default stats window is for the selected period

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -19,6 +19,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
+* Make the sensor page load much faster for sensors with lots of data, by avoiding to load statistics over all of its history by default [see `PR #2129 <https://www.github.com/FlexMeasures/flexmeasures/pull/2129>`_]
 * Return a clear validation error (instead of a server ZeroDivisionError) when posting instantaneous (0-minute) data to non-instantaneous sensors via ``[POST] /sensors/(id)/data`` [see `PR #2116 <https://www.github.com/FlexMeasures/flexmeasures/pull/2116>`_]
 * Fix asset context page for asset names containing apostrophes [see `PR #2117 <https://www.github.com/FlexMeasures/flexmeasures/pull/2117>`_]
 

--- a/flexmeasures/ui/static/js/flexmeasures.js
+++ b/flexmeasures/ui/static/js/flexmeasures.js
@@ -658,6 +658,7 @@ function loadSensorStats(sensor_id, event_start_time="", event_end_time="", fres
     const dropdownButton = document.getElementById('sourceKeyDropdown');
     const noDataWarning = document.getElementById('noDataWarning');
     const fetchError = document.getElementById('fetchError');
+    const allTimeStatsWarning = document.getElementById('allTimeStatsWarning');
     let queryParams = '?sort=false';
     // Show the spinner
     spinner.classList.remove('d-none');
@@ -673,6 +674,14 @@ function loadSensorStats(sensor_id, event_start_time="", event_end_time="", fres
     dropdownMenu.innerHTML = '';
     noDataWarning.classList.add('d-none');
     fetchError.classList.add('d-none');
+    // Show all-time warning when the checkbox is unchecked (showing all-time stats)
+    if (allTimeStatsWarning) {
+        if (!toggleStatsCheckbox.checked) {
+            allTimeStatsWarning.classList.remove('d-none');
+        } else {
+            allTimeStatsWarning.classList.add('d-none');
+        }
+    }
     tableBody.innerHTML = '';
     
     fetch('/api/v3_0/sensors/' + sensor_id + '/stats' + queryParams)

--- a/flexmeasures/ui/templates/sensors/index.html
+++ b/flexmeasures/ui/templates/sensors/index.html
@@ -328,7 +328,7 @@ For the data, note the following:
                         <div class="form-check form-switch" id="toggleStatsCheckboxContainer">
                             <label for="toggleStatsCheckbox" class="form-check-label d-flex">
                                 <small class="text-muted">Show stats for selected duration</small>
-                                <input class="form-check-input me-2" style="margin-left: 5px;" type="checkbox" id="toggleStatsCheckbox">
+                                <input class="form-check-input me-2" style="margin-left: 5px;" type="checkbox" id="toggleStatsCheckbox" checked>
                             </label>
                         </div>
                         <!-- Alert for no data -->

--- a/flexmeasures/ui/templates/sensors/index.html
+++ b/flexmeasures/ui/templates/sensors/index.html
@@ -331,6 +331,10 @@ For the data, note the following:
                                 <input class="form-check-input me-2" style="margin-left: 5px;" type="checkbox" id="toggleStatsCheckbox" checked>
                             </label>
                         </div>
+                        <!-- Alert for all-time stats -->
+                        <div class="alert alert-info d-none" id="allTimeStatsWarning">
+                            This table is showing all-time statistics &mdash; the graph still shows the selected time range.
+                        </div>
                         <!-- Alert for no data -->
                         <div class="alert alert-warning d-none" id="noDataWarning">
                             There is no data for this sensor yet.


### PR DESCRIPTION
## Description

- [x] Improve loading speed of sensor page for sensors with lots of data, by defaulting the sensor stats query to the currently selected period.
- [x] When all time is selected & loaded, display a warning (bootstrap alert) below the statistics: "This table is showing all-time statistics - the graph still shows the selected time range."
- [x] Added changelog item in `documentation/changelog.rst`

## Look & Feel

Showing stats for a subset of the sensor data is now the default:

<img width="358" height="95" alt="image" src="https://github.com/user-attachments/assets/f7841607-a4a6-4799-a19f-2d9729f561e9" />

---

When selecting all data:

<img width="517" height="147" alt="image" src="https://github.com/user-attachments/assets/571d4c6b-0fef-42a7-a9f0-91c5356c5b69" />

## How to test

Go the a sensor page and notice the toggle to select only the current daterange is now on by default. Toggle off to see the info div.

## Further Improvements

...

## Related Items

Closes #2128.