### PR TITLE
Standardize resolution formatting across API endpoints for consistent response payloads

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -19,7 +19,6 @@ Infrastructure / Support
 * Remove legacy rolling viewpoint forecasting code and utilities after migrating to fixed-point forecasting [see `PR #2082 <https://www.github.com/FlexMeasures/flexmeasures/pull/2082>`_]
 * Upgraded dependencies [see `PR #2114 <https://www.github.com/FlexMeasures/flexmeasures/pull/2114>`_ and `PR #2148 <https://www.github.com/FlexMeasures/flexmeasures/pull/2148>`_]
 * Run ``flexmeasures jobs run-worker`` with RQ's embedded scheduler on by default so jobs created with ``enqueue_in`` are promoted from the scheduled registry when due; pass ``--without-scheduler`` to disable [see `PR #2112 <https://www.github.com/FlexMeasures/flexmeasures/pull/2112>`_]
-* Standardize resolution formatting across API endpoints for consistent response payloads [see `PR #2152 <https://www.github.com/FlexMeasures/flexmeasures/pull/2152>`_]
 
 Bugfixes
 -----------
@@ -28,6 +27,7 @@ Bugfixes
 * Make the sensor page load much faster for sensors with lots of data, by avoiding to load statistics over all of its history by default [see `PR #2129 <https://www.github.com/FlexMeasures/flexmeasures/pull/2129>`_]
 * Return a clear validation error (instead of a server ZeroDivisionError) when posting instantaneous (0-minute) data to non-instantaneous sensors via ``[POST] /sensors/(id)/data`` [see `PR #2116 <https://www.github.com/FlexMeasures/flexmeasures/pull/2116>`_]
 * Fix asset context page for asset names containing apostrophes [see `PR #2117 <https://www.github.com/FlexMeasures/flexmeasures/pull/2117>`_]
+* Standardize resolution formatting across API endpoints for consistent response payloads [see `PR #2152 <https://www.github.com/FlexMeasures/flexmeasures/pull/2152>`_]
 
 
 v0.32.1 | May XX, 2026

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -19,6 +19,7 @@ Infrastructure / Support
 * Remove legacy rolling viewpoint forecasting code and utilities after migrating to fixed-point forecasting [see `PR #2082 <https://www.github.com/FlexMeasures/flexmeasures/pull/2082>`_]
 * Upgraded dependencies [see `PR #2114 <https://www.github.com/FlexMeasures/flexmeasures/pull/2114>`_ and `PR #2148 <https://www.github.com/FlexMeasures/flexmeasures/pull/2148>`_]
 * Run ``flexmeasures jobs run-worker`` with RQ's embedded scheduler on by default so jobs created with ``enqueue_in`` are promoted from the scheduled registry when due; pass ``--without-scheduler`` to disable [see `PR #2112 <https://www.github.com/FlexMeasures/flexmeasures/pull/2112>`_]
+* Standardize resolution formatting across API endpoints for consistent response payloads [see `PR #2152 <https://www.github.com/FlexMeasures/flexmeasures/pull/2152>`_]
 
 Bugfixes
 -----------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -24,9 +24,6 @@ Infrastructure / Support
 Bugfixes
 -----------
 * Check read permissions for sensors referenced in forecasting and scheduling config payloads, and return a clearer 403 error when a referenced sensor is not readable [see `PR #2096 <https://www.github.com/FlexMeasures/flexmeasures/pull/2096>`_ and `PR #2125 <https://www.github.com/FlexMeasures/flexmeasures/pull/2125>`_]
-* Make the sensor page load much faster for sensors with lots of data, by avoiding to load statistics over all of its history by default [see `PR #2129 <https://www.github.com/FlexMeasures/flexmeasures/pull/2129>`_]
-* Return a clear validation error (instead of a server ZeroDivisionError) when posting instantaneous (0-minute) data to non-instantaneous sensors via ``[POST] /sensors/(id)/data`` [see `PR #2116 <https://www.github.com/FlexMeasures/flexmeasures/pull/2116>`_]
-* Fix asset context page for asset names containing apostrophes [see `PR #2117 <https://www.github.com/FlexMeasures/flexmeasures/pull/2117>`_]
 * Standardize resolution formatting across API endpoints for consistent response payloads [see `PR #2152 <https://www.github.com/FlexMeasures/flexmeasures/pull/2152>`_]
 
 

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -457,7 +457,9 @@ class AssetAPI(FlaskView):
                       value:
                         data:
                         - id: 1
-                          name: Test battery
+                          name: Test battery power
+                          unit: kW
+                          event_resolution: PT15M
                           latitude: 10
                           longitude: 100
                           account_id: 2

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 from datetime import datetime, timedelta
 from http import HTTPStatus
-from humanize import naturaldelta
 
 from flask import request, current_app
 from flask_classful import FlaskView, route
@@ -524,7 +523,6 @@ class AssetAPI(FlaskView):
         sensors_response: list = [
             {
                 **sensor_schema.dump(sensor),
-                "event_resolution": naturaldelta(sensor.event_resolution),
             }
             for sensor in select_pagination.items
         ]

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -431,7 +431,7 @@ class AssetAPI(FlaskView):
           description: |
             This endpoint returns all sensors under an asset.
 
-            The endpoint supports pagination of the asset list using the `page` and `per_page` query parameters.
+            The endpoint supports pagination of the sensor list using the `page` and `per_page` query parameters.
 
             - If the `page` parameter is not provided, all sensors are returned, without pagination information. The result will be a list of sensors.
             - If a `page` parameter is provided, the response will be paginated, showing a specific number of assets per page as defined by `per_page` (default is 10).

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -503,6 +503,7 @@ class AssetAPI(FlaskView):
                 "name": Sensor.name,
                 "resolution": Sensor.event_resolution,
             }
+            sort_dir = sort_dir or "asc"
 
             query = query.order_by(
                 valid_sort_columns[sort_by].asc()

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -497,7 +497,7 @@ class AssetAPI(FlaskView):
                 or_(*[Sensor.name.ilike(f"%{term}%") for term in search_terms])
             )
 
