### PR TITLE
Fix issue-time regressor filtering in forecasting

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -23,6 +23,10 @@ Infrastructure / Support
 * Add ``--resolution`` option to ``flexmeasures show chart`` to produce charts in different time resolutions [see `PR #1007 <https://github.com/FlexMeasures/flexmeasures/pull/1007/>`_]
 * Add ``FLEXMEASURES_JSON_COMPACT`` config setting and deprecate ``JSONIFY_PRETTYPRINT_REGULAR`` setting [see `PR #1090 <https://github.com/FlexMeasures/flexmeasures/pull/1090/>`_]
 
+Bugfixes
+-----------
+* Fix forecasting regressor filtering to respect issue-time availability and prevent improper data exclusion around forecast boundaries [see `PR #2133 <https://github.com/FlexMeasures/flexmeasures/pull/2133>`_]
+
 
 v0.21.0 | May 16, 2024
 ============================

--- a/flexmeasures/data/models/forecasting/model_spec_factory.py
+++ b/flexmeasures/data/models/forecasting/model_spec_factory.py
@@ -73,14 +73,149 @@ class TBSeriesSpecs(SeriesSpecs):
         self.search_params = search_params
         self.search_fnc = search_fnc
 
+    @staticmethod
+    def _extract_regressor_policy(
+        search_params: dict[str, Any],
+    ) -> tuple[dict[str, Any], datetime | None]:
+        """Return cleaned search params and optional regressor-policy context."""
+        cleaned_params = dict(search_params)
+        issue_time = cleaned_params.pop("policy_issue_time", None)
+        # Legacy compatibility: ignore this key if present.
+        cleaned_params.pop("policy_future_horizon_floor", None)
+        return cleaned_params, issue_time
+
+    def _load_beliefs_data(self, search_params: dict[str, Any]) -> BeliefsDataFrame:
+        return getattr(self.time_series_class, self.search_fnc)(**search_params)
+
+    @staticmethod
+    def _collapse_regressor_duplicates(
+        df: pd.DataFrame, issue_time: pd.Timestamp
+    ) -> pd.DataFrame:
+        """Keep one belief per event_start with source-aware tie-breaking.
+
+        Strategy:
+        - Historical events (< issue_time): prefer source "flex.service".
+        - Future events (>= issue_time): prefer source "Thiink forecaster".
+        - Within same preference bucket, keep most recent belief_time.
+        """
+        if not df.index.has_duplicates:
+            return df
+
+        work = df.copy()
+        work = work.reset_index().rename(columns={"index": "event_start"})
+        work["event_start"] = pd.to_datetime(work["event_start"], utc=True)
+
+        # Normalize source name for robust matching (source objects or plain strings).
+        if "source" in work.columns:
+            work["_source_name"] = work["source"].map(
+                lambda s: getattr(s, "name", str(s))
+            )
+        else:
+            work["_source_name"] = ""
+
+        if "belief_time" in work.columns:
+            work["_belief_time"] = pd.to_datetime(work["belief_time"], utc=True)
+        else:
+            work["_belief_time"] = pd.NaT
+
+        historical_mask = work["event_start"] < issue_time
+        preferred_hist = work["_source_name"] == "flex.service"
+        preferred_future = work["_source_name"] == "Thiink forecaster"
+        work["_preferred_source"] = False
+        work.loc[historical_mask, "_preferred_source"] = preferred_hist[historical_mask]
+        work.loc[~historical_mask, "_preferred_source"] = preferred_future[~historical_mask]
+
+        # Deterministic tie-breaks:
+        # 1) preferred source first
+        # 2) most recent belief_time
+        # 3) keep stable order for any remaining ties
+        work = work.sort_values(
+            by=["event_start", "_preferred_source", "_belief_time"],
+            ascending=[True, False, False],
+            kind="stable",
+        )
+        work = work.groupby("event_start", as_index=False).head(1)
+        work = work.drop(columns=["_source_name", "_belief_time", "_preferred_source"])
+        work = work.set_index("event_start")
+        return work
+
+    def _load_regressor_beliefs_split_by_issue_time(
+        self,
+        search_params: dict[str, Any],
+        issue_time: datetime,
+    ) -> BeliefsDataFrame:
+        """Load regressor beliefs with policy split.
+
+        Historical events (< issue_time) have no horizon floor.
+        Future events (>= issue_time) also avoid hard horizon filtering here,
+        so simulation/backfill data remains usable.
+        """
+        original_event_starts_after = search_params.get("event_starts_after")
+        original_event_ends_before = search_params.get("event_ends_before")
+        issue_time_ts = pd.Timestamp(issue_time)
+
+        historical_params = dict(search_params)
+        historical_params["horizons_at_least"] = None
+        if (
+            original_event_ends_before is None
+            or pd.Timestamp(original_event_ends_before) > issue_time_ts
+        ):
+            historical_params["event_ends_before"] = issue_time_ts
+
+        future_params = dict(search_params)
+        # Keep this explicit to avoid accidental policy coupling to belief_horizon
+        # values written by providers/simulations.
+        future_params["horizons_at_least"] = None
+        if (
+            original_event_starts_after is None
+            or pd.Timestamp(original_event_starts_after) < issue_time_ts
+        ):
+            future_params["event_starts_after"] = issue_time_ts
+        if original_event_ends_before is not None:
+            future_params["event_ends_before"] = original_event_ends_before
+
+        frames = []
+        if (
+            original_event_starts_after is None
+            or pd.Timestamp(original_event_starts_after) < issue_time_ts
+        ):
+            frames.append(self._load_beliefs_data(historical_params))
+        if (
+            original_event_ends_before is None
+            or pd.Timestamp(original_event_ends_before) > issue_time_ts
+        ):
+            frames.append(self._load_beliefs_data(future_params))
+
+        if not frames:
+            return self._load_beliefs_data(search_params)
+        if len(frames) == 1:
+            return frames[0]
+        merged = pd.concat(frames).sort_index()
+        # If both queries include the same belief row at the boundary (DB-dependent
+        # interval semantics), remove exact duplicates to keep indexes unique later.
+        merged = merged.loc[~merged.index.duplicated(keep="last")]
+        return merged
+
     def _load_series(self) -> pd.Series:
         logger.info("Reading %s data from database" % self.time_series_class.__name__)
 
-        bdf: BeliefsDataFrame = getattr(self.time_series_class, self.search_fnc)(
-            **self.search_params
-        )
+        (
+            search_params,
+            issue_time,
+        ) = self._extract_regressor_policy(self.search_params)
+        if issue_time is not None:
+            bdf: BeliefsDataFrame = self._load_regressor_beliefs_split_by_issue_time(
+                search_params=search_params,
+                issue_time=issue_time,
+            )
+        else:
+            bdf = self._load_beliefs_data(search_params)
         assert isinstance(bdf, BeliefsDataFrame)
