### PR TITLE
 Derive seasonal lags from sensor resolution

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -18,6 +18,7 @@ New features
 * New ``GET /api/v3_0/sources`` endpoint to list accessible data sources and defined types, with ``only_latest=true`` by default to return only the most recent version per source [see `PR #2126 <https://www.github.com/FlexMeasures/flexmeasures/pull/2126>`_]
 * Add support for filtering sensor data GET requests by ``source-type`` on ``/api/v3_0/sensors/<id>/data`` [see `PR #2127 <https://www.github.com/FlexMeasures/flexmeasures/pull/2127>`_]
 * Making monitoring alerts more flexible: allow ``flexmeasures monitor`` alerts to target one or more user IDs or email addresses with ``--recipient``; ``flexmeasures monitor last-seen`` can now narrow monitored users to one or more accounts with ``--account`` or to client accounts with ``--consultancy`` [see `PR #2158 <https://www.github.com/FlexMeasures/flexmeasures/pull/2158>`_]
+* Improve LightGBM daily seasonal lag handling for sub-hourly forecasting sensors [see `PR #2157 <https://www.github.com/FlexMeasures/flexmeasures/pull/2157>`_]
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
+++ b/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
@@ -30,6 +30,7 @@ class CustomLGBM(BaseModel):
         use_past_covariates=False,
         use_future_covariates=False,
         ensure_positive=False,
+        seasonal_lag_steps=24,
     ):
 
         if models_params is None:
@@ -52,6 +53,7 @@ class CustomLGBM(BaseModel):
             }
         else:
             self.models_params = models_params
+        self.seasonal_lag_steps = seasonal_lag_steps
         super().__init__(
             max_forecast_horizon=max_forecast_horizon,
             probabilistic=probabilistic,
@@ -70,9 +72,9 @@ class CustomLGBM(BaseModel):
 
             # Lag features are dynamically set based on the forecast horizon
             lag = (
-                24
+                self.seasonal_lag_steps
                 - (  # temporarily make the adaptation to the sensor resolution; To do: inlude a list of seasonal lags to include, given as pd.timedelta objects
-                    horizon % 24
+                    horizon % self.seasonal_lag_steps
                 )
             )  # Adjust to repeat the lag structure every 24 hours
             lags = [-1, -lag, -lag - 1]
@@ -80,11 +82,11 @@ class CustomLGBM(BaseModel):
             # Special cases for lags
             if (
                 horizon == 0
-                or horizon % 24 == 0
+                or horizon % self.seasonal_lag_steps == 0
                 or horizon == self.max_forecast_horizon - 1
             ):
-                lags = [-1, -24]
-            elif horizon % 24 == 23:
+                lags = [-1, -self.seasonal_lag_steps]
+            elif horizon % self.seasonal_lag_steps == self.seasonal_lag_steps - 1:
                 lags = [-1, -2]
 
             # lags = list(range(-1, -25, -1))  # todo: consider letting the model figure out which lags are important

--- a/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
+++ b/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
@@ -31,6 +31,9 @@ class CustomLGBM(BaseModel):
         use_future_covariates=False,
         ensure_positive=False,
         seasonal_lag_steps=24,
+        fallback_lag_steps=24,
+        training_sample_count=None,
+        min_samples_per_horizon=2,
     ):
 
         if models_params is None:
@@ -53,6 +56,12 @@ class CustomLGBM(BaseModel):
             }
         else:
             self.models_params = models_params
+        if (
+            training_sample_count is not None
+            and training_sample_count - seasonal_lag_steps - (max_forecast_horizon - 1)
+            < min_samples_per_horizon
+        ):
+            seasonal_lag_steps = fallback_lag_steps
         self.seasonal_lag_steps = seasonal_lag_steps
         super().__init__(
             max_forecast_horizon=max_forecast_horizon,

--- a/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
+++ b/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
@@ -153,7 +153,7 @@ class CustomLGBM(BaseModel):
 
         Example
         -------
-        
+
         .. mermaid::
 
             timeline
@@ -200,18 +200,19 @@ class CustomLGBM(BaseModel):
         For horizons near the maximum forecast horizon, only ``l`` is returned.
 
         This avoids generating additional lag references that are not guaranteed to exist consistently during recursive multi-horizon prediction.
-    """
-    offset = horizon % seasonal_lag_steps
-    aligned_darts_lag = -(seasonal_lag_steps - offset)
+        """
 
-    # The preceding lag is omitted for the final forecast horizon,
-    # because it is not guaranteed to exist consistently during recursive inference.
-    if horizon != max_forecast_horizon - 1:
-        darts_lags = [aligned_darts_lag, aligned_darts_lag - 1]
-    else:
-        darts_lags = [aligned_darts_lag]
+        offset = horizon % seasonal_lag_steps
+        aligned_darts_lag = -(seasonal_lag_steps - offset)
 
-    return darts_lags
+        # The preceding lag is omitted for the final forecast horizon,
+        # because it is not guaranteed to exist consistently during recursive inference.
+        if horizon != max_forecast_horizon - 1:
+            darts_lags = [aligned_darts_lag, aligned_darts_lag - 1]
+        else:
+            darts_lags = [aligned_darts_lag]
+
+        return darts_lags
 
     def _setup(self) -> None:
         for horizon in range(self.max_forecast_horizon):
@@ -231,7 +232,7 @@ class CustomLGBM(BaseModel):
                     for seasonal_lag_steps in eligible_seasonal_lags_steps
                     for darts_lag in self._lags_for_horizon(
                         horizon, self.max_forecast_horizon, seasonal_lag_steps
-                    ),
+                    )
                 }
             )
 

--- a/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
+++ b/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
@@ -48,8 +48,8 @@ class CustomLGBM(BaseModel):
         :param use_future_covariates: Whether future covariates are used for fitting and prediction.
         :param ensure_positive: Whether negative predictions should be clipped to zero.
         :param seasonal_lags_steps: Candidate seasonal lag steps to keep if enough training samples remain.
