### PR TITLE
Fix: All use of raw json when updating flex_configs

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -28,7 +28,7 @@ Bugfixes
 -----------
 * Fix forecasting regressor filtering to use only regressor beliefs known at the forecast ``belief_time`` [see `PR #2134 <https://www.github.com/FlexMeasures/flexmeasures/pull/2134>`_]
 * Check read permissions for sensors referenced in forecasting and scheduling config payloads, and return a clearer 403 error when a referenced sensor is not readable [see `PR #2096 <https://www.github.com/FlexMeasures/flexmeasures/pull/2096>`_ and `PR #2125 <https://www.github.com/FlexMeasures/flexmeasures/pull/2125>`_]
-* Corrected flex-config data format for Asset API updates to prevent JSON parsing failures. [see `PR #2149 <https://www.github.com/FlexMeasures/flexmeasures/pull/2149>`_]
+* Corrected flex-config data format for Asset API updates to prevent JSON parsing failures. [see `PR #2162 <https://www.github.com/FlexMeasures/flexmeasures/pull/2162>`_]
 
 
 v0.32.1 | May 5, 2026

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -28,6 +28,7 @@ Bugfixes
 -----------
 * Fix forecasting regressor filtering to use only regressor beliefs known at the forecast ``belief_time`` [see `PR #2134 <https://www.github.com/FlexMeasures/flexmeasures/pull/2134>`_]
 * Check read permissions for sensors referenced in forecasting and scheduling config payloads, and return a clearer 403 error when a referenced sensor is not readable [see `PR #2096 <https://www.github.com/FlexMeasures/flexmeasures/pull/2096>`_ and `PR #2125 <https://www.github.com/FlexMeasures/flexmeasures/pull/2125>`_]
+* Corrected flex-config data format for Asset API updates to prevent JSON parsing failures. [see `PR #2149 <https://www.github.com/FlexMeasures/flexmeasures/pull/2149>`_]
 
 
 v0.32.1 | May 5, 2026

--- a/flexmeasures/api/v3_0/tests/test_assets_api_fresh_db.py
+++ b/flexmeasures/api/v3_0/tests/test_assets_api_fresh_db.py
@@ -75,6 +75,7 @@ def test_delete_an_asset(client, setup_api_fresh_test_data, requesting_user, db)
     assert deleted_asset is None
 
 
+@pytest.mark.parametrize("requesting_user", ["test_admin_user@seita.nl"], indirect=True)
 def test_patch_asset_accepts_flex_context_object(
     client, setup_api_fresh_test_data, requesting_user, fresh_db
 ):

--- a/flexmeasures/api/v3_0/tests/test_assets_api_fresh_db.py
+++ b/flexmeasures/api/v3_0/tests/test_assets_api_fresh_db.py
@@ -73,3 +73,29 @@ def test_delete_an_asset(client, setup_api_fresh_test_data, requesting_user, db)
         select(GenericAsset).filter_by(id=existing_asset_id)
     ).scalar_one_or_none()
     assert deleted_asset is None
+
+
+def test_patch_asset_accepts_flex_context_object(
+    client, setup_api_fresh_test_data, requesting_user, fresh_db
+):
+    db = fresh_db
+    with AccountContext("Test Supplier Account") as supplier:
+        existing_asset = supplier.generic_assets[0]
+    assert existing_asset.flex_context == {}
+
+    patch_data = {
+        "flex_context": {
+            "site-power-capacity": "1000 kW",
+        }
+    }
+    response = client.patch(
+        url_for("AssetAPI:patch", id=existing_asset.id),
+        json=patch_data,
+    )
+
+    assert response.status_code == 200
+    updated_asset = db.session.execute(
+        select(GenericAsset).filter_by(id=existing_asset.id)
+    ).scalar_one_or_none()
+    assert updated_asset is not None
+    assert updated_asset.flex_context["site-power-capacity"] == "1000 kW"

--- a/flexmeasures/data/schemas/attributes.py
+++ b/flexmeasures/data/schemas/attributes.py
@@ -6,11 +6,19 @@ from marshmallow import fields, ValidationError
 
 
 class JSON(fields.Field):
-    def _deserialize(self, value, attr, data, **kwargs) -> dict:
-        try:
-            return json.loads(value)
-        except ValueError:
-            raise ValidationError("Not a valid JSON string.")
+    def _deserialize(self, value, attr, data, **kwargs):
+        # Accept already-deserialized JSON values from request parsers.
+        if isinstance(value, (dict, list, int, float, bool)) or value is None:
+            return value
+
+        # Backward-compatible path: allow JSON-encoded strings.
+        if isinstance(value, (str, bytes, bytearray)):
+            try:
+                return json.loads(value)
+            except ValueError:
+                raise ValidationError("Not a valid JSON string.")
+
+        raise ValidationError("Not a valid JSON value.")
 
     def _serialize(self, value, attr, obj, **kwargs) -> str:
         return json.dumps(value)


### PR DESCRIPTION
## Description

In this PR I fixed a bug where RAW JSON had to be loaded before it can be parsed as a flex-config. These forced users to take extra steps just to modify flex-configs.

## Look & Feel

Before
<img width="529" height="127" alt="image" src="https://github.com/user-attachments/assets/d0266109-e6da-4d08-aa16-fd99e086e75d" />

After
<img width="529" height="376" alt="image" src="https://github.com/user-attachments/assets/dbbb3aa6-25b4-4c69-9ba0-138b197e7ade" />


## How to test

I noticed i didn't experience this issue while use a `http` client like "insomnia" you'll probably also not experience it if you use POSTMAN as well. But rather running it though a python script reveals the issue.

Use this script for testing
```
import requests

token = "xxxxxxxxxxxxxxxxxxxxxxxx"

res = requests.patch("http://localhost:5000/api/v3_0/assets/<asset_id>",
    headers = {
        "Authorization": <token>,
    },
    json={
        "flex_context":
        {
            "site-power-capacity":"1000 kW"
        }
    }
)
print(res.text)
```

## Further Improvements

None

## Related Items

This PR closes #2144

#### Sign-off

<!--
We ask contributors outside the FlexMeasures organisation to sign off on their contribution.
Please mark the below fields with an [x].
-->

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