-        df = simplify_index(bdf)
+        df = simplify_index(bdf, index_levels_to_columns=["belief_time", "source"])
+        if issue_time is not None:
+            df = self._collapse_regressor_duplicates(df, pd.Timestamp(issue_time))
+        if getattr(df.index, "tz", None) is not None and str(df.index.tz) != "UTC":
+            df = df.tz_convert("UTC")
         self.check_data(df)
 
         if self.post_load_processing is not None:
@@ -165,6 +300,7 @@ def create_initial_model_specs(  # noqa: C901
             sensor,
             query_window,
             forecast_horizon,
+            forecast_start,
             regressor_transformation,
             transform_to_normal,
         )
@@ -258,6 +394,7 @@ def configure_regressors_for_nearest_weather_sensor(
     sensor: Sensor,
     query_window,
     horizon,
+    forecast_start,
     regressor_transformation,  # the regressor transformation can be passed in
     transform_to_normal,  # if not, it a normalization can be applied
 ) -> list[TBSeriesSpecs]:
@@ -287,12 +424,22 @@ def configure_regressors_for_nearest_weather_sensor(
                 )
                 # Collect the weather data for the requested time window
                 regressor_specs_name = "%s_l0" % sensor_name
-                if len(regressor_transformation.keys()) == 0 and transform_to_normal:
-                    regressor_transformation = (
-                        get_normalization_transformation_from_sensor_attributes(
-                            closest_sensor,
+                # Handle transformation per regressor and avoid mutating shared state across loop iterations.
+                feature_transformation = regressor_transformation
+                if transform_to_normal:
+                    if isinstance(regressor_transformation, dict):
+                        if len(regressor_transformation.keys()) == 0:
+                            feature_transformation = (
+                                get_normalization_transformation_from_sensor_attributes(
+                                    closest_sensor,
+                                )
+                            )
+                    elif regressor_transformation is None:
+                        feature_transformation = (
+                            get_normalization_transformation_from_sensor_attributes(
+                                closest_sensor,
+                            )
                         )
-                    )
                 regressor_specs.append(
                     TBSeriesSpecs(
                         name=regressor_specs_name,
@@ -301,10 +448,12 @@ def configure_regressors_for_nearest_weather_sensor(
                             sensors=closest_sensor,
                             event_starts_after=query_window[0],
                             event_ends_before=query_window[1],
-                            horizons_at_least=horizon,
+                            horizons_at_least=None,
                             horizons_at_most=None,
+                            policy_issue_time=forecast_start,
                         ),
-                        feature_transformation=regressor_transformation,
+                        feature_transformation=feature_transformation,
+                        resampling_config={"upsampling_method": "ffill"},
                         interpolation_config={"method": "time"},
                     )
                 )

--- a/flexmeasures/data/tests/test_forecasting_pipeline.py
+++ b/flexmeasures/data/tests/test_forecasting_pipeline.py
@@ -1,0 +1,837 @@
+from __future__ import annotations
+
+import pytest
+
+import logging
+import pandas as pd
+from datetime import datetime, timedelta
+
+from marshmallow import ValidationError
+
+from flexmeasures.data.models.data_sources import DataSource
+from flexmeasures.data.models.forecasting.exceptions import NotEnoughDataException
+from flexmeasures.data.models.generic_assets import (
+    GenericAsset as Asset,
+    GenericAssetType,
+)
+from flexmeasures.data.models.forecasting.pipelines import TrainPredictPipeline
+from flexmeasures.data.models.time_series import Sensor, TimedBelief
+from flexmeasures.utils.job_utils import work_on_rq
+from flexmeasures.data.services.forecasting import handle_forecasting_exception
+
+
+@pytest.mark.parametrize(
+    ["config", "params", "as_job", "expected_error"],
+    [
+        (
+            {
+                # "model": "CustomLGBM",
+                "train-start": "2025-01-01T00:00+02:00",
+                "train-period": "P2D",
+                "retrain-frequency": "P0D",  # 0 days is expected to fail
+            },
+            {
+                "sensor": "solar-sensor",
+                "model-save-dir": "flexmeasures/data/models/forecasting/artifacts/models",
+                "output-path": None,
+                "end": "2025-01-03T00:00+02:00",
+                "sensor-to-save": None,
+                "start": "2025-01-02T00:00+02:00",
+                "max-forecast-horizon": "PT1H",
+                "forecast-frequency": "PT1H",
+                "probabilistic": False,
+            },
+            False,
+            (ValidationError, "retrain-frequency must be at least 1 hour"),
+        ),
+        (
+            {
+                # "model": "CustomLGBM",
+                "future-regressors": ["irradiance-sensor"],
+                "train-start": "2025-01-01T00:00+02:00",
+            },
+            {
+                "sensor": "solar-sensor",
+                "model-save-dir": "flexmeasures/data/models/forecasting/artifacts/models",
+                "output-path": None,
+                "start": "2025-01-08T00:00+02:00",  # start coincides with end of available data in sensor
+                "end": "2025-01-09T00:00+02:00",
+                "sensor-to-save": None,
+                "max-forecast-horizon": "PT1H",
+                "forecast-frequency": "PT24H",  # 1 cycle and 1 viewpoint
+                "probabilistic": False,
+            },
+            True,
+            None,
+        ),
+        (
+            {
+                # "model": "CustomLGBM",
+                "future-regressors": ["irradiance-sensor"],
+                "train-start": "2025-01-01T00:00+02:00",
+                "retrain-frequency": "PT12H",
+            },
+            {
+                "sensor": "solar-sensor",
+                "model-save-dir": "flexmeasures/data/models/forecasting/artifacts/models",
+                "output-path": None,
+                "start": "2025-01-08T00:00+02:00",  # start coincides with end of available data in sensor
+                "end": "2025-01-09T00:00+02:00",
+                "sensor-to-save": None,
+                "max-forecast-horizon": "PT1H",
+                "forecast-frequency": "PT12H",  # 2 cycles and 2 viewpoints
+                "probabilistic": False,
+            },
+            True,
+            None,
+        ),
+        (
+            {
+                # "model": "CustomLGBM",
+                "future-regressors": ["irradiance-sensor"],
+                # "train-start": "2025-01-01T00:00+02:00",  # without a start date, max-training-period takes over
+                "max-training-period": "P7D",
+            },
+            {
+                "sensor": "solar-sensor",
+                "model-save-dir": "flexmeasures/data/models/forecasting/artifacts/models",
+                "output-path": None,
+                "start": "2025-01-08T00:00+02:00",  # start coincides with end of available data in sensor
+                "end": "2025-01-09T00:00+02:00",
+                "sensor-to-save": None,
+                "max-forecast-horizon": "PT1H",
+                "forecast-frequency": "PT24H",  # 1 cycle and 1 viewpoint
+                "probabilistic": False,
+            },
+            False,
+            None,
+        ),
+        (
+            {
+                # "model": "CustomLGBM",
+                "past-regressors": ["irradiance-sensor"],
+                "future-regressors": ["irradiance-sensor"],
+                "train-start": "2025-01-01T00:00+02:00",
+            },
+            {  # Test: duplicate sensor names in past and future regressors
+                "sensor": "solar-sensor",
+                "model-save-dir": "flexmeasures/data/models/forecasting/artifacts/models",
+                "output-path": None,
+                "start": "2025-01-08T00:00+02:00",
+                "end": "2025-01-09T00:00+02:00",
+                "sensor-to-save": None,
+                "max-forecast-horizon": "PT1H",
+                "forecast-frequency": "PT24H",
+                "probabilistic": False,
+            },
+            False,
+            None,
+        ),
+        (
+            {
+                # "model": "CustomLGBM",
+                "future-regressors": ["irradiance-sensor", "solar-sensor-1"],
+                "train-start": "2025-01-01T00:00+02:00",
+            },
+            {
+                "sensor": "solar-sensor",
+                "model-save-dir": "flexmeasures/data/models/forecasting/artifacts/models",
+                "output-path": None,
+                "start": "2025-01-08T00:00+02:00",
+                "end": "2025-01-09T00:00+02:00",
+                "sensor-to-save": None,
+                "max-forecast-horizon": "PT1H",
+                "forecast-frequency": "PT24H",
+                "probabilistic": False,
+            },
+            False,
+            None,
+        ),
+        (
+            {
+                # "model": "CustomLGBM",
+                "past-regressors": ["irradiance-sensor", "solar-sensor-1"],
+                "train-start": "2025-01-01T00:00+02:00",
+            },
+            {
+                "sensor": "solar-sensor",
+                "model-save-dir": "flexmeasures/data/models/forecasting/artifacts/models",
+                "output-path": None,
+                "start": "2025-01-08T00:00+02:00",
+                "end": "2025-01-09T00:00+02:00",
+                "sensor-to-save": None,
+                "max-forecast-horizon": "PT1H",
+                "forecast-frequency": "PT24H",
+                "probabilistic": False,
+            },
+            False,
+            None,
+        ),
+        (
+            {
+                # "model": "CustomLGBM",
+                "regressors": ["irradiance-sensor", "solar-sensor-1"],
+                "train-start": "2025-01-01T00:00+02:00",
+            },
+            {
+                "sensor": "solar-sensor",
+                "model-save-dir": "flexmeasures/data/models/forecasting/artifacts/models",
+                "output-path": None,
+                "start": "2025-01-08T00:00+02:00",
+                "end": "2025-01-09T00:00+02:00",
+                "sensor-to-save": None,
+                "max-forecast-horizon": "PT1H",
+                "forecast-frequency": "PT24H",
+                "probabilistic": False,
+            },
+            False,
+            None,
+        ),
+        (
+            {
+                # "model": "CustomLGBM",
+                "future-regressors": ["irradiance-sensor"],
+                "retrain-frequency": "P1D",
+                "train-start": "2025-01-01T00:00+02:00",
+                "train-period": "P2D",
+            },
+            {
+                "sensor": "solar-sensor",
+                "model-save-dir": "flexmeasures/data/models/forecasting/artifacts/models",
+                "output-path": None,
+                "end": "2025-01-03T00:00+02:00",
+                "sensor-to-save": None,
+                "start": "2025-01-02T00:00+02:00",
+                "max-forecast-horizon": "PT1H",
+                "forecast-frequency": "PT24H",
+                "probabilistic": False,
+            },
+            False,
+            None,
+        ),
+    ],
+)
+def test_train_predict_pipeline(  # noqa: C901
+    app,
+    setup_fresh_test_forecast_data,
+    config,  # config passed to the Forecaster
+    params,  # parameters passed to the compute method of the Forecaster
+    as_job: bool,
+    expected_error: bool | tuple[type[BaseException], str],
+):
+    sensor = setup_fresh_test_forecast_data[params["sensor"]]
+    params["sensor"] = sensor.id
+
+    past_regressors = [
+        setup_fresh_test_forecast_data[regressor_name]
+        for regressor_name in config.get("past-regressors", [])
+    ]
+    future_regressors = [
+        setup_fresh_test_forecast_data[regressor_name]
+        for regressor_name in config.get("future-regressors", [])
+    ]
+    config_regressors = [
+        setup_fresh_test_forecast_data[regressor_name]
+        for regressor_name in config.get("regressors", [])
+    ]
+    regressors = [
+        setup_fresh_test_forecast_data[regressor_name]
+        for regressor_name in params.get("regressors", [])
+    ]
+
+    if config.get("past-regressors"):
+        config["past-regressors"] = [regressor.id for regressor in past_regressors]
+
+    if config.get("future-regressors"):
+        config["future-regressors"] = [regressor.id for regressor in future_regressors]
+
+    if config.get("regressors"):
+        config["regressors"] = [regressor.id for regressor in config_regressors]
+
+    if params.get("regressors"):
+        params["regressors"] = [regressor.id for regressor in regressors]
+
+    if expected_error:
+        with pytest.raises(expected_error[0]) as e_info:
+            pipeline = TrainPredictPipeline(config=config)
+            pipeline.compute(parameters=params)
+        assert expected_error[1] in str(e_info)
+    else:
+        pipeline = TrainPredictPipeline(config=config)
+        pipeline_returns = pipeline.compute(parameters=params, as_job=as_job)
+
+        # Check pipeline properties
+        for attr in ("model",):
+            if config.get(attr):
+                assert hasattr(pipeline, attr)
+
+        if as_job:
+            work_on_rq(
+                app.queues["forecasting"], exc_handler=handle_forecasting_exception
+            )
+
+            # Fetch returned job
+            job = app.queues["forecasting"].fetch_job(pipeline_returns["job_id"])
+
+            assert (
+                job is not None
+            ), "a returned job should exist in the forecasting queue"
+
+            if not job.dependency_ids:
+                cycle_job_ids = [job.id]  # only one cycle job, no wrap-up job
+            else:
+                assert (
+                    job.is_finished
+                ), f"The wrap-up job should be finished, and not {job.get_status()}"
+                cycle_job_ids = job.kwargs.get("cycle_job_ids", [])  # wrap-up job case
+
+            finished_jobs = app.queues["forecasting"].finished_job_registry
+
+            for job_id in cycle_job_ids:
+                job = app.queues["forecasting"].fetch_job(job_id)
+                assert job is not None, f"Job {job_id} should exist"
+                assert (
+                    job_id in finished_jobs
+                ), f"Job {job_id} should be in the finished registry"
+
+        forecasts = sensor.search_beliefs(
+            source_types=["forecaster"], most_recent_beliefs_only=False
+        )
+
+        dg_params = pipeline._parameters  # parameters stored in the data generator
+        m_viewpoints = (dg_params["end_date"] - dg_params["predict_start"]) / (
+            dg_params["forecast_frequency"]
+        )
+        # 1 hour of forecasts is saved over 4 15-minute resolution events
+        n_events_per_horizon = timedelta(hours=1) / dg_params["sensor"].event_resolution
+        n_hourly_horizons = dg_params["max_forecast_horizon"] // timedelta(hours=1)
+        n_cycles = max(
+            timedelta(hours=dg_params["predict_period_in_hours"])
+            // max(
+                pipeline._config["retrain_frequency"],
+                pipeline._parameters["forecast_frequency"],
+            ),
+            1,
+        )
+        assert (
+            len(forecasts)
+            == m_viewpoints * n_hourly_horizons * n_events_per_horizon * n_cycles
+        ), (
+            f"we expect {n_events_per_horizon} event(s) per horizon, "
+            f"{n_hourly_horizons} horizon(s), {m_viewpoints} viewpoint(s)"
+            f"{f', and {n_cycles} cycle(s)' if n_cycles > 1 else ''}"
+        )
+        assert (
+            forecasts.lineage.number_of_belief_times == m_viewpoints
+        ), f"we expect {m_viewpoints} viewpoints"
+        source = forecasts.lineage.sources[0]
+        assert "TrainPredictPipeline" in str(
+            source
+        ), "string representation of the Forecaster (DataSource) should mention the used model"
+
+        if not as_job:
+            # Sync case: pipeline returns a non-empty list
+            assert (
+                isinstance(pipeline_returns, list) and len(pipeline_returns) > 0
+            ), "pipeline should return a non-empty list"
+            assert all(
+                isinstance(item, dict) for item in pipeline_returns
+            ), "each item should be a dict"
+
+            for pipeline_return in pipeline_returns:
+                assert {"data", "sensor"}.issubset(
+                    pipeline_return.keys()
+                ), "returned dict should have data and sensor keys"
+                assert (
+                    pipeline_return["sensor"].id == dg_params["sensor_to_save"].id
+                ), "returned sensor should match sensor that forecasts will be saved into"
+                pd.testing.assert_frame_equal(
+                    forecasts.sort_index(),
+                    pipeline_return["data"].sort_index(),
+                )
+
+        # Check DataGenerator configuration stored under DataSource attributes
+        data_generator_config = source.attributes["data_generator"]["config"]
+        assert data_generator_config["model"] == "CustomLGBM"
+        assert (
+            "missing-threshold" in data_generator_config
+        ), "data generator config should mention missing_threshold"
+        for regressor in past_regressors:
+            assert (
+                regressor.id in data_generator_config["past-regressors"]
+            ), f"data generator config should mention past regressor {regressor.name}"
+
+        for regressor in future_regressors:
+            assert (
+                regressor.id in data_generator_config["future-regressors"]
+            ), f"data generator config should mention future regressor {regressor.name}"
+        for regressor in regressors:
+            assert (
+                regressor.id in data_generator_config["past-regressors"]
+            ), f"data generator config should mention regressor {regressor.name} as a past regressor"
+            assert (
+                regressor.id in data_generator_config["future-regressors"]
+            ), f"data generator config should mention regressor {regressor.name} as a future regressor"
+        assert (
+            "regressors" not in data_generator_config
+        ), "(past and future) regressors should be stored under 'past_regressors' and 'future_regressors' instead"
+        assert "max-training-period" in data_generator_config
+
+        # Check DataGenerator parameters stored under DataSource attributes is empty
+        assert "parameters" not in source.attributes["data_generator"]
+
+
+# Test that missing data logging works and raises NotEnoughDataException when threshold exceeded
+@pytest.mark.parametrize(
+    ["config", "params"],
+    [  # Target sensor has missing data
+        (
+            {
+                # "model": "CustomLGBM",
+                "missing-threshold": "0.0",
+                "train-start": "2025-01-01T00:00+02:00",
+            },
+            {
+                "sensor": "solar-sensor",
+                "model-save-dir": "flexmeasures/data/models/forecasting/artifacts/models",
+                "output-path": None,
+                "end": "2025-01-30T00:00+02:00",
+                "sensor-to-save": None,
+                "start": "2025-01-25T00:00+02:00",
+                "max-forecast-horizon": "PT1H",
+                "forecast-frequency": "PT1H",
+                "probabilistic": False,
+            },
+        ),
+        # Empty forecasts in sensor passed as future regressor.
+        (
+            {
+                # "model": "CustomLGBM",
+                "future-regressors": ["irradiance-sensor"],
+                "missing-threshold": "0.0",
+                "train-start": "2025-01-01T00:00+02:00",
+            },
+            {
+                "sensor": "solar-sensor",
+                "model-save-dir": "flexmeasures/data/models/forecasting/artifacts/models",
+                "output-path": None,
+                "end": "2025-01-30T00:00+02:00",
+                "sensor-to-save": None,
+                "start": "2025-01-25T00:00+02:00",
+                "max-forecast-horizon": "PT1H",
+                "forecast-frequency": "PT1H",
+                "probabilistic": False,
+            },
+        ),
+    ],
+)
+def test_missing_data_logs_warning(
+    setup_fresh_test_forecast_data_with_missing_data,
+    config,
+    params,
+    caplog,
+):
+    """
+    Verify that a NotEnoughDataException is raised (wrapping a ValueError)
+    """
+    sensor = setup_fresh_test_forecast_data_with_missing_data[params["sensor"]]
+    params["sensor"] = sensor.id
+
+    past_regressors = [
+        setup_fresh_test_forecast_data_with_missing_data[reg]
+        for reg in params.get("past_regressors", [])
+    ]
+    future_regressors = [
+        setup_fresh_test_forecast_data_with_missing_data[reg]
+        for reg in params.get("future_regressors", [])
+    ]
+    regressors = [
+        setup_fresh_test_forecast_data_with_missing_data[reg]
+        for reg in params.get("regressors", [])
+    ]
+    config["missing-threshold"] = float(config.get("missing-threshold"))
+    if config.get("past-regressors"):
+        config["past-regressors"] = [r.id for r in past_regressors]
+    if config.get("future-regressors"):
+        config["future-regressors"] = [r.id for r in future_regressors]
+    if params.get("regressors"):
+        params["regressors"] = [r.id for r in regressors]
+
+    pipeline = TrainPredictPipeline(config=config)
+    # Expect ValueError when missing data exceeds threshold
+    with pytest.raises(NotEnoughDataException) as excinfo:
+        pipeline.compute(parameters=params)
+    assert "missing values" in str(
+        excinfo.value
+    ), "Expected NotEnoughDataException for missing data threshold"
+
+
+# Test that max_training-period caps train-period and logs a warning
+@pytest.mark.parametrize(
+    ["config", "params"],
+    [
+        (
+            {
+                # "model": "CustomLGBM",
+                "retrain-frequency": "P1D",
+                "train-start": "2025-01-01T00:00+02:00",
+                "max-training-period": "P10D",  # cap at 10 days
+            },
+            {
+                "sensor": "solar-sensor",
+                "model-save-dir": "flexmeasures/data/models/forecasting/artifacts/models",
+                "output-path": None,
+                "end": "2025-01-30T00:00+02:00",
+                "sensor-to-save": None,
+                "start": "2025-01-25T00:00+02:00",
+                "max-forecast-horizon": "PT1H",
+                "forecast-frequency": "PT1H",
+                "probabilistic": False,
+            },
+        ),
+    ],
+)
+def test_train_period_capped_logs_warning(
+    setup_fresh_test_forecast_data,
+    config,  # config passed to the Forecaster
+    params,  # parameters passed to the compute method of the Forecaster
+    caplog,
+):
+    """
+    Verify that a warning is logged when train-period exceeds max-training-period,
+    and that train-period is capped accordingly.
+    """
+    sensor = setup_fresh_test_forecast_data[params["sensor"]]
+    params["sensor"] = sensor.id
+
+    with caplog.at_level(logging.WARNING):
+        pipeline = TrainPredictPipeline(config=config)
+        pipeline.compute(parameters=params)
+
+    assert any(
+        "train-period is greater than max-training-period" in message
+        for message in caplog.messages
+    ), "Expected warning about capping train_period"
+
+    config_used = pipeline._config
+    assert config_used["missing_threshold"] == 1
+    assert config_used["train_period_in_hours"] == timedelta(days=10) / timedelta(
+        hours=1
+    ), "train_period_in_hours should be capped to max_training_period"
+
+
+def test_prior_restricts_training_beliefs(
+    app,
+    setup_fresh_test_forecast_data_with_anomalous_beliefs,
+):
+    """
+    Verify that the 'prior' parameter restricts which beliefs are used by the forecasting pipeline.
+
+    The fixture provides a sensor with two sets of beliefs for Jan 1–7 2025:
+    - Phase 1 (normal): value = 50 kW, recorded on Dec 31, 2024
+    - Phase 2 (anomalous): value = 5000 kW, recorded on Jan 10, 2025
+
+    When 'prior' is set before Jan 10, only Phase 1 beliefs are available,
+    so the model is trained on normal values and produces low forecasts.
+    When 'prior' is set after Jan 10, Phase 2 beliefs become the most recent
+    per event, so the model is trained on anomalous values and produces high forecasts.
+    """
+    sensor = setup_fresh_test_forecast_data_with_anomalous_beliefs["anomaly-sensor"]
+
+    normal_value = 50.0
+    anomalous_value = 5000.0
+
+    base_config = {
+        "train-start": "2025-01-01T00:00+00:00",
+    }
+    base_params = {
+        "sensor": sensor.id,
+        "model-save-dir": "flexmeasures/data/models/forecasting/artifacts/models",
+        "output-path": None,
+        "start": "2025-01-08T00:00+00:00",
+        "end": "2025-01-09T00:00+00:00",
+        "sensor-to-save": None,
+        "max-forecast-horizon": "PT1H",
+        "forecast-frequency": "PT1H",
+        "probabilistic": False,
+    }
+
+    # Run with prior before the anomalous beliefs (Jan 10) → only normal values used
+    params_before_anomaly = {
+        **base_params,
+        "prior": "2025-01-05T00:00+00:00",  # before late_belief_time (Jan 10)
+    }
+    pipeline_before = TrainPredictPipeline(config=base_config)
+    returns_before = pipeline_before.compute(parameters=params_before_anomaly)
+    forecasts_before = returns_before[0]["data"]
+
+    # Run with prior after the anomalous beliefs (Jan 10) → anomalous values used
+    params_after_anomaly = {
+        **base_params,
+        "prior": "2025-01-15T00:00+00:00",  # after late_belief_time (Jan 10)
+    }
+    pipeline_after = TrainPredictPipeline(config=base_config)
+    returns_after = pipeline_after.compute(parameters=params_after_anomaly)
+    forecasts_after = returns_after[0]["data"]
+
+    mean_before = float(forecasts_before["event_value"].mean())
+    mean_after = float(forecasts_after["event_value"].mean())
+
+    # When prior is before the anomaly, forecasts should reflect normal values (close to 50)
+    assert mean_before < anomalous_value / 2, (
+        f"Forecasts with prior before anomaly should be well below {anomalous_value / 2}, "
+        f"but mean was {mean_before:.1f}"
+    )
+
+    # When prior is after the anomaly, forecasts should reflect anomalous values (close to 5000)
+    assert mean_after > normal_value * 5, (
+        f"Forecasts with prior after anomaly should be well above {normal_value * 5}, "
+        f"but mean was {mean_after:.1f}"
+    )
+
+    # The two runs must produce meaningfully different forecasts
+    assert mean_after > mean_before * 10, (
+        f"Forecasts after anomaly ({mean_after:.1f}) should be at least 10x higher "
+        f"than forecasts before anomaly ({mean_before:.1f})"
+    )
+
+
+def test_future_regressor_changes_forecasts_in_issue_time_window(
+    app, fresh_db, tmp_path
+):
+    """
+    Integration check for deterministic regressor behavior around issue-time splitting.
+
+    We build two target sensors with identical history, run one with a future regressor
+    and one without, and assert the forecast window output differs.
+    """
+    db = fresh_db
+
+    asset_type = GenericAssetType(name="deterministic-regressor-asset-type")
+    asset = Asset(
+        name="Deterministic regressor test asset",
+        generic_asset_type=asset_type,
+        latitude=1.0,
+        longitude=1.0,
+    )
+    source_actual = DataSource(name="deterministic-regressor-actual", type="test")
+    source_forecaster = DataSource(name="deterministic-regressor-forecast", type="test")
+    db.session.add_all([asset_type, asset, source_actual, source_forecaster])
+    db.session.flush()
+
+    target_without_regressor = Sensor(
+        name="target-without-regressor",
+        generic_asset=asset,
+        unit="kW",
+        event_resolution=timedelta(hours=1),
+    )
+    target_with_regressor = Sensor(
+        name="target-with-regressor",
+        generic_asset=asset,
+        unit="kW",
+        event_resolution=timedelta(hours=1),
+    )
+    weather_regressor = Sensor(
+        name="weather-regressor",
+        generic_asset=asset,
+        unit="kW",
+        event_resolution=timedelta(hours=1),
+    )
+    db.session.add_all(
+        [target_without_regressor, target_with_regressor, weather_regressor]
+    )
+    db.session.flush()
+
+    history_index = pd.date_range(
+        datetime(2025, 1, 1),
+        datetime(2025, 1, 7, 23, 0),
+        freq="1h",
+        tz="UTC",
+    )
+    forecast_index = pd.date_range(
+        datetime(2025, 1, 8),
+        datetime(2025, 1, 8, 23, 0),
+        freq="1h",
+        tz="UTC",
+    )
+
+    # Deterministic but non-periodic-enough pattern so autoregressive-only models
+    # cannot trivially extrapolate future behavior from target history alone.
+    historical_regressor_values = [
+        ((37 * i + 13) % 97) + ((i % 5) * 0.1) for i in range(len(history_index))
+    ]
+    future_regressor_values = [
+        ((53 * i + 7) % 101) + 150 + ((i % 7) * 0.1)
+        for i in range(len(forecast_index))
+    ]
+    target_historical_values = [3 * value + 5 for value in historical_regressor_values]
+    target_future_truth = [3 * value + 5 for value in future_regressor_values]
+
+    beliefs = []
+    for ts, reg_value, target_value in zip(
+        history_index,
+        historical_regressor_values,
+        target_historical_values,
+    ):
+        beliefs.extend(
+            [
+                TimedBelief(
+                    sensor=weather_regressor,
+                    event_start=ts,
+                    event_value=reg_value,
+                    source=source_actual,
+                    belief_horizon=timedelta(0),
+                ),
+                TimedBelief(
+                    sensor=target_with_regressor,
+                    event_start=ts,
+                    event_value=target_value,
+                    source=source_actual,
+                    belief_horizon=timedelta(0),
+                ),
+                TimedBelief(
+                    sensor=target_without_regressor,
+                    event_start=ts,
+                    event_value=target_value,
+                    source=source_actual,
+                    belief_horizon=timedelta(0),
+                ),
+            ]
+        )
+
+    for ts, reg_value in zip(forecast_index, future_regressor_values):
+        # Keep a very short horizon for future regressors; this used to be
+        # vulnerable to stricter horizon filtering around issue time.
+        beliefs.append(
+            TimedBelief(
+                sensor=weather_regressor,
+                event_start=ts,
+                event_value=reg_value,
+                source=source_forecaster,
+                belief_time=ts - timedelta(minutes=5),
+            )
+        )
+
+    db.session.add_all(beliefs)
+    db.session.commit()
+
+    base_config = {"train-start": "2025-01-01T00:00+00:00"}
+    common_params = {
+        "model-save-dir": str(tmp_path / "models"),
+        "output-path": None,
+        "start": "2025-01-08T00:00+00:00",
+        "end": "2025-01-09T00:00+00:00",
+        "sensor-to-save": None,
+        "max-forecast-horizon": "PT1H",
+        "forecast-frequency": "PT1H",
+        "probabilistic": False,
+    }
+
+    pipeline_without_regressor = TrainPredictPipeline(config=base_config)
+    returns_without_regressor = pipeline_without_regressor.compute(
+        parameters={
+            **common_params,
+            "sensor": target_without_regressor.id,
+        }
+    )
+
+    pipeline_with_regressor = TrainPredictPipeline(
+        config={
+            **base_config,
+            "future-regressors": [weather_regressor.id],
+        }
+    )
+    returns_with_regressor = pipeline_with_regressor.compute(
+        parameters={
+            **common_params,
+            "sensor": target_with_regressor.id,
+        }
+    )
+
+    def collapse_to_event_start_series(forecast_df, series_name: str) -> pd.Series:
+        """Align forecasts across runs by event_start only.
+
+        BeliefsDataFrame indexes include run-specific belief metadata (e.g. source),
+        so joining on the full index can produce empty intersections even when both
+        runs contain forecasts for the same event starts.
+        """
+        series = forecast_df["event_value"].sort_index()
+        if not isinstance(series.index, pd.MultiIndex):
+            series.index = pd.to_datetime(series.index, utc=True)
+            return series.sort_index().rename(series_name)
+
+        assert "event_start" in series.index.names, (
+            "Expected event_start in forecast index for deterministic alignment."
+        )
+        values_by_event = series.rename("event_value").reset_index()
+        sort_cols = ["event_start"]
+        if "belief_time" in values_by_event.columns:
+            sort_cols.append("belief_time")
+        values_by_event = values_by_event.sort_values(sort_cols)
+        unique_values_per_event = values_by_event.groupby("event_start")[
+            "event_value"
+        ].nunique()
+        assert (unique_values_per_event <= 1).all(), (
+            "Expected at most one unique forecast value per event_start. "
+            "Conflicting duplicates indicate a forecasting regression."
+        )
+        values_by_event = values_by_event.drop_duplicates(
+            subset=["event_start"], keep="last"
+        )
+        collapsed_series = values_by_event.set_index("event_start")["event_value"]
+        collapsed_series.index = pd.to_datetime(collapsed_series.index, utc=True)
+        return collapsed_series.sort_index().rename(series_name)
+
+    forecasts_without_regressor = (
+        collapse_to_event_start_series(
+            returns_without_regressor[0]["data"], "without_regressor"
+        )
+    )
+    forecasts_with_regressor = (
+        collapse_to_event_start_series(
+            returns_with_regressor[0]["data"], "with_regressor"
+        )
+    )
+    aligned_forecasts = pd.concat(
+        [forecasts_without_regressor, forecasts_with_regressor],
+        axis=1,
+        join="inner",
+    )
+
+    assert list(forecasts_without_regressor.index) == list(forecast_index)
+    assert list(forecasts_with_regressor.index) == list(forecast_index)
+    assert not aligned_forecasts.empty
+    assert aligned_forecasts.notna().all(axis=None)
+    assert (
+        aligned_forecasts["without_regressor"]
+        .ne(aligned_forecasts["with_regressor"])
+        .any()
+    ), "Forecasts should differ for at least one timestamp when a future regressor is used."
+
+    truth = pd.Series(target_future_truth, index=forecast_index, name="truth")
+    mae_without_regressor = (
+        aligned_forecasts["without_regressor"]
+        .reindex(truth.index)
+        .sub(truth)
+        .abs()
+        .mean()
+    )
+    mae_with_regressor = (
+        aligned_forecasts["with_regressor"].reindex(truth.index).sub(truth).abs().mean()
+    )
+    first_forecast_timestamp = forecast_index[0]
+    first_error_without_regressor = abs(
+        aligned_forecasts.loc[first_forecast_timestamp, "without_regressor"]
+        - truth.loc[first_forecast_timestamp]
+    )
+    first_error_with_regressor = abs(
+        aligned_forecasts.loc[first_forecast_timestamp, "with_regressor"]
+        - truth.loc[first_forecast_timestamp]
+    )
+    assert first_error_with_regressor < first_error_without_regressor, (
+        "At the issue-time boundary, the future-regressor run should be more accurate."
+    )
+    assert mae_with_regressor < mae_without_regressor, (
+        "The future-regressor forecast is expected to be more accurate "
+        "on this deterministic synthetic dataset."
+    )