-        :param training_sample_count: Optional number of target training samples, used to decide whether fallback is needed.
-        :param min_samples_per_horizon: Minimum training rows required for the farthest forecast horizon.
+        :param training_sample_count: Optional number of target training samples, used to decide which lags are eligible.
+        :param min_samples_per_horizon: Minimum training rows required for each horizon model.
         """
         if models_params is None:
             self.models_params = {
@@ -93,7 +93,7 @@ class CustomLGBM(BaseModel):
         seasonal_lags_steps: list[int],
     ) -> list[int]:
         """Validate lag candidates and return them without duplicates."""
-        if any(seasonal_lag_steps < 1 for seasonal_lag_steps in seasonal_lags_steps):
+        if any(lag_steps < 1 for lag_steps in seasonal_lags_steps):
             raise ValueError("seasonal_lags_steps values must be at least 1.")
         return list(dict.fromkeys(seasonal_lags_steps))
 
@@ -103,9 +103,9 @@ class CustomLGBM(BaseModel):
             return self.seasonal_lags_steps
 
         eligible_lags_steps = [
-            seasonal_lag_steps
-            for seasonal_lag_steps in self.seasonal_lags_steps
-            if self.training_sample_count - seasonal_lag_steps - horizon
+            lag_steps
+            for lag_steps in self.seasonal_lags_steps
+            if self.training_sample_count - lag_steps - horizon
             >= self.min_samples_per_horizon
         ]
 
@@ -118,22 +118,22 @@ class CustomLGBM(BaseModel):
 
     @staticmethod
     def _lags_for_horizon(
-        horizon: int, max_forecast_horizon: int, seasonal_lag: int
+        horizon: int, max_forecast_horizon: int, seasonal_lag_steps: int
     ) -> list[int]:
-        """Return lags for one seasonal cycle at the given forecast horizon."""
-        lag = seasonal_lag - (horizon % seasonal_lag)
-        lags = [-lag, -lag - 1]
+        """Return Darts lags for one seasonal cycle at the given forecast horizon."""
+        lag_steps = seasonal_lag_steps - (horizon % seasonal_lag_steps)
+        darts_lags = [-lag_steps, -lag_steps - 1]
 
         if (
             horizon == 0
-            or horizon % seasonal_lag == 0
+            or horizon % seasonal_lag_steps == 0
             or horizon == max_forecast_horizon - 1
         ):
-            lags = [-seasonal_lag]
-        elif horizon % seasonal_lag == seasonal_lag - 1:
-            lags = [-2]
+            darts_lags = [-seasonal_lag_steps]
+        elif horizon % seasonal_lag_steps == seasonal_lag_steps - 1:
+            darts_lags = [-2]
 
-        return lags
+        return darts_lags
 
     def _setup(self) -> None:
         for horizon in range(self.max_forecast_horizon):
@@ -147,30 +147,30 @@ class CustomLGBM(BaseModel):
             eligible_seasonal_lags_steps = self._filter_eligible_lags_for_horizon(
                 horizon
             )
-            lags = sorted(
+            darts_lags = sorted(
                 {
                     -1,
                     *(
-                        lag
-                        for seasonal_lag in eligible_seasonal_lags_steps
-                        for lag in self._lags_for_horizon(
-                            horizon, self.max_forecast_horizon, seasonal_lag
+                        darts_lag
+                        for seasonal_lag_steps in eligible_seasonal_lags_steps
+                        for darts_lag in self._lags_for_horizon(
+                            horizon, self.max_forecast_horizon, seasonal_lag_steps
                         )
                     ),
                 }
             )
 
             # lags = list(range(-1, -25, -1))  # todo: consider letting the model figure out which lags are important
-            model_params["lags"] = lags
+            model_params["lags"] = darts_lags
             if self.use_past_covariates:
-                model_params["lags_past_covariates"] = lags
+                model_params["lags_past_covariates"] = darts_lags
 
             # The one future covariate lag that is probably the most important is the one at the `horizon`,
             # but here we pass all future lags up until `max_horizon`, and let the model figure it out.
             # One future covariate that is of considerable importance is the cyclic time encoder, which contains information about the time at the `horizon`,
             # i.e. the time of the event that we forecast, rather than the time at which the forecast is made, which would be at lag `0`.
 
-            model_params["lags_future_covariates"] = lags + [0]
+            model_params["lags_future_covariates"] = darts_lags + [0]
 
             model = LightGBMModel(**model_params)
             self.models.append(model)

--- a/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
+++ b/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
@@ -47,7 +47,7 @@ class CustomLGBM(BaseModel):
         :param use_past_covariates: Whether past covariates are used for fitting and prediction.
         :param use_future_covariates: Whether future covariates are used for fitting and prediction.
         :param ensure_positive: Whether negative predictions should be clipped to zero.
-        :param seasonal_lags_steps: Candidate seasonal lag steps to keep if enough training samples remain.
+        :param seasonal_lags_steps: Candidate seasonal lag steps to keep if enough training samples remain. Include 1 in the list to account for the most recent observation (recommended).
         :param training_sample_count: Optional number of target training samples, used to decide which lags are eligible.
         :param min_samples_per_horizon: Minimum training rows required for each horizon model.
         """

--- a/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
+++ b/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
@@ -118,22 +118,100 @@ class CustomLGBM(BaseModel):
 
     @staticmethod
     def _lags_for_horizon(
-        horizon: int, max_forecast_horizon: int, seasonal_lag_steps: int
+        horizon: int,
+        max_forecast_horizon: int,
+        seasonal_lag_steps: int,
     ) -> list[int]:
-        """Return Darts lags for one seasonal cycle at the given forecast horizon."""
-        lag_steps = seasonal_lag_steps - (horizon % seasonal_lag_steps)
-        darts_lags = [-lag_steps, -lag_steps - 1]
+        """Build Darts target lags for a forecasting horizon.
 
-        if (
-            horizon == 0
-            or horizon % seasonal_lag_steps == 0
-            or horizon == max_forecast_horizon - 1
-        ):
-            darts_lags = [-seasonal_lag_steps]
-        elif horizon % seasonal_lag_steps == seasonal_lag_steps - 1:
-            darts_lags = [-2]
+        For a forecast target at horizon ``h`` and a seasonal period ``s``, the aligned seasonal reference point is:
 
-        return darts_lags
+            (t + h) - s
+
+        expressed relative to prediction origin ``t``.
+
+        The corresponding aligned Darts lag ``l`` is therefore:
+
+            l = -(s - (h % s))
+
+        where the modulo wraps the horizon within the seasonal cycle.
+
+        Returned lags
+        -------------
+        The returned lag list always contains:
+
+        - ``l``:
+            the lag corresponding to the aligned seasonal position
+
+        In most cases, it additionally contains:
+
+        - ``l - 1``:
+            the observation immediately preceding the aligned seasonal position
+
+        Including both lags helps the model capture short-term local dynamics around the seasonal reference point,
+        rather than relying on a single aligned observation.
+
+        Example
+        -------
+        
+        .. mermaid::
+
+            timeline
+                title Seasonal alignment example for h=3 and s=24
+
+                section  Model lags
+                    t-25
+                    t-24 : seasonal anchor for s=24
+                    t-23
+                    t-22 : preceding point (second Darts lag)
+                section Δ24h seasonal offset
+                    t-21 : aligned seasonal point for t+3 (first Darts lag)
+                    ... t+l ...
+                    t-1
+                    t : prediction origin (belief time)
+                    t+1
+                    t+2
+                section Forecast horizons
+                    t+3 : forecast target at h=3 (event start)
+                    t+4
+                    ... t+H : max forecast horizon
+
+        For:
+
+            horizon = 3
+            seasonal_lag_steps = 24
+
+        we obtain:
+
+            l = -(24 - (3 % 24))
+              = -21
+
+        yielding:
+
+            [-21, -22]
+
+        corresponding to:
+
+            t-21 : aligned seasonal position for target t+3
+            t-22 : observation immediately preceding it
+
+        Edge case near maximum forecast horizon
+        ---------------------------------------
+        For horizons near the maximum forecast horizon, only ``l`` is returned.
+
+        This avoids generating additional lag references that are not guaranteed to exist consistently during recursive multi-horizon prediction.
+    """
+    offset = horizon % seasonal_lag_steps
+    aligned_darts_lag = -(seasonal_lag_steps - offset)
+
+    # The preceding lag is omitted for the final forecast horizon,
+    # because it is not guaranteed to exist consistently during recursive inference.
+    if horizon != max_forecast_horizon - 1:
+        darts_lags = [aligned_darts_lag, aligned_darts_lag - 1]
+    else:
+        darts_lags = [aligned_darts_lag]
+
+    return darts_lags
 
     def _setup(self) -> None:
         for horizon in range(self.max_forecast_horizon):

--- a/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
+++ b/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
@@ -111,7 +111,10 @@ class CustomLGBM(BaseModel):
 
         if eligible_lags_steps:
             return eligible_lags_steps