-        if sort_by is not None and sort_dir is not None:
+        if sort_by is not None:
             valid_sort_columns = {
                 "id": Sensor.id,
                 "name": Sensor.name,

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -434,7 +434,7 @@ class AssetAPI(FlaskView):
             The endpoint supports pagination of the sensor list using the `page` and `per_page` query parameters.
 
             - If the `page` parameter is not provided, all sensors are returned, without pagination information. The result will be a list of sensors.
-            - If a `page` parameter is provided, the response will be paginated, showing a specific number of assets per page as defined by `per_page` (default is 10).
+            - If a `page` parameter is provided, the response will be paginated, showing a specific number of sensors per page as defined by `per_page` (default is 10).
             The response schema for pagination is inspired by https://datatables.net/manual/server-side#Returned-data
           security:
             - ApiKeyAuth: []

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -460,24 +460,20 @@ class AssetAPI(FlaskView):
                           name: Test battery power
                           unit: kW
                           event_resolution: PT15M
-                          latitude: 10
-                          longitude: 100
-                          account_id: 2
-                          generic_asset_type:
-                            id: 1
-                            name: battery
+                          generic_asset_id: 1
+                          timezone: Europe/Amsterdam
+                          entity_address: "ea1.2021-01.io.flexmeasures.company:fm1.42"
                     paginated_sensors:
                       summary: A paginated list of sensors being returned in the response
                       value:
                         data:
                         - id: 1
-                          name: Test battery
-                          latitude: 10
-                          longitude: 100
-                          account_id: 2
-                          generic_asset_type:
-                            id: 1
-                            name: battery
+                          name: Test battery power
+                          unit: kW
+                          event_resolution: PT15M
+                          generic_asset_id: 1
+                          timezone: Europe/Amsterdam
+                          entity_address: "ea1.2021-01.io.flexmeasures.company:fm1.42"
                         num-records: 1
                         filtered-records: 1
             400:

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -464,7 +464,7 @@ class AssetAPI(FlaskView):
                           generic_asset_type:
                             id: 1
                             name: battery
-                    paginated_assets:
+                    paginated_sensors:
                       summary: A paginated list of assets being returned in the response
                       value:
                         data:

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -467,7 +467,7 @@ class AssetAPI(FlaskView):
                             id: 1
                             name: battery
                     paginated_sensors:
-                      summary: A paginated list of assets being returned in the response
+                      summary: A paginated list of sensors being returned in the response
                       value:
                         data:
                         - id: 1

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -453,7 +453,7 @@ class AssetAPI(FlaskView):
                 application/json:
                   examples:
                     single_sensor:
-                      summary: One asset being returned in the response
+                      summary: One sensor being returned in the response
                       value:
                         data:
                         - id: 1

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -452,7 +452,7 @@ class AssetAPI(FlaskView):
               content:
                 application/json:
                   examples:
-                    single_asset:
+                    single_sensor:
                       summary: One asset being returned in the response
                       value:
                         data:

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -1647,14 +1647,14 @@ class SensorAPI(FlaskView):
                       summary: Successful response
                       description: A successful response with sensor status data
                       value:
-                        - staleness: "2 hours"
+                        - staleness: "PT2H"
                           stale: true
                           staleness_since: "2024-01-15T14:30:00+00:00"
                           reason: "data is outdated"
                           source_type: "forecast"
                           id: 64907
                           name: "temperature"
-                          resolution: "5 minutes"
+                          resolution: "PT5M"
                           asset_name: "Building A"
                           relation: "sensor belongs to this asset"
             400:

--- a/flexmeasures/api/v3_0/users.py
+++ b/flexmeasures/api/v3_0/users.py
@@ -25,7 +25,7 @@ from flexmeasures.data.services.users import (
 )
 from flexmeasures.auth.decorators import permission_required_for_context
 from flexmeasures.data import db
-from flexmeasures.utils.time_utils import server_now, naturalized_datetime_str
+from flexmeasures.utils.time_utils import server_now
 from flexmeasures.api.common.schemas.generic_schemas import PaginationSchema
 
 
@@ -193,8 +193,16 @@ class UserAPI(FlaskView):
                     "flexmeasures_roles": [
                         role.name for role in user.flexmeasures_roles
                     ],
-                    "last_login_at": naturalized_datetime_str(user.last_login_at),
-                    "last_seen_at": naturalized_datetime_str(user.last_seen_at),
+                    "last_login_at": (
+                        user.last_login_at.isoformat()
+                        if user.last_login_at is not None
+                        else None
+                    ),
+                    "last_seen_at": (
+                        user.last_seen_at.isoformat()
+                        if user.last_seen_at is not None
+                        else None
+                    ),
                 }
                 for user in paginated_users.items
             ]
@@ -212,8 +220,16 @@ class UserAPI(FlaskView):
                     "flexmeasures_roles": [
                         role.name for role in user.flexmeasures_roles
                     ],
-                    "last_login_at": naturalized_datetime_str(user.last_login_at),
-                    "last_seen_at": naturalized_datetime_str(user.last_seen_at),
+                    "last_login_at": (
+                        user.last_login_at.isoformat()
+                        if user.last_login_at is not None
+                        else None
+                    ),
+                    "last_seen_at": (
+                        user.last_seen_at.isoformat()
+                        if user.last_seen_at is not None
+                        else None
+                    ),
                 }
                 for user in users
             ]
