### PR TITLE
Fix auth check when running CLI command with `flask`

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -29,6 +29,7 @@ Bugfixes
 * Fix forecasting regressor filtering to use only regressor beliefs known at the forecast ``belief_time`` [see `PR #2134 <https://www.github.com/FlexMeasures/flexmeasures/pull/2134>`_]
 * Check read permissions for sensors referenced in forecasting and scheduling config payloads, and return a clearer 403 error when a referenced sensor is not readable [see `PR #2096 <https://www.github.com/FlexMeasures/flexmeasures/pull/2096>`_ and `PR #2125 <https://www.github.com/FlexMeasures/flexmeasures/pull/2125>`_]
 * Standardize resolution formatting across API endpoints for consistent response payloads [see `PR #2152 <https://www.github.com/FlexMeasures/flexmeasures/pull/2152>`_]
+* Make the auth check for CLI commands work with ``flask``, too, instead of only with the ``flexmeasures`` alias [see `PR #2169 <https://www.github.com/FlexMeasures/flexmeasures/pull/2169>`_]
 
 
 v0.32.2 | May 12, 2026

--- a/flexmeasures/cli/__init__.py
+++ b/flexmeasures/cli/__init__.py
@@ -37,7 +37,10 @@ def is_running() -> bool:
     cli_sets = current_app.cli.list_commands(ctx=None)
     command_line = " ".join(sys.argv)
     for cli_set in cli_sets:
-        if f"flexmeasures {cli_set}" in command_line:
+        if (
+            f"flexmeasures {cli_set}" in command_line
+            or f"flask {cli_set}" in command_line
+        ):
             return True
     if current_app.config.get("PRETEND_RUNNING_AS_CLI", False):
         return True


### PR DESCRIPTION
## Description

- [x] Fix issue I ran into when running `flask weather get-weather-forecasts --location 30,40` instead of `flexmeasures weather ...`
- [x] Added changelog item in `documentation/changelog.rst`

## Look & Feel

<!--
This section can contain example pictures for the UI, Input/Output for the CLI, Request / Response for an API endpoint, etc.
-->

...

## How to test

<!--
Steps to test it or name of the tests functions.

The library [flexmeasures-client](https://github.com/FlexMeasures/flexmeasures-client/) can be useful to showcase new features.
For example, it can be used to set some example data to be used in a new UI feature.
-->

...

## Further Improvements

<!--
Potential improvements to be done in the same PR or follow-up Issues/Discussions/PRs.
-->

...

## Related Items

I ran into this while testing https://github.com/FlexMeasures/flexmeasures-weather/pull/13.