### PR TITLE
Fix/force new job when scheduling an asset (tree)

### DIFF
--- a/documentation/api/change_log.rst
+++ b/documentation/api/change_log.rst
@@ -5,10 +5,12 @@ API change log
 
 .. note:: The FlexMeasures API follows its own versioning scheme. This is also reflected in the URL (e.g. `/api/v3_0`), allowing developers to upgrade at their own pace.
 
-v3.0-31 | 2026-04-28
+v3.0-31 | 2026-05-20
 """"""""""""""""""""
 
 - Added a unified job status endpoint ``GET /api/v3_0/jobs/<uuid>`` that returns the current execution status and a human-readable result message for any background job (scheduling, forecasting, etc.) identified by its UUID.
+- Switched from ``force_new_job_creation`` to ``force-new-job-creation`` (maintaining backwards compatibility) and added the field to `/assets/(id)/schedules/trigger` (POST) endpoint, too.
+- Support both snake_case and kebab-case fields in `/sensors/<id>/data` (GET), while only documenting the kebab-case ones.
 
 v3.0-30 | 2026-04-15
 """"""""""""""""""""

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -42,6 +42,7 @@ Bugfixes
 -----------
 * Fix forecasting regressor filtering to use only regressor beliefs known at the forecast ``belief_time`` [see `PR #2134 <https://www.github.com/FlexMeasures/flexmeasures/pull/2134>`_]
 * Check read permissions for sensors referenced in forecasting and scheduling config payloads, and return a clearer 403 error when a referenced sensor is not readable [see `PR #2096 <https://www.github.com/FlexMeasures/flexmeasures/pull/2096>`_ and `PR #2125 <https://www.github.com/FlexMeasures/flexmeasures/pull/2125>`_]
+* Add the missing ``force-new-job-creation`` field for triggering a schedule on an asset (tree) [see `PR #2182 <https://www.github.com/FlexMeasures/flexmeasures/pull/2182>`_]
 * Clean up stale sensor references from ``flex-config`` and ``sensors_to_show`` when deleting a sensor, using JSONB queries to find affected assets before pruning those references [see `PR #2106 <https://www.github.com/FlexMeasures/flexmeasures/pull/2106>`_]
 * Standardize resolution formatting across API endpoints for consistent response payloads [see `PR #2152 <https://www.github.com/FlexMeasures/flexmeasures/pull/2152>`_]
 * Make the auth check for CLI commands work with ``flask``, too, instead of only with the ``flexmeasures`` alias [see `PR #2169 <https://www.github.com/FlexMeasures/flexmeasures/pull/2169>`_]

--- a/flexmeasures/api/common/schemas/sensor_data.py
+++ b/flexmeasures/api/common/schemas/sensor_data.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 
 from flask_login import current_user
 from isodate import datetime_isoformat
-from marshmallow import fields, post_load, validates_schema, ValidationError
+from marshmallow import fields, post_load, pre_load, validates_schema, ValidationError
 from marshmallow.validate import OneOf, Length
 from marshmallow_polyfield import PolyField
 from timely_beliefs import BeliefsDataFrame
@@ -184,6 +184,11 @@ class GetSensorDataFilterSchemaMixin:
             example="forecaster",
         ),
     )
+
+    @pre_load
+    def support_legacy_field_name(self, data, **kwargs):
+        """Accept old snake_case input for backwards compatibility."""
+        return {key.replace("_", "-"): value for key, value in data.items()}
 
 
 class GetSensorDataSchema(GetSensorDataFilterSchemaMixin, SensorDataDescriptionSchema):

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -1341,6 +1341,7 @@ class AssetAPI(FlaskView):
         flex_model: dict | None = None,
         flex_context: dict | None = None,
         sequential: bool = False,
+        force_new_job_creation: bool | None = False,
         **kwargs,
     ):
         """
@@ -1513,7 +1514,12 @@ class AssetAPI(FlaskView):
         else:
             f = create_simultaneous_scheduling_job
         try:
-            job = f(asset=asset, enqueue=True, **scheduler_kwargs)
+            job = f(
+                asset=asset,
+                enqueue=True,
+                force_new_job_creation=force_new_job_creation,
+                **scheduler_kwargs,
+            )
         except ValidationError as err:
             return unprocessable_entity(err.messages)
         except ValueError as err:

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -12,7 +12,7 @@ from flask import current_app, url_for, request
 from flask_classful import FlaskView, route
 from flask_json import as_json
 from flask_security import auth_required, current_user
-from marshmallow import fields, Schema, ValidationError, validates_schema
+from marshmallow import fields, pre_load, Schema, ValidationError, validates_schema
 import marshmallow.validate as validate
 from rq.job import Job, JobStatus, NoSuchJobError
 import timely_beliefs as tb
@@ -267,11 +267,20 @@ class TriggerScheduleKwargsSchema(Schema):
         ),
     )
     force_new_job_creation = fields.Boolean(
+        data_key="force-new-job-creation",
         required=False,
         metadata=dict(
             description="If True, this bypasses the cache that the server keeps for results of scheduling jobs. This cache helps prevents redundant computation when schedules with the exact same request parameters are triggered.",
         ),
     )
+
+    @pre_load
+    def support_legacy_field_name(self, data, **kwargs):
+        """Accept old snake_case input for backwards compatibility."""
+        if "force_new_job_creation" in data and "force-new-job-creation" not in data:
+            data["force-new-job-creation"] = data["force_new_job_creation"]
+
+        return data
 
 
 class SensorAPI(FlaskView):

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -278,7 +278,7 @@ class TriggerScheduleKwargsSchema(Schema):
     def support_legacy_field_name(self, data, **kwargs):
         """Accept old snake_case input for backwards compatibility."""
         if "force_new_job_creation" in data and "force-new-job-creation" not in data:
-            data["force-new-job-creation"] = data["force_new_job_creation"]
+            data["force-new-job-creation"] = data.pop("force_new_job_creation")
 
         return data
 

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -976,6 +976,7 @@ class AssetTriggerSchema(Schema):
         ),
     )
     force_new_job_creation = fields.Boolean(
+        data_key="force-new-job-creation",
         required=False,
         metadata=dict(
             description="If True, this bypasses the cache that the server keeps for results of scheduling jobs. This cache helps prevents redundant computation when schedules with the exact same request parameters are triggered.",

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -975,6 +975,12 @@ class AssetTriggerSchema(Schema):
             description="If true, each asset within the asset tree is scheduled one after the other, where the next schedule takes into account the previously scheduled assets as inflexible device.",
         ),
     )
+    force_new_job_creation = fields.Boolean(
+        required=False,
+        metadata=dict(
+            description="If True, this bypasses the cache that the server keeps for results of scheduling jobs. This cache helps prevents redundant computation when schedules with the exact same request parameters are triggered.",
+        ),
+    )
 
     @validates_schema
     def check_flex_model_sensors(self, data, **kwargs):

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -6158,6 +6158,10 @@
             "type": "boolean",
             "default": false,
             "description": "If true, each asset within the asset tree is scheduled one after the other, where the next schedule takes into account the previously scheduled assets as inflexible device."
+          },
+          "force_new_job_creation": {
+            "type": "boolean",
+            "description": "If True, this bypasses the cache that the server keeps for results of scheduling jobs. This cache helps prevents redundant computation when schedules with the exact same request parameters are triggered."
           }
         },
         "required": [

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -5832,7 +5832,7 @@
             "description": "The flex-context is validated according to the scheduler's `FlexContextSchema`.",
             "additionalProperties": {}
           },
-          "force_new_job_creation": {
+          "force-new-job-creation": {
             "type": "boolean",
             "description": "If True, this bypasses the cache that the server keeps for results of scheduling jobs. This cache helps prevents redundant computation when schedules with the exact same request parameters are triggered."
           }
@@ -6159,7 +6159,7 @@
             "default": false,
             "description": "If true, each asset within the asset tree is scheduled one after the other, where the next schedule takes into account the previously scheduled assets as inflexible device."
           },
-          "force_new_job_creation": {
+          "force-new-job-creation": {
             "type": "boolean",
             "description": "If True, this bypasses the cache that the server keeps for results of scheduling jobs. This cache helps prevents redundant computation when schedules with the exact same request parameters are triggered."
           }


### PR DESCRIPTION
## Description

- [x] Move `force_new_job_creation` field (not mentioned in Sphinx docs) from snake_case to kebab-case, while maintaining backwards compatibility, for instance, for the flexmeasures-client
- [x] Add missing `force-new-job-creation` for asset schedule trigger endpoint (related: https://github.com/FlexMeasures/flexmeasures-client/issues/207)
- [x] Initiate a more general policy to document input fields using kebab-case, while also supporting snake_case input fields. In some cases for backwards compatibility, but in other cases actually expanding what we accept as valid input. Here, it's the latter. Specifically, the endpoint for fetching sensor data will now happily accept `source_type` and `source_account`, too, which makes it slightly more straightforward to work with the `client.get_sensor_data` method in the flexmeasures-client.
- [x] Added changelog item in `documentation/changelog.rst`

## Look & Feel

<!--
This section can contain example pictures for the UI, Input/Output for the CLI, Request / Response for an API endpoint, etc.
-->

...

## How to test

<!--
Steps to test it or name of the tests functions.

The library [flexmeasures-client](https://github.com/FlexMeasures/flexmeasures-client/) can be useful to showcase new features.
For example, it can be used to set some example data to be used in a new UI feature.
-->

...

## Further Improvements

<!--
Potential improvements to be done in the same PR or follow-up Issues/Discussions/PRs.
-->

...

## Related Items

<!--
Mention if this PR closes an Issue or Project.
-->

...