--- a/flexmeasures/data/tests/test_model_spec_factory_regressor_policy.py
+++ b/flexmeasures/data/tests/test_model_spec_factory_regressor_policy.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+import pytz
+import timely_beliefs as tb
+
+from flexmeasures.data.models.forecasting.model_spec_factory import (
+    TBSeriesSpecs,
+    configure_regressors_for_nearest_weather_sensor,
+)
+
+
+class _SensorWithWeatherCorrelations:
+    def __init__(self, correlations: list[str]):
+        self.name = "target-sensor"
+        self._correlations = correlations
+
+    def get_attribute(self, key: str):
+        if key == "weather_correlations":
+            return self._correlations
+        return None
+
+
+def _make_bdf() -> tb.BeliefsDataFrame:
+    sensor = tb.Sensor(
+        name="mock-regressor",
+        unit="kW",
+        timezone="UTC",
+        event_resolution=timedelta(hours=1),
+    )
+    source = tb.BeliefSource(name="mock-source")
+    belief = tb.TimedBelief(
+        sensor=sensor,
+        source=source,
+        event_start=datetime(2025, 1, 1, tzinfo=pytz.utc),
+        event_value=1.0,
+        belief_horizon=timedelta(hours=1),
+    )
+    return tb.BeliefsDataFrame([belief])
+
+
+def _make_bdf_with_source_duplicates() -> tb.BeliefsDataFrame:
+    sensor = tb.Sensor(
+        name="mock-regressor",
+        unit="kW",
+        timezone="UTC",
+        event_resolution=timedelta(hours=1),
+    )
+    source_actual = tb.BeliefSource(name="flex.service")
+    source_forecast = tb.BeliefSource(name="Thiink forecaster")
+
+    # Historical event: prefer flex.service
+    hist_event = datetime(2025, 1, 9, tzinfo=pytz.utc)
+    # Future event: prefer Thiink forecaster
+    fut_event = datetime(2025, 1, 11, tzinfo=pytz.utc)
+
+    beliefs = [
+        tb.TimedBelief(
+            sensor=sensor,
+            source=source_actual,
+            event_start=hist_event,
+            event_value=10.0,
+            belief_time=datetime(2025, 1, 8, 12, tzinfo=pytz.utc),
+        ),
+        tb.TimedBelief(
+            sensor=sensor,
+            source=source_forecast,
+            event_start=hist_event,
+            event_value=11.0,
+            belief_time=datetime(2025, 1, 8, 13, tzinfo=pytz.utc),
+        ),
+        tb.TimedBelief(
+            sensor=sensor,
+            source=source_actual,
+            event_start=fut_event,
+            event_value=20.0,
+            belief_time=datetime(2025, 1, 10, 10, tzinfo=pytz.utc),
+        ),
+        tb.TimedBelief(
+            sensor=sensor,
+            source=source_forecast,
+            event_start=fut_event,
+            event_value=21.0,
+            belief_time=datetime(2025, 1, 10, 11, tzinfo=pytz.utc),
+        ),
+    ]
+    return tb.BeliefsDataFrame(beliefs)
+
+
+def test_regressor_specs_include_issue_time_policy(monkeypatch):
+    target_sensor = _SensorWithWeatherCorrelations(["irradiance"])
+    closest_sensor = object()
+    issue_time = pd.Timestamp("2025-01-10T00:00:00Z")
+    query_window = (
+        pd.Timestamp("2024-12-01T00:00:00Z"),
+        pd.Timestamp("2025-01-20T00:00:00Z"),
+    )
+
+    monkeypatch.setattr(
+        "flexmeasures.data.models.forecasting.model_spec_factory.Sensor.find_closest",
+        lambda **_: closest_sensor,
+    )
+    monkeypatch.setattr(
+        "flexmeasures.data.models.forecasting.model_spec_factory.current_app",
+        SimpleNamespace(
+            logger=SimpleNamespace(info=lambda *args, **kwargs: None),
+        ),
+    )
+
+    specs = configure_regressors_for_nearest_weather_sensor(
+        sensor=target_sensor,
+        query_window=query_window,
+        horizon=timedelta(days=2),
+        forecast_start=issue_time,
+        regressor_transformation={},
+        transform_to_normal=False,
+    )
+
+    assert len(specs) == 1
+    search_params = specs[0].search_params
+    assert search_params["sensors"] is closest_sensor
+    assert search_params["policy_issue_time"] == issue_time
+    assert search_params["horizons_at_least"] is None
+
+
+def test_tb_series_specs_splits_regressor_queries_by_issue_time():
+    class MockSearch:
+        calls: list[dict] = []
+
+        @classmethod
+        def search(cls, **kwargs):
+            cls.calls.append(kwargs)
+            return _make_bdf()
+
+    issue_time = pd.Timestamp("2025-01-10T00:00:00Z")
+    spec = TBSeriesSpecs(
+        name="irradiance_l0",
+        time_series_class=MockSearch,
+        search_params=dict(
+            sensors=object(),
+            event_starts_after=pd.Timestamp("2024-12-01T00:00:00Z"),
+            event_ends_before=pd.Timestamp("2025-01-20T00:00:00Z"),
+            horizons_at_least=None,
+            horizons_at_most=None,
+            policy_issue_time=issue_time,
+        ),
+    )
+
+    series = spec._load_series()
+
+    assert not series.empty
+    assert len(MockSearch.calls) == 2
+
+    historical_call, future_call = MockSearch.calls
+    assert "policy_issue_time" not in historical_call
+    assert "policy_future_horizon_floor" not in historical_call
+    assert "policy_issue_time" not in future_call
+    assert "policy_future_horizon_floor" not in future_call
+    assert historical_call["horizons_at_least"] is None
+    assert historical_call["event_ends_before"] == issue_time
+
+    assert future_call["horizons_at_least"] is None
+    assert future_call["event_starts_after"] == issue_time
+
+
+def test_tb_series_specs_keeps_single_query_without_policy():
+    class MockSearch:
+        calls: list[dict] = []
+
+        @classmethod
+        def search(cls, **kwargs):
+            cls.calls.append(kwargs)
+            return _make_bdf()
+
+    spec = TBSeriesSpecs(
+        name="outcome",
+        time_series_class=MockSearch,
+        search_params=dict(
+            sensors=object(),
+            event_starts_after=pd.Timestamp("2024-12-01T00:00:00Z"),
+            event_ends_before=pd.Timestamp("2025-01-20T00:00:00Z"),
+            horizons_at_least=None,
+            horizons_at_most=timedelta(hours=0),
+        ),
+    )
+
+    series = spec._load_series()
+
+    assert not series.empty
+    assert len(MockSearch.calls) == 1
+
+
+def test_tb_series_specs_accepts_issue_time_only_policy():
+    class MockSearch:
+        @classmethod
+        def search(cls, **kwargs):
+            return _make_bdf()
+
+    spec = TBSeriesSpecs(
+        name="irradiance_l0",
+        time_series_class=MockSearch,
+        search_params=dict(
+            sensors=object(),
+            event_starts_after=pd.Timestamp("2024-12-01T00:00:00Z"),
+            event_ends_before=pd.Timestamp("2025-01-20T00:00:00Z"),
+            horizons_at_least=None,
+            horizons_at_most=None,
+            policy_issue_time=pd.Timestamp("2025-01-10T00:00:00Z"),
+        ),
+    )
+
+    series = spec._load_series()
+    assert not series.empty
+
+
+def test_tb_series_specs_skips_historical_query_for_future_only_window():
+    class MockSearch:
+        calls: list[dict] = []
+
+        @classmethod
+        def search(cls, **kwargs):
+            cls.calls.append(kwargs)
+            return _make_bdf()
+
+    issue_time = pd.Timestamp("2025-01-10T00:00:00Z")
+    spec = TBSeriesSpecs(
+        name="irradiance_l0",
+        time_series_class=MockSearch,
+        search_params=dict(
+            sensors=object(),
+            event_starts_after=pd.Timestamp("2025-01-12T00:00:00Z"),
+            event_ends_before=pd.Timestamp("2025-01-20T00:00:00Z"),
+            horizons_at_least=None,
+            horizons_at_most=None,
+            policy_issue_time=issue_time,
+        ),
+    )
+
+    spec._load_series()
+    assert len(MockSearch.calls) == 1
+    assert MockSearch.calls[0]["horizons_at_least"] is None
+
+
+def test_tb_series_specs_source_preference_per_issue_time_bucket():
+    class MockSearch:
+        @classmethod
+        def search(cls, **kwargs):
+            return _make_bdf_with_source_duplicates()
+
+    issue_time = pd.Timestamp("2025-01-10T00:00:00Z")
+    spec = TBSeriesSpecs(
+        name="irradiance_l0",
+        time_series_class=MockSearch,
+        search_params=dict(
+            sensors=object(),
+            event_starts_after=pd.Timestamp("2025-01-08T00:00:00Z"),
+            event_ends_before=pd.Timestamp("2025-01-12T00:00:00Z"),
+            horizons_at_least=None,
+            horizons_at_most=None,
+            policy_issue_time=issue_time,
+        ),
+    )
+
+    series = spec._load_series()
+
+    # One value per event after duplicate collapse.
+    assert not series.index.duplicated().any()
+    assert series.loc[pd.Timestamp("2025-01-09T00:00:00Z")] == 10.0  # historical -> flex.service
+    assert series.loc[pd.Timestamp("2025-01-11T00:00:00Z")] == 21.0  # future -> Thiink forecaster


