### PR TITLE
Feat/speed up stats panel on sensor page

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -25,6 +25,7 @@ Infrastructure / Support
 * Run ``flexmeasures jobs run-worker`` with RQ's embedded scheduler on by default so jobs created with ``enqueue_in`` are promoted from the scheduled registry when due; pass ``--without-scheduler`` to disable [see `PR #2112 <https://www.github.com/FlexMeasures/flexmeasures/pull/2112>`_]
 * Support filtering time series data by data source account [`PR #2065 <https://www.github.com/FlexMeasures/flexmeasures/pull/2065>`_]
 * Speed up finding the data sources associated with a sensor and the sensors associated with a data source [`PR #2151 <https://www.github.com/FlexMeasures/flexmeasures/pull/2151>`_]
+* Speed up sensor stats, especially potent when viewing sensors stats over a large sensor history [`PR #2173 <https://www.github.com/FlexMeasures/flexmeasures/pull/2173>`_]
 
 Bugfixes
 -----------

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -815,27 +815,10 @@ def _get_sensor_stats(
     start_dt = pd.to_datetime(event_start_time) if event_start_time else None
     end_dt = pd.to_datetime(event_end_time) if event_end_time else None
 
-    # Subquery for filtered aggregates
-    subq = sa.select(
-        TimedBelief.source_id,
-        sa.func.max(TimedBelief.event_value).label("max_event_value"),
-        sa.func.avg(TimedBelief.event_value).label("avg_event_value"),
-        sa.func.sum(TimedBelief.event_value).label("sum_event_value"),
-        sa.func.min(TimedBelief.event_value).label("min_event_value"),
-    ).filter(
-        TimedBelief.event_value != float("NaN"),
-        TimedBelief.sensor_id == sensor.id,
-    )
+    # In PostgreSQL NaN = NaN is TRUE (unlike IEEE-754), so this predicate correctly excludes NaN rows from value aggregates while keeping them in the row count.
+    # We pass it to aggregate FILTER clauses so that the planner can compute all aggregates in a single pass over the belief rows.
+    not_nan = TimedBelief.event_value != float("nan")
 
-    # apply start/end filters if provided
-    if start_dt:
-        subq = subq.filter(TimedBelief.event_start >= start_dt)
-    if end_dt:
-        subq = subq.filter(TimedBelief.event_start < end_dt)
-
-    subquery_for_filtered_aggregates = subq.group_by(TimedBelief.source_id).subquery()
-
-    # build main query
     q = (
         sa.select(
             DataSource,
@@ -846,36 +829,31 @@ def _get_sensor_stats(
                 + sensor.event_resolution
                 - TimedBelief.belief_horizon
             ).label("max_belief_time"),
-            subquery_for_filtered_aggregates.c.min_event_value,
-            subquery_for_filtered_aggregates.c.max_event_value,
-            subquery_for_filtered_aggregates.c.avg_event_value,
-            subquery_for_filtered_aggregates.c.sum_event_value,
+            sa.func.min(TimedBelief.event_value)
+            .filter(not_nan)
+            .label("min_event_value"),
+            sa.func.max(TimedBelief.event_value)
+            .filter(not_nan)
+            .label("max_event_value"),
+            sa.func.avg(TimedBelief.event_value)
+            .filter(not_nan)
+            .label("avg_event_value"),
+            sa.func.sum(TimedBelief.event_value)
+            .filter(not_nan)
+            .label("sum_event_value"),
             sa.func.count(TimedBelief.event_value).label("count_event_value"),
         )
         .select_from(TimedBelief)
         .join(DataSource, DataSource.id == TimedBelief.source_id)
-        .join(
-            subquery_for_filtered_aggregates,
-            subquery_for_filtered_aggregates.c.source_id == TimedBelief.source_id,
-        )
         .filter(TimedBelief.sensor_id == sensor.id)
     )
 
-    # apply the same start/end filters to the main query
     if start_dt:
         q = q.filter(TimedBelief.event_start >= start_dt)
     if end_dt:
         q = q.filter(TimedBelief.event_start < end_dt)
 
-    raw_stats = db.session.execute(
-        q.group_by(
-            DataSource.id,
-            subquery_for_filtered_aggregates.c.min_event_value,
-            subquery_for_filtered_aggregates.c.max_event_value,
-            subquery_for_filtered_aggregates.c.avg_event_value,
-            subquery_for_filtered_aggregates.c.sum_event_value,
-        )
-    ).fetchall()
+    raw_stats = db.session.execute(q.group_by(DataSource.id)).fetchall()
 
     stats = dict()
     for row in raw_stats:

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -819,6 +819,9 @@ def _get_sensor_stats(
     # We pass it to aggregate FILTER clauses so that the planner can compute all aggregates in a single pass over the belief rows.
     not_nan = TimedBelief.event_value != float("nan")
 
+    def filtered_agg(func):
+        return func(TimedBelief.event_value).filter(not_nan)
+
     q = (
         sa.select(
             DataSource,
@@ -829,18 +832,10 @@ def _get_sensor_stats(
                 + sensor.event_resolution
                 - TimedBelief.belief_horizon
             ).label("max_belief_time"),
-            sa.func.min(TimedBelief.event_value)
-            .filter(not_nan)
-            .label("min_event_value"),
-            sa.func.max(TimedBelief.event_value)
-            .filter(not_nan)
-            .label("max_event_value"),
-            sa.func.avg(TimedBelief.event_value)
-            .filter(not_nan)
-            .label("avg_event_value"),
-            sa.func.sum(TimedBelief.event_value)
-            .filter(not_nan)
-            .label("sum_event_value"),
+            filtered_agg(sa.func.min).label("min_event_value"),
+            filtered_agg(sa.func.max).label("max_event_value"),
+            filtered_agg(sa.func.avg).label("avg_event_value"),
+            filtered_agg(sa.func.sum).label("sum_event_value"),
             sa.func.count(TimedBelief.event_value).label("count_event_value"),
         )
         .select_from(TimedBelief)
@@ -855,35 +850,27 @@ def _get_sensor_stats(
 
     raw_stats = db.session.execute(q.group_by(DataSource.id)).fetchall()
 
+    def to_local_iso(ts):
+        return pd.Timestamp(ts).tz_convert(sensor.timezone).isoformat()
+
     stats = dict()
-    for row in raw_stats:
-        (
-            data_source_obj,
-            min_event_start,
-            max_event_start,
-            max_belief_time,
-            min_value,
-            max_value,
-            mean_value,
-            sum_values,
-            count_values,
-        ) = row
-        first_event_start = (
-            pd.Timestamp(min_event_start).tz_convert(sensor.timezone).isoformat()
-        )
-        last_event_end = (
-            pd.Timestamp(max_event_start + sensor.event_resolution)
-            .tz_convert(sensor.timezone)
-            .isoformat()
-        )
-        last_belief_time = (
-            pd.Timestamp(max_belief_time).tz_convert(sensor.timezone).isoformat()
-        )
+    for (
+        data_source_obj,
+        min_event_start,
+        max_event_start,
+        max_belief_time,
+        min_value,
+        max_value,
+        mean_value,
+        sum_values,
+        count_values,
+    ) in raw_stats:
         data_source = f"{data_source_obj.description} (ID: {data_source_obj.id})"
+        last_event_end = max_event_start + sensor.event_resolution
         stats[data_source] = {
-            "First event start": first_event_start,
-            "Last event end": last_event_end,
-            "Last recorded": last_belief_time,
+            "First event start": to_local_iso(min_event_start),
+            "Last event end": to_local_iso(last_event_end),
+            "Last recorded": to_local_iso(max_belief_time),
             "Min value": min_value,
             "Max value": max_value,
             "Mean value": mean_value,

--- a/flexmeasures/data/services/sensors.py
+++ b/flexmeasures/data/services/sensors.py
@@ -877,7 +877,7 @@ def _get_sensor_stats(
             "Sum over values": sum_values,
             "Number of values": count_values,
         }
-        if sort_keys is False:
+        if not sort_keys:
             stats[data_source] = stats[data_source].items()
     return stats
 


### PR DESCRIPTION
## Description

- [x] Faster sensor stats by filtering NaN values without the need for a subquery.
- [x] Added changelog item in `documentation/changelog.rst`

## Look & Feel

For over >10M rows, the sensors stats query would take too long to show on the sensor page. Now it shows again.

## How to test

Use the stats widget on a sensor page.

## Further Improvements

<!--
Potential improvements to be done in the same PR or follow-up Issues/Discussions/PRs.
-->

...

## Related Items

Closes #2174.