@@ -624,9 +640,7 @@ class UserAPI(FlaskView):
             response = [
                 {
                     "event": audit_log.event,
-                    "event_datetime": naturalized_datetime_str(
-                        audit_log.event_datetime
-                    ),
+                    "event_datetime": audit_log.event_datetime.isoformat(),
                     "active_user_name": audit_log.active_user_name,
                     "active_user_id": audit_log.active_user_id,
                 }
@@ -644,9 +658,7 @@ class UserAPI(FlaskView):
             audit_logs_response = [
                 {
                     "event": audit_log.event,
-                    "event_datetime": naturalized_datetime_str(
-                        audit_log.event_datetime
-                    ),
+                    "event_datetime": audit_log.event_datetime.isoformat(),
                     "active_user_name": audit_log.active_user_name,
                     "active_user_id": audit_log.active_user_id,
                 }

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -13,7 +13,6 @@ from timely_beliefs import BeliefsDataFrame
 import pandas as pd
 
 from humanize.time import precisedelta
-from humanize import naturaldelta
 
 from flexmeasures.data.models.time_series import TimedBelief
 
@@ -702,14 +701,14 @@ def serialize_sensor_status_data(
     for sensor_status in sensor_statuses:
         sensor_status["id"] = sensor.id
         sensor_status["name"] = sensor.name
-        sensor_status["resolution"] = naturaldelta(sensor.event_resolution)
+        sensor_status["resolution"] = duration_isoformat(sensor.event_resolution)
         sensor_status["staleness"] = (
-            naturaldelta(sensor_status["staleness"])
+            duration_isoformat(sensor_status["staleness"])
             if sensor_status["staleness"] is not None
             else None
         )
         sensor_status["staleness_since"] = (
-            naturaldelta(sensor_status["staleness_since"])
+            sensor_status["staleness_since"].isoformat()
             if sensor_status["staleness_since"] is not None
             else None
         )

--- a/flexmeasures/ui/static/js/flexmeasures.js
+++ b/flexmeasures/ui/static/js/flexmeasures.js
@@ -480,6 +480,11 @@ const dateFormatter = new Intl.DateTimeFormat(
   [], {"year": "numeric", "month": "long", "day": "numeric"}
 )
 
+// Renders a compact date in the local timezone without a time component.
+const shortDateFormatter = new Intl.DateTimeFormat(
+    [], {"year": "numeric", "month": "short", "day": "2-digit"}
+)
+
 // Renders an HH:MM time in the local timezone, including timezone info.
 // e.g. "12:17 BST"
 const timeFormatter = new Intl.DateTimeFormat(
@@ -523,7 +528,8 @@ function getHumanFriendlyDateString(iso8601_date_string) {
  * 
  * If longer ago than 24 hours, let getHumanFriendlyDateString take over.
  */
-function getHumanFriendlyDeltaOrTimeStr(iso8601_date_string) {
+function getHumanFriendlyDeltaOrTimeStr(iso8601_date_string, options = {}) {
+    const dateOnlyForOlder = options.dateOnlyForOlder === true;
   const date = new Date(Date.parse(iso8601_date_string));
   const now = new Date();
 
@@ -583,9 +589,48 @@ function getHumanFriendlyDeltaOrTimeStr(iso8601_date_string) {
 
   // 3. Fallback: Too far in the past or future
   else {
-    // If the difference is 7 days or more, return the full date string.
-    return getHumanFriendlyDateString(iso8601_date_string);
+        // For table views, optionally hide time for older moments.
+        if (dateOnlyForOlder) {
+            return shortDateFormatter.format(date);
+        }
+
+        // If the difference is 7 days or more, return the full date string.
+        return getHumanFriendlyDateString(iso8601_date_string);
   }
+}
+
+function humanizeIsoDuration(isoDuration) {
+  if (typeof isoDuration !== "string") {
+    return isoDuration;
+  }
+
+  const match = isoDuration.match(
+    /^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$/,
+  );
+
+  if (!match) {
+    return isoDuration;
+  }
+
+  const units = [
+    { value: match[1], label: "year" },
+    { value: match[2], label: "month" },
+    { value: match[3], label: "week" },
+    { value: match[4], label: "day" },
+    { value: match[5], label: "hour" },
+    { value: match[6], label: "minute" },
+    { value: match[7], label: "second" },
+  ];
+
+  const parts = units
+    .filter((unit) => unit.value !== undefined)
+    .map((unit) => {
+      const num = Number(unit.value);
+      const suffix = num === 1 ? "" : "s";
+      return `${unit.value} ${unit.label}${suffix}`;
+    });
+
+  return parts.length > 0 ? parts.join(" ") : isoDuration;
 }
 
 // Function to return a loading row for a table

--- a/flexmeasures/ui/static/js/ui-utils.js
+++ b/flexmeasures/ui/static/js/ui-utils.js
@@ -1,5 +1,39 @@
 export const apiBasePath = window.location.origin;
 
+export function humanizeIsoDuration(isoDuration) {
+  if (typeof isoDuration !== "string") {
+    return isoDuration;
+  }
+
+  const match = isoDuration.match(
+    /^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$/,
+  );
+
+  if (!match) {
+    return isoDuration;
+  }
+
+  const units = [
+    { value: match[1], label: "year" },
+    { value: match[2], label: "month" },
+    { value: match[3], label: "week" },
+    { value: match[4], label: "day" },
+    { value: match[5], label: "hour" },
+    { value: match[6], label: "minute" },
+    { value: match[7], label: "second" },
+  ];
+
+  const parts = units
+    .filter((unit) => unit.value !== undefined)
+    .map((unit) => {
+      const num = Number(unit.value);
+      const suffix = num === 1 ? "" : "s";
+      return `${unit.value} ${unit.label}${suffix}`;
+    });
+
+  return parts.length > 0 ? parts.join(" ") : isoDuration;
+}
+
 // Fetch Account Details
 export async function getAccount(accountId) {
   const cacheKey = `account_${accountId}`;

--- a/flexmeasures/ui/static/js/ui-utils.js
+++ b/flexmeasures/ui/static/js/ui-utils.js
@@ -1,39 +1,5 @@
 export const apiBasePath = window.location.origin;
 
-export function humanizeIsoDuration(isoDuration) {
-  if (typeof isoDuration !== "string") {
-    return isoDuration;
-  }
-
-  const match = isoDuration.match(
-    /^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$/,
-  );
-
-  if (!match) {
-    return isoDuration;
-  }
-
-  const units = [
-    { value: match[1], label: "year" },
-    { value: match[2], label: "month" },
-    { value: match[3], label: "week" },
-    { value: match[4], label: "day" },
-    { value: match[5], label: "hour" },
-    { value: match[6], label: "minute" },
-    { value: match[7], label: "second" },
-  ];
-
-  const parts = units
-    .filter((unit) => unit.value !== undefined)
-    .map((unit) => {
-      const num = Number(unit.value);
-      const suffix = num === 1 ? "" : "s";
-      return `${unit.value} ${unit.label}${suffix}`;
-    });
-
-  return parts.length > 0 ? parts.join(" ") : isoDuration;
-}
-
 // Fetch Account Details
 export async function getAccount(accountId) {
   const cacheKey = `account_${accountId}`;
@@ -417,8 +383,8 @@ export function extractApiErrorMessage(errorData, fallbackMessage) {
   return fallbackMessage || "Unknown error";
 }
 
-/**  
-  * Optionally show a confirmation dialog, then perform a fetch request.
+/**
+ * Optionally show a confirmation dialog, then perform a fetch request.
  *
  * Error responses are normalised: a JSON body's `message` field is used
  * when available, otherwise the HTTP status text is used. Network errors
@@ -433,20 +399,22 @@ export function extractApiErrorMessage(errorData, fallbackMessage) {
  * @param {string}   errorPrefix    - Prefix for the showToast error message.
  */
 function confirmAndFetch(confirmMessage, url, options, onSuccess, errorPrefix) {
-    if (confirmMessage && !confirm(confirmMessage)) return;
-    fetch(url, options)
-        .then(response => {
-            if (response.ok) return response;
-            const contentType = response.headers.get("content-type");
-            if (contentType && contentType.includes("application/json")) {
-                return response.json().then(err => {
-                    throw new Error(err.message || response.statusText || "Request failed");
-                });
-            }
-            throw new Error(response.statusText || "Request failed");
-        })
-        .then(onSuccess)
-        .catch(err => showToast(errorPrefix + ": " + err.message, "error"));
+  if (confirmMessage && !confirm(confirmMessage)) return;
+  fetch(url, options)
+    .then((response) => {
+      if (response.ok) return response;
+      const contentType = response.headers.get("content-type");
+      if (contentType && contentType.includes("application/json")) {
+        return response.json().then((err) => {
+          throw new Error(
+            err.message || response.statusText || "Request failed",
+          );
+        });
+      }
+      throw new Error(response.statusText || "Request failed");
+    })
+    .then(onSuccess)
+    .catch((err) => showToast(errorPrefix + ": " + err.message, "error"));
 }
 
 /**
@@ -462,54 +430,59 @@ function confirmAndFetch(confirmMessage, url, options, onSuccess, errorPrefix) {
  * responsible for pruning unwanted copies.
  */
 export function initCopyAssetButtons() {
-    document.querySelectorAll(".js-copy-asset-btn").forEach(btn => {
-        const assetId = btn.dataset.assetId;
-        // Present on the "copy to my account" button; absent on the sibling-copy button.
-        const targetAccountId = btn.dataset.targetAccountId || null;
+  document.querySelectorAll(".js-copy-asset-btn").forEach((btn) => {
+    const assetId = btn.dataset.assetId;
+    // Present on the "copy to my account" button; absent on the sibling-copy button.
+    const targetAccountId = btn.dataset.targetAccountId || null;
 
-        btn.addEventListener("click", function (event) {
-            const openInNewTab = event.ctrlKey || event.metaKey;
-            const url = targetAccountId
-                ? "/api/v3_0/assets/" + assetId + "/copy?account=" + targetAccountId
-                : "/api/v3_0/assets/" + assetId + "/copy";
-            confirmAndFetch(
-                null,
-                url,
-                {method: "POST", headers: {"Content-Type": "application/json"}, credentials: "same-origin"},
-                response => response.json().then(data => {
-                    showToast("Asset copied successfully.", "success");
-                    setTimeout(() => {
-                        const dest = "/assets/" + data.asset + "/properties";
-                        if (openInNewTab) {
-                            window.open(dest, "_blank");
-                        } else {
-                            window.location.href = dest;
-                        }
-                    }, 1500);
-                }),
-                "Failed to copy asset"
-            );
-        });
+    btn.addEventListener("click", function (event) {
+      const openInNewTab = event.ctrlKey || event.metaKey;
+      const url = targetAccountId
+        ? "/api/v3_0/assets/" + assetId + "/copy?account=" + targetAccountId
+        : "/api/v3_0/assets/" + assetId + "/copy";
+      confirmAndFetch(
+        null,
+        url,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "same-origin",
+        },
+        (response) =>
+          response.json().then((data) => {
+            showToast("Asset copied successfully.", "success");
+            setTimeout(() => {
+              const dest = "/assets/" + data.asset + "/properties";
+              if (openInNewTab) {
+                window.open(dest, "_blank");
+              } else {
+                window.location.href = dest;
+              }
+            }, 1500);
+          }),
+        "Failed to copy asset",
+      );
     });
+  });
 }
 
 export function initDeleteAssetButton() {
-    const btn = document.getElementById("delete-asset-button");
-    if (!btn) return;
-    const assetId = btn.dataset.assetId;
+  const btn = document.getElementById("delete-asset-button");
+  if (!btn) return;
+  const assetId = btn.dataset.assetId;
 
-    btn.addEventListener("click", function () {
-        confirmAndFetch(
-            "Are you sure you want to delete this asset and all time series data associated with it?",
-            "/assets/delete_with_data/" + assetId,
-            {method: "GET", credentials: "same-origin"},
-            response => {
-                showToast("Asset deleted successfully.", "success");
-                setTimeout(() => {
-                    window.location.href = response.url;
-                }, 1500);
-            },
-            "Failed to delete asset"
-        );
-    });
+  btn.addEventListener("click", function () {
+    confirmAndFetch(
+      "Are you sure you want to delete this asset and all time series data associated with it?",
+      "/assets/delete_with_data/" + assetId,
+      { method: "GET", credentials: "same-origin" },
+      (response) => {
+        showToast("Asset deleted successfully.", "success");
+        setTimeout(() => {
+          window.location.href = response.url;
+        }, 1500);
+      },
+      "Failed to delete asset",
+    );
+  });
 }

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -7,7 +7,7 @@
     },
     "termsOfService": null,
     "title": "FlexMeasures",
-    "version": "0.32.0"
+    "version": "0.33.0"
   },
   "externalDocs": {
     "description": "FlexMeasures runs on the open source FlexMeasures technology. Read the docs here.",
@@ -2567,7 +2567,7 @@
     "/api/v3_0/assets/{id}/sensors": {
       "get": {
         "summary": "Return all sensors under an asset.",
-        "description": "This endpoint returns all sensors under an asset.\n\nThe endpoint supports pagination of the asset list using the `page` and `per_page` query parameters.\n\n- If the `page` parameter is not provided, all sensors are returned, without pagination information. The result will be a list of sensors.\n- If a `page` parameter is provided, the response will be paginated, showing a specific number of assets per page as defined by `per_page` (default is 10).\nThe response schema for pagination is inspired by https://datatables.net/manual/server-side#Returned-data\n",
+        "description": "This endpoint returns all sensors under an asset.\n\nThe endpoint supports pagination of the sensor list using the `page` and `per_page` query parameters.\n\n- If the `page` parameter is not provided, all sensors are returned, without pagination information. The result will be a list of sensors.\n- If a `page` parameter is provided, the response will be paginated, showing a specific number of sensors per page as defined by `per_page` (default is 10).\nThe response schema for pagination is inspired by https://datatables.net/manual/server-side#Returned-data\n",
         "security": [
           {
             "ApiKeyAuth": []
@@ -2643,38 +2643,34 @@
             "content": {
               "application/json": {
                 "examples": {
-                  "single_asset": {
-                    "summary": "One asset being returned in the response",
+                  "single_sensor": {
+                    "summary": "One sensor being returned in the response",
                     "value": {
                       "data": [
                         {
                           "id": 1,
-                          "name": "Test battery",
-                          "latitude": 10,
-                          "longitude": 100,
-                          "account_id": 2,
-                          "generic_asset_type": {
-                            "id": 1,
-                            "name": "battery"
-                          }
+                          "name": "Test battery power",
+                          "unit": "kW",
+                          "event_resolution": "PT15M",
+                          "generic_asset_id": 1,
+                          "timezone": "Europe/Amsterdam",
+                          "entity_address": "ea1.2021-01.io.flexmeasures.company:fm1.42"
                         }
                       ]
                     }
                   },
-                  "paginated_assets": {
-                    "summary": "A paginated list of assets being returned in the response",
+                  "paginated_sensors": {
+                    "summary": "A paginated list of sensors being returned in the response",
                     "value": {
                       "data": [
                         {
                           "id": 1,
-                          "name": "Test battery",
-                          "latitude": 10,
-                          "longitude": 100,
-                          "account_id": 2,
-                          "generic_asset_type": {
-                            "id": 1,
-                            "name": "battery"
-                          }
+                          "name": "Test battery power",
+                          "unit": "kW",
+                          "event_resolution": "PT15M",
+                          "generic_asset_id": 1,
+                          "timezone": "Europe/Amsterdam",
+                          "entity_address": "ea1.2021-01.io.flexmeasures.company:fm1.42"
                         }
                       ],
                       "num-records": 1,

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -7,7 +7,7 @@
     },
     "termsOfService": null,
     "title": "FlexMeasures",
-    "version": "0.32.0"
+    "version": "0.31.0"
   },
   "externalDocs": {
     "description": "FlexMeasures runs on the open source FlexMeasures technology. Read the docs here.",

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -7,7 +7,7 @@
     },
     "termsOfService": null,
     "title": "FlexMeasures",
-    "version": "0.31.0"
+    "version": "0.32.0"
   },
   "externalDocs": {
     "description": "FlexMeasures runs on the open source FlexMeasures technology. Read the docs here.",

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -950,14 +950,14 @@
                     "description": "A successful response with sensor status data",
                     "value": [
                       {
-                        "staleness": "2 hours",
+                        "staleness": "PT2H",
                         "stale": true,
                         "staleness_since": "2024-01-15T14:30:00+00:00",
                         "reason": "data is outdated",
                         "source_type": "forecast",
                         "id": 64907,
                         "name": "temperature",
-                        "resolution": "5 minutes",
+                        "resolution": "PT5M",
                         "asset_name": "Building A",
                         "relation": "sensor belongs to this asset"
                       }

--- a/flexmeasures/ui/templates/accounts/account.html
+++ b/flexmeasures/ui/templates/accounts/account.html
@@ -424,8 +424,12 @@
               <a href="/accounts/${account["id"]}" title="View this account">${account["name"]}</a>
             `;
     this.timezone = timezone;
-    this.lastLogin = lastLogin ? getHumanFriendlyDeltaOrTimeStr(lastLogin) : "";
-    this.lastSeen = lastSeen ? getHumanFriendlyDeltaOrTimeStr(lastSeen) : "";
+    this.lastLogin = lastLogin
+      ? getHumanFriendlyDeltaOrTimeStr(lastLogin, { dateOnlyForOlder: true })
+      : "";
+    this.lastSeen = lastSeen
+      ? getHumanFriendlyDeltaOrTimeStr(lastSeen, { dateOnlyForOlder: true })
+      : "";
     this.active = active;
  }
 

--- a/flexmeasures/ui/templates/accounts/account.html
+++ b/flexmeasures/ui/templates/accounts/account.html
@@ -424,8 +424,8 @@
               <a href="/accounts/${account["id"]}" title="View this account">${account["name"]}</a>
             `;
     this.timezone = timezone;
-    this.lastLogin = lastLogin;
-    this.lastSeen = lastSeen;
+    this.lastLogin = lastLogin ? getHumanFriendlyDeltaOrTimeStr(lastLogin) : "";
+    this.lastSeen = lastSeen ? getHumanFriendlyDeltaOrTimeStr(lastSeen) : "";
     this.active = active;
  }
 

--- a/flexmeasures/ui/templates/assets/asset_properties.html
+++ b/flexmeasures/ui/templates/assets/asset_properties.html
@@ -411,10 +411,8 @@
     <script type="module" type="text/javascript">
 
         import {
-            getFlexFieldTitle, renderFlexFieldOptions, renderSensor,
-            createReactiveState, processResourceRawJSON, getAsset, getHumanFriendlyDeltaOrTimeStr,
-            getAccount, getSensor, apiBasePath, renderSensorSearchResults, extractApiErrorMessage,
-            humanizeIsoDuration
+            getFlexFieldTitle, renderFlexFieldOptions, renderSensor, createReactiveState, getAsset, humanizeIsoDuration,
+            getAccount, getSensor, apiBasePath, renderSensorSearchResults, extractApiErrorMessage, processResourceRawJSON
         } from "{{ url_for('flexmeasures_ui.static', filename='js/ui-utils.js') }}?v={{ flexmeasures_version }}";
 
         // Expose helper to the classic script block below.

--- a/flexmeasures/ui/templates/assets/asset_properties.html
+++ b/flexmeasures/ui/templates/assets/asset_properties.html
@@ -411,12 +411,9 @@
     <script type="module" type="text/javascript">
 
         import {
-            getFlexFieldTitle, renderFlexFieldOptions, renderSensor, createReactiveState, getAsset, humanizeIsoDuration,
+            getFlexFieldTitle, renderFlexFieldOptions, renderSensor, createReactiveState, getAsset,
             getAccount, getSensor, apiBasePath, renderSensorSearchResults, extractApiErrorMessage, processResourceRawJSON
         } from "{{ url_for('flexmeasures_ui.static', filename='js/ui-utils.js') }}?v={{ flexmeasures_version }}";
-
-        // Expose helper to the classic script block below.
-        window.humanizeIsoDuration = humanizeIsoDuration;
 
         const sensorsApiUrl = `${apiBasePath}/api/v3_0/sensors?page=1&per_page=100&asset_id={{ site_asset.id }}`;
         const senSearchResEle = document.getElementById("sensorsSearchResults")
@@ -1245,7 +1242,7 @@
             this.id = id;
             this.name = name;
             this.unit = unit === '' ? '<span title="A sensor recording numbers rather than physical or economical quantities.">dimensionless</span>' : unit;
-            this.resolution = window.humanizeIsoDuration ? window.humanizeIsoDuration(resolution) : resolution;
+            this.resolution = humanizeIsoDuration(resolution);
             this.url = `/sensors/${id}`;
         }
 

--- a/flexmeasures/ui/templates/assets/asset_properties.html
+++ b/flexmeasures/ui/templates/assets/asset_properties.html
@@ -16,109 +16,108 @@
             {% if user_can_update_asset %}
             {% from "_macros.html" import json_attributes_editor_button %}
             <div class="sidepanel">
-                <div class="sidepanel-container" style="--sidepanel-width: 450px">
-                    <div class="sidepanel-label">Edit asset</div>
-                    <div class="sidepanel-content">
-                        <form class="form-horizontal" method="POST" action="/assets/{{ asset.id }}">
-                            {{ asset_form.csrf_token }}
-                            {{ asset_form.hidden_tag() }}
-                            <fieldset>
-                                <div class="asset-form">
+            <div class="sidepanel-container" style="--sidepanel-width: 450px">
+                <div class="sidepanel-label">Edit asset</div>
+                <div class="sidepanel-content">
+                    <form class="form-horizontal" method="POST" action="/assets/{{ asset.id }}">
+                        {{ asset_form.csrf_token }}
+                        {{ asset_form.hidden_tag() }}
+                        <fieldset>
+                            <div class="asset-form">
 
-                                    <h3>Edit {{ asset.name }}</h3>
-                                    <small>Owned by account: {{ asset.account_id | accountname }} (ID: {{
-                                        asset.account_id
-                                        }})</small>
+                                <h3>Edit {{ asset.name }}</h3>
+                                <small>Owned by account: {{ asset.account_id | accountname }} (ID: {{ asset.account_id
+                                    }})</small>
 
-                                    <div class="form-group">
-                                        {{ asset_form.name.label(class="control-label") }}
-                                        <div class="col-md-3">
-                                            {{ asset_form.name(class_="form-control") }}
-                                            {% for error in asset_form.errors.name %}
-                                            <span style="color: red;">[{{error}}]</span>
+                                <div class="form-group">
+                                    {{ asset_form.name.label(class="control-label") }}
+                                    <div class="col-md-3">
+                                        {{ asset_form.name(class_="form-control") }}
+                                        {% for error in asset_form.errors.name %}
+                                        <span style="color: red;">[{{error}}]</span>
+                                        {% endfor %}
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    {{ asset_form.latitude.label(class="control-label") }}
+                                    <div class="col-md-6">
+                                        {{ asset_form.latitude(class_="form-control") }}
+                                        {% for error in asset_form.errors.latitude %}
+                                        <span style="color: red;">[{{error}}]</span>
+                                        {% endfor %}
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    {{ asset_form.longitude.label(class="control-label") }}
+                                    <div class="col-md-6">
+                                        {{ asset_form.longitude(class_="form-control") }}
+                                        {% for error in asset_form.errors.longitude %}
+                                        <span style="color: red;">[{{error}}]</span>
+                                        {% endfor %}
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    {{ asset_form.parent_asset_id.label(class="col-sm-6 control-label") }}
+                                    <div class="col-md-6">
+                                        <select name="parent_asset_id" id="parent_asset_id" class="form-control">
+                                            <option value="" {% if asset.parent_asset_id is none %} selected {%
+                                                endif %}>No Parent</option>
+                                            {% for account_asset in account_assets %}
+                                            {% if account_asset.id != asset.id %}
+                                            <option value="{{ account_asset.id }}" {% if
+                                                asset.parent_asset_id==account_asset.id %} selected {% endif %}>
+                                                {{ account_asset.name }} (ID: {{ account_asset.id }})</option>
+                                            {% endif %}
                                             {% endfor %}
-                                        </div>
-                                    </div>
-                                    <div class="form-group">
-                                        {{ asset_form.latitude.label(class="control-label") }}
-                                        <div class="col-md-6">
-                                            {{ asset_form.latitude(class_="form-control") }}
-                                            {% for error in asset_form.errors.latitude %}
-                                            <span style="color: red;">[{{error}}]</span>
-                                            {% endfor %}
-                                        </div>
-                                    </div>
-                                    <div class="form-group">
-                                        {{ asset_form.longitude.label(class="control-label") }}
-                                        <div class="col-md-6">
-                                            {{ asset_form.longitude(class_="form-control") }}
-                                            {% for error in asset_form.errors.longitude %}
-                                            <span style="color: red;">[{{error}}]</span>
-                                            {% endfor %}
-                                        </div>
-                                    </div>
-                                    <div class="form-group">
-                                        {{ asset_form.parent_asset_id.label(class="col-sm-6 control-label") }}
-                                        <div class="col-md-6">
-                                            <select name="parent_asset_id" id="parent_asset_id" class="form-control">
-                                                <option value="" {% if asset.parent_asset_id is none %} selected {%
-                                                    endif %}>No Parent</option>
-                                                {% for account_asset in account_assets %}
-                                                {% if account_asset.id != asset.id %}
-                                                <option value="{{ account_asset.id }}" {% if
-                                                    asset.parent_asset_id==account_asset.id %} selected {% endif %}>
-                                                    {{ account_asset.name }} (ID: {{ account_asset.id }})</option>
-                                                {% endif %}
-                                                {% endfor %}
-                                            </select>
+                                        </select>
 
-                                        </div>
                                     </div>
-                                    <div class="form-group">
-                                        <label for="assset-type" class="control-label">Asset Type</label>
-                                        <div class="col-md-6">
-                                            <input class="form-control" id="asset-type-id" name="asset-type" type="text"
-                                                value="{{ asset.generic_asset_type.name }}" disabled></input>
-                                        </div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="assset-type" class="control-label">Asset Type</label>
+                                    <div class="col-md-6">
+                                        <input class="form-control" id="asset-type-id" name="asset-type" type="text"
+                                            value="{{ asset.generic_asset_type.name }}" disabled></input>
                                     </div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="asset-id" class="control-label">Asset id</label>
+                                    <div class="col-md-6">
+                                        <input class="form-control" id="asset-id" name="asset-id" type="text"
+                                            value="{{ asset.id }}" disabled></input>
+                                    </div>
+
+                                <div class="form-group">
+                                    {{ asset_form.sensors_to_show_as_kpis.label(class="control-label") }}
+                                    <div class="col-md-3">
+                                        <small>{{ asset_form.sensors_to_show_as_kpis.description }}</small>
+                                        {{ asset_form.sensors_to_show_as_kpis(class_="form-control") }}
+                                        {% for error in asset_form.errors.sensors_to_show_as_kpis %}
+                                        <span style="color: red;">[{{error}}]</span>
+                                        {% endfor %}
+                                    </div>
+
+                                <div class="form-group">
+                                    {{ asset_form.external_id.label(class="control-label") }}
+                                    <div class="col-md-3">
+                                        <small>{{ asset_form.external_id.description }}</small>
+                                        {{ asset_form.external_id(class_="form-control") }}
+                                        {% for error in asset_form.errors.external_id %}
+                                        <span style="color: red;">[{{error}}]</span>
+                                        {% endfor %}
+                                    </div>
+
                                     <div class="form-group">
-                                        <label for="asset-id" class="control-label">Asset id</label>
-                                        <div class="col-md-6">
-                                            <input class="form-control" id="asset-id" name="asset-id" type="text"
-                                                value="{{ asset.id }}" disabled></input>
-                                        </div>
-
-                                        <div class="form-group">
-                                            {{ asset_form.sensors_to_show_as_kpis.label(class="control-label") }}
-                                            <div class="col-md-3">
-                                                <small>{{ asset_form.sensors_to_show_as_kpis.description }}</small>
-                                                {{ asset_form.sensors_to_show_as_kpis(class_="form-control") }}
-                                                {% for error in asset_form.errors.sensors_to_show_as_kpis %}
-                                                <span style="color: red;">[{{error}}]</span>
-                                                {% endfor %}
-                                            </div>
-
-                                            <div class="form-group">
-                                                {{ asset_form.external_id.label(class="control-label") }}
-                                                <div class="col-md-3">
-                                                    <small>{{ asset_form.external_id.description }}</small>
-                                                    {{ asset_form.external_id(class_="form-control") }}
-                                                    {% for error in asset_form.errors.external_id %}
-                                                    <span style="color: red;">[{{error}}]</span>
-                                                    {% endfor %}
-                                                </div>
-
-                                                <div class="form-group">
-                                                    <label class="control-label">Location</label>
-                                                    <small>(Click map to edit latitude and longitude in form)</small>
-                                                    <div id="mapid"></div>
-                                                    <button class="btn btn-sm btn-responsive btn-success create-button"
-                                                        type="submit" value="Save"
-                                                        style="margin-top: 20px; float: right; border: 1px solid var(--light-gray);">
-                                                        Save
-                                                    </button>
-                                                </div>
-                                            </div>
+                                        <label class="control-label">Location</label>
+                                        <small>(Click map to edit latitude and longitude in form)</small>
+                                        <div id="mapid"></div>
+                                        <button class="btn btn-sm btn-responsive btn-success create-button"
+                                            type="submit" value="Save"
+                                            style="margin-top: 20px; float: right; border: 1px solid var(--light-gray);">
+                                            Save
+                                        </button>
+                                    </div>
+                                </div>
                             </fieldset>
                         </form>
                         <div class="form-group pt-3">
@@ -145,7 +144,8 @@
                 {% if user_can_copy_to_own_account %}
                 <div>
                     <button class="js-copy-asset-btn btn btn-sm btn-responsive create-button" type="button"
-                        data-asset-id="{{ asset.id }}" data-target-account-id="{{ copy_target_account_id }}"
+                        data-asset-id="{{ asset.id }}"
+                        data-target-account-id="{{ copy_target_account_id }}"
                         title="Copy asset and all its children to {{ own_organisation_name }}{% if not user_can_delete_asset %} — note: you can copy but not delete; contact your organisation admin to remove unwanted copies{% endif %}. Ctrl-click to open the copy in a new tab.">
                         Copy to {{ own_organisation_name }}
                     </button>
@@ -153,8 +153,8 @@
                 {% endif %}
                 {% if user_can_delete_asset %}
                 <div>
-                    <button id="delete-asset-button" class="btn btn-sm btn-responsive delete-button" type="button"
-                        data-asset-id="{{ asset.id }}">Delete this asset
+                    <button id="delete-asset-button" class="btn btn-sm btn-responsive delete-button"
+                        type="button" data-asset-id="{{ asset.id }}">Delete this asset
                     </button>
                 </div>
                 {% endif %}

--- a/flexmeasures/ui/templates/assets/asset_properties.html
+++ b/flexmeasures/ui/templates/assets/asset_properties.html
@@ -16,108 +16,109 @@
             {% if user_can_update_asset %}
             {% from "_macros.html" import json_attributes_editor_button %}
             <div class="sidepanel">
-            <div class="sidepanel-container" style="--sidepanel-width: 450px">
-                <div class="sidepanel-label">Edit asset</div>
-                <div class="sidepanel-content">
-                    <form class="form-horizontal" method="POST" action="/assets/{{ asset.id }}">
-                        {{ asset_form.csrf_token }}
-                        {{ asset_form.hidden_tag() }}
-                        <fieldset>
-                            <div class="asset-form">
+                <div class="sidepanel-container" style="--sidepanel-width: 450px">
+                    <div class="sidepanel-label">Edit asset</div>
+                    <div class="sidepanel-content">
+                        <form class="form-horizontal" method="POST" action="/assets/{{ asset.id }}">
+                            {{ asset_form.csrf_token }}
+                            {{ asset_form.hidden_tag() }}
+                            <fieldset>
+                                <div class="asset-form">
 
-                                <h3>Edit {{ asset.name }}</h3>
-                                <small>Owned by account: {{ asset.account_id | accountname }} (ID: {{ asset.account_id
-                                    }})</small>
-
-                                <div class="form-group">
-                                    {{ asset_form.name.label(class="control-label") }}
-                                    <div class="col-md-3">
-                                        {{ asset_form.name(class_="form-control") }}
-                                        {% for error in asset_form.errors.name %}
-                                        <span style="color: red;">[{{error}}]</span>
-                                        {% endfor %}
-                                    </div>
-                                </div>
-                                <div class="form-group">
-                                    {{ asset_form.latitude.label(class="control-label") }}
-                                    <div class="col-md-6">
-                                        {{ asset_form.latitude(class_="form-control") }}
-                                        {% for error in asset_form.errors.latitude %}
-                                        <span style="color: red;">[{{error}}]</span>
-                                        {% endfor %}
-                                    </div>
-                                </div>
-                                <div class="form-group">
-                                    {{ asset_form.longitude.label(class="control-label") }}
-                                    <div class="col-md-6">
-                                        {{ asset_form.longitude(class_="form-control") }}
-                                        {% for error in asset_form.errors.longitude %}
-                                        <span style="color: red;">[{{error}}]</span>
-                                        {% endfor %}
-                                    </div>
-                                </div>
-                                <div class="form-group">
-                                    {{ asset_form.parent_asset_id.label(class="col-sm-6 control-label") }}
-                                    <div class="col-md-6">
-                                        <select name="parent_asset_id" id="parent_asset_id" class="form-control">
-                                            <option value="" {% if asset.parent_asset_id is none %} selected {%
-                                                endif %}>No Parent</option>
-                                            {% for account_asset in account_assets %}
-                                            {% if account_asset.id != asset.id %}
-                                            <option value="{{ account_asset.id }}" {% if
-                                                asset.parent_asset_id==account_asset.id %} selected {% endif %}>
-                                                {{ account_asset.name }} (ID: {{ account_asset.id }})</option>
-                                            {% endif %}
-                                            {% endfor %}
-                                        </select>
-
-                                    </div>
-                                </div>
-                                <div class="form-group">
-                                    <label for="assset-type" class="control-label">Asset Type</label>
-                                    <div class="col-md-6">
-                                        <input class="form-control" id="asset-type-id" name="asset-type" type="text"
-                                            value="{{ asset.generic_asset_type.name }}" disabled></input>
-                                    </div>
-                                </div>
-                                <div class="form-group">
-                                    <label for="asset-id" class="control-label">Asset id</label>
-                                    <div class="col-md-6">
-                                        <input class="form-control" id="asset-id" name="asset-id" type="text"
-                                            value="{{ asset.id }}" disabled></input>
-                                    </div>
-
-                                <div class="form-group">
-                                    {{ asset_form.sensors_to_show_as_kpis.label(class="control-label") }}
-                                    <div class="col-md-3">
-                                        <small>{{ asset_form.sensors_to_show_as_kpis.description }}</small>
-                                        {{ asset_form.sensors_to_show_as_kpis(class_="form-control") }}
-                                        {% for error in asset_form.errors.sensors_to_show_as_kpis %}
-                                        <span style="color: red;">[{{error}}]</span>
-                                        {% endfor %}
-                                    </div>
-
-                                <div class="form-group">
-                                    {{ asset_form.external_id.label(class="control-label") }}
-                                    <div class="col-md-3">
-                                        <small>{{ asset_form.external_id.description }}</small>
-                                        {{ asset_form.external_id(class_="form-control") }}
-                                        {% for error in asset_form.errors.external_id %}
-                                        <span style="color: red;">[{{error}}]</span>
-                                        {% endfor %}
-                                    </div>
+                                    <h3>Edit {{ asset.name }}</h3>
+                                    <small>Owned by account: {{ asset.account_id | accountname }} (ID: {{
+                                        asset.account_id
+                                        }})</small>
 
                                     <div class="form-group">
-                                        <label class="control-label">Location</label>
-                                        <small>(Click map to edit latitude and longitude in form)</small>
-                                        <div id="mapid"></div>
-                                        <button class="btn btn-sm btn-responsive btn-success create-button"
-                                            type="submit" value="Save"
-                                            style="margin-top: 20px; float: right; border: 1px solid var(--light-gray);">
-                                            Save
-                                        </button>
+                                        {{ asset_form.name.label(class="control-label") }}
+                                        <div class="col-md-3">
+                                            {{ asset_form.name(class_="form-control") }}
+                                            {% for error in asset_form.errors.name %}
+                                            <span style="color: red;">[{{error}}]</span>
+                                            {% endfor %}
+                                        </div>
                                     </div>
-                                </div>
+                                    <div class="form-group">
+                                        {{ asset_form.latitude.label(class="control-label") }}
+                                        <div class="col-md-6">
+                                            {{ asset_form.latitude(class_="form-control") }}
+                                            {% for error in asset_form.errors.latitude %}
+                                            <span style="color: red;">[{{error}}]</span>
+                                            {% endfor %}
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        {{ asset_form.longitude.label(class="control-label") }}
+                                        <div class="col-md-6">
+                                            {{ asset_form.longitude(class_="form-control") }}
+                                            {% for error in asset_form.errors.longitude %}
+                                            <span style="color: red;">[{{error}}]</span>
+                                            {% endfor %}
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        {{ asset_form.parent_asset_id.label(class="col-sm-6 control-label") }}
+                                        <div class="col-md-6">
+                                            <select name="parent_asset_id" id="parent_asset_id" class="form-control">
+                                                <option value="" {% if asset.parent_asset_id is none %} selected {%
+                                                    endif %}>No Parent</option>
+                                                {% for account_asset in account_assets %}
+                                                {% if account_asset.id != asset.id %}
+                                                <option value="{{ account_asset.id }}" {% if
+                                                    asset.parent_asset_id==account_asset.id %} selected {% endif %}>
+                                                    {{ account_asset.name }} (ID: {{ account_asset.id }})</option>
+                                                {% endif %}
+                                                {% endfor %}
+                                            </select>
+
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="assset-type" class="control-label">Asset Type</label>
+                                        <div class="col-md-6">
+                                            <input class="form-control" id="asset-type-id" name="asset-type" type="text"
+                                                value="{{ asset.generic_asset_type.name }}" disabled></input>
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="asset-id" class="control-label">Asset id</label>
+                                        <div class="col-md-6">
+                                            <input class="form-control" id="asset-id" name="asset-id" type="text"
+                                                value="{{ asset.id }}" disabled></input>
+                                        </div>
+
+                                        <div class="form-group">
+                                            {{ asset_form.sensors_to_show_as_kpis.label(class="control-label") }}
+                                            <div class="col-md-3">
+                                                <small>{{ asset_form.sensors_to_show_as_kpis.description }}</small>
+                                                {{ asset_form.sensors_to_show_as_kpis(class_="form-control") }}
+                                                {% for error in asset_form.errors.sensors_to_show_as_kpis %}
+                                                <span style="color: red;">[{{error}}]</span>
+                                                {% endfor %}
+                                            </div>
+
+                                            <div class="form-group">
+                                                {{ asset_form.external_id.label(class="control-label") }}
+                                                <div class="col-md-3">
+                                                    <small>{{ asset_form.external_id.description }}</small>
+                                                    {{ asset_form.external_id(class_="form-control") }}
+                                                    {% for error in asset_form.errors.external_id %}
+                                                    <span style="color: red;">[{{error}}]</span>
+                                                    {% endfor %}
+                                                </div>
+
+                                                <div class="form-group">
+                                                    <label class="control-label">Location</label>
+                                                    <small>(Click map to edit latitude and longitude in form)</small>
+                                                    <div id="mapid"></div>
+                                                    <button class="btn btn-sm btn-responsive btn-success create-button"
+                                                        type="submit" value="Save"
+                                                        style="margin-top: 20px; float: right; border: 1px solid var(--light-gray);">
+                                                        Save
+                                                    </button>
+                                                </div>
+                                            </div>
                             </fieldset>
                         </form>
                         <div class="form-group pt-3">
@@ -144,8 +145,7 @@
                 {% if user_can_copy_to_own_account %}
                 <div>
                     <button class="js-copy-asset-btn btn btn-sm btn-responsive create-button" type="button"
-                        data-asset-id="{{ asset.id }}"
-                        data-target-account-id="{{ copy_target_account_id }}"
+                        data-asset-id="{{ asset.id }}" data-target-account-id="{{ copy_target_account_id }}"
                         title="Copy asset and all its children to {{ own_organisation_name }}{% if not user_can_delete_asset %} — note: you can copy but not delete; contact your organisation admin to remove unwanted copies{% endif %}. Ctrl-click to open the copy in a new tab.">
                         Copy to {{ own_organisation_name }}
                     </button>
@@ -153,8 +153,8 @@
                 {% endif %}
                 {% if user_can_delete_asset %}
                 <div>
-                    <button id="delete-asset-button" class="btn btn-sm btn-responsive delete-button"
-                        type="button" data-asset-id="{{ asset.id }}">Delete this asset
+                    <button id="delete-asset-button" class="btn btn-sm btn-responsive delete-button" type="button"
+                        data-asset-id="{{ asset.id }}">Delete this asset
                     </button>
                 </div>
                 {% endif %}
@@ -340,7 +340,8 @@
                     </div>
 
                     <div class="d-flex ms-auto align-items-center gap-2">
-                        <button type="button" id="saveChangesBtn" class="btn btn-primary ms-auto create-button">Save</button>
+                        <button type="button" id="saveChangesBtn"
+                            class="btn btn-primary ms-auto create-button">Save</button>
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
 
@@ -411,9 +412,13 @@
 
         import {
             getFlexFieldTitle, renderFlexFieldOptions, renderSensor,
-            createReactiveState, processResourceRawJSON, getAsset,
-            getAccount, getSensor, apiBasePath, renderSensorSearchResults, extractApiErrorMessage
+            createReactiveState, processResourceRawJSON, getAsset, getHumanFriendlyDeltaOrTimeStr,
+            getAccount, getSensor, apiBasePath, renderSensorSearchResults, extractApiErrorMessage,
+            humanizeIsoDuration
         } from "{{ url_for('flexmeasures_ui.static', filename='js/ui-utils.js') }}?v={{ flexmeasures_version }}";
+
+        // Expose helper to the classic script block below.
+        window.humanizeIsoDuration = humanizeIsoDuration;
 
         const sensorsApiUrl = `${apiBasePath}/api/v3_0/sensors?page=1&per_page=100&asset_id={{ site_asset.id }}`;
         const senSearchResEle = document.getElementById("sensorsSearchResults")
@@ -1242,7 +1247,7 @@
             this.id = id;
             this.name = name;
             this.unit = unit === '' ? '<span title="A sensor recording numbers rather than physical or economical quantities.">dimensionless</span>' : unit;
-            this.resolution = resolution
+            this.resolution = window.humanizeIsoDuration ? window.humanizeIsoDuration(resolution) : resolution;
             this.url = `/sensors/${id}`;
         }
 

--- a/flexmeasures/ui/templates/users/user_audit_log.html
+++ b/flexmeasures/ui/templates/users/user_audit_log.html
@@ -20,7 +20,10 @@
 
 <script>
 function AuditLog(event_datetime, event, acting_user_name) {
-    this.event_datetime = event_datetime;
+    const naturalDateTime = new Date(event_datetime);
+    const naturalDate = naturalDateTime.toLocaleDateString(undefined, { day: '2-digit', month: 'short' });
+
+    this.event_datetime = `<span title="${naturalDateTime}">${naturalDate}</span>`;
     this.event = event;
     this.acting_user_name = acting_user_name;
 }

--- a/flexmeasures/ui/templates/users/users.html
+++ b/flexmeasures/ui/templates/users/users.html
@@ -58,8 +58,12 @@
                 <a href="/accounts/${account["id"]}" title="View this account">${account["name"]}</a>
               `;
       this.timezone = timezone;
-      this.lastLogin = lastLogin ? getHumanFriendlyDeltaOrTimeStr(lastLogin) : "";
-      this.lastSeen = lastSeen ? getHumanFriendlyDeltaOrTimeStr(lastSeen) : "";
+      this.lastLogin = lastLogin
+        ? getHumanFriendlyDeltaOrTimeStr(lastLogin, { dateOnlyForOlder: true })
+        : "";
+      this.lastSeen = lastSeen
+        ? getHumanFriendlyDeltaOrTimeStr(lastSeen, { dateOnlyForOlder: true })
+        : "";
       this.active = active;
    }
 

--- a/flexmeasures/ui/templates/users/users.html
+++ b/flexmeasures/ui/templates/users/users.html
@@ -58,8 +58,8 @@
                 <a href="/accounts/${account["id"]}" title="View this account">${account["name"]}</a>
               `;
       this.timezone = timezone;
-      this.lastLogin = lastLogin;
-      this.lastSeen = lastSeen;
+      this.lastLogin = lastLogin ? getHumanFriendlyDeltaOrTimeStr(lastLogin) : "";
+      this.lastSeen = lastSeen ? getHumanFriendlyDeltaOrTimeStr(lastSeen) : "";
       this.active = active;
    }
 


### PR DESCRIPTION
## Description
- Standardizes API time/resolution fields to machine-readable ISO values:
  - `GET /api/v3_0/assets/{id}/sensors` -> `event_resolution` in ISO duration.
  - `GET /api/v3_0/sensors/{id}/status` -> ISO `resolution`, ISO `staleness`, ISO `staleness_since` datetime.
  - `GET /api/v3_0/users` -> ISO `last_login_at` and `last_seen_at`.
  - `GET /api/v3_0/users/{id}/auditlog` -> ISO `event_datetime`.
- Preserves human-friendly display in UI by formatting these values in frontend templates/JS.
- Aligns docs/changelog updates with the expanded endpoint scope.

## Look & Feel
Before:
<img width="429" height="381" alt="image" src="https://github.com/user-attachments/assets/35d26078-2954-4792-b9a7-eab8c897d81c" />

After:
<img width="429" height="381" alt="image" src="https://github.com/user-attachments/assets/1402a701-b002-4196-ae0b-78058369e4dc" />

## How to test
- Verify API responses from the endpoints above return ISO values.
- Verify users/account/asset pages still render human-friendly time strings.

## Further Improvements
- Optional follow-up cleanup: isolate datetime/duration formatting helpers into a dedicated frontend module.

## Related Items
Closes #2145

<!--
We ask contributors outside the FlexMeasures organisation to sign off on their contribution.
Please mark the below fields with an [x].
-->

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
