### PR TITLE
Feat/monitoring more fine grained

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -6,6 +6,8 @@ FlexMeasures Changelog
 v0.33.0 | May XX, 2026
 ============================
 
+.. warning:: We are deprecating ``FLEXMEASURES_MONITORING_MAIL_RECIPIENTS`` in favor of ``FLEXMEASURES_DEFAULT_MONITORING_MAIL_RECIPIENTS``.
+
 New features
 -------------
 * Added API and UI support for copying assets and their subtrees [see `PR #2017 <https://www.github.com/FlexMeasures/flexmeasures/pull/2017>`_ and `PR #2120 <https://www.github.com/FlexMeasures/flexmeasures/pull/2120>`_]
@@ -14,6 +16,7 @@ New features
 * Added a unified job status endpoint ``GET /api/v3_0/jobs/<uuid>`` to retrieve the current execution status and result message for any background job [see `PR #2141 <https://www.github.com/FlexMeasures/flexmeasures/pull/2141>`_]
 * New ``GET /api/v3_0/sources`` endpoint to list accessible data sources and defined types, with ``only_latest=true`` by default to return only the most recent version per source [see `PR #2126 <https://www.github.com/FlexMeasures/flexmeasures/pull/2126>`_]
 * Add support for filtering sensor data GET requests by ``source-type`` on ``/api/v3_0/sensors/<id>/data`` [see `PR #2127 <https://www.github.com/FlexMeasures/flexmeasures/pull/2127>`_]