### PR DESCRIPTION
## Description

- Apply issue-time-aware regressor loading by splitting historical (`event_start < T`) and future (`event_start >= T`) windows in `TBSeriesSpecs`.
- Remove the uniform horizon floor for regressors and pass explicit policy context (`policy_issue_time`) from model spec configuration.
- Add deterministic tie-breaking and duplicate collapse for regressor beliefs around issue-time boundaries.
- Add targeted tests:
  - unit coverage in `test_model_spec_factory_regressor_policy.py`
  - integration coverage in `test_future_regressor_changes_forecasts_in_issue_time_window`.

## Look & Feel

- N/A (no UI/API surface change).

## How to test

- Docker targeted node:
  - `docker compose run --rm --no-deps -e SQLALCHEMY_TEST_DATABASE_URI=\"postgresql://fm-test-db-user:fm-test-db-pass@test-db:5432/fm-test-db\" server \"/app/.venv/bin/python -m ensurepip && /app/.venv/bin/python -m pip install pytest pytest-flask pytest-mock fakeredis requests requests-mock openpyxl pytest-runner && /app/.venv/bin/python -m pytest flexmeasures/data/tests/test_forecasting_pipeline.py::test_future_regressor_changes_forecasts_in_issue_time_window -q\"`
- Nearby subset:
  - `docker compose run --rm --no-deps -e SQLALCHEMY_TEST_DATABASE_URI=\"postgresql://fm-test-db-user:fm-test-db-pass@test-db:5432/fm-test-db\" server \"/app/.venv/bin/python -m ensurepip && /app/.venv/bin/python -m pip install pytest pytest-flask pytest-mock fakeredis requests requests-mock openpyxl pytest-runner && /app/.venv/bin/python -m pytest flexmeasures/data/tests/test_forecasting_pipeline.py -k 'future_regressor_changes_forecasts_in_issue_time_window or prior_restricts_training_beliefs' -q\"`

## Further Improvements

- Reduce warning noise in forecasting tests (FutureWarning/SAWarning) to make regressions easier to spot.

## Related Items

- Closes #2131

---

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures

Made with [Cursor](https://cursor.com)