### PR TITLE
Fix: include belief time in fixed-value records for chart data

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -25,7 +25,7 @@ Bugfixes
 * Make the sensor page load much faster for sensors with lots of data, by avoiding to load statistics over all of its history by default [see `PR #2129 <https://www.github.com/FlexMeasures/flexmeasures/pull/2129>`_]
 * Return a clear validation error (instead of a server ZeroDivisionError) when posting instantaneous (0-minute) data to non-instantaneous sensors via ``[POST] /sensors/(id)/data`` [see `PR #2116 <https://www.github.com/FlexMeasures/flexmeasures/pull/2116>`_]
 * Fix asset context page for asset names containing apostrophes [see `PR #2117 <https://www.github.com/FlexMeasures/flexmeasures/pull/2117>`_]
-
+* Fix disappearing plots on asset graphs during playback [see `PR #2147 <https://www.github.com/FlexMeasures/flexmeasures/pull/2147>`_]
 
 v0.32.1 | May XX, 2026
 ============================

--- a/documentation/views/asset-data.rst
+++ b/documentation/views/asset-data.rst
@@ -121,7 +121,7 @@ Finally, it is possible to set custom titles for any graph by clicking on the "e
 |
 
 Internally, the asset has a `sensors_to_show` field, which controls which sensor data appears in the plot. This can also be set by a script or through the API. 
-The accepted format is a dictionary with a graph title followed by a plot containing senors or asset flex-config reference (e.g. `[{"title":"Power","plots":[{"sensor":2}]},{"title":"Costs","plots":[{"sensor":5},{"asset":10,"flex-model":"soc-min"},]}]`).
+The accepted format is a dictionary with a graph title followed by a plot containing sensors or asset flex-config reference (e.g. `[{"title":"Power","plots":[{"sensor":2}]},{"title":"Costs","plots":[{"sensor":5},{"asset":10,"flex-model":"soc-min"},]}]`).
 
 
 Showing daily KPIs

--- a/documentation/views/asset-data.rst
+++ b/documentation/views/asset-data.rst
@@ -110,7 +110,7 @@ Click the "Edit Graph" button to open the graph editor.
 
 Use the "Add Graph" button to create graphs. For each graph, you can select one or more sensors, from all available sensors associated with the asset, including public sensors, and add them to your plot.
 
-In addition, you can add an asset's flex-config to the graph, as long as the value of that config is a sensor(e.g. `[{"title":"Power","plots":[{"sensor":2}]},{"title":"Costs","plots":[{"sensors":[5,6]}]}]`).
+In addition, you can add an asset's flex-config to the graph, whether the value is a sensor or a fixed value (e.g. `[{"title":"Power","plots":[{"sensor":2}]},{"title":"Costs","plots":[{"sensors":[5,6]}]}]`).
 
 Finally, it is possible to set custom titles for any graph by clicking on the "edit" button right next to the default or current title.
 

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -434,7 +434,9 @@ class GenericAsset(db.Model, AuthModelMixin):
             extract_sensors_from_flex_config,
         )
 
-        sensors_to_show_schema = SensorsToShowSchema()
+        sensors_to_show_schema = SensorsToShowSchema(
+            allow_missing_asset_flex_field=True
+        )
 
         # Deserialize the sensor_ids_to_show using SensorsToShowSchema
         standardized_sensors_to_show = sensors_to_show_schema.deserialize(
@@ -538,14 +540,29 @@ class GenericAsset(db.Model, AuthModelMixin):
         self, plot, sensors_list, asset_refs_list, extract_utils, SensorClass
     ):
         """Helper to extract sensors and asset refs from a single plot configuration."""
+        from marshmallow import ValidationError
+
         if "sensor" in plot:
             sensors_list.append(plot["sensor"])
         if "sensors" in plot:
             sensors_list.extend(plot["sensors"])
         if "asset" in plot:
-            extracted_sensors, refs = extract_utils(plot)
+            try:
+                extracted_sensors, refs = extract_utils(plot)
+            except ValidationError as err:
+                # Keep chart rendering resilient when a previously saved flex reference
+                # is no longer configured on the referenced asset.
+                current_app.logger.warning(
+                    "Skipping invalid asset plot reference %s on asset %s: %s",
+                    plot,
+                    self.id,
+                    err,
+                )
+                return
             for sensor_id in extracted_sensors:
                 sensor = db.session.get(SensorClass, sensor_id)
+                if sensor is None:
+                    continue
                 flex_config_key = plot.get("flex-context") or plot.get("flex-model")
                 sensor.name = f"{sensor.name} ({flex_config_key})"
             sensors_list.extend(extracted_sensors)

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -116,6 +116,7 @@ def _generate_fixed_value_records(
     timestamps_ms = _fixed_value_timestamps_ms(
         event_starts_after, event_ends_before, resolution
     )
+    belief_time_ms = int(event_starts_after.timestamp() * 1000)
     sensor_meta = sensor.as_dict  # uses _as_dict_override for fixed-value sensors
     source_dict = _fixed_value_source_dict(flex_source)
 
@@ -123,6 +124,7 @@ def _generate_fixed_value_records(
         {
             "event_start": ts_ms,
             "event_value": constant_value,
+            "belief_time": belief_time_ms,
             "sensor": sensor_meta,
             "source": source_dict,
             "sensor_unit": sensor.unit,
@@ -160,12 +162,14 @@ def _generate_fixed_value_records_compressed(
     timestamps_ms = _fixed_value_timestamps_ms(
         event_starts_after, event_ends_before, resolution
     )
+    belief_time_ms = int(event_starts_after.timestamp() * 1000)
 
     return [
         {
             "ts": ts_ms,
             "sid": sensor.id,
             "val": constant_value,
+            "bt": belief_time_ms,
             "sf": 1.0,
             "src": source_id,
             "bh": 0,

--- a/flexmeasures/data/schemas/generic_assets.py
+++ b/flexmeasures/data/schemas/generic_assets.py
@@ -56,6 +56,10 @@ class SensorsToShowSchema(fields.Field):
     - `[{"title": "Test", "plots": [{"sensors": [1, 2]}]}, {"title": None, "plots": [{"sensors": [3, 4]}]}, {"title": None, "plots": [{"sensor": 5}]}]`
     """
 
+    def __init__(self, *args, allow_missing_asset_flex_field: bool = False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.allow_missing_asset_flex_field = allow_missing_asset_flex_field
+
     def deserialize(self, value, **kwargs) -> list:
         """
         Validate and deserialize the input value.
@@ -209,6 +213,8 @@ class SensorsToShowSchema(fields.Field):
             asset_flex_config = getattr(asset, attr_to_check, {})
 
             if value not in asset_flex_config:
+                if self.allow_missing_asset_flex_field:
+                    return
                 raise ValidationError(
                     f"The asset with ID '{asset_id}' does not have a '{value}' set in its '{attr_to_check}'."
                 )

--- a/flexmeasures/data/schemas/generic_assets.py
+++ b/flexmeasures/data/schemas/generic_assets.py
@@ -205,6 +205,8 @@ class SensorsToShowSchema(fields.Field):
                 raise ValidationError(f"The value for '{field_name}' must be a string.")
 
             if value not in valid_collection:
+                if self.allow_missing_asset_flex_field:
+                    return
                 raise ValidationError(f"'{field_name}' value '{value}' is not valid.")
 
             attr_to_check = (

--- a/flexmeasures/data/tests/test_belief_charts.py
+++ b/flexmeasures/data/tests/test_belief_charts.py
@@ -372,34 +372,6 @@ def test_chart_data_json_compressed_fixed_value_records_are_correct(
         assert "src" in r, "Compressed fixed-value record must carry a 'src' key"
 
 
-def test_chart_data_json_compressed_fixed_value_records_use_start_as_belief_time(
-    battery_with_soc_flex_model,
-):
-    """Fixed-value records must be visible from the first replay step."""
-    battery, _ = battery_with_soc_flex_model
-
-    start = datetime(2015, 1, 1, tzinfo=pytz.utc)
-    end = datetime(2015, 1, 2, tzinfo=pytz.utc)
-
-    import json
-
-    parsed = json.loads(
-        battery.chart_data_json(
-            compress_json=True,
-            event_starts_after=start,
-            event_ends_before=end,
-        )
-    )
-
-    fixed_value_records = [r for r in parsed["data"] if r["sid"] in (-1, -2)]
-    expected_belief_time = int(start.timestamp() * 1000)
-
-    assert fixed_value_records, "Expected fixed-value records in compressed data"
-    assert all(
-        r.get("bt") == expected_belief_time for r in fixed_value_records
-    ), "Fixed-value compressed records must use the selected chart start as belief time"
-
-
 def test_chart_data_json_compressed_source_references_flex_model(
     battery_with_soc_flex_model,
 ):

--- a/flexmeasures/data/tests/test_belief_charts.py
+++ b/flexmeasures/data/tests/test_belief_charts.py
@@ -372,6 +372,34 @@ def test_chart_data_json_compressed_fixed_value_records_are_correct(
         assert "src" in r, "Compressed fixed-value record must carry a 'src' key"
 
 
+def test_chart_data_json_compressed_fixed_value_records_use_start_as_belief_time(
+    battery_with_soc_flex_model,
+):
+    """Fixed-value records must be visible from the first replay step."""
+    battery, _ = battery_with_soc_flex_model
+
+    start = datetime(2015, 1, 1, tzinfo=pytz.utc)
+    end = datetime(2015, 1, 2, tzinfo=pytz.utc)
+
+    import json
+
+    parsed = json.loads(
+        battery.chart_data_json(
+            compress_json=True,
+            event_starts_after=start,
+            event_ends_before=end,
+        )
+    )
+
+    fixed_value_records = [r for r in parsed["data"] if r["sid"] in (-1, -2)]
+    expected_belief_time = int(start.timestamp() * 1000)
+
+    assert fixed_value_records, "Expected fixed-value records in compressed data"
+    assert all(
+        r.get("bt") == expected_belief_time for r in fixed_value_records
+    ), "Fixed-value compressed records must use the selected chart start as belief time"
+
+
 def test_chart_data_json_compressed_source_references_flex_model(
     battery_with_soc_flex_model,
 ):

--- a/flexmeasures/data/tests/test_belief_charts.py
+++ b/flexmeasures/data/tests/test_belief_charts.py
@@ -398,3 +398,38 @@ def test_chart_data_json_compressed_source_references_flex_model(
         "Source metadata must reference 'flex-model' for values from the flex_model; "
         f"got descriptions: {source_descriptions}"
     )
+
+
+def test_chart_data_json_skips_invalid_saved_asset_reference(
+    battery_with_soc_flex_model,
+):
+    """Invalid saved flex references should be ignored instead of crashing chart endpoints."""
+    battery, soc_sensor = battery_with_soc_flex_model
+
+    # Keep one valid sensor plot and add one invalid flex-context reference.
+    battery.sensors_to_show = [
+        {
+            "title": "Mixed",
+            "plots": [
+                {"sensor": soc_sensor.id},
+                {"asset": battery.id, "flex-context": "non-existing-field"},
+            ],
+        }
+    ]
+
+    start = datetime(2015, 1, 1, tzinfo=pytz.utc)
+    end = datetime(2015, 1, 2, tzinfo=pytz.utc)
+
+    import json
+
+    parsed = json.loads(
+        battery.chart_data_json(
+            compress_json=True,
+            event_starts_after=start,
+            event_ends_before=end,
+        )
+    )
+
+    sensor_ids_in_data = {r["sid"] for r in parsed["data"]}
+    assert soc_sensor.id in sensor_ids_in_data
+    assert -1 not in sensor_ids_in_data

--- a/flexmeasures/ui/static/js/components.js
+++ b/flexmeasures/ui/static/js/components.js
@@ -52,7 +52,12 @@ export async function renderAssetPlotCard(
   graphIndex,
   plotIndex,
 ) {
-  const Asset = await getAsset(assetPlot.asset, false);
+  let Asset;
+  try {
+    Asset = await getAsset(assetPlot.asset, false);
+  } catch (e) {
+    Asset = null;
+  }
   let IsFlexContext = false;
   let IsFlexModel = false;
   let flexConfigValue = null;
@@ -96,9 +101,9 @@ export async function renderAssetPlotCard(
   disabledInput.disabled = true;
 
   let flexConfigData = IsFlexContext
-    ? Asset["flex_context"]
+    ? Asset?.["flex_context"]
     : IsFlexModel
-      ? Asset["flex_model"]
+      ? Asset?.["flex_model"]
       : null;
 
   // convert string to object if it's a string, otherwise keep it as is (could be null or already an object)
@@ -110,8 +115,21 @@ export async function renderAssetPlotCard(
     }
   }
 
-  const valueToDisplay =
-    flexConfigData[assetPlot[IsFlexContext ? "flex-context" : "flex-model"]];
+  const flexConfigField = assetPlot[IsFlexContext ? "flex-context" : "flex-model"];
+  const hasConfigObject =
+    flexConfigData !== null && typeof flexConfigData === "object";
+  const valueToDisplay = hasConfigObject
+    ? flexConfigData[flexConfigField]
+    : undefined;
+
+  if (valueToDisplay === undefined || valueToDisplay === null) {
+    disabledInput.value = "FlexConfig Not configured";
+    infoDiv.appendChild(disabledInput);
+    flexDiv.appendChild(infoDiv);
+    flexDiv.appendChild(closeIcon);
+    container.appendChild(flexDiv);
+    return container;
+  }
   const isSensorReference =
     typeof valueToDisplay === "object" &&
     valueToDisplay !== null &&
@@ -141,8 +159,7 @@ export async function renderAssetPlotCard(
     if (typeof valueToDisplay === "object") {
       disabledInput.value = JSON.stringify(valueToDisplay);
     } else {
-      disabledInput.value =
-        valueToDisplay || "No Flex Context/Model Configured";
+      disabledInput.value = valueToDisplay;
     }
     infoDiv.appendChild(disabledInput);
   }

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -7,7 +7,7 @@
     },
     "termsOfService": null,
     "title": "FlexMeasures",
-    "version": "0.32.0"
+    "version": "0.33.0"
   },
   "externalDocs": {
     "description": "FlexMeasures runs on the open source FlexMeasures technology. Read the docs here.",

--- a/flexmeasures/ui/templates/assets/asset_graph.html
+++ b/flexmeasures/ui/templates/assets/asset_graph.html
@@ -443,6 +443,26 @@
         const saveChangesBtn = document.getElementById("saveChangesBtn");
         const addPlotBtn = document.getElementById("addPlotBtn");
 
+        function graphAlreadyHasSensor(graph, sensorId) {
+            return (graph.plots || []).some((plot) => {
+                if (plot.sensor === sensorId) {
+                    return true;
+                }
+                if (Array.isArray(plot.sensors)) {
+                    return plot.sensors.includes(sensorId);
+                }
+                return false;
+            });
+        }
+
+        function graphAlreadyHasAssetReference(graph, payload) {
+            return (graph.plots || []).some((plot) =>
+                plot.asset === payload.asset &&
+                plot["flex-context"] === payload["flex-context"] &&
+                plot["flex-model"] === payload["flex-model"],
+            );
+        }
+
         saveChangesBtn.onclick = async function () {
             await updateAssetSensorsToShow();
         };
@@ -458,6 +478,11 @@
                 }
 
                 const sensorsToShowOldState = getSensorToShow();
+                const selectedGraph = sensorsToShowOldState[index];
+                if (graphAlreadyHasAssetReference(selectedGraph, payload)) {
+                    showToast("This asset reference is already added to this graph.", "warning");
+                    return;
+                }
                 sensorsToShowOldState[index].plots.push(payload);
                 setSensorToShow(sensorsToShowOldState);
             } else {
@@ -1152,6 +1177,11 @@
             const oldSensorsToShow = getSensorToShow();
 
             if (editingIndex()) {
+                const selectedGraph = oldSensorsToShow[editingIndex()];
+                if (graphAlreadyHasSensor(selectedGraph, id)) {
+                    showToast("This sensor is already added to this graph.", "warning");
+                    return;
+                }
                 oldSensorsToShow[editingIndex()]["plots"].push({ sensor: id });
             } else {
                 const newAsset = {
@@ -1180,6 +1210,10 @@
             // renderGraphCards();
 
             const oldSensorsToShow = getSensorToShow();
+            if (graphAlreadyHasSensor(oldSensorsToShow[graphIndex], sensorId)) {
+                showToast("This sensor is already added to this graph.", "warning");
+                return;
+            }
             oldSensorsToShow[graphIndex].plots.push({ sensor: sensorId });
             setSensorToShow(oldSensorsToShow);
         }

--- a/flexmeasures/ui/templates/includes/graphs.html
+++ b/flexmeasures/ui/templates/includes/graphs.html
@@ -150,6 +150,9 @@
                 });
                 // Reload daterange
                 embedAndLoad(chartSpecsPath + 'event_starts_after=' + storeStartDate.toISOString() + '&event_ends_before=' + storeEndDate.toISOString() + '&', elementId, datasetName, previousResult, storeStartDate, storeEndDate)
+                if (!vegaView || !previousResult) {
+                    return;
+                }
                 vegaView.change(datasetName, vega.changeset().remove(vega.truthy).insert(previousResult.data)).resize().run();
                 if (chartType === "bar_chart") {
                     vegaView.change(datasetName + '_annotations', vega.changeset().remove(vega.truthy).insert(previousResult.annotations)).resize().run();
@@ -604,6 +607,10 @@
         signal = controller.signal;
 
         // Remove replay ruler and replay time
+        if (!vegaView) {
+            document.getElementById('replay-time').innerHTML = '';
+            return;
+        }
         vegaView.change('replay', vega.changeset().remove(vega.truthy).insert({ 'belief_time': null })).run().finalize();
         document.getElementById('replay-time').innerHTML = '';
 
@@ -682,6 +689,10 @@
 
                 // Update beliefs in the replayed data given the new data
                 replayedData = updateBeliefs(replayedData, newData);
+
+                if (!vegaView) {
+                    break;
+                }
 
                 /** When selecting a longer time period (more than a week), the replay slows down a bit. This
                  * seems to be mainly from reloading the data into the graph. Slicing the data takes 10-30 ms, and


### PR DESCRIPTION
## Description

This PR resolves an issue where fixed values in graphs were not displayed during playback. These values are now visible.

## Look & Feel
Before:
<img width="1371" height="374" alt="image" src="https://github.com/user-attachments/assets/10a8da11-36cb-4c07-9d82-7be0ff29465d" />

After:
<img width="1371" height="374" alt="image" src="https://github.com/user-attachments/assets/b20130c1-820a-4bcb-a396-a47325a59d10" />

## How to test

1. Find an asset with a fixed value set in any of its flex-configs
2. Go to the graph page and add a graph using that flex-config field. (You could also have an already existing graph using a flex-config field with a fixed value)
3. Observe and confirm that the fixed value plot does not disappear on playback.

## Further Improvements
None

## Related Items

This PR closes #2110 
#### Sign-off

<!--
We ask contributors outside the FlexMeasures organisation to sign off on their contribution.
Please mark the below fields with an [x].
-->

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