+* Making monitoring alerts more flexible:Allow ``flexmeasures monitor`` alerts to target one or more user IDs or email addresses with ``--inform-this-user`` [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -16,7 +16,7 @@ New features
 * Added a unified job status endpoint ``GET /api/v3_0/jobs/<uuid>`` to retrieve the current execution status and result message for any background job [see `PR #2141 <https://www.github.com/FlexMeasures/flexmeasures/pull/2141>`_]
 * New ``GET /api/v3_0/sources`` endpoint to list accessible data sources and defined types, with ``only_latest=true`` by default to return only the most recent version per source [see `PR #2126 <https://www.github.com/FlexMeasures/flexmeasures/pull/2126>`_]
 * Add support for filtering sensor data GET requests by ``source-type`` on ``/api/v3_0/sensors/<id>/data`` [see `PR #2127 <https://www.github.com/FlexMeasures/flexmeasures/pull/2127>`_]
-* Making monitoring alerts more flexible: allow ``flexmeasures monitor`` alerts to target one or more user IDs or email addresses with ``--inform-this-user``; ``flexmeasures monitor last-seen`` can now narrow monitored users to one or more accounts with ``--account`` or to client accounts with ``--clients-of-this-consultant`` [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
+* Making monitoring alerts more flexible: allow ``flexmeasures monitor`` alerts to target one or more user IDs or email addresses with ``--inform-this-user``; ``flexmeasures monitor last-seen`` can now narrow monitored users to one or more accounts with ``--account`` or to client accounts with ``--clients-of-this-consultant`` [see `PR #2158 <https://www.github.com/FlexMeasures/flexmeasures/pull/2158>`_]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -16,7 +16,7 @@ New features
 * Added a unified job status endpoint ``GET /api/v3_0/jobs/<uuid>`` to retrieve the current execution status and result message for any background job [see `PR #2141 <https://www.github.com/FlexMeasures/flexmeasures/pull/2141>`_]
 * New ``GET /api/v3_0/sources`` endpoint to list accessible data sources and defined types, with ``only_latest=true`` by default to return only the most recent version per source [see `PR #2126 <https://www.github.com/FlexMeasures/flexmeasures/pull/2126>`_]
 * Add support for filtering sensor data GET requests by ``source-type`` on ``/api/v3_0/sensors/<id>/data`` [see `PR #2127 <https://www.github.com/FlexMeasures/flexmeasures/pull/2127>`_]
-* Making monitoring alerts more flexible: allow ``flexmeasures monitor`` alerts to target one or more user IDs or email addresses with ``--inform-this-user``; ``flexmeasures monitor last-seen`` can now narrow monitored users to one or more accounts with ``--account`` [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
+* Making monitoring alerts more flexible: allow ``flexmeasures monitor`` alerts to target one or more user IDs or email addresses with ``--inform-this-user``; ``flexmeasures monitor last-seen`` can now narrow monitored users to one or more accounts with ``--account`` or to client accounts with ``--clients-of-this-consultant`` [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -16,7 +16,7 @@ New features
 * Added a unified job status endpoint ``GET /api/v3_0/jobs/<uuid>`` to retrieve the current execution status and result message for any background job [see `PR #2141 <https://www.github.com/FlexMeasures/flexmeasures/pull/2141>`_]
 * New ``GET /api/v3_0/sources`` endpoint to list accessible data sources and defined types, with ``only_latest=true`` by default to return only the most recent version per source [see `PR #2126 <https://www.github.com/FlexMeasures/flexmeasures/pull/2126>`_]
 * Add support for filtering sensor data GET requests by ``source-type`` on ``/api/v3_0/sensors/<id>/data`` [see `PR #2127 <https://www.github.com/FlexMeasures/flexmeasures/pull/2127>`_]
-* Making monitoring alerts more flexible: allow ``flexmeasures monitor`` alerts to target one or more user IDs with ``--inform-this-user`` or email addresses with ``--inform-this-email``; ``flexmeasures monitor last-seen`` can now narrow monitored users to one or more accounts with ``--account`` or to client accounts with ``--consultancy`` [see `PR #2158 <https://www.github.com/FlexMeasures/flexmeasures/pull/2158>`_]
+* Making monitoring alerts more flexible: allow ``flexmeasures monitor`` alerts to target one or more user IDs or email addresses with ``--recipient``; ``flexmeasures monitor last-seen`` can now narrow monitored users to one or more accounts with ``--account`` or to client accounts with ``--consultancy`` [see `PR #2158 <https://www.github.com/FlexMeasures/flexmeasures/pull/2158>`_]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -16,7 +16,7 @@ New features
 * Added a unified job status endpoint ``GET /api/v3_0/jobs/<uuid>`` to retrieve the current execution status and result message for any background job [see `PR #2141 <https://www.github.com/FlexMeasures/flexmeasures/pull/2141>`_]
 * New ``GET /api/v3_0/sources`` endpoint to list accessible data sources and defined types, with ``only_latest=true`` by default to return only the most recent version per source [see `PR #2126 <https://www.github.com/FlexMeasures/flexmeasures/pull/2126>`_]
 * Add support for filtering sensor data GET requests by ``source-type`` on ``/api/v3_0/sensors/<id>/data`` [see `PR #2127 <https://www.github.com/FlexMeasures/flexmeasures/pull/2127>`_]
-* Making monitoring alerts more flexible:Allow ``flexmeasures monitor`` alerts to target one or more user IDs or email addresses with ``--inform-this-user`` [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
+* Making monitoring alerts more flexible: allow ``flexmeasures monitor`` alerts to target one or more user IDs or email addresses with ``--inform-this-user``; ``flexmeasures monitor last-seen`` can now narrow monitored users to one or more accounts with ``--account`` [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -16,7 +16,7 @@ New features
 * Added a unified job status endpoint ``GET /api/v3_0/jobs/<uuid>`` to retrieve the current execution status and result message for any background job [see `PR #2141 <https://www.github.com/FlexMeasures/flexmeasures/pull/2141>`_]
 * New ``GET /api/v3_0/sources`` endpoint to list accessible data sources and defined types, with ``only_latest=true`` by default to return only the most recent version per source [see `PR #2126 <https://www.github.com/FlexMeasures/flexmeasures/pull/2126>`_]
 * Add support for filtering sensor data GET requests by ``source-type`` on ``/api/v3_0/sensors/<id>/data`` [see `PR #2127 <https://www.github.com/FlexMeasures/flexmeasures/pull/2127>`_]
-* Making monitoring alerts more flexible: allow ``flexmeasures monitor`` alerts to target one or more user IDs or email addresses with ``--inform-this-user``; ``flexmeasures monitor last-seen`` can now narrow monitored users to one or more accounts with ``--account`` or to client accounts with ``--clients-of-this-consultant`` [see `PR #2158 <https://www.github.com/FlexMeasures/flexmeasures/pull/2158>`_]
+* Making monitoring alerts more flexible: allow ``flexmeasures monitor`` alerts to target one or more user IDs or email addresses with ``--inform-this-user``; ``flexmeasures monitor last-seen`` can now narrow monitored users to one or more accounts with ``--account`` or to client accounts with ``--consultancy`` [see `PR #2158 <https://www.github.com/FlexMeasures/flexmeasures/pull/2158>`_]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -16,7 +16,7 @@ New features
 * Added a unified job status endpoint ``GET /api/v3_0/jobs/<uuid>`` to retrieve the current execution status and result message for any background job [see `PR #2141 <https://www.github.com/FlexMeasures/flexmeasures/pull/2141>`_]
 * New ``GET /api/v3_0/sources`` endpoint to list accessible data sources and defined types, with ``only_latest=true`` by default to return only the most recent version per source [see `PR #2126 <https://www.github.com/FlexMeasures/flexmeasures/pull/2126>`_]
 * Add support for filtering sensor data GET requests by ``source-type`` on ``/api/v3_0/sensors/<id>/data`` [see `PR #2127 <https://www.github.com/FlexMeasures/flexmeasures/pull/2127>`_]
-* Making monitoring alerts more flexible: allow ``flexmeasures monitor`` alerts to target one or more user IDs or email addresses with ``--inform-this-user``; ``flexmeasures monitor last-seen`` can now narrow monitored users to one or more accounts with ``--account`` or to client accounts with ``--consultancy`` [see `PR #2158 <https://www.github.com/FlexMeasures/flexmeasures/pull/2158>`_]
+* Making monitoring alerts more flexible: allow ``flexmeasures monitor`` alerts to target one or more user IDs with ``--inform-this-user`` or email addresses with ``--inform-this-email``; ``flexmeasures monitor last-seen`` can now narrow monitored users to one or more accounts with ``--account`` or to client accounts with ``--consultancy`` [see `PR #2158 <https://www.github.com/FlexMeasures/flexmeasures/pull/2158>`_]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/configuration.rst
+++ b/documentation/configuration.rst
@@ -682,13 +682,18 @@ Default: ``None``
 
 
 .. _monitoring_mail_recipients:
+.. _default_monitoring_mail_recipients:
 
-FLEXMEASURES_MONITORING_MAIL_RECIPIENTS
-^^^^^^^^^^^^^^^^^^^^^^^
+FLEXMEASURES_DEFAULT_MONITORING_MAIL_RECIPIENTS
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-E-mail addresses to send monitoring alerts to from the CLI task ``flexmeasures monitor tasks``. For example ``["fred@one.com", "wilma@two.com"]``
+E-mail addresses to send monitoring alerts to from the CLI tasks ``flexmeasures monitor latest-run`` and ``flexmeasures monitor last-seen`` if no explicit user recipients are given. For example ``["fred@one.com", "wilma@two.com"]``.
 
 Default: ``[]``
+
+.. deprecated:: 0.33
+
+    ``FLEXMEASURES_MONITORING_MAIL_RECIPIENTS`` is deprecated. Use ``FLEXMEASURES_DEFAULT_MONITORING_MAIL_RECIPIENTS`` instead.
 
 
 .. _redis-config:

--- a/documentation/host/error-monitoring.rst
+++ b/documentation/host/error-monitoring.rst
@@ -23,7 +23,7 @@ Here is an example for illustration:
 
     $ flexmeasures monitor last-seen --account-role SubscriberToServiceXYZ --user-role bot --maximum-minutes-since-last-seen 100
 
-As you see, users are filtered by roles. You might need to add roles before this works as you want. Use ``--inform-this-user`` one or more times to send the monitoring alert to specific FlexMeasures user IDs, and ``--inform-this-email`` one or more times to send it to specific email addresses. If you do not use either option, FlexMeasures falls back to :ref:`default_monitoring_mail_recipients`.
+As you see, users are filtered by roles. You might need to add roles before this works as you want. Use ``--recipient`` one or more times to send the monitoring alert to specific FlexMeasures user IDs or email addresses. If you do not use this option, FlexMeasures falls back to :ref:`default_monitoring_mail_recipients`.
 You can also narrow the check to users in one or more accounts with ``--account``.
 Use ``--account`` multiple times to include multiple accounts.
 Use ``--consultancy`` to narrow the check to users in accounts that are clients of the given consultant account.
@@ -31,7 +31,7 @@ If you run distinct filters, such as separate checks per account, account group 
 
 .. code-block:: bash
 
-    $ flexmeasures monitor last-seen --task-name monitor-last-seen-account-12 --account 12 --account-role SubscriberToServiceXYZ --user-role bot --maximum-minutes-since-last-seen 100 --inform-this-user 42 --inform-this-email alerts@example.com
+    $ flexmeasures monitor last-seen --task-name monitor-last-seen-account-12 --account 12 --account-role SubscriberToServiceXYZ --user-role bot --maximum-minutes-since-last-seen 100 --recipient 42 --recipient alerts@example.com
 
 .. todo:: Adding roles and assigning them to accounts is not supported by the UI yet (user roles can be added in the UI). Account roles can be added with ``flexmeasures add account-role``.
 
@@ -40,7 +40,7 @@ Monitoring task runs
 ---------------------
 
 The CLI task ``flexmeasures monitor latest-run`` lets you be alerted when tasks have not successfully run at least so-and-so many minutes ago.
-The alerts will come in via Sentry, but you can also send them to specific FlexMeasures user IDs with ``--inform-this-user``, specific email addresses with ``--inform-this-email`` or to email addresses with the config setting :ref:`default_monitoring_mail_recipients`.
+The alerts will come in via Sentry, but you can also send them to specific FlexMeasures user IDs or email addresses with ``--recipient`` or to email addresses with the config setting :ref:`default_monitoring_mail_recipients`.
 
 For illustration, here is one example of how we monitor the latest run times of tasks on a server ― the below is run in a cron script every hour and checks if every listed task ran 60, 6 or 1440 minutes ago, respectively:
 

--- a/documentation/host/error-monitoring.rst
+++ b/documentation/host/error-monitoring.rst
@@ -24,10 +24,13 @@ Here is an example for illustration:
     $ flexmeasures monitor last-seen --account-role SubscriberToServiceXYZ --user-role bot --maximum-minutes-since-last-seen 100
 
 As you see, users are filtered by roles. You might need to add roles before this works as you want. Use ``--inform-this-user`` one or more times to send the monitoring alert to specific FlexMeasures user IDs or email addresses. If you do not use ``--inform-this-user``, FlexMeasures falls back to :ref:`default_monitoring_mail_recipients`.
+You can also narrow the check to users in one or more accounts with ``--account``.
+Use ``--account`` multiple times to include multiple accounts.
+If you run distinct filters, such as separate checks per account or account group, use distinct ``--task-name`` values so the ``--only-newly-absent-users`` feature tracks each filter independently.
 
 .. code-block:: bash
 
-    $ flexmeasures monitor last-seen --account-role SubscriberToServiceXYZ --user-role bot --maximum-minutes-since-last-seen 100 --inform-this-user 42 --inform-this-user alerts@example.com
+    $ flexmeasures monitor last-seen --task-name monitor-last-seen-account-12 --account 12 --account-role SubscriberToServiceXYZ --user-role bot --maximum-minutes-since-last-seen 100 --inform-this-user 42 --inform-this-user alerts@example.com
 
 .. todo:: Adding roles and assigning them to accounts is not supported by the UI yet (user roles can be added in the UI). Account roles can be added with ``flexmeasures add account-role``.
 

--- a/documentation/host/error-monitoring.rst
+++ b/documentation/host/error-monitoring.rst
@@ -26,7 +26,7 @@ Here is an example for illustration:
 As you see, users are filtered by roles. You might need to add roles before this works as you want. Use ``--inform-this-user`` one or more times to send the monitoring alert to specific FlexMeasures user IDs or email addresses. If you do not use ``--inform-this-user``, FlexMeasures falls back to :ref:`default_monitoring_mail_recipients`.
 You can also narrow the check to users in one or more accounts with ``--account``.
 Use ``--account`` multiple times to include multiple accounts.
-Use ``--clients-of-this-consultant`` to narrow the check to users in accounts that are clients of the given consultant account.
+Use ``--consultancy`` to narrow the check to users in accounts that are clients of the given consultant account.
 If you run distinct filters, such as separate checks per account, account group or consultant, use distinct ``--task-name`` values so the ``--only-newly-absent-users`` feature tracks each filter independently.
 
 .. code-block:: bash

--- a/documentation/host/error-monitoring.rst
+++ b/documentation/host/error-monitoring.rst
@@ -23,16 +23,20 @@ Here is an example for illustration:
 
     $ flexmeasures monitor last-seen --account-role SubscriberToServiceXYZ --user-role bot --maximum-minutes-since-last-seen 100
 
-As you see, users are filtered by roles. You might need to add roles before this works as you want.
+As you see, users are filtered by roles. You might need to add roles before this works as you want. Use ``--inform-this-user`` one or more times to send the monitoring alert to specific FlexMeasures user IDs or email addresses. If you do not use ``--inform-this-user``, FlexMeasures falls back to :ref:`default_monitoring_mail_recipients`.
 
-.. todo:: Adding roles and assigning them to users and/or accounts is not supported by the CLI or UI yet (besides ``flexmeasures add account-role``). This is `work in progress <https://github.com/FlexMeasures/flexmeasures/projects/18>`_. Right now, it requires you to add roles on the database level. 
+.. code-block:: bash
+
+    $ flexmeasures monitor last-seen --account-role SubscriberToServiceXYZ --user-role bot --maximum-minutes-since-last-seen 100 --inform-this-user 42 --inform-this-user alerts@example.com
+
+.. todo:: Adding roles and assigning them to accounts is not supported by the UI yet (user roles can be added in the UI). Account roles can be added with ``flexmeasures add account-role``.
 
 
 Monitoring task runs
 ---------------------
 
 The CLI task ``flexmeasures monitor latest-run`` lets you be alerted when tasks have not successfully run at least so-and-so many minutes ago.
-The alerts will come in via Sentry, but you can also send them to email addresses with the config setting :ref:`monitoring_mail_recipients`.
+The alerts will come in via Sentry, but you can also send them to specific FlexMeasures user IDs or email addresses with ``--inform-this-user`` or to email addresses with the config setting :ref:`default_monitoring_mail_recipients`.
 
 For illustration, here is one example of how we monitor the latest run times of tasks on a server ― the below is run in a cron script every hour and checks if every listed task ran 60, 6 or 1440 minutes ago, respectively:
 
@@ -61,4 +65,3 @@ Per default the function name is used as task name. If the number of tasks accum
     @task_with_status_report("pluginA_myFunction")
     def my_function():
         ...
-

--- a/documentation/host/error-monitoring.rst
+++ b/documentation/host/error-monitoring.rst
@@ -23,7 +23,7 @@ Here is an example for illustration:
 
     $ flexmeasures monitor last-seen --account-role SubscriberToServiceXYZ --user-role bot --maximum-minutes-since-last-seen 100
 
-As you see, users are filtered by roles. You might need to add roles before this works as you want. Use ``--inform-this-user`` one or more times to send the monitoring alert to specific FlexMeasures user IDs or email addresses. If you do not use ``--inform-this-user``, FlexMeasures falls back to :ref:`default_monitoring_mail_recipients`.
+As you see, users are filtered by roles. You might need to add roles before this works as you want. Use ``--inform-this-user`` one or more times to send the monitoring alert to specific FlexMeasures user IDs, and ``--inform-this-email`` one or more times to send it to specific email addresses. If you do not use either option, FlexMeasures falls back to :ref:`default_monitoring_mail_recipients`.
 You can also narrow the check to users in one or more accounts with ``--account``.
 Use ``--account`` multiple times to include multiple accounts.
 Use ``--consultancy`` to narrow the check to users in accounts that are clients of the given consultant account.
@@ -31,7 +31,7 @@ If you run distinct filters, such as separate checks per account, account group 
 
 .. code-block:: bash
 
-    $ flexmeasures monitor last-seen --task-name monitor-last-seen-account-12 --account 12 --account-role SubscriberToServiceXYZ --user-role bot --maximum-minutes-since-last-seen 100 --inform-this-user 42 --inform-this-user alerts@example.com
+    $ flexmeasures monitor last-seen --task-name monitor-last-seen-account-12 --account 12 --account-role SubscriberToServiceXYZ --user-role bot --maximum-minutes-since-last-seen 100 --inform-this-user 42 --inform-this-email alerts@example.com
 
 .. todo:: Adding roles and assigning them to accounts is not supported by the UI yet (user roles can be added in the UI). Account roles can be added with ``flexmeasures add account-role``.
 
@@ -40,7 +40,7 @@ Monitoring task runs
 ---------------------
 
 The CLI task ``flexmeasures monitor latest-run`` lets you be alerted when tasks have not successfully run at least so-and-so many minutes ago.
-The alerts will come in via Sentry, but you can also send them to specific FlexMeasures user IDs or email addresses with ``--inform-this-user`` or to email addresses with the config setting :ref:`default_monitoring_mail_recipients`.
+The alerts will come in via Sentry, but you can also send them to specific FlexMeasures user IDs with ``--inform-this-user``, specific email addresses with ``--inform-this-email`` or to email addresses with the config setting :ref:`default_monitoring_mail_recipients`.
 
 For illustration, here is one example of how we monitor the latest run times of tasks on a server ― the below is run in a cron script every hour and checks if every listed task ran 60, 6 or 1440 minutes ago, respectively:
 

--- a/documentation/host/error-monitoring.rst
+++ b/documentation/host/error-monitoring.rst
@@ -26,7 +26,8 @@ Here is an example for illustration:
 As you see, users are filtered by roles. You might need to add roles before this works as you want. Use ``--inform-this-user`` one or more times to send the monitoring alert to specific FlexMeasures user IDs or email addresses. If you do not use ``--inform-this-user``, FlexMeasures falls back to :ref:`default_monitoring_mail_recipients`.
 You can also narrow the check to users in one or more accounts with ``--account``.
 Use ``--account`` multiple times to include multiple accounts.
-If you run distinct filters, such as separate checks per account or account group, use distinct ``--task-name`` values so the ``--only-newly-absent-users`` feature tracks each filter independently.
+Use ``--clients-of-this-consultant`` to narrow the check to users in accounts that are clients of the given consultant account.
+If you run distinct filters, such as separate checks per account, account group or consultant, use distinct ``--task-name`` values so the ``--only-newly-absent-users`` feature tracks each filter independently.
 
 .. code-block:: bash
 

--- a/flexmeasures/api/common/schemas/users.py
+++ b/flexmeasures/api/common/schemas/users.py
@@ -1,12 +1,15 @@
 from typing import Any
 
+import click
 from flask import abort
 from flask_security import current_user
 from marshmallow import fields, validate
 from sqlalchemy import select
+from werkzeug.exceptions import NotFound
 
 from flexmeasures.data import db
 from flexmeasures.data.models.user import User, Account
+from flexmeasures.data.schemas.utils import MarshmallowClickMixin
 from flexmeasures.api.common.schemas.generic_schemas import PaginationSchema
 
 
@@ -36,7 +39,7 @@ class AccountIdField(fields.Integer):
         return current_user.account if not current_user.is_anonymous else None
 
 
-class UserIdField(fields.Integer):
+class UserIdField(fields.Integer, MarshmallowClickMixin):
     """
     Field that represents a user ID. It deserializes from the user id to a user instance.
     """
@@ -55,6 +58,14 @@ class UserIdField(fields.Integer):
         if user is None:
             raise abort(404, f"User {user_id} not found")
         return user
+
+    def convert(self, value, param, ctx, **kwargs):
+        try:
+            return super().convert(value, param, ctx, **kwargs)
+        except NotFound as exc:
+            raise click.BadParameter(
+                f"User {value} not found.", ctx=ctx, param=param
+            ) from exc
 
     def _serialize(self, value: User, attr, obj, **kwargs) -> int:
         return value.id

--- a/flexmeasures/cli/monitor.py
+++ b/flexmeasures/cli/monitor.py
@@ -29,10 +29,42 @@ def fm_monitor():
     """FlexMeasures: Monitor tasks."""
 
 
-def get_email_recipients():
-    recipients = app.config.get("FLEXMEASURES_MONITORING_MAIL_RECIPIENTS", [])
+def get_default_monitoring_email_recipients():
+    recipients = app.config.get("FLEXMEASURES_DEFAULT_MONITORING_MAIL_RECIPIENTS", [])
+    deprecated_recipients = app.config.get("FLEXMEASURES_MONITORING_MAIL_RECIPIENTS")
+    if deprecated_recipients:
+        app.logger.warning(
+            "FLEXMEASURES_MONITORING_MAIL_RECIPIENTS is deprecated. Use "
+            "FLEXMEASURES_DEFAULT_MONITORING_MAIL_RECIPIENTS instead."
+        )
+        if not recipients:
+            recipients = deprecated_recipients
     if isinstance(recipients, str):
         recipients = [recipients]
+    return recipients
+
+
+def get_monitoring_email_recipients(
+    informed_users: tuple[str | int, ...] = ()
+) -> list[str]:
+    if not informed_users:
+        return get_default_monitoring_email_recipients()
+
+    recipients = []
+    for user_identifier in informed_users:
+        user_identifier = str(user_identifier)
+        if user_identifier.isdecimal():
+            user = db.session.get(User, int(user_identifier))
+        else:
+            user = db.session.execute(
+                select(User).filter_by(email=user_identifier)
+            ).scalar_one_or_none()
+        if user is None:
+            raise click.BadParameter(
+                f"No user with ID or email address {user_identifier} exists.",
+                param_hint="--inform-this-user",
+            )
+        recipients.append(user.email)
     return recipients
 
 
@@ -41,6 +73,7 @@ def send_task_monitoring_alert(
     msg: str,
     latest_run: LatestTaskRun | None = None,
     custom_msg: str | None = None,
+    email_recipients: list[str] | None = None,
 ):
     """
     Send any monitoring message per Sentry and per email. Also log an error.
@@ -60,8 +93,12 @@ def send_task_monitoring_alert(
 
     capture_message_for_sentry(msg)
 
-    email_recipients = get_email_recipients()
+    if email_recipients is None:
+        email_recipients = get_default_monitoring_email_recipients()
     if len(email_recipients) > 0:
+        app.logger.debug(
+            f"Monitoring alert about latest task run of {task_name}, send to {email_recipients}"
+        )
         email = Message(subject=f"Problem with task {task_name}", bcc=email_recipients)
         email.body = (
             f"{msg}\n\n{latest_run_txt}\nWe suggest to check the logs.{custom_msg_txt}"
@@ -86,13 +123,20 @@ def send_task_monitoring_alert(
     default="",
     help="Add this message to the monitoring alert (if one is sent).",
 )
-def monitor_latest_run(task, custom_message):
+@click.option(
+    "--inform-this-user",
+    type=str,
+    multiple=True,
+    help="User ID or email address to send the monitoring alert to. Use multiple times if needed. If not used, the default monitoring mail recipients are informed.",
+)
+def monitor_latest_run(task, custom_message, inform_this_user: tuple[str, ...] = ()):
     """
     Check if the given task's last successful execution happened less than the allowed time ago.
 
     Tasks are CLI commands with the @task_with_status_report decorator.
     If not, alert someone, via email or sentry.
     """
+    email_recipients = get_monitoring_email_recipients(inform_this_user)
     for t in task:
         task_name = t[0]
         app.logger.info(f"Checking latest run of task {task_name} ...")
@@ -100,11 +144,21 @@ def monitor_latest_run(task, custom_message):
             latest_run: LatestTaskRun = db.session.get(LatestTaskRun, task_name)
         except (sqla_exc.ResourceClosedError, sqla_exc.DatabaseError):
             msg = f"Task {task_name} could not be checked due to a database connectivity problem."
-            send_task_monitoring_alert(task_name, msg, custom_msg=custom_message)
+            send_task_monitoring_alert(
+                task_name,
+                msg,
+                custom_msg=custom_message,
+                email_recipients=email_recipients,
+            )
             raise click.Abort()
         if latest_run is None:
             msg = f"Task {task_name} has no last run and thus cannot be monitored. Is it configured properly?"
-            send_task_monitoring_alert(task_name, msg, custom_msg=custom_message)
+            send_task_monitoring_alert(
+                task_name,
+                msg,
+                custom_msg=custom_message,
+                email_recipients=email_recipients,
+            )
             raise click.Abort()
 
         now = server_now()
@@ -115,7 +169,11 @@ def monitor_latest_run(task, custom_message):
             if latest_run.status is False:
                 msg = f"A failure has been reported on task {task_name}."
                 send_task_monitoring_alert(
-                    task_name, msg, latest_run=latest_run, custom_msg=custom_message
+                    task_name,
+                    msg,
+                    latest_run=latest_run,
+                    custom_msg=custom_message,
+                    email_recipients=email_recipients,
                 )
         else:
             msg = (
@@ -123,7 +181,11 @@ def monitor_latest_run(task, custom_message):
                 f" ({acceptable_interval})."
             )
             send_task_monitoring_alert(
-                task_name, msg, latest_run=latest_run, custom_msg=custom_message
+                task_name,
+                msg,
+                latest_run=latest_run,
+                custom_msg=custom_message,
+                email_recipients=email_recipients,
             )
     app.logger.info("Done checking task runs ...")
 
@@ -135,6 +197,7 @@ def send_lastseen_monitoring_alert(
     account_role: str | None = None,
     user_role: str | None = None,
     txt_about_already_alerted_users: str = "",
+    email_recipients: list[str] | None = None,
 ):
     """
     Tell monitoring recipients and Sentry about user(s) we haven't seen in a while.
@@ -178,13 +241,17 @@ def send_lastseen_monitoring_alert(
         msg += (
             "\n\nThe user(s) has/have not been notified (--alert-users was not used)."
         )
-    email_recipients = get_email_recipients()
+    if email_recipients is None:
+        email_recipients = get_default_monitoring_email_recipients()
     if len(email_recipients) > 0:
         email = Message(
             subject="Last contact by user(s) too long ago", bcc=email_recipients
         )
         email.body = msg
         app.mail.send(email)
+    app.logger.debug(
+        f"Monitoring alert about users not seen in a while, send to {email_recipients}"
+    )
 
     app.logger.error(msg)
 
@@ -231,6 +298,12 @@ def send_lastseen_monitoring_alert(
     default="monitor-last-seen-users",
     help="Optional name of the task, to distinguish finding out when the last monitoring happened (see --only-newly-absent-users).",
 )
+@click.option(
+    "--inform-this-user",
+    type=str,
+    multiple=True,
+    help="User ID or email address to send the monitoring alert to. Use multiple times if needed. If not used, the default monitoring mail recipients are informed.",
+)
 def monitor_last_seen(
     maximum_minutes_since_last_seen: int,
     alert_users: bool = False,
@@ -239,6 +312,7 @@ def monitor_last_seen(
     custom_user_message: str | None = None,
     only_newly_absent_users: bool = True,
     task_name: str = "monitor-last-seen-users",
+    inform_this_user: tuple[str, ...] = (),
 ):
     """
     Check if given users last contact (via a request) happened less than the allowed time ago.
@@ -259,17 +333,19 @@ def monitor_last_seen(
     last_seen_delta = timedelta(minutes=maximum_minutes_since_last_seen)
     latest_run: LatestTaskRun | None = None
     users: list[User] = []
+    app.logger.debug(
+        f"Checking which users have not been seen for more than {last_seen_delta} ..."
+    )
+    email_recipients = get_monitoring_email_recipients(inform_this_user)
 
     try:
         latest_run: LatestTaskRun = db.session.get(LatestTaskRun, task_name)
         # find users we haven't seen in the given time window (last_seen_at is naive UTC)
-        users = db.session.scalars(
-            select(User).filter(
-                User.last_seen_at < datetime.now(timezone.utc) - last_seen_delta
-            )
-        ).all()
+        query = select(User).filter(
+            User.last_seen_at < datetime.now(timezone.utc) - last_seen_delta
+        )
+        users = db.session.scalars(query).all()
     except (sqla_exc.ResourceClosedError, sqla_exc.DatabaseError):
-        email_recipients = get_email_recipients()
         if len(email_recipients) > 0:
             email = Message(
                 subject="Could not monitor last seen status of users",
@@ -333,6 +409,7 @@ def monitor_last_seen(
         account_role=account_role,
         user_role=user_role,
         txt_about_already_alerted_users=txt_about_already_alerted_users,
+        email_recipients=email_recipients,
     )
 
     # remember that we checked at this time

--- a/flexmeasures/cli/monitor.py
+++ b/flexmeasures/cli/monitor.py
@@ -10,6 +10,8 @@ import click
 from flask import current_app as app
 from flask.cli import with_appcontext
 from flask_mail import Message
+from marshmallow import ValidationError, fields
+from werkzeug.exceptions import NotFound
 from sentry_sdk import (
     capture_message as capture_message_for_sentry,
     set_context as set_sentry_context,
@@ -46,14 +48,29 @@ def get_default_monitoring_email_recipients():
     return recipients
 
 
-def get_monitoring_email_recipients(
-    informed_users: tuple[User, ...] = (),
-    informed_email_addresses: tuple[str, ...] = (),
-) -> list[str]:
-    if not informed_users and not informed_email_addresses:
+def get_monitoring_email_recipients(recipients: tuple[str, ...] = ()) -> list[str]:
+    if not recipients:
         return get_default_monitoring_email_recipients()
 
-    return [user.email for user in informed_users] + list(informed_email_addresses)
+    email_recipients = []
+    for recipient in recipients:
+        if recipient.isdecimal():
+            try:
+                user = UserIdField().deserialize(recipient)
+            except NotFound as exc:
+                raise click.BadParameter(
+                    f"User {recipient} not found.", param_hint="--recipient"
+                ) from exc
+            email_recipients.append(user.email)
+        else:
+            try:
+                email_recipients.append(fields.Email().deserialize(recipient))
+            except ValidationError as exc:
+                raise click.BadParameter(
+                    f"Recipient {recipient} is neither a valid user ID nor email address.",
+                    param_hint="--recipient",
+                ) from exc
+    return email_recipients
 
 
 def send_task_monitoring_alert(
@@ -112,22 +129,15 @@ def send_task_monitoring_alert(
     help="Add this message to the monitoring alert (if one is sent).",
 )
 @click.option(
-    "--inform-this-user",
-    type=UserIdField(),
-    multiple=True,
-    help="User ID to send the monitoring alert to. Use multiple times if needed. If not used, the default monitoring mail recipients are informed.",
-)
-@click.option(
-    "--inform-this-email",
+    "--recipient",
     type=str,
     multiple=True,
-    help="Email address to send the monitoring alert to. Use multiple times if needed. If not used, the default monitoring mail recipients are informed.",
+    help="User ID or email address to send the monitoring alert to. Use multiple times if needed. If not used, the default monitoring mail recipients are informed.",
 )
 def monitor_latest_run(
     task,
     custom_message,
-    inform_this_user: tuple[User, ...] = (),
-    inform_this_email: tuple[str, ...] = (),
+    recipient: tuple[str, ...] = (),
 ):
     """
     Check if the given task's last successful execution happened less than the allowed time ago.
@@ -135,9 +145,7 @@ def monitor_latest_run(
     Tasks are CLI commands with the @task_with_status_report decorator.
     If not, alert someone, via email or sentry.
     """
-    email_recipients = get_monitoring_email_recipients(
-        inform_this_user, inform_this_email
-    )
+    email_recipients = get_monitoring_email_recipients(recipient)
     for t in task:
         task_name = t[0]
         app.logger.info(f"Checking latest run of task {task_name} ...")
@@ -371,16 +379,10 @@ def get_absent_users(
     help="Optional name of the task, to distinguish finding out when the last monitoring happened (see --only-newly-absent-users). Helps to distinguish multiple versions of this command.",
 )
 @click.option(
-    "--inform-this-user",
-    type=UserIdField(),
-    multiple=True,
-    help="User ID to send the monitoring alert to. Use multiple times if needed. If not used, the default monitoring mail recipients are informed.",
-)
-@click.option(
-    "--inform-this-email",
+    "--recipient",
     type=str,
     multiple=True,
-    help="Email address to send the monitoring alert to. Use multiple times if needed. If not used, the default monitoring mail recipients are informed.",
+    help="User ID or email address to send the monitoring alert to. Use multiple times if needed. If not used, the default monitoring mail recipients are informed.",
 )
 def monitor_last_seen(
     maximum_minutes_since_last_seen: int,
@@ -392,8 +394,7 @@ def monitor_last_seen(
     custom_user_message: str | None = None,
     only_newly_absent_users: bool = True,
     task_name: str = "monitor-last-seen-users",
-    inform_this_user: tuple[User, ...] = (),
-    inform_this_email: tuple[str, ...] = (),
+    recipient: tuple[str, ...] = (),
 ):
     """
     Check if given users last contact (via a request) happened less than the allowed time ago.
@@ -417,9 +418,7 @@ def monitor_last_seen(
     app.logger.debug(
         f"Checking which users have not been seen for more than {last_seen_delta} ..."
     )
-    email_recipients = get_monitoring_email_recipients(
-        inform_this_user, inform_this_email
-    )
+    email_recipients = get_monitoring_email_recipients(recipient)
     account_ids = [account.id for account in accounts]
     client_account_ids = (
         [account.id for account in consultancy.get_all_client_accounts()]

--- a/flexmeasures/cli/monitor.py
+++ b/flexmeasures/cli/monitor.py
@@ -344,7 +344,7 @@ def get_absent_users(
     help="The ID of an account to filter for. Use multiple times if needed.",
 )
 @click.option(
-    "--clients-of-this-consultant",
+    "--consultancy",
     type=AccountIdField(),
     help="The ID of a consultant account whose client accounts should be monitored.",
 )
@@ -363,13 +363,13 @@ def get_absent_users(
     "--only-newly-absent-users/--all-absent-users",
     type=bool,
     default=True,
-    help="If True, a user is only included in this alert once after they were absent for too long. Defaults to True, so as to keep regular emails to low volume with newsworthy alerts.",
+    help="If True, a user is only included in this alert once after they were absent for too long. Defaults to True, so as to keep regular emails to low volume with newsworthy alerts. See also --task-name.",
 )
 @click.option(
     "--task-name",
     type=str,
     default="monitor-last-seen-users",
-    help="Optional name of the task, to distinguish finding out when the last monitoring happened (see --only-newly-absent-users).",
+    help="Optional name of the task, to distinguish finding out when the last monitoring happened (see --only-newly-absent-users). Helps to distinguish multiple versions of this command.",
 )
 @click.option(
     "--inform-this-user",
@@ -382,7 +382,7 @@ def monitor_last_seen(
     alert_users: bool = False,
     account_role: str | None = None,
     accounts: tuple[Account, ...] = (),
-    clients_of_this_consultant: Account | None = None,
+    consultancy: Account | None = None,
     user_role: str | None = None,
     custom_user_message: str | None = None,
     only_newly_absent_users: bool = True,
@@ -414,8 +414,8 @@ def monitor_last_seen(
     email_recipients = get_monitoring_email_recipients(inform_this_user)
     account_ids = [account.id for account in accounts]
     client_account_ids = (
-        [account.id for account in clients_of_this_consultant.get_all_client_accounts()]
-        if clients_of_this_consultant is not None
+        [account.id for account in consultancy.get_all_client_accounts()]
+        if consultancy is not None
         else []
     )
 
@@ -425,7 +425,7 @@ def monitor_last_seen(
             last_seen_delta,
             account_ids,
             client_account_ids,
-            clients_of_this_consultant is not None,
+            consultancy is not None,
             account_role,
             user_role,
         )
@@ -487,9 +487,7 @@ def monitor_last_seen(
         alerted_users=alert_users,
         account_ids=account_ids,
         client_account_ids=client_account_ids,
-        consultant_account_id=(
-            clients_of_this_consultant.id if clients_of_this_consultant else None
-        ),
+        consultant_account_id=consultancy.id if consultancy else None,
         account_role=account_role,
         user_role=user_role,
         txt_about_already_alerted_users=txt_about_already_alerted_users,

--- a/flexmeasures/cli/monitor.py
+++ b/flexmeasures/cli/monitor.py
@@ -196,6 +196,8 @@ def send_lastseen_monitoring_alert(
     last_seen_delta: timedelta,
     alerted_users: bool,
     account_ids: list[int] | None = None,
+    client_account_ids: list[int] | None = None,
+    consultant_account_id: int | None = None,
     account_role: str | None = None,
     user_role: str | None = None,
     txt_about_already_alerted_users: str = "",
@@ -231,6 +233,8 @@ def send_lastseen_monitoring_alert(
             "delta": last_seen_delta,
             "alerted_users": alerted_users,
             "account_ids": account_ids,
+            "client_account_ids": client_account_ids,
+            "consultant_account_id": consultant_account_id,
             "account_role": account_role,
             "user_role": user_role,
         },
@@ -245,6 +249,18 @@ def send_lastseen_monitoring_alert(
         else:
             account_ids_txt = ", ".join(str(account_id) for account_id in account_ids)
             msg += f"\nThis alert concerns users whose accounts have IDs {account_ids_txt}."
+    if consultant_account_id:
+        msg += (
+            "\nThis alert concerns users whose accounts are clients of consultant "
+            f"account {consultant_account_id}"
+        )
+        if client_account_ids:
+            client_account_ids_txt = ", ".join(
+                str(account_id) for account_id in client_account_ids
+            )
+            msg += f" ({client_account_ids_txt})."
+        else:
+            msg += "."
     if account_role:
         msg += f"\nThis alert concerns users whose accounts have the role '{account_role}'."
     if user_role:
@@ -270,6 +286,34 @@ def send_lastseen_monitoring_alert(
     )
 
     app.logger.error(msg)
+
+
+def get_absent_users(
+    last_seen_delta: timedelta,
+    account_ids: list[int],
+    client_account_ids: list[int],
+    filter_by_client_accounts: bool,
+    account_role: str | None = None,
+    user_role: str | None = None,
+) -> list[User]:
+    """
+    Get users whose last contact is too old, narrowed down by account and role filters.
+    """
+    query = select(User).filter(
+        User.last_seen_at < datetime.now(timezone.utc) - last_seen_delta
+    )
+    if account_ids:
+        query = query.filter(User.account_id.in_(account_ids))
+    if filter_by_client_accounts:
+        query = query.filter(User.account_id.in_(client_account_ids))
+    query = query.order_by(User.last_seen_at.asc())
+    users = db.session.scalars(query).all()
+
+    if account_role is not None:
+        users = [user for user in users if user.account.has_role(account_role)]
+    if user_role is not None:
+        users = [user for user in users if user.has_role(user_role)]
+    return users
 
 
 @fm_monitor.command("last-seen")
@@ -298,6 +342,11 @@ def send_lastseen_monitoring_alert(
     type=AccountIdField(),
     multiple=True,
     help="The ID of an account to filter for. Use multiple times if needed.",
+)
+@click.option(
+    "--clients-of-this-consultant",
+    type=AccountIdField(),
+    help="The ID of a consultant account whose client accounts should be monitored.",
 )
 @click.option(
     "--user-role",
@@ -333,6 +382,7 @@ def monitor_last_seen(
     alert_users: bool = False,
     account_role: str | None = None,
     accounts: tuple[Account, ...] = (),
+    clients_of_this_consultant: Account | None = None,
     user_role: str | None = None,
     custom_user_message: str | None = None,
     only_newly_absent_users: bool = True,
@@ -363,17 +413,22 @@ def monitor_last_seen(
     )
     email_recipients = get_monitoring_email_recipients(inform_this_user)
     account_ids = [account.id for account in accounts]
+    client_account_ids = (
+        [account.id for account in clients_of_this_consultant.get_all_client_accounts()]
+        if clients_of_this_consultant is not None
+        else []
+    )
 
     try:
         latest_run: LatestTaskRun = db.session.get(LatestTaskRun, task_name)
-        # find users we haven't seen in the given time window (last_seen_at is naive UTC)
-        query = select(User).filter(
-            User.last_seen_at < datetime.now(timezone.utc) - last_seen_delta
+        users = get_absent_users(
+            last_seen_delta,
+            account_ids,
+            client_account_ids,
+            clients_of_this_consultant is not None,
+            account_role,
+            user_role,
         )
-        if account_ids:
-            query = query.filter(User.account_id.in_(account_ids))
-        query = query.order_by(User.last_seen_at.asc())
-        users = db.session.scalars(query).all()
     except (sqla_exc.ResourceClosedError, sqla_exc.DatabaseError):
         if len(email_recipients) > 0:
             email = Message(
@@ -384,11 +439,6 @@ def monitor_last_seen(
             app.mail.send(email)
         raise click.Abort()
 
-    # role filters
-    if account_role is not None:
-        users = [user for user in users if user.account.has_role(account_role)]
-    if user_role is not None:
-        users = [user for user in users if user.has_role(user_role)]
     # filter out users who we already included in this check's last run
     txt_about_already_alerted_users = ""
     if only_newly_absent_users and latest_run:
@@ -436,6 +486,10 @@ def monitor_last_seen(
         last_seen_delta,
         alerted_users=alert_users,
         account_ids=account_ids,
+        client_account_ids=client_account_ids,
+        consultant_account_id=(
+            clients_of_this_consultant.id if clients_of_this_consultant else None
+        ),
         account_role=account_role,
         user_role=user_role,
         txt_about_already_alerted_users=txt_about_already_alerted_users,

--- a/flexmeasures/cli/monitor.py
+++ b/flexmeasures/cli/monitor.py
@@ -21,6 +21,7 @@ from flexmeasures.data import db
 from flexmeasures.data.models.task_runs import LatestTaskRun
 from flexmeasures.data.models.user import Account, User
 from flexmeasures.data.schemas.account import AccountIdField
+from flexmeasures.api.common.schemas.users import UserIdField
 from flexmeasures.utils.time_utils import server_now
 from flexmeasures.cli.utils import MsgStyle
 
@@ -46,27 +47,13 @@ def get_default_monitoring_email_recipients():
 
 
 def get_monitoring_email_recipients(
-    informed_users: tuple[str | int, ...] = ()
+    informed_users: tuple[User, ...] = (),
+    informed_email_addresses: tuple[str, ...] = (),
 ) -> list[str]:
-    if not informed_users:
+    if not informed_users and not informed_email_addresses:
         return get_default_monitoring_email_recipients()
 
-    recipients = []
-    for user_identifier in informed_users:
-        user_identifier = str(user_identifier)
-        if user_identifier.isdecimal():
-            user = db.session.get(User, int(user_identifier))
-        else:
-            user = db.session.execute(
-                select(User).filter_by(email=user_identifier)
-            ).scalar_one_or_none()
-        if user is None:
-            raise click.BadParameter(
-                f"No user with ID or email address {user_identifier} exists.",
-                param_hint="--inform-this-user",
-            )
-        recipients.append(user.email)
-    return recipients
+    return [user.email for user in informed_users] + list(informed_email_addresses)
 
 
 def send_task_monitoring_alert(
@@ -126,18 +113,31 @@ def send_task_monitoring_alert(
 )
 @click.option(
     "--inform-this-user",
+    type=UserIdField(),
+    multiple=True,
+    help="User ID to send the monitoring alert to. Use multiple times if needed. If not used, the default monitoring mail recipients are informed.",
+)
+@click.option(
+    "--inform-this-email",
     type=str,
     multiple=True,
-    help="User ID or email address to send the monitoring alert to. Use multiple times if needed. If not used, the default monitoring mail recipients are informed.",
+    help="Email address to send the monitoring alert to. Use multiple times if needed. If not used, the default monitoring mail recipients are informed.",
 )
-def monitor_latest_run(task, custom_message, inform_this_user: tuple[str, ...] = ()):
+def monitor_latest_run(
+    task,
+    custom_message,
+    inform_this_user: tuple[User, ...] = (),
+    inform_this_email: tuple[str, ...] = (),
+):
     """
     Check if the given task's last successful execution happened less than the allowed time ago.
 
     Tasks are CLI commands with the @task_with_status_report decorator.
     If not, alert someone, via email or sentry.
     """
-    email_recipients = get_monitoring_email_recipients(inform_this_user)
+    email_recipients = get_monitoring_email_recipients(
+        inform_this_user, inform_this_email
+    )
     for t in task:
         task_name = t[0]
         app.logger.info(f"Checking latest run of task {task_name} ...")
@@ -251,7 +251,7 @@ def send_lastseen_monitoring_alert(
             msg += f"\nThis alert concerns users whose accounts have IDs {account_ids_txt}."
     if consultant_account_id:
         msg += (
-            "\nThis alert concerns users whose accounts are clients of consultant "
+            "\nThis alert concerns users whose accounts are clients of consultancy "
             f"account {consultant_account_id}"
         )
         if client_account_ids:
@@ -291,8 +291,7 @@ def send_lastseen_monitoring_alert(
 def get_absent_users(
     last_seen_delta: timedelta,
     account_ids: list[int],
-    client_account_ids: list[int],
-    filter_by_client_accounts: bool,
+    client_account_ids: list[int] | None = None,
     account_role: str | None = None,
     user_role: str | None = None,
 ) -> list[User]:
@@ -304,7 +303,7 @@ def get_absent_users(
     )
     if account_ids:
         query = query.filter(User.account_id.in_(account_ids))
-    if filter_by_client_accounts:
+    if client_account_ids is not None:
         query = query.filter(User.account_id.in_(client_account_ids))
     query = query.order_by(User.last_seen_at.asc())
     users = db.session.scalars(query).all()
@@ -346,7 +345,7 @@ def get_absent_users(
 @click.option(
     "--consultancy",
     type=AccountIdField(),
-    help="The ID of a consultant account whose client accounts should be monitored.",
+    help="The ID of a consultancy account whose client accounts should be monitored.",
 )
 @click.option(
     "--user-role",
@@ -373,9 +372,15 @@ def get_absent_users(
 )
 @click.option(
     "--inform-this-user",
+    type=UserIdField(),
+    multiple=True,
+    help="User ID to send the monitoring alert to. Use multiple times if needed. If not used, the default monitoring mail recipients are informed.",
+)
+@click.option(
+    "--inform-this-email",
     type=str,
     multiple=True,
-    help="User ID or email address to send the monitoring alert to. Use multiple times if needed. If not used, the default monitoring mail recipients are informed.",
+    help="Email address to send the monitoring alert to. Use multiple times if needed. If not used, the default monitoring mail recipients are informed.",
 )
 def monitor_last_seen(
     maximum_minutes_since_last_seen: int,
@@ -387,7 +392,8 @@ def monitor_last_seen(
     custom_user_message: str | None = None,
     only_newly_absent_users: bool = True,
     task_name: str = "monitor-last-seen-users",
-    inform_this_user: tuple[str, ...] = (),
+    inform_this_user: tuple[User, ...] = (),
+    inform_this_email: tuple[str, ...] = (),
 ):
     """
     Check if given users last contact (via a request) happened less than the allowed time ago.
@@ -411,12 +417,14 @@ def monitor_last_seen(
     app.logger.debug(
         f"Checking which users have not been seen for more than {last_seen_delta} ..."
     )
-    email_recipients = get_monitoring_email_recipients(inform_this_user)
+    email_recipients = get_monitoring_email_recipients(
+        inform_this_user, inform_this_email
+    )
     account_ids = [account.id for account in accounts]
     client_account_ids = (
         [account.id for account in consultancy.get_all_client_accounts()]
         if consultancy is not None
-        else []
+        else None
     )
 
     try:
@@ -425,7 +433,6 @@ def monitor_last_seen(
             last_seen_delta,
             account_ids,
             client_account_ids,
-            consultancy is not None,
             account_role,
             user_role,
         )

--- a/flexmeasures/cli/monitor.py
+++ b/flexmeasures/cli/monitor.py
@@ -19,7 +19,8 @@ from tabulate import tabulate
 
 from flexmeasures.data import db
 from flexmeasures.data.models.task_runs import LatestTaskRun
-from flexmeasures.data.models.user import User
+from flexmeasures.data.models.user import Account, User
+from flexmeasures.data.schemas.account import AccountIdField
 from flexmeasures.utils.time_utils import server_now
 from flexmeasures.cli.utils import MsgStyle
 
@@ -194,6 +195,7 @@ def send_lastseen_monitoring_alert(
     users: list[User],
     last_seen_delta: timedelta,
     alerted_users: bool,
+    account_ids: list[int] | None = None,
     account_role: str | None = None,
     user_role: str | None = None,
     txt_about_already_alerted_users: str = "",
@@ -204,7 +206,12 @@ def send_lastseen_monitoring_alert(
     """
 
     user_info = [
-        [user.username, user.last_seen_at.strftime("%d %b %Y %I:%M:%S %p")]
+        [
+            user.username,
+            user.id,
+            user.account_id,
+            user.last_seen_at.strftime("%d %b %Y %I:%M:%S %p"),
+        ]
         for user in users
     ]
 
@@ -213,7 +220,9 @@ def send_lastseen_monitoring_alert(
         f" than {last_seen_delta}, even though we expect they would have:\n\n"
     )
 
-    msg += tabulate(user_info, headers=["User", "Last contact"])
+    msg += tabulate(
+        user_info, headers=["User", "User ID", "Account ID", "Last contact"]
+    )
 
     # Sentry
     set_sentry_context(
@@ -221,6 +230,7 @@ def send_lastseen_monitoring_alert(
         {
             "delta": last_seen_delta,
             "alerted_users": alerted_users,
+            "account_ids": account_ids,
             "account_role": account_role,
             "user_role": user_role,
         },
@@ -229,6 +239,12 @@ def send_lastseen_monitoring_alert(
 
     # Email
     msg += "\n"
+    if account_ids:
+        if len(account_ids) == 1:
+            msg += f"\nThis alert concerns users whose account has ID {account_ids[0]}."
+        else:
+            account_ids_txt = ", ".join(str(account_id) for account_id in account_ids)
+            msg += f"\nThis alert concerns users whose accounts have IDs {account_ids_txt}."
     if account_role:
         msg += f"\nThis alert concerns users whose accounts have the role '{account_role}'."
     if user_role:
@@ -276,6 +292,14 @@ def send_lastseen_monitoring_alert(
     help="The name of an account role to filter for.",
 )
 @click.option(
+    "--account",
+    "accounts",
+    required=False,
+    type=AccountIdField(),
+    multiple=True,
+    help="The ID of an account to filter for. Use multiple times if needed.",
+)
+@click.option(
     "--user-role",
     type=str,
     help="The name of a user role to filter for.",
@@ -308,6 +332,7 @@ def monitor_last_seen(
     maximum_minutes_since_last_seen: int,
     alert_users: bool = False,
     account_role: str | None = None,
+    accounts: tuple[Account, ...] = (),
     user_role: str | None = None,
     custom_user_message: str | None = None,
     only_newly_absent_users: bool = True,
@@ -337,6 +362,7 @@ def monitor_last_seen(
         f"Checking which users have not been seen for more than {last_seen_delta} ..."
     )
     email_recipients = get_monitoring_email_recipients(inform_this_user)
+    account_ids = [account.id for account in accounts]
 
     try:
         latest_run: LatestTaskRun = db.session.get(LatestTaskRun, task_name)
@@ -344,6 +370,9 @@ def monitor_last_seen(
         query = select(User).filter(
             User.last_seen_at < datetime.now(timezone.utc) - last_seen_delta
         )
+        if account_ids:
+            query = query.filter(User.account_id.in_(account_ids))
+        query = query.order_by(User.last_seen_at.asc())
         users = db.session.scalars(query).all()
     except (sqla_exc.ResourceClosedError, sqla_exc.DatabaseError):
         if len(email_recipients) > 0:
@@ -406,6 +435,7 @@ def monitor_last_seen(
         users,
         last_seen_delta,
         alerted_users=alert_users,
+        account_ids=account_ids,
         account_role=account_role,
         user_role=user_role,
         txt_about_already_alerted_users=txt_about_already_alerted_users,

--- a/flexmeasures/cli/tests/test_monitor.py
+++ b/flexmeasures/cli/tests/test_monitor.py
@@ -23,8 +23,7 @@ def test_monitor_help(app):
         result = runner.invoke(command, ["--help"])
 
         assert result.exit_code == 0
-        assert "--inform-this-user" in result.output
-        assert "--inform-this-email" in result.output
+        assert "--recipient" in result.output
     result = runner.invoke(monitor_last_seen, ["--help"])
     assert "--account" in result.output
     assert "--consultancy" in result.output
@@ -99,9 +98,9 @@ def test_monitor_latest_run_informs_requested_users(
                 "--task",
                 "import-data",
                 "10",
-                "--inform-this-user",
+                "--recipient",
                 str(first_user.id),
-                "--inform-this-user",
+                "--recipient",
                 str(second_user.id),
             ],
         )
@@ -138,7 +137,7 @@ def test_monitor_latest_run_informs_requested_email(
                 "--task",
                 "import-data",
                 "10",
-                "--inform-this-email",
+                "--recipient",
                 informed_user.email,
             ],
         )
@@ -178,9 +177,9 @@ def test_monitor_latest_run_informs_requested_users_and_emails(
                 "--task",
                 "import-data",
                 "10",
-                "--inform-this-user",
+                "--recipient",
                 str(first_user.id),
-                "--inform-this-email",
+                "--recipient",
                 second_user.email,
             ],
         )
@@ -195,7 +194,7 @@ def test_monitor_latest_run_rejects_unknown_informed_user(app, fresh_db):
 
     result = app.test_cli_runner().invoke(
         monitor_latest_run,
-        ["--task", "import-data", "10", "--inform-this-user", "9999"],
+        ["--task", "import-data", "10", "--recipient", "9999"],
     )
 
     assert result.exit_code != 0
@@ -224,7 +223,7 @@ def test_monitor_latest_run_informs_requested_unknown_email(app, fresh_db, monke
                 "--task",
                 "import-data",
                 "10",
-                "--inform-this-email",
+                "--recipient",
                 "missing@example.test",
             ],
         )
@@ -232,6 +231,21 @@ def test_monitor_latest_run_informs_requested_unknown_email(app, fresh_db, monke
     assert result.exit_code == 0
     assert len(outbox) == 1
     assert outbox[0].bcc == ["missing@example.test"]
+
+
+def test_monitor_latest_run_rejects_invalid_recipient(app, fresh_db):
+    from flexmeasures.cli.monitor import monitor_latest_run
+
+    result = app.test_cli_runner().invoke(
+        monitor_latest_run,
+        ["--task", "import-data", "10", "--recipient", "not-an-email"],
+    )
+
+    assert result.exit_code != 0
+    assert (
+        "Recipient not-an-email is neither a valid user ID nor email address"
+        in result.output
+    )
 
 
 def test_monitor_last_seen_uses_deprecated_config_fallback(
@@ -498,7 +512,7 @@ def test_monitor_last_seen_informs_requested_user(
                 "--maximum-minutes-since-last-seen",
                 "30",
                 "--all-absent-users",
-                "--inform-this-user",
+                "--recipient",
                 str(informed_user.id),
             ],
         )
@@ -532,7 +546,7 @@ def test_monitor_last_seen_informs_requested_email(
                 "--maximum-minutes-since-last-seen",
                 "30",
                 "--all-absent-users",
-                "--inform-this-email",
+                "--recipient",
                 informed_user.email,
             ],
         )

--- a/flexmeasures/cli/tests/test_monitor.py
+++ b/flexmeasures/cli/tests/test_monitor.py
@@ -26,6 +26,7 @@ def test_monitor_help(app):
         assert "--inform-this-user" in result.output
     result = runner.invoke(monitor_last_seen, ["--help"])
     assert "--account" in result.output
+    assert "--clients-of-this-consultant" in result.output
 
 
 def test_get_default_monitoring_email_recipients_prefers_new_config(app, monkeypatch):

--- a/flexmeasures/cli/tests/test_monitor.py
+++ b/flexmeasures/cli/tests/test_monitor.py
@@ -1,4 +1,7 @@
+import re
 from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
 
 from flexmeasures.data.models.task_runs import LatestTaskRun
 from flexmeasures.data.models.user import User
@@ -21,6 +24,8 @@ def test_monitor_help(app):
 
         assert result.exit_code == 0
         assert "--inform-this-user" in result.output
+    result = runner.invoke(monitor_last_seen, ["--help"])
+    assert "--account" in result.output
 
 
 def test_get_default_monitoring_email_recipients_prefers_new_config(app, monkeypatch):
@@ -250,6 +255,163 @@ def test_monitor_last_seen_uses_deprecated_config_fallback(
     assert result.exit_code == 0
     assert len(outbox) == 1
     assert outbox[0].bcc == ["ops@example.test"]
+
+
+def test_monitor_last_seen_filters_users_by_account_id(
+    app, fresh_db, setup_roles_users_fresh_db, setup_accounts_fresh_db, monkeypatch
+):
+    from flexmeasures.cli import monitor
+    from flexmeasures.cli.monitor import monitor_last_seen
+
+    monkeypatch.setattr(monitor, "capture_message_for_sentry", lambda msg: None)
+    monkeypatch.setattr(monitor, "set_sentry_context", lambda *args, **kwargs: None)
+    monkeypatch.setitem(
+        app.config,
+        "FLEXMEASURES_DEFAULT_MONITORING_MAIL_RECIPIENTS",
+        ["ops@example.test"],
+    )
+    for user in fresh_db.session.scalars(select(User)).all():
+        user.last_seen_at = datetime.now(timezone.utc)
+    prosumer_user = fresh_db.session.get(
+        User, setup_roles_users_fresh_db["Test Prosumer User"]
+    )
+    supplier_user = fresh_db.session.get(
+        User, setup_roles_users_fresh_db["Test Supplier User"]
+    )
+    prosumer_user.last_seen_at = datetime.now(timezone.utc) - timedelta(minutes=120)
+    supplier_user.last_seen_at = datetime.now(timezone.utc) - timedelta(minutes=120)
+    fresh_db.session.commit()
+
+    with app.mail.record_messages() as outbox:
+        result = app.test_cli_runner().invoke(
+            monitor_last_seen,
+            [
+                "--maximum-minutes-since-last-seen",
+                "30",
+                "--all-absent-users",
+                "--account",
+                str(setup_accounts_fresh_db["Prosumer"].id),
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert len(outbox) == 1
+    assert "User ID" in outbox[0].body
+    assert "Account ID" in outbox[0].body
+    assert re.search(
+        rf"^{prosumer_user.username}\s+{prosumer_user.id}\s+{prosumer_user.account_id}\s+",
+        outbox[0].body,
+        flags=re.MULTILINE,
+    )
+    assert prosumer_user.username in outbox[0].body
+    assert supplier_user.username not in outbox[0].body
+    assert f"account has ID {setup_accounts_fresh_db['Prosumer'].id}" in outbox[0].body
+
+
+def test_monitor_last_seen_combines_account_id_and_user_role_filters(
+    app, fresh_db, setup_roles_users_fresh_db, setup_accounts_fresh_db, monkeypatch
+):
+    from flexmeasures.cli import monitor
+    from flexmeasures.cli.monitor import monitor_last_seen
+
+    monkeypatch.setattr(monitor, "capture_message_for_sentry", lambda msg: None)
+    monkeypatch.setattr(monitor, "set_sentry_context", lambda *args, **kwargs: None)
+    monkeypatch.setitem(
+        app.config,
+        "FLEXMEASURES_DEFAULT_MONITORING_MAIL_RECIPIENTS",
+        ["ops@example.test"],
+    )
+    plain_user = fresh_db.session.get(
+        User, setup_roles_users_fresh_db["Test Prosumer User"]
+    )
+    account_admin = fresh_db.session.get(
+        User, setup_roles_users_fresh_db["Test Prosumer User 2"]
+    )
+    plain_user.last_seen_at = datetime.now(timezone.utc) - timedelta(minutes=120)
+    account_admin.last_seen_at = datetime.now(timezone.utc) - timedelta(minutes=120)
+    fresh_db.session.commit()
+
+    with app.mail.record_messages() as outbox:
+        result = app.test_cli_runner().invoke(
+            monitor_last_seen,
+            [
+                "--maximum-minutes-since-last-seen",
+                "30",
+                "--all-absent-users",
+                "--account",
+                str(setup_accounts_fresh_db["Prosumer"].id),
+                "--user-role",
+                "account-admin",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert len(outbox) == 1
+    assert account_admin.username in outbox[0].body
+    assert f"{plain_user.username}  " not in outbox[0].body
+
+
+def test_monitor_last_seen_without_account_id_reports_users_from_all_accounts(
+    app, fresh_db, setup_roles_users_fresh_db, monkeypatch
+):
+    from flexmeasures.cli import monitor
+    from flexmeasures.cli.monitor import monitor_last_seen
+
+    monkeypatch.setattr(monitor, "capture_message_for_sentry", lambda msg: None)
+    monkeypatch.setattr(monitor, "set_sentry_context", lambda *args, **kwargs: None)
+    monkeypatch.setitem(
+        app.config,
+        "FLEXMEASURES_DEFAULT_MONITORING_MAIL_RECIPIENTS",
+        ["ops@example.test"],
+    )
+    for user in fresh_db.session.scalars(select(User)).all():
+        user.last_seen_at = datetime.now(timezone.utc)
+    prosumer_user = fresh_db.session.get(
+        User, setup_roles_users_fresh_db["Test Prosumer User"]
+    )
+    supplier_user = fresh_db.session.get(
+        User, setup_roles_users_fresh_db["Test Supplier User"]
+    )
+    prosumer_user.last_seen_at = datetime.now(timezone.utc) - timedelta(minutes=120)
+    supplier_user.last_seen_at = datetime.now(timezone.utc) - timedelta(minutes=180)
+    fresh_db.session.commit()
+
+    with app.mail.record_messages() as outbox:
+        result = app.test_cli_runner().invoke(
+            monitor_last_seen,
+            [
+                "--maximum-minutes-since-last-seen",
+                "30",
+                "--all-absent-users",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert len(outbox) == 1
+    assert prosumer_user.username in outbox[0].body
+    assert supplier_user.username in outbox[0].body
+    assert outbox[0].body.index(supplier_user.username) < outbox[0].body.index(
+        prosumer_user.username
+    )
+
+
+def test_monitor_last_seen_rejects_unknown_account_id(app, fresh_db):
+    from flexmeasures.cli.monitor import monitor_last_seen
+
+    with app.mail.record_messages() as outbox:
+        result = app.test_cli_runner().invoke(
+            monitor_last_seen,
+            [
+                "--maximum-minutes-since-last-seen",
+                "30",
+                "--account",
+                "9999",
+            ],
+        )
+
+    assert result.exit_code != 0
+    assert "No account found with id 9999" in result.output
+    assert len(outbox) == 0
 
 
 def test_monitor_last_seen_informs_requested_user(

--- a/flexmeasures/cli/tests/test_monitor.py
+++ b/flexmeasures/cli/tests/test_monitor.py
@@ -26,7 +26,7 @@ def test_monitor_help(app):
         assert "--inform-this-user" in result.output
     result = runner.invoke(monitor_last_seen, ["--help"])
     assert "--account" in result.output
-    assert "--clients-of-this-consultant" in result.output
+    assert "--consultancy" in result.output
 
 
 def test_get_default_monitoring_email_recipients_prefers_new_config(app, monkeypatch):

--- a/flexmeasures/cli/tests/test_monitor.py
+++ b/flexmeasures/cli/tests/test_monitor.py
@@ -365,6 +365,47 @@ def test_monitor_last_seen_combines_account_id_and_user_role_filters(
     assert f"{plain_user.username}  " not in outbox[0].body
 
 
+def test_monitor_last_seen_filters_users_by_consultancy(
+    app, fresh_db, setup_roles_users_fresh_db, setup_accounts_fresh_db, monkeypatch
+):
+    from flexmeasures.cli import monitor
+    from flexmeasures.cli.monitor import monitor_last_seen
+
+    monkeypatch.setattr(monitor, "capture_message_for_sentry", lambda msg: None)
+    monkeypatch.setattr(monitor, "set_sentry_context", lambda *args, **kwargs: None)
+    monkeypatch.setitem(
+        app.config,
+        "FLEXMEASURES_DEFAULT_MONITORING_MAIL_RECIPIENTS",
+        ["ops@example.test"],
+    )
+    client_user = fresh_db.session.get(
+        User, setup_roles_users_fresh_db["Test Consultancy Client User"]
+    )
+    supplier_user = fresh_db.session.get(
+        User, setup_roles_users_fresh_db["Test Supplier User"]
+    )
+    client_user.last_seen_at = datetime.now(timezone.utc) - timedelta(minutes=120)
+    supplier_user.last_seen_at = datetime.now(timezone.utc) - timedelta(minutes=120)
+    fresh_db.session.commit()
+
+    with app.mail.record_messages() as outbox:
+        result = app.test_cli_runner().invoke(
+            monitor_last_seen,
+            [
+                "--maximum-minutes-since-last-seen",
+                "30",
+                "--all-absent-users",
+                "--consultancy",
+                str(setup_accounts_fresh_db["Consultancy"].id),
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert len(outbox) == 1
+    assert client_user.username in outbox[0].body
+    assert supplier_user.username not in outbox[0].body
+
+
 def test_monitor_last_seen_without_account_id_reports_users_from_all_accounts(
     app, fresh_db, setup_roles_users_fresh_db, monkeypatch
 ):

--- a/flexmeasures/cli/tests/test_monitor.py
+++ b/flexmeasures/cli/tests/test_monitor.py
@@ -24,6 +24,7 @@ def test_monitor_help(app):
 
         assert result.exit_code == 0
         assert "--inform-this-user" in result.output
+        assert "--inform-this-email" in result.output
     result = runner.invoke(monitor_last_seen, ["--help"])
     assert "--account" in result.output
     assert "--consultancy" in result.output
@@ -110,7 +111,7 @@ def test_monitor_latest_run_informs_requested_users(
     assert outbox[0].bcc == [first_user.email, second_user.email]
 
 
-def test_monitor_latest_run_informs_requested_user_by_email(
+def test_monitor_latest_run_informs_requested_email(
     app, fresh_db, setup_roles_users_fresh_db, monkeypatch
 ):
     from flexmeasures.cli import monitor
@@ -137,7 +138,7 @@ def test_monitor_latest_run_informs_requested_user_by_email(
                 "--task",
                 "import-data",
                 "10",
-                "--inform-this-user",
+                "--inform-this-email",
                 informed_user.email,
             ],
         )
@@ -147,7 +148,7 @@ def test_monitor_latest_run_informs_requested_user_by_email(
     assert outbox[0].bcc == [informed_user.email]
 
 
-def test_monitor_latest_run_informs_requested_users_by_mixed_identifiers(
+def test_monitor_latest_run_informs_requested_users_and_emails(
     app, fresh_db, setup_roles_users_fresh_db, monkeypatch
 ):
     from flexmeasures.cli import monitor
@@ -179,7 +180,7 @@ def test_monitor_latest_run_informs_requested_users_by_mixed_identifiers(
                 "10",
                 "--inform-this-user",
                 str(first_user.id),
-                "--inform-this-user",
+                "--inform-this-email",
                 second_user.email,
             ],
         )
@@ -198,27 +199,39 @@ def test_monitor_latest_run_rejects_unknown_informed_user(app, fresh_db):
     )
 
     assert result.exit_code != 0
-    assert "No user with ID or email address 9999 exists" in result.output
+    assert "User 9999 not found" in result.output
 
 
-def test_monitor_latest_run_rejects_unknown_informed_user_email(app, fresh_db):
+def test_monitor_latest_run_informs_requested_unknown_email(app, fresh_db, monkeypatch):
+    from flexmeasures.cli import monitor
     from flexmeasures.cli.monitor import monitor_latest_run
 
-    result = app.test_cli_runner().invoke(
-        monitor_latest_run,
-        [
-            "--task",
-            "import-data",
-            "10",
-            "--inform-this-user",
-            "missing@example.test",
-        ],
+    monkeypatch.setattr(monitor, "capture_message_for_sentry", lambda msg: None)
+    monkeypatch.setattr(monitor, "set_sentry_context", lambda *args, **kwargs: None)
+    fresh_db.session.add(
+        LatestTaskRun(
+            name="import-data",
+            datetime=datetime.now(timezone.utc) - timedelta(minutes=5),
+            status=False,
+        )
     )
+    fresh_db.session.commit()
 
-    assert result.exit_code != 0
-    assert (
-        "No user with ID or email address missing@example.test exists" in result.output
-    )
+    with app.mail.record_messages() as outbox:
+        result = app.test_cli_runner().invoke(
+            monitor_latest_run,
+            [
+                "--task",
+                "import-data",
+                "10",
+                "--inform-this-email",
+                "missing@example.test",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert len(outbox) == 1
+    assert outbox[0].bcc == ["missing@example.test"]
 
 
 def test_monitor_last_seen_uses_deprecated_config_fallback(
@@ -454,7 +467,7 @@ def test_monitor_last_seen_informs_requested_user(
     assert outbox[0].bcc == [informed_user.email]
 
 
-def test_monitor_last_seen_informs_requested_user_by_email(
+def test_monitor_last_seen_informs_requested_email(
     app, fresh_db, setup_roles_users_fresh_db, monkeypatch
 ):
     from flexmeasures.cli import monitor
@@ -478,7 +491,7 @@ def test_monitor_last_seen_informs_requested_user_by_email(
                 "--maximum-minutes-since-last-seen",
                 "30",
                 "--all-absent-users",
-                "--inform-this-user",
+                "--inform-this-email",
                 informed_user.email,
             ],
         )

--- a/flexmeasures/cli/tests/test_monitor.py
+++ b/flexmeasures/cli/tests/test_monitor.py
@@ -1,0 +1,325 @@
+from datetime import datetime, timedelta, timezone
+
+from flexmeasures.data.models.task_runs import LatestTaskRun
+from flexmeasures.data.models.user import User
+
+
+def test_monitor_help(app):
+    from flexmeasures.cli.monitor import (
+        fm_monitor,
+        monitor_last_seen,
+        monitor_latest_run,
+    )
+
+    runner = app.test_cli_runner()
+
+    result = runner.invoke(fm_monitor, ["--help"])
+    assert result.exit_code == 0
+
+    for command in (monitor_last_seen, monitor_latest_run):
+        result = runner.invoke(command, ["--help"])
+
+        assert result.exit_code == 0
+        assert "--inform-this-user" in result.output
+
+
+def test_get_default_monitoring_email_recipients_prefers_new_config(app, monkeypatch):
+    from flexmeasures.cli import monitor
+
+    monkeypatch.setitem(
+        app.config,
+        "FLEXMEASURES_DEFAULT_MONITORING_MAIL_RECIPIENTS",
+        "new@example.test",
+    )
+    monkeypatch.setitem(
+        app.config,
+        "FLEXMEASURES_MONITORING_MAIL_RECIPIENTS",
+        ["old@example.test"],
+    )
+
+    assert monitor.get_default_monitoring_email_recipients() == ["new@example.test"]
+
+
+def test_get_default_monitoring_email_recipients_falls_back_to_deprecated_config(
+    app, monkeypatch
+):
+    from flexmeasures.cli import monitor
+
+    monkeypatch.setitem(
+        app.config, "FLEXMEASURES_DEFAULT_MONITORING_MAIL_RECIPIENTS", []
+    )
+    monkeypatch.setitem(
+        app.config,
+        "FLEXMEASURES_MONITORING_MAIL_RECIPIENTS",
+        "old@example.test",
+    )
+
+    assert monitor.get_default_monitoring_email_recipients() == ["old@example.test"]
+
+
+def test_monitor_latest_run_informs_requested_users(
+    app, fresh_db, setup_roles_users_fresh_db, monkeypatch
+):
+    from flexmeasures.cli import monitor
+    from flexmeasures.cli.monitor import monitor_latest_run
+
+    monkeypatch.setattr(monitor, "capture_message_for_sentry", lambda msg: None)
+    monkeypatch.setattr(monitor, "set_sentry_context", lambda *args, **kwargs: None)
+    monkeypatch.setitem(
+        app.config,
+        "FLEXMEASURES_DEFAULT_MONITORING_MAIL_RECIPIENTS",
+        ["ops@example.test"],
+    )
+    first_user = fresh_db.session.get(
+        User, setup_roles_users_fresh_db["Test Prosumer User"]
+    )
+    second_user = fresh_db.session.get(
+        User, setup_roles_users_fresh_db["Test Supplier User"]
+    )
+    fresh_db.session.add(
+        LatestTaskRun(
+            name="import-data",
+            datetime=datetime.now(timezone.utc) - timedelta(minutes=5),
+            status=False,
+        )
+    )
+    fresh_db.session.commit()
+
+    with app.mail.record_messages() as outbox:
+        result = app.test_cli_runner().invoke(
+            monitor_latest_run,
+            [
+                "--task",
+                "import-data",
+                "10",
+                "--inform-this-user",
+                str(first_user.id),
+                "--inform-this-user",
+                str(second_user.id),
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert len(outbox) == 1
+    assert outbox[0].bcc == [first_user.email, second_user.email]
+
+
+def test_monitor_latest_run_informs_requested_user_by_email(
+    app, fresh_db, setup_roles_users_fresh_db, monkeypatch
+):
+    from flexmeasures.cli import monitor
+    from flexmeasures.cli.monitor import monitor_latest_run
+
+    monkeypatch.setattr(monitor, "capture_message_for_sentry", lambda msg: None)
+    monkeypatch.setattr(monitor, "set_sentry_context", lambda *args, **kwargs: None)
+    informed_user = fresh_db.session.get(
+        User, setup_roles_users_fresh_db["Test Supplier User"]
+    )
+    fresh_db.session.add(
+        LatestTaskRun(
+            name="import-data",
+            datetime=datetime.now(timezone.utc) - timedelta(minutes=5),
+            status=False,
+        )
+    )
+    fresh_db.session.commit()
+
+    with app.mail.record_messages() as outbox:
+        result = app.test_cli_runner().invoke(
+            monitor_latest_run,
+            [
+                "--task",
+                "import-data",
+                "10",
+                "--inform-this-user",
+                informed_user.email,
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert len(outbox) == 1
+    assert outbox[0].bcc == [informed_user.email]
+
+
+def test_monitor_latest_run_informs_requested_users_by_mixed_identifiers(
+    app, fresh_db, setup_roles_users_fresh_db, monkeypatch
+):
+    from flexmeasures.cli import monitor
+    from flexmeasures.cli.monitor import monitor_latest_run
+
+    monkeypatch.setattr(monitor, "capture_message_for_sentry", lambda msg: None)
+    monkeypatch.setattr(monitor, "set_sentry_context", lambda *args, **kwargs: None)
+    first_user = fresh_db.session.get(
+        User, setup_roles_users_fresh_db["Test Prosumer User"]
+    )
+    second_user = fresh_db.session.get(
+        User, setup_roles_users_fresh_db["Test Supplier User"]
+    )
+    fresh_db.session.add(
+        LatestTaskRun(
+            name="import-data",
+            datetime=datetime.now(timezone.utc) - timedelta(minutes=5),
+            status=False,
+        )
+    )
+    fresh_db.session.commit()
+
+    with app.mail.record_messages() as outbox:
+        result = app.test_cli_runner().invoke(
+            monitor_latest_run,
+            [
+                "--task",
+                "import-data",
+                "10",
+                "--inform-this-user",
+                str(first_user.id),
+                "--inform-this-user",
+                second_user.email,
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert len(outbox) == 1
+    assert outbox[0].bcc == [first_user.email, second_user.email]
+
+
+def test_monitor_latest_run_rejects_unknown_informed_user(app, fresh_db):
+    from flexmeasures.cli.monitor import monitor_latest_run
+
+    result = app.test_cli_runner().invoke(
+        monitor_latest_run,
+        ["--task", "import-data", "10", "--inform-this-user", "9999"],
+    )
+
+    assert result.exit_code != 0
+    assert "No user with ID or email address 9999 exists" in result.output
+
+
+def test_monitor_latest_run_rejects_unknown_informed_user_email(app, fresh_db):
+    from flexmeasures.cli.monitor import monitor_latest_run
+
+    result = app.test_cli_runner().invoke(
+        monitor_latest_run,
+        [
+            "--task",
+            "import-data",
+            "10",
+            "--inform-this-user",
+            "missing@example.test",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert (
+        "No user with ID or email address missing@example.test exists" in result.output
+    )
+
+
+def test_monitor_last_seen_uses_deprecated_config_fallback(
+    app, fresh_db, setup_roles_users_fresh_db, monkeypatch
+):
+    from flexmeasures.cli import monitor
+    from flexmeasures.cli.monitor import monitor_last_seen
+
+    monkeypatch.setattr(monitor, "capture_message_for_sentry", lambda msg: None)
+    monkeypatch.setattr(monitor, "set_sentry_context", lambda *args, **kwargs: None)
+    monkeypatch.setitem(
+        app.config, "FLEXMEASURES_DEFAULT_MONITORING_MAIL_RECIPIENTS", []
+    )
+    monkeypatch.setitem(
+        app.config,
+        "FLEXMEASURES_MONITORING_MAIL_RECIPIENTS",
+        ["ops@example.test"],
+    )
+    absent_user = fresh_db.session.get(
+        User, setup_roles_users_fresh_db["Test Prosumer User"]
+    )
+    absent_user.last_seen_at = datetime.now(timezone.utc) - timedelta(minutes=120)
+    fresh_db.session.commit()
+
+    with app.mail.record_messages() as outbox:
+        result = app.test_cli_runner().invoke(
+            monitor_last_seen,
+            [
+                "--maximum-minutes-since-last-seen",
+                "30",
+                "--all-absent-users",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert len(outbox) == 1
+    assert outbox[0].bcc == ["ops@example.test"]
+
+
+def test_monitor_last_seen_informs_requested_user(
+    app, fresh_db, setup_roles_users_fresh_db, monkeypatch
+):
+    from flexmeasures.cli import monitor
+    from flexmeasures.cli.monitor import monitor_last_seen
+
+    monkeypatch.setattr(monitor, "capture_message_for_sentry", lambda msg: None)
+    monkeypatch.setattr(monitor, "set_sentry_context", lambda *args, **kwargs: None)
+    monkeypatch.setitem(
+        app.config,
+        "FLEXMEASURES_DEFAULT_MONITORING_MAIL_RECIPIENTS",
+        ["ops@example.test"],
+    )
+    absent_user = fresh_db.session.get(
+        User, setup_roles_users_fresh_db["Test Prosumer User"]
+    )
+    informed_user = fresh_db.session.get(
+        User, setup_roles_users_fresh_db["Test Supplier User"]
+    )
+    absent_user.last_seen_at = datetime.now(timezone.utc) - timedelta(minutes=120)
+    fresh_db.session.commit()
+
+    with app.mail.record_messages() as outbox:
+        result = app.test_cli_runner().invoke(
+            monitor_last_seen,
+            [
+                "--maximum-minutes-since-last-seen",
+                "30",
+                "--all-absent-users",
+                "--inform-this-user",
+                str(informed_user.id),
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert len(outbox) == 1
+    assert outbox[0].bcc == [informed_user.email]
+
+
+def test_monitor_last_seen_informs_requested_user_by_email(
+    app, fresh_db, setup_roles_users_fresh_db, monkeypatch
+):
+    from flexmeasures.cli import monitor
+    from flexmeasures.cli.monitor import monitor_last_seen
+
+    monkeypatch.setattr(monitor, "capture_message_for_sentry", lambda msg: None)
+    monkeypatch.setattr(monitor, "set_sentry_context", lambda *args, **kwargs: None)
+    absent_user = fresh_db.session.get(
+        User, setup_roles_users_fresh_db["Test Prosumer User"]
+    )
+    informed_user = fresh_db.session.get(
+        User, setup_roles_users_fresh_db["Test Supplier User"]
+    )
+    absent_user.last_seen_at = datetime.now(timezone.utc) - timedelta(minutes=120)
+    fresh_db.session.commit()
+
+    with app.mail.record_messages() as outbox:
+        result = app.test_cli_runner().invoke(
+            monitor_last_seen,
+            [
+                "--maximum-minutes-since-last-seen",
+                "30",
+                "--all-absent-users",
+                "--inform-this-user",
+                informed_user.email,
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert len(outbox) == 1
+    assert outbox[0].bcc == [informed_user.email]

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -7,7 +7,7 @@
     },
     "termsOfService": null,
     "title": "FlexMeasures",
-    "version": "0.32.0"
+    "version": "0.33.0"
   },
   "externalDocs": {
     "description": "FlexMeasures runs on the open source FlexMeasures technology. Read the docs here.",

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -102,8 +102,9 @@ class Config(object):
     # you probably want to adjust this.
     FLEXMEASURES_SENTRY_CONFIG: dict = dict(traces_sample_rate=0.33)
     FLEXMEASURES_DO_NOT_SEND_NOTFOUND_TO_SENTRY: bool = True
-    FLEXMEASURES_DEFAULT_MONITORING_MAIL_RECIPIENTS: list[str] = []
-    # Deprecated. Use FLEXMEASURES_DEFAULT_MONITORING_MAIL_RECIPIENTS instead.
+    FLEXMEASURES_DEFAULT_MONITORING_MAIL_RECIPIENTS: list[str] = (
+        []
+    )  # Deprecated. Use FLEXMEASURES_DEFAULT_MONITORING_MAIL_RECIPIENTS instead.
     FLEXMEASURES_MONITORING_MAIL_RECIPIENTS: list[str] = []
 
     FLEXMEASURES_PLATFORM_NAME: str | list[str | tuple[str, list[str]]] = "FlexMeasures"

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -102,6 +102,8 @@ class Config(object):
     # you probably want to adjust this.
     FLEXMEASURES_SENTRY_CONFIG: dict = dict(traces_sample_rate=0.33)
     FLEXMEASURES_DO_NOT_SEND_NOTFOUND_TO_SENTRY: bool = True
+    FLEXMEASURES_DEFAULT_MONITORING_MAIL_RECIPIENTS: list[str] = []
+    # Deprecated. Use FLEXMEASURES_DEFAULT_MONITORING_MAIL_RECIPIENTS instead.
     FLEXMEASURES_MONITORING_MAIL_RECIPIENTS: list[str] = []
 
     FLEXMEASURES_PLATFORM_NAME: str | list[str | tuple[str, list[str]]] = "FlexMeasures"


### PR DESCRIPTION
## Description

Our partners ask us to make monitoring more usable to be used per-account, instead of being a site-wide feature (alerting the ame number of recipients for everything). Some of them get alerts they are not really interested in, this also holds for us as hosts.

We  add three improvements, for monitoring users and monitoring tasks:

1. Add a `--recipient` parameter to both  monitor_last_seen() and  monitor_latest_run(), which expects a user ID. It should be possible (via click) to add this parameter more than once (informing more than one user). Check if the ID points to an actual user. If this parameter is not given, then we fall back on FLEXMEASURES_MONITORING_MAIL_RECIPIENTS. In fact, this config setting should be renamed FLEXMEASURES_DEFAULT_MONITORING_MAIL_RECIPIENTS (original one gets deprecated, add a note in the docs for configuration settings). Make it possible that `--recipient` can also receive email addresses as value.

2. monitor_last_seen() gets another parameter `--account`, so the list of users can also be filtered by belonging to a specific account. Also make this possible to be specified multiple times.

3. monitor_last_seen() gets another parameter `--consultancy`. If given, the list of users is filtered by all the accounts which this account is a consultant for. This does not influence which users get notified.


- [x] `--recipient` parameter
- [x] monitor_last_seen() gets another parameter `--account`
- [x] monitor_last_seen() gets another parameter `--consultancy`
- [x] Added changelog item in `documentation/changelog.rst`


## How to test manually

- `uv run flexmeasures monitor last-seen --maximum-minutes-since-last-seen 1000 --account 1 --account 2  --recipient nicolas@seita.nl --task-name monitor-last-seen-account-1`
- `uv run flexmeasures monitor latest-run --task some-task --recipient 55 --inform-this-user nicolas@seita.nl`
- You can also leave out `--recipient nicolas@seita.nl` to see the fallback
- `uv run flexmeasures monitor last-seen --maximum-minutes-since-last-seen 1000 --consultancy 1  --recipient nicolas@seita.nl --task-name monitor-last-seen-account-1-2`

I use mailhog so real mails are not sent and I can still check. The command line outut shows several emails are sent, but mailhog is not showing me that there were multiple copies...

For clean reproducibilty, you can delete the entry about the latest task run: `delete from latest_task_run where name = 'monitor-last-seen-account-1';`

## Further Improvements

I want to add a CLI command to monitor failed jobs.