### PR TITLE
fix attributes being overwritten in asset form

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -25,6 +25,14 @@ Bugfixes
 * Fix asset context page for asset names containing apostrophes [see `PR #2117 <https://www.github.com/FlexMeasures/flexmeasures/pull/2117>`_]
 
 
+v0.32.1 | May XX, 2026
+============================
+
+Bugfixes
+-----------
+* Fix asset form overwriting attributes [see `PR #2138 <https://www.github.com/FlexMeasures/flexmeasures/pull/2138>`_]
+
+
 v0.32.0 | April 15, 2026
 ============================
 

--- a/flexmeasures/ui/templates/assets/asset_new.html
+++ b/flexmeasures/ui/templates/assets/asset_new.html
@@ -75,16 +75,6 @@
                         </div>
                     </div>
                     <div class="form-group">
-                        {{ asset_form.attributes.label(class="col-md-6 control-label") }}
-                        <div class="col-md-6">
-                            <small>{{ asset_form.attributes.description }}</small>
-                            {{ asset_form.attributes(class_="form-control") }}
-                            {% for error in asset_form.errors.attributes %}
-                            <span style="color: red;">[{{error}}]</span>
-                            {% endfor %}
-                        </div>
-                    </div>
-                    <div class="form-group">
                         {{ asset_form.sensors_to_show_as_kpis.label(class="col-sm-6 control-label") }}
                         <div class="col-md-6">
                             <small>{{ asset_form.sensors_to_show_as_kpis.description }}</small>

--- a/flexmeasures/ui/views/__init__.py
+++ b/flexmeasures/ui/views/__init__.py
@@ -10,6 +10,15 @@ from flexmeasures.ui.views.users.logged_in_user import (  # noqa: F401  # noqa: 
 )
 
 
+# Shared label/description for the "attributes" JSON field.
+# Imported by sensor and account views so the text is defined exactly once.
+# Actually, attributes are edited not in the form itself anymore, but in their own modal dialogue.
+ATTRIBUTES_FIELD_LABEL = "Other attributes (JSON)"
+ATTRIBUTES_FIELD_DESCRIPTION = (
+    "Custom attributes as JSON, for custom functionality, e.g. used in plugins."
+)
+
+
 @flexmeasures_ui.route("/docs")
 def docs_view():
     """Render the Sphinx documentation"""

--- a/flexmeasures/ui/views/accounts.py
+++ b/flexmeasures/ui/views/accounts.py
@@ -14,7 +14,7 @@ from flexmeasures.data.models.audit_log import AuditLog
 from flexmeasures.data.models.user import Account
 from flexmeasures.data.services.accounts import get_accounts, get_audit_log_records
 from flexmeasures.data import db
-from flexmeasures.ui.views.assets.forms import (
+from flexmeasures.ui.views import (
     ATTRIBUTES_FIELD_LABEL,
     ATTRIBUTES_FIELD_DESCRIPTION,
 )

--- a/flexmeasures/ui/views/assets/forms.py
+++ b/flexmeasures/ui/views/assets/forms.py
@@ -18,14 +18,6 @@ from flexmeasures.data.models.user import Account
 from flexmeasures.data.schemas.generic_assets import SensorsToShowAsKPIsSchema
 
 
-# Shared label/description for the "attributes" JSON field.
-# Imported by sensor and account views so the text is defined exactly once.
-ATTRIBUTES_FIELD_LABEL = "Other attributes (JSON)"
-ATTRIBUTES_FIELD_DESCRIPTION = (
-    "Custom attributes as JSON, for custom functionality, e.g. used in plugins."
-)
-
-
 class AssetForm(FlaskForm):
     """The default asset form only allows to edit the name and location."""
 
@@ -48,11 +40,6 @@ class AssetForm(FlaskForm):
     parent_asset_id = IntegerField(
         "Parent Asset Id",
         validators=[optional()],
-    )
-    attributes = StringField(
-        ATTRIBUTES_FIELD_LABEL,
-        default="{}",
-        description=ATTRIBUTES_FIELD_DESCRIPTION,
     )
     sensors_to_show_as_kpis = StringField(
         "Sensors to show as KPIs (JSON)",

--- a/flexmeasures/ui/views/assets/views.py
+++ b/flexmeasures/ui/views/assets/views.py
@@ -26,7 +26,7 @@ from flexmeasures.data.models.user import Account
 from flexmeasures.utils.time_utils import duration_isoformat
 from flexmeasures.ui.utils.view_utils import render_flexmeasures_template
 from flexmeasures.ui.views.assets.forms import NewAssetForm, AssetForm
-from flexmeasures.ui.views.assets.forms import (
+from flexmeasures.ui.views import (
     ATTRIBUTES_FIELD_LABEL,
     ATTRIBUTES_FIELD_DESCRIPTION,
 )
@@ -392,7 +392,6 @@ class AssetCrudUI(FlaskView):
         asset_form.process(obj=asset)
 
         # JSON fields need to be pre-processed to be valid form data
-        asset_form.attributes.data = json.dumps(asset.attributes)
         asset_form.sensors_to_show_as_kpis.data = json.dumps(
             asset.sensors_to_show_as_kpis
         )

--- a/flexmeasures/ui/views/sensors.py
+++ b/flexmeasures/ui/views/sensors.py
@@ -20,7 +20,7 @@ from flexmeasures.ui.views.assets.utils import (
     user_can_delete,
     user_can_update,
 )
-from flexmeasures.ui.views.assets.forms import (
+from flexmeasures.ui.views import (
     ATTRIBUTES_FIELD_LABEL,
     ATTRIBUTES_FIELD_DESCRIPTION,
 )


### PR DESCRIPTION

## Description

Closes #2137 

- [x] remove field from form, so it is not being used in that PATCH call
- [x] hang the field descriptions higher in the hierarchy
- [x] Added changelog item in `documentation/changelog.rst`

## Look & Feel

No visual change.

## How to test

See issue for reproduction of the issue.