-        return [self.seasonal_lags_steps[-1]]
+        raise ValueError(
+            "None of the seasonal_lags_steps values leave enough training samples "
+            f"for forecast horizon {horizon}."
+        )
 
     @staticmethod
     def _lags_for_horizon(

--- a/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
+++ b/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
@@ -86,20 +86,11 @@ class CustomLGBM(BaseModel):
 
         if seasonal_lags_steps is None:
             seasonal_lags_steps = [seasonal_lag_steps]
-        self.seasonal_lags_steps = self._filter_eligible_lags(
-            seasonal_lags_steps=seasonal_lags_steps,
-            training_sample_count=training_sample_count,
-            max_forecast_horizon=max_forecast_horizon,
-            min_samples_per_horizon=min_samples_per_horizon,
-        )
-
-        if not self.seasonal_lags_steps:
-            self.seasonal_lags_steps = self._filter_eligible_lags(
-                seasonal_lags_steps=[fallback_lag_steps],
-                training_sample_count=training_sample_count,
-                max_forecast_horizon=max_forecast_horizon,
-                min_samples_per_horizon=min_samples_per_horizon,
-            )
+        self.seasonal_lags_steps = self._validate_lag_candidates(seasonal_lags_steps)
+        if fallback_lag_steps not in self.seasonal_lags_steps:
+            self.seasonal_lags_steps.append(fallback_lag_steps)
+        self.training_sample_count = training_sample_count
+        self.min_samples_per_horizon = min_samples_per_horizon
         super().__init__(
             max_forecast_horizon=max_forecast_horizon,
             probabilistic=probabilistic,
@@ -110,29 +101,32 @@ class CustomLGBM(BaseModel):
         )
 
     @staticmethod
-    def _filter_eligible_lags(
+    def _validate_lag_candidates(
         seasonal_lags_steps: list[int],
-        training_sample_count: int | None,
-        max_forecast_horizon: int,
-        min_samples_per_horizon: int,
     ) -> list[int]:
-        """Keep lag candidates that leave enough samples for the farthest horizon."""
-        eligible_lags_steps = []
+        """Validate lag candidates and return them without duplicates."""
+        valid_lags_steps = []
         for seasonal_lag_steps in dict.fromkeys(seasonal_lags_steps):
             if seasonal_lag_steps < 1:
                 raise ValueError("seasonal_lags_steps values must be at least 1.")
-            if training_sample_count is None:
-                eligible_lags_steps.append(seasonal_lag_steps)
-                continue
+            valid_lags_steps.append(seasonal_lag_steps)
+        return valid_lags_steps
 
-            # The farthest model uses output_chunk_shift=max_forecast_horizon - 1,
-            # so each lag also needs to leave enough rows at that horizon.
-            remaining_samples = (
-                training_sample_count - seasonal_lag_steps - (max_forecast_horizon - 1)
-            )
-            if remaining_samples >= min_samples_per_horizon:
-                eligible_lags_steps.append(seasonal_lag_steps)
-        return eligible_lags_steps
+    def _filter_eligible_lags_for_horizon(self, horizon: int) -> list[int]:
+        """Keep lag candidates that leave enough samples for this horizon."""
+        if self.training_sample_count is None:
+            return self.seasonal_lags_steps
+
+        eligible_lags_steps = [
+            seasonal_lag_steps
+            for seasonal_lag_steps in self.seasonal_lags_steps
+            if self.training_sample_count - seasonal_lag_steps - horizon
+            >= self.min_samples_per_horizon
+        ]
+
+        if eligible_lags_steps:
+            return eligible_lags_steps
+        return [self.seasonal_lags_steps[-1]]
 
     @staticmethod
     def _lags_for_horizon(
@@ -162,12 +156,15 @@ class CustomLGBM(BaseModel):
 
             # Lag features are dynamically set based on the forecast horizon.
             # todo: include a list of seasonal lags as pd.timedelta objects
+            eligible_seasonal_lags_steps = self._filter_eligible_lags_for_horizon(
+                horizon
+            )
             lags = sorted(
                 {
                     -1,
                     *(
                         lag
-                        for seasonal_lag in self.seasonal_lags_steps
+                        for seasonal_lag in eligible_seasonal_lags_steps
                         for lag in self._lags_for_horizon(
                             horizon, self.max_forecast_horizon, seasonal_lag
                         )

--- a/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
+++ b/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
@@ -33,9 +33,7 @@ class CustomLGBM(BaseModel):
         use_past_covariates: bool = False,
         use_future_covariates: bool = False,
         ensure_positive: bool = False,
-        seasonal_lag_steps: int = DEFAULT_SEASONAL_LAGS_STEPS[0],
         seasonal_lags_steps: list[int] | None = None,
-        fallback_lag_steps: int = DEFAULT_SEASONAL_LAGS_STEPS[0],
         training_sample_count: int | None = None,
         min_samples_per_horizon: int = 2,
     ) -> None:
@@ -49,18 +47,10 @@ class CustomLGBM(BaseModel):
         :param use_past_covariates: Whether past covariates are used for fitting and prediction.
         :param use_future_covariates: Whether future covariates are used for fitting and prediction.
         :param ensure_positive: Whether negative predictions should be clipped to zero.
-        :param seasonal_lag_steps: Number of sensor-resolution steps in the preferred seasonal lag.
-            Used when ``seasonal_lags_steps`` is not provided.
         :param seasonal_lags_steps: Candidate seasonal lag steps to keep if enough training samples remain.
-        :param fallback_lag_steps: Seasonal lag steps to try when no preferred lag leaves enough training data.
         :param training_sample_count: Optional number of target training samples, used to decide whether fallback is needed.
         :param min_samples_per_horizon: Minimum training rows required for the farthest forecast horizon.
         """
-        if seasonal_lag_steps < 1:
-            raise ValueError("seasonal_lag_steps must be at least 1.")
-        if fallback_lag_steps < 1:
-            raise ValueError("fallback_lag_steps must be at least 1.")
-
         if models_params is None:
             self.models_params = {
                 "output_chunk_length": 1,
@@ -85,10 +75,8 @@ class CustomLGBM(BaseModel):
             raise ValueError("min_samples_per_horizon must be at least 1.")
 
         if seasonal_lags_steps is None:
-            seasonal_lags_steps = [seasonal_lag_steps]
+            seasonal_lags_steps = DEFAULT_SEASONAL_LAGS_STEPS
         self.seasonal_lags_steps = self._validate_lag_candidates(seasonal_lags_steps)
-        if fallback_lag_steps not in self.seasonal_lags_steps:
-            self.seasonal_lags_steps.append(fallback_lag_steps)
         self.training_sample_count = training_sample_count
         self.min_samples_per_horizon = min_samples_per_horizon
         super().__init__(

--- a/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
+++ b/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
@@ -149,13 +149,10 @@ class CustomLGBM(BaseModel):
             )
             darts_lags = sorted(
                 {
-                    -1,
-                    *(
-                        darts_lag
-                        for seasonal_lag_steps in eligible_seasonal_lags_steps
-                        for darts_lag in self._lags_for_horizon(
-                            horizon, self.max_forecast_horizon, seasonal_lag_steps
-                        )
+                    darts_lag
+                    for seasonal_lag_steps in eligible_seasonal_lags_steps
+                    for darts_lag in self._lags_for_horizon(
+                        horizon, self.max_forecast_horizon, seasonal_lag_steps
                     ),
                 }
             )

--- a/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
+++ b/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
@@ -35,6 +35,10 @@ class CustomLGBM(BaseModel):
         training_sample_count=None,
         min_samples_per_horizon=2,
     ):
+        if seasonal_lag_steps < 1:
+            raise ValueError("seasonal_lag_steps must be at least 1.")
+        if fallback_lag_steps < 1:
+            raise ValueError("fallback_lag_steps must be at least 1.")
 
         if models_params is None:
             self.models_params = {
@@ -82,7 +86,7 @@ class CustomLGBM(BaseModel):
             # Lag features are dynamically set based on the forecast horizon
             lag = (
                 self.seasonal_lag_steps
-                - (  # temporarily make the adaptation to the sensor resolution; To do: inlude a list of seasonal lags to include, given as pd.timedelta objects
+                - (  # todo: include a list of seasonal lags as pd.timedelta objects
                     horizon % self.seasonal_lag_steps
                 )
             )  # Adjust to repeat the lag structure every 24 hours

--- a/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
+++ b/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
@@ -3,7 +3,7 @@ from darts.models import LightGBMModel
 from flexmeasures.data.models.forecasting.custom_models.base_model import BaseModel
 
 
-DEFAULT_SEASONAL_LAGS_STEPS = [24]
+DEFAULT_SEASONAL_LAGS_STEPS = [1, 24]
 
 
 class CustomLGBM(BaseModel):

--- a/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
+++ b/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
@@ -23,18 +23,33 @@ class CustomLGBM(BaseModel):
 
     def __init__(
         self,
-        max_forecast_horizon=48,
-        probabilistic=True,
-        models_params=None,
-        auto_regressive=True,
-        use_past_covariates=False,
-        use_future_covariates=False,
-        ensure_positive=False,
-        seasonal_lag_steps=24,
-        fallback_lag_steps=24,
-        training_sample_count=None,
-        min_samples_per_horizon=2,
-    ):
+        max_forecast_horizon: int = 48,
+        probabilistic: bool = True,
+        models_params: dict | None = None,
+        auto_regressive: bool = True,
+        use_past_covariates: bool = False,
+        use_future_covariates: bool = False,
+        ensure_positive: bool = False,
+        seasonal_lag_steps: int = 24,
+        fallback_lag_steps: int = 24,
+        training_sample_count: int | None = None,
+        min_samples_per_horizon: int = 2,
+    ) -> None:
+        """
+        Initialize the LightGBM forecasting model.
+
+        :param max_forecast_horizon: Maximum number of sensor-resolution steps to forecast.
+        :param probabilistic: Whether to configure LightGBM for quantile predictions.
+        :param models_params: Optional LightGBM parameter overrides.
+        :param auto_regressive: Whether the target history should provide autoregressive features.
+        :param use_past_covariates: Whether past covariates are used for fitting and prediction.
+        :param use_future_covariates: Whether future covariates are used for fitting and prediction.
+        :param ensure_positive: Whether negative predictions should be clipped to zero.
+        :param seasonal_lag_steps: Number of sensor-resolution steps in the preferred seasonal lag.
+        :param fallback_lag_steps: Seasonal lag steps to use when the preferred lag leaves too little training data.
+        :param training_sample_count: Optional number of target training samples, used to decide whether fallback is needed.
+        :param min_samples_per_horizon: Minimum training rows required for the farthest forecast horizon.
+        """
         if seasonal_lag_steps < 1:
             raise ValueError("seasonal_lag_steps must be at least 1.")
         if fallback_lag_steps < 1:

--- a/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
+++ b/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
@@ -75,6 +75,8 @@ class CustomLGBM(BaseModel):
             }
         else:
             self.models_params = models_params
+        # The farthest horizon still needs rows after applying both the horizon
+        # shift and seasonal lag; otherwise the shorter fallback lag trains more robustly.
         if (
             training_sample_count is not None
             and training_sample_count - seasonal_lag_steps - (max_forecast_horizon - 1)

--- a/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
+++ b/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
@@ -3,6 +3,9 @@ from darts.models import LightGBMModel
 from flexmeasures.data.models.forecasting.custom_models.base_model import BaseModel
 
 
+DEFAULT_SEASONAL_LAGS_STEPS = [24]
+
+
 class CustomLGBM(BaseModel):
     """
     Multi-horizon forecasting model using LightGBM.
@@ -30,8 +33,9 @@ class CustomLGBM(BaseModel):
         use_past_covariates: bool = False,
         use_future_covariates: bool = False,
         ensure_positive: bool = False,
-        seasonal_lag_steps: int = 24,
-        fallback_lag_steps: int = 24,
+        seasonal_lag_steps: int = DEFAULT_SEASONAL_LAGS_STEPS[0],
+        seasonal_lags_steps: list[int] | None = None,
+        fallback_lag_steps: int = DEFAULT_SEASONAL_LAGS_STEPS[0],
         training_sample_count: int | None = None,
         min_samples_per_horizon: int = 2,
     ) -> None:
@@ -46,7 +50,9 @@ class CustomLGBM(BaseModel):
         :param use_future_covariates: Whether future covariates are used for fitting and prediction.
         :param ensure_positive: Whether negative predictions should be clipped to zero.
         :param seasonal_lag_steps: Number of sensor-resolution steps in the preferred seasonal lag.
-        :param fallback_lag_steps: Seasonal lag steps to use when the preferred lag leaves too little training data.
+            Used when ``seasonal_lags_steps`` is not provided.
+        :param seasonal_lags_steps: Candidate seasonal lag steps to keep if enough training samples remain.
+        :param fallback_lag_steps: Seasonal lag steps to try when no preferred lag leaves enough training data.
         :param training_sample_count: Optional number of target training samples, used to decide whether fallback is needed.
         :param min_samples_per_horizon: Minimum training rows required for the farthest forecast horizon.
         """
@@ -75,15 +81,25 @@ class CustomLGBM(BaseModel):
             }
         else:
             self.models_params = models_params
-        # The farthest horizon still needs rows after applying both the horizon
-        # shift and seasonal lag; otherwise the shorter fallback lag trains more robustly.
-        if (
-            training_sample_count is not None
-            and training_sample_count - seasonal_lag_steps - (max_forecast_horizon - 1)
-            < min_samples_per_horizon
-        ):
-            seasonal_lag_steps = fallback_lag_steps
-        self.seasonal_lag_steps = seasonal_lag_steps
+        if min_samples_per_horizon < 1:
+            raise ValueError("min_samples_per_horizon must be at least 1.")
+
+        if seasonal_lags_steps is None:
+            seasonal_lags_steps = [seasonal_lag_steps]
+        self.seasonal_lags_steps = self._filter_eligible_lags(
+            seasonal_lags_steps=seasonal_lags_steps,
+            training_sample_count=training_sample_count,
+            max_forecast_horizon=max_forecast_horizon,
+            min_samples_per_horizon=min_samples_per_horizon,
+        )
+
+        if not self.seasonal_lags_steps:
+            self.seasonal_lags_steps = self._filter_eligible_lags(
+                seasonal_lags_steps=[fallback_lag_steps],
+                training_sample_count=training_sample_count,
+                max_forecast_horizon=max_forecast_horizon,
+                min_samples_per_horizon=min_samples_per_horizon,
+            )
         super().__init__(
             max_forecast_horizon=max_forecast_horizon,
             probabilistic=probabilistic,
@@ -93,6 +109,50 @@ class CustomLGBM(BaseModel):
             ensure_positive=ensure_positive,
         )
 
+    @staticmethod
+    def _filter_eligible_lags(
+        seasonal_lags_steps: list[int],
+        training_sample_count: int | None,
+        max_forecast_horizon: int,
+        min_samples_per_horizon: int,
+    ) -> list[int]:
+        """Keep lag candidates that leave enough samples for the farthest horizon."""
+        eligible_lags_steps = []
+        for seasonal_lag_steps in dict.fromkeys(seasonal_lags_steps):
+            if seasonal_lag_steps < 1:
+                raise ValueError("seasonal_lags_steps values must be at least 1.")
+            if training_sample_count is None:
+                eligible_lags_steps.append(seasonal_lag_steps)
+                continue
+
+            # The farthest model uses output_chunk_shift=max_forecast_horizon - 1,
+            # so each lag also needs to leave enough rows at that horizon.
+            remaining_samples = (
+                training_sample_count - seasonal_lag_steps - (max_forecast_horizon - 1)
+            )
+            if remaining_samples >= min_samples_per_horizon:
+                eligible_lags_steps.append(seasonal_lag_steps)
+        return eligible_lags_steps
+
+    @staticmethod
+    def _lags_for_horizon(
+        horizon: int, max_forecast_horizon: int, seasonal_lag: int
+    ) -> list[int]:
+        """Return lags for one seasonal cycle at the given forecast horizon."""
+        lag = seasonal_lag - (horizon % seasonal_lag)
+        lags = [-lag, -lag - 1]
+
+        if (
+            horizon == 0
+            or horizon % seasonal_lag == 0
+            or horizon == max_forecast_horizon - 1
+        ):
+            lags = [-seasonal_lag]
+        elif horizon % seasonal_lag == seasonal_lag - 1:
+            lags = [-2]
+
+        return lags
+
     def _setup(self) -> None:
         for horizon in range(self.max_forecast_horizon):
             model_params = self.models_params.copy()
@@ -100,24 +160,20 @@ class CustomLGBM(BaseModel):
                 horizon  # Shift the output by i hours of each sub-model
             )
 
-            # Lag features are dynamically set based on the forecast horizon
-            lag = (
-                self.seasonal_lag_steps
-                - (  # todo: include a list of seasonal lags as pd.timedelta objects
-                    horizon % self.seasonal_lag_steps
-                )
-            )  # Adjust to repeat the lag structure every 24 hours
-            lags = [-1, -lag, -lag - 1]
-
-            # Special cases for lags
-            if (
-                horizon == 0
-                or horizon % self.seasonal_lag_steps == 0
-                or horizon == self.max_forecast_horizon - 1
-            ):
-                lags = [-1, -self.seasonal_lag_steps]
-            elif horizon % self.seasonal_lag_steps == self.seasonal_lag_steps - 1:
-                lags = [-1, -2]
+            # Lag features are dynamically set based on the forecast horizon.
+            # todo: include a list of seasonal lags as pd.timedelta objects
+            lags = sorted(
+                {
+                    -1,
+                    *(
+                        lag
+                        for seasonal_lag in self.seasonal_lags_steps
+                        for lag in self._lags_for_horizon(
+                            horizon, self.max_forecast_horizon, seasonal_lag
+                        )
+                    ),
+                }
+            )
 
             # lags = list(range(-1, -25, -1))  # todo: consider letting the model figure out which lags are important
             model_params["lags"] = lags

--- a/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
+++ b/flexmeasures/data/models/forecasting/custom_models/lgbm_model.py
@@ -93,12 +93,9 @@ class CustomLGBM(BaseModel):
         seasonal_lags_steps: list[int],
     ) -> list[int]:
         """Validate lag candidates and return them without duplicates."""
-        valid_lags_steps = []
-        for seasonal_lag_steps in dict.fromkeys(seasonal_lags_steps):
-            if seasonal_lag_steps < 1:
-                raise ValueError("seasonal_lags_steps values must be at least 1.")
-            valid_lags_steps.append(seasonal_lag_steps)
-        return valid_lags_steps
+        if any(seasonal_lag_steps < 1 for seasonal_lag_steps in seasonal_lags_steps):
+            raise ValueError("seasonal_lags_steps values must be at least 1.")
+        return list(dict.fromkeys(seasonal_lags_steps))
 
     def _filter_eligible_lags_for_horizon(self, horizon: int) -> list[int]:
         """Keep lag candidates that leave enough samples for this horizon."""

--- a/flexmeasures/data/models/forecasting/pipelines/train.py
+++ b/flexmeasures/data/models/forecasting/pipelines/train.py
@@ -129,6 +129,7 @@ class TrainPipeline(BasePipeline):
                 seasonal_lag_steps=max(
                     int(timedelta(days=1) / self.target_sensor.event_resolution), 1
                 ),
+                training_sample_count=len(y_train),
             )
         }
 

--- a/flexmeasures/data/models/forecasting/pipelines/train.py
+++ b/flexmeasures/data/models/forecasting/pipelines/train.py
@@ -4,7 +4,7 @@ import os
 import pickle
 import warnings
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from darts import TimeSeries
 
@@ -126,6 +126,9 @@ class TrainPipeline(BasePipeline):
                 use_past_covariates=past_covariates_list is not None,
                 use_future_covariates=future_covariates_list is not None,
                 ensure_positive=self.ensure_positive,
+                seasonal_lag_steps=max(
+                    int(timedelta(days=1) / self.target_sensor.event_resolution), 1
+                ),
             )
         }
 

--- a/flexmeasures/data/models/forecasting/pipelines/train.py
+++ b/flexmeasures/data/models/forecasting/pipelines/train.py
@@ -15,6 +15,22 @@ from flexmeasures.data.models.forecasting.pipelines.base import BasePipeline
 warnings.filterwarnings("ignore")
 
 
+def derive_daily_lag_steps(
+    sensor_resolution: timedelta, fallback_lag_steps: int = 24
+) -> int:
+    """Return a daily lag in sensor-resolution steps, if one exists."""
+    one_day = timedelta(days=1)
+    if one_day % sensor_resolution == timedelta(0):
+        return max(int(one_day / sensor_resolution), 1)
+    logging.warning(
+        "Sensor resolution %s does not evenly divide one day. Falling back to "
+        "%s seasonal lag steps.",
+        sensor_resolution,
+        fallback_lag_steps,
+    )
+    return fallback_lag_steps
+
+
 class TrainPipeline(BasePipeline):
     def __init__(
         self,
@@ -126,8 +142,8 @@ class TrainPipeline(BasePipeline):
                 use_past_covariates=past_covariates_list is not None,
                 use_future_covariates=future_covariates_list is not None,
                 ensure_positive=self.ensure_positive,
-                seasonal_lag_steps=max(
-                    int(timedelta(days=1) / self.target_sensor.event_resolution), 1
+                seasonal_lag_steps=derive_daily_lag_steps(
+                    self.target_sensor.event_resolution
                 ),
                 training_sample_count=len(y_train),
             )

--- a/flexmeasures/data/models/forecasting/pipelines/train.py
+++ b/flexmeasures/data/models/forecasting/pipelines/train.py
@@ -9,7 +9,10 @@ from datetime import datetime, timedelta
 from darts import TimeSeries
 
 from flexmeasures import Sensor
-from flexmeasures.data.models.forecasting.custom_models.lgbm_model import CustomLGBM
+from flexmeasures.data.models.forecasting.custom_models.lgbm_model import (
+    CustomLGBM,
+    DEFAULT_SEASONAL_LAGS_STEPS,
+)
 from flexmeasures.data.models.forecasting.pipelines.base import BasePipeline
 
 warnings.filterwarnings("ignore")
@@ -142,9 +145,10 @@ class TrainPipeline(BasePipeline):
                 use_past_covariates=past_covariates_list is not None,
                 use_future_covariates=future_covariates_list is not None,
                 ensure_positive=self.ensure_positive,
-                seasonal_lag_steps=derive_daily_lag_steps(
-                    self.target_sensor.event_resolution
-                ),
+                seasonal_lags_steps=[
+                    derive_daily_lag_steps(self.target_sensor.event_resolution),
+                    *DEFAULT_SEASONAL_LAGS_STEPS,
+                ],
                 training_sample_count=len(y_train),
             )
         }

--- a/flexmeasures/data/tests/test_forecasting_pipeline.py
+++ b/flexmeasures/data/tests/test_forecasting_pipeline.py
@@ -8,10 +8,31 @@ from datetime import timedelta
 
 from marshmallow import ValidationError
 
+from flexmeasures.data.models.forecasting.custom_models.lgbm_model import CustomLGBM
 from flexmeasures.data.models.forecasting.exceptions import NotEnoughDataException
 from flexmeasures.data.models.forecasting.pipelines import TrainPredictPipeline
 from flexmeasures.utils.job_utils import work_on_rq
 from flexmeasures.data.services.forecasting import handle_forecasting_exception
+
+
+def test_custom_lgbm_falls_back_when_daily_lag_is_under_sampled():
+    """Short histories should keep the old lag pattern instead of failing."""
+    under_sampled_model = CustomLGBM(
+        max_forecast_horizon=192,
+        probabilistic=False,
+        seasonal_lag_steps=96,
+        training_sample_count=288,
+    )
+    assert under_sampled_model.models[96].lags["target"] == [-24, -1]
+    assert under_sampled_model.models[-1].lags["target"] == [-24, -1]
+
+    sufficiently_sampled_model = CustomLGBM(
+        max_forecast_horizon=192,
+        probabilistic=False,
+        seasonal_lag_steps=96,
+        training_sample_count=384,
+    )
+    assert sufficiently_sampled_model.models[-1].lags["target"] == [-96, -1]
 
 
 @pytest.mark.parametrize(

--- a/flexmeasures/data/tests/test_forecasting_pipeline.py
+++ b/flexmeasures/data/tests/test_forecasting_pipeline.py
@@ -12,6 +12,7 @@ from flexmeasures.data.models.forecasting.custom_models.lgbm_model import Custom
 from flexmeasures.data.models.data_sources import DataSource
 from flexmeasures.data.models.forecasting.exceptions import NotEnoughDataException
 from flexmeasures.data.models.forecasting.pipelines.base import BasePipeline
+from flexmeasures.data.models.forecasting.pipelines.train import derive_daily_lag_steps
 from flexmeasures.data.models.generic_assets import (
     GenericAsset as Asset,
     GenericAssetType,
@@ -41,6 +42,33 @@ def test_custom_lgbm_falls_back_when_daily_lag_is_under_sampled():
         training_sample_count=384,
     )
     assert sufficiently_sampled_model.models[-1].lags["target"] == [-96, -1]
+
+
+def test_custom_lgbm_rejects_invalid_lag_steps():
+    with pytest.raises(ValueError, match="seasonal_lag_steps must be at least 1"):
+        CustomLGBM(
+            max_forecast_horizon=1,
+            probabilistic=False,
+            seasonal_lag_steps=0,
+        )
+
+    with pytest.raises(ValueError, match="fallback_lag_steps must be at least 1"):
+        CustomLGBM(
+            max_forecast_horizon=1,
+            probabilistic=False,
+            fallback_lag_steps=0,
+        )
+
+
+def test_derive_daily_lag_steps_requires_divisible_resolution(caplog):
+    assert derive_daily_lag_steps(timedelta(minutes=15)) == 96
+
+    with caplog.at_level(logging.WARNING):
+        assert derive_daily_lag_steps(timedelta(minutes=35)) == 24
+
+    assert any(
+        "does not evenly divide one day" in message for message in caplog.messages
+    )
 
 
 @pytest.mark.parametrize(

--- a/flexmeasures/data/tests/test_forecasting_pipeline.py
+++ b/flexmeasures/data/tests/test_forecasting_pipeline.py
@@ -48,20 +48,6 @@ def test_custom_lgbm_falls_back_when_daily_lag_is_under_sampled():
 
 
 def test_custom_lgbm_rejects_invalid_lag_steps():
-    with pytest.raises(ValueError, match="seasonal_lag_steps must be at least 1"):
-        CustomLGBM(
-            max_forecast_horizon=1,
-            probabilistic=False,
-            seasonal_lag_steps=0,
-        )
-
-    with pytest.raises(ValueError, match="fallback_lag_steps must be at least 1"):
-        CustomLGBM(
-            max_forecast_horizon=1,
-            probabilistic=False,
-            fallback_lag_steps=0,
-        )
-
     with pytest.raises(ValueError, match="seasonal_lags_steps values"):
         CustomLGBM(
             max_forecast_horizon=1,

--- a/flexmeasures/data/tests/test_forecasting_pipeline.py
+++ b/flexmeasures/data/tests/test_forecasting_pipeline.py
@@ -29,22 +29,36 @@ def test_custom_lgbm_falls_back_when_daily_lag_is_under_sampled():
     under_sampled_model = CustomLGBM(
         max_forecast_horizon=192,
         probabilistic=False,
-        seasonal_lags_steps=[96, 24],
+        seasonal_lags_steps=[96, 1, 24],
         training_sample_count=288,
     )
-    assert under_sampled_model.seasonal_lags_steps == [96, 24]
-    assert under_sampled_model.models[0].lags["target"] == [-96, -24, -1]
-    assert under_sampled_model.models[48].lags["target"] == [-49, -48, -24, -1]
-    assert under_sampled_model.models[-1].lags["target"] == [-24, -1]
+    assert under_sampled_model.seasonal_lags_steps == [96, 1, 24]
+    assert under_sampled_model.models[0].lags["target"] == [
+        -97,
+        -96,
+        -25,
+        -24,
+        -2,
+        -1,
+    ]
+    assert under_sampled_model.models[48].lags["target"] == [
+        -49,
+        -48,
+        -25,
+        -24,
+        -2,
+        -1,
+    ]
+    assert under_sampled_model.models[-1].lags["target"] == [-1]
 
     sufficiently_sampled_model = CustomLGBM(
         max_forecast_horizon=192,
         probabilistic=False,
-        seasonal_lags_steps=[96, 24],
+        seasonal_lags_steps=[96, 1, 24],
         training_sample_count=384,
     )
-    assert sufficiently_sampled_model.seasonal_lags_steps == [96, 24]
-    assert sufficiently_sampled_model.models[-1].lags["target"] == [-96, -24, -1]
+    assert sufficiently_sampled_model.seasonal_lags_steps == [96, 1, 24]
+    assert sufficiently_sampled_model.models[-1].lags["target"] == [-1]
 
 
 def test_custom_lgbm_rejects_invalid_lag_steps():

--- a/flexmeasures/data/tests/test_forecasting_pipeline.py
+++ b/flexmeasures/data/tests/test_forecasting_pipeline.py
@@ -29,19 +29,21 @@ def test_custom_lgbm_falls_back_when_daily_lag_is_under_sampled():
     under_sampled_model = CustomLGBM(
         max_forecast_horizon=192,
         probabilistic=False,
-        seasonal_lag_steps=96,
+        seasonal_lags_steps=[96, 24],
         training_sample_count=288,
     )
+    assert under_sampled_model.seasonal_lags_steps == [24]
     assert under_sampled_model.models[96].lags["target"] == [-24, -1]
     assert under_sampled_model.models[-1].lags["target"] == [-24, -1]
 
     sufficiently_sampled_model = CustomLGBM(
         max_forecast_horizon=192,
         probabilistic=False,
-        seasonal_lag_steps=96,
+        seasonal_lags_steps=[96, 24],
         training_sample_count=384,
     )
-    assert sufficiently_sampled_model.models[-1].lags["target"] == [-96, -1]
+    assert sufficiently_sampled_model.seasonal_lags_steps == [96, 24]
+    assert sufficiently_sampled_model.models[-1].lags["target"] == [-96, -24, -1]
 
 
 def test_custom_lgbm_rejects_invalid_lag_steps():
@@ -57,6 +59,13 @@ def test_custom_lgbm_rejects_invalid_lag_steps():
             max_forecast_horizon=1,
             probabilistic=False,
             fallback_lag_steps=0,
+        )
+
+    with pytest.raises(ValueError, match="seasonal_lags_steps values"):
+        CustomLGBM(
+            max_forecast_horizon=1,
+            probabilistic=False,
+            seasonal_lags_steps=[24, 0],
         )
 
 

--- a/flexmeasures/data/tests/test_forecasting_pipeline.py
+++ b/flexmeasures/data/tests/test_forecasting_pipeline.py
@@ -25,15 +25,16 @@ from flexmeasures.data.services.forecasting import handle_forecasting_exception
 
 
 def test_custom_lgbm_falls_back_when_daily_lag_is_under_sampled():
-    """Short histories should keep the old lag pattern instead of failing."""
+    """Short histories should drop daily lags only where they are under-sampled."""
     under_sampled_model = CustomLGBM(
         max_forecast_horizon=192,
         probabilistic=False,
         seasonal_lags_steps=[96, 24],
         training_sample_count=288,
     )
-    assert under_sampled_model.seasonal_lags_steps == [24]
-    assert under_sampled_model.models[96].lags["target"] == [-24, -1]
+    assert under_sampled_model.seasonal_lags_steps == [96, 24]
+    assert under_sampled_model.models[0].lags["target"] == [-96, -24, -1]
+    assert under_sampled_model.models[48].lags["target"] == [-49, -48, -24, -1]
     assert under_sampled_model.models[-1].lags["target"] == [-24, -1]
 
     sufficiently_sampled_model = CustomLGBM(

--- a/flexmeasures/data/tests/test_forecasting_pipeline.py
+++ b/flexmeasures/data/tests/test_forecasting_pipeline.py
@@ -55,6 +55,14 @@ def test_custom_lgbm_rejects_invalid_lag_steps():
             seasonal_lags_steps=[24, 0],
         )
 
+    with pytest.raises(ValueError, match="None of the seasonal_lags_steps"):
+        CustomLGBM(
+            max_forecast_horizon=2,
+            probabilistic=False,
+            seasonal_lags_steps=[24],
+            training_sample_count=2,
+        )
+
 
 def test_derive_daily_lag_steps_requires_divisible_resolution(caplog):
     assert derive_daily_lag_steps(timedelta(minutes=15)) == 96


### PR DESCRIPTION
## Description

- Make the LightGBM forecaster's seasonal lag configurable.
- Derive daily seasonal lag steps from the target sensor resolution.
- Improves daily-seasonality handling for sub-hourly sensors such as PT15M sensors.
- [x] add a changelog entry for this PR.

## Look & Feel
forecast improvement for 3 day case:

- Before: 
<img width="1307" height="437" alt="visualization (8)" src="https://github.com/user-attachments/assets/feace5f9-44c6-49f9-a69f-280e4a2c4270" />
- After:
<img width="1307" height="437" alt="visualization (9)" src="https://github.com/user-attachments/assets/a0764079-938a-49c4-91fc-7ed7b34c71a5" />

## How to test
- uv run pytest flexmeasures/data/tests/test_forecasting_pipeline.py -q
- pre-commit run --all-files

## Further Improvements
- Add validation or warnings when the available training history is too short for the requested forecast horizon.

## Related Items
- closes #2094


#### Sign-off

<!--
We ask contributors outside the FlexMeasures organisation to sign off on their contribution.
Please mark the below fields with an [x].
-->

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
