### PR TITLE
Fix: visually distinguish data sources beyond source name

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -34,6 +34,7 @@ Bugfixes
 * Check read permissions for sensors referenced in forecasting and scheduling config payloads, and return a clearer 403 error when a referenced sensor is not readable [see `PR #2096 <https://www.github.com/FlexMeasures/flexmeasures/pull/2096>`_ and `PR #2125 <https://www.github.com/FlexMeasures/flexmeasures/pull/2125>`_]
 * Standardize resolution formatting across API endpoints for consistent response payloads [see `PR #2152 <https://www.github.com/FlexMeasures/flexmeasures/pull/2152>`_]
 * Make the auth check for CLI commands work with ``flask``, too, instead of only with the ``flexmeasures`` alias [see `PR #2169 <https://www.github.com/FlexMeasures/flexmeasures/pull/2169>`_]
+* Distinguish data sources with duplicate names in chart legends without showing source IDs [see `PR #2185 <https://www.github.com/FlexMeasures/flexmeasures/pull/2185>`_]
 
 
 v0.32.3 | May 15, 2026

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -8,6 +8,9 @@ from flexmeasures.data.models.charts.defaults import (
     REPLAY_RULER,
     STROKE_WIDTH,
 )
+from flexmeasures.data.models.charts.utils import (
+    source_name_and_optional_id_transformation,
+)
 from flexmeasures.utils.flexmeasures_inflection import (
     capitalize,
 )
@@ -103,7 +106,9 @@ def create_bar_chart_or_histogram_specs(
                     "stroke": {
                         "condition": {
                             "test": "datum.event_value === 0",
-                            "field": FIELD_DEFINITIONS["source_name"]["field"],
+                            "field": FIELD_DEFINITIONS["source_name_and_optional_id"][
+                                "field"
+                            ],
                         },
                         "value": None,
                     },
@@ -114,8 +119,7 @@ def create_bar_chart_or_histogram_specs(
                         },
                         "value": 0,
                     },
-                    "color": FIELD_DEFINITIONS["source_name"],
-                    "detail": FIELD_DEFINITIONS["source"],
+                    "color": FIELD_DEFINITIONS["source_name_and_optional_id"],
                     "opacity": {"value": 0.7},
                     "tooltip": [
                         (
@@ -136,6 +140,7 @@ def create_bar_chart_or_histogram_specs(
                         "calculate": "datum.source.name + ' (ID: ' + datum.source.id + ')'",
                         "as": "source_name_and_id",
                     },
+                    *source_name_and_optional_id_transformation,
                 ],
                 "selection": {
                     "scroll": {"type": "interval", "bind": "scales", "encodings": ["x"]}

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -132,6 +132,7 @@ def create_bar_chart_or_histogram_specs(
                         FIELD_DEFINITIONS["source_name_and_id"],
                         FIELD_DEFINITIONS["source_display_type"],
                         FIELD_DEFINITIONS["source_model"],
+                        FIELD_DEFINITIONS["source_version"],
                     ],
                 },
                 "transform": [
@@ -333,6 +334,7 @@ def heatmap(
         },
         FIELD_DEFINITIONS["source_name_and_id"],
         FIELD_DEFINITIONS["source_model"],
+        FIELD_DEFINITIONS["source_version"],
     ]
     chart_specs = {
         "description": f"A {split} heatmap showing sensor data.",
@@ -587,6 +589,7 @@ def _setup_shared_tooltip(
         FIELD_DEFINITIONS["source_name_and_id"],
         FIELD_DEFINITIONS["source_display_type"],
         FIELD_DEFINITIONS["source_model"],
+        FIELD_DEFINITIONS["source_version"],
     ]
 
 

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -9,7 +9,7 @@ from flexmeasures.data.models.charts.defaults import (
     STROKE_WIDTH,
 )
 from flexmeasures.data.models.charts.utils import (
-    source_name_and_optional_id_transformation,
+    source_legend_label_transformation,
 )
 from flexmeasures.utils.flexmeasures_inflection import (
     capitalize,
@@ -106,9 +106,7 @@ def create_bar_chart_or_histogram_specs(
                     "stroke": {
                         "condition": {
                             "test": "datum.event_value === 0",
-                            "field": FIELD_DEFINITIONS["source_name_and_optional_id"][
-                                "field"
-                            ],
+                            "field": FIELD_DEFINITIONS["source_legend_label"]["field"],
                         },
                         "value": None,
                     },
@@ -119,7 +117,7 @@ def create_bar_chart_or_histogram_specs(
                         },
                         "value": 0,
                     },
-                    "color": FIELD_DEFINITIONS["source_name_and_optional_id"],
+                    "color": FIELD_DEFINITIONS["source_legend_label"],
                     "opacity": {"value": 0.7},
                     "tooltip": [
                         (
@@ -132,6 +130,7 @@ def create_bar_chart_or_histogram_specs(
                             **dict(title=f"{capitalize(sensor.sensor_type)}"),
                         },
                         FIELD_DEFINITIONS["source_name_and_id"],
+                        FIELD_DEFINITIONS["source_display_type"],
                         FIELD_DEFINITIONS["source_model"],
                     ],
                 },
@@ -140,7 +139,7 @@ def create_bar_chart_or_histogram_specs(
                         "calculate": "datum.source.name + ' (ID: ' + datum.source.id + ')'",
                         "as": "source_name_and_id",
                     },
-                    *source_name_and_optional_id_transformation,
+                    *source_legend_label_transformation,
                 ],
                 "selection": {
                     "scroll": {"type": "interval", "bind": "scales", "encodings": ["x"]}
@@ -586,7 +585,7 @@ def _setup_shared_tooltip(
         ),
         {**event_value_field_definition, **dict(title=f"{capitalize(sensor_type)}")},
         FIELD_DEFINITIONS["source_name_and_id"],
-        FIELD_DEFINITIONS["source_type"],
+        FIELD_DEFINITIONS["source_display_type"],
         FIELD_DEFINITIONS["source_model"],
     ]
 

--- a/flexmeasures/data/models/charts/belief_charts.py
+++ b/flexmeasures/data/models/charts/belief_charts.py
@@ -133,7 +133,7 @@ def create_bar_chart_or_histogram_specs(
                 },
                 "transform": [
                     {
-                        "calculate": "datum.source.id >= 0 ? datum.source.name + ' (ID: ' + datum.source.id + ')' : datum.source.name",
+                        "calculate": "datum.source.name + ' (ID: ' + datum.source.id + ')'",
                         "as": "source_name_and_id",
                     },
                 ],
@@ -350,7 +350,7 @@ def heatmap(
                         "filter": "timezoneoffset(datum.event_start) >= timezoneoffset(datum.event_start + 60 * 60 * 1000) && timezoneoffset(datum.event_start) <= timezoneoffset(datum.event_start - 60 * 60 * 1000)"
                     },
                     {
-                        "calculate": "datum.source.id >= 0 ? datum.source.name + ' (ID: ' + datum.source.id + ')' : datum.source.name",
+                        "calculate": "datum.source.name + ' (ID: ' + datum.source.id + ')'",
                         "as": "source_name_and_id",
                     },
                     # In case of multiple sources, show the one with the most visible data
@@ -485,7 +485,7 @@ def create_fall_dst_transition_layer(
                 "as": "dst_transition_event_start_next",
             },
             {
-                "calculate": "datum.source.id >= 0 ? datum.source.name + ' (ID: ' + datum.source.id + ')' : datum.source.name",
+                "calculate": "datum.source.name + ' (ID: ' + datum.source.id + ')'",
                 "as": "source_name_and_id",
             },
         ],
@@ -640,7 +640,7 @@ def _build_chart_specs(
         vconcat=[*sensors_specs],
         transform=[
             {
-                "calculate": "datum.source.id >= 0 ? datum.source.name + ' (ID: ' + datum.source.id + ')' : datum.source.name",
+                "calculate": "datum.source.name + ' (ID: ' + datum.source.id + ')'",
                 "as": "source_name_and_id",
             },
         ],

--- a/flexmeasures/data/models/charts/defaults.py
+++ b/flexmeasures/data/models/charts/defaults.py
@@ -54,6 +54,11 @@ FIELD_DEFINITIONS = {
         type="nominal",
         title="Type",
     ),
+    "source_display_type": dict(
+        field="source.display_type",
+        type="nominal",
+        title="Type",
+    ),
     "source_name": dict(
         field="source.name",
         type="nominal",
@@ -74,8 +79,8 @@ FIELD_DEFINITIONS = {
         type="nominal",
         title="Source",
     ),
-    "source_name_and_optional_id": dict(
-        field="source_name_and_optional_id",
+    "source_legend_label": dict(
+        field="source_legend_label",
         type="nominal",
         title="Source",
     ),

--- a/flexmeasures/data/models/charts/defaults.py
+++ b/flexmeasures/data/models/charts/defaults.py
@@ -69,6 +69,11 @@ FIELD_DEFINITIONS = {
         type="nominal",
         title="Model",
     ),
+    "source_version": dict(
+        field="source.version",
+        type="nominal",
+        title="Version",
+    ),
     "full_date": dict(
         field="full_date",
         type="nominal",

--- a/flexmeasures/data/models/charts/defaults.py
+++ b/flexmeasures/data/models/charts/defaults.py
@@ -74,6 +74,11 @@ FIELD_DEFINITIONS = {
         type="nominal",
         title="Source",
     ),
+    "source_name_and_optional_id": dict(
+        field="source_name_and_optional_id",
+        type="nominal",
+        title="Source",
+    ),
 }
 REPLAY_RULER = {
     "data": {"name": "replay"},

--- a/flexmeasures/data/models/charts/utils.py
+++ b/flexmeasures/data/models/charts/utils.py
@@ -1,0 +1,12 @@
+source_name_and_optional_id_transformation = [
+    {
+        "joinaggregate": [
+            {"op": "distinct", "field": "source.id", "as": "distinct_ids_per_name"}
+        ],
+        "groupby": ["source.name"],
+    },
+    {
+        "calculate": "datum.distinct_ids_per_name > 1 ? datum.source.name + ' (ID: ' + datum.source.id + ')' : datum.source.name",
+        "as": "source_name_and_optional_id",
+    },
+]

--- a/flexmeasures/data/models/charts/utils.py
+++ b/flexmeasures/data/models/charts/utils.py
@@ -1,3 +1,10 @@
+"""Shared Vega-Lite transforms for chart source labels.
+
+The source legend label transform keeps ``source.name`` visible and appends the
+shortest available metadata that distinguishes sources with duplicate names. It
+falls back to ``source.id`` only when non-ID source metadata is identical.
+"""
+
 source_legend_label_transformation = [
     {
         "calculate": "datum.source.display_type || datum.source.raw_type || datum.source.type || ''",

--- a/flexmeasures/data/models/charts/utils.py
+++ b/flexmeasures/data/models/charts/utils.py
@@ -11,6 +11,14 @@ source_legend_label_transformation = [
         "as": "source_display_type",
     },
     {
+        "calculate": "datum.source.model || ''",
+        "as": "source_model_detail",
+    },
+    {
+        "calculate": "datum.source.version ? 'v' + datum.source.version : ''",
+        "as": "source_version_detail",
+    },
+    {
         "joinaggregate": [
             {
                 "op": "distinct",
@@ -35,7 +43,27 @@ source_legend_label_transformation = [
         "groupby": ["source.name", "source_type_detail"],
     },
     {
-        "calculate": "datum.source.model ? (datum.source_type_detail ? datum.source_type_detail + ' ' + datum.source.model : datum.source.model) : datum.source_type_detail",
+        "joinaggregate": [
+            {
+                "op": "distinct",
+                "field": "source.id",
+                "as": "distinct_ids_per_source_name_and_model",
+            }
+        ],
+        "groupby": ["source.name", "source_model_detail"],
+    },
+    {
+        "joinaggregate": [
+            {
+                "op": "distinct",
+                "field": "source.id",
+                "as": "distinct_ids_per_source_name_and_version",
+            }
+        ],
+        "groupby": ["source.name", "source_version_detail"],
+    },
+    {
+        "calculate": "datum.source_type_detail && datum.source_model_detail ? datum.source_type_detail + ' ' + datum.source_model_detail : datum.source_type_detail || datum.source_model_detail",
         "as": "source_type_model_detail",
     },
     {
@@ -49,7 +77,35 @@ source_legend_label_transformation = [
         "groupby": ["source.name", "source_type_model_detail"],
     },
     {
-        "calculate": "datum.source.version ? (datum.source_type_model_detail ? datum.source_type_model_detail + ' v' + datum.source.version : 'v' + datum.source.version) : datum.source_type_model_detail",
+        "calculate": "datum.source_type_detail && datum.source_version_detail ? datum.source_type_detail + ' ' + datum.source_version_detail : datum.source_type_detail || datum.source_version_detail",
+        "as": "source_type_version_detail",
+    },
+    {
+        "joinaggregate": [
+            {
+                "op": "distinct",
+                "field": "source.id",
+                "as": "distinct_ids_per_source_name_type_version",
+            }
+        ],
+        "groupby": ["source.name", "source_type_version_detail"],
+    },
+    {
+        "calculate": "datum.source_model_detail && datum.source_version_detail ? datum.source_model_detail + ' ' + datum.source_version_detail : datum.source_model_detail || datum.source_version_detail",
+        "as": "source_model_version_detail",
+    },
+    {
+        "joinaggregate": [
+            {
+                "op": "distinct",
+                "field": "source.id",
+                "as": "distinct_ids_per_source_name_model_version",
+            }
+        ],
+        "groupby": ["source.name", "source_model_version_detail"],
+    },
+    {
+        "calculate": "datum.source_version_detail ? (datum.source_type_model_detail ? datum.source_type_model_detail + ' ' + datum.source_version_detail : datum.source_version_detail) : datum.source_type_model_detail",
         "as": "source_type_model_version_detail",
     },
     {
@@ -63,7 +119,7 @@ source_legend_label_transformation = [
         "groupby": ["source.name", "source_type_model_version_detail"],
     },
     {
-        "calculate": "datum.distinct_ids_per_source_name == 1 ? datum.source.name : datum.distinct_ids_per_source_name_and_type == 1 && datum.source_type_detail ? datum.source.name + ' (' + datum.source_type_detail + ')' : datum.distinct_ids_per_source_name_type_model == 1 && datum.source_type_model_detail ? datum.source.name + ' (' + datum.source_type_model_detail + ')' : datum.source_type_model_version_detail ? datum.source.name + ' (' + datum.source_type_model_version_detail + ')' : datum.source.name",
+        "calculate": "datum.distinct_ids_per_source_name == 1 ? datum.source.name : datum.distinct_ids_per_source_name_and_type == 1 && datum.source_type_detail ? datum.source.name + ' (' + datum.source_type_detail + ')' : datum.distinct_ids_per_source_name_and_model == 1 && datum.source_model_detail ? datum.source.name + ' (' + datum.source_model_detail + ')' : datum.distinct_ids_per_source_name_and_version == 1 && datum.source_version_detail ? datum.source.name + ' (' + datum.source_version_detail + ')' : datum.distinct_ids_per_source_name_type_model == 1 && datum.source_type_model_detail ? datum.source.name + ' (' + datum.source_type_model_detail + ')' : datum.distinct_ids_per_source_name_type_version == 1 && datum.source_type_version_detail ? datum.source.name + ' (' + datum.source_type_version_detail + ')' : datum.distinct_ids_per_source_name_model_version == 1 && datum.source_model_version_detail ? datum.source.name + ' (' + datum.source_model_version_detail + ')' : datum.distinct_ids_per_source_name_type_model_version == 1 && datum.source_type_model_version_detail ? datum.source.name + ' (' + datum.source_type_model_version_detail + ')' : datum.source.name + ' (ID: ' + datum.source.id + ')'",
         "as": "source_legend_label",
     },
 ]

--- a/flexmeasures/data/models/charts/utils.py
+++ b/flexmeasures/data/models/charts/utils.py
@@ -1,12 +1,62 @@
-source_name_and_optional_id_transformation = [
+source_legend_label_transformation = [
+    {
+        "calculate": "datum.source.display_type || datum.source.raw_type || datum.source.type || ''",
+        "as": "source_display_type",
+    },
     {
         "joinaggregate": [
-            {"op": "distinct", "field": "source.id", "as": "distinct_ids_per_name"}
+            {
+                "op": "distinct",
+                "field": "source.id",
+                "as": "distinct_ids_per_source_name",
+            }
         ],
         "groupby": ["source.name"],
     },
     {
-        "calculate": "datum.distinct_ids_per_name > 1 ? datum.source.name + ' (ID: ' + datum.source.id + ')' : datum.source.name",
-        "as": "source_name_and_optional_id",
+        "calculate": "datum.source_display_type",
+        "as": "source_type_detail",
+    },
+    {
+        "joinaggregate": [
+            {
+                "op": "distinct",
+                "field": "source.id",
+                "as": "distinct_ids_per_source_name_and_type",
+            }
+        ],
+        "groupby": ["source.name", "source_type_detail"],
+    },
+    {
+        "calculate": "datum.source.model ? (datum.source_type_detail ? datum.source_type_detail + ' ' + datum.source.model : datum.source.model) : datum.source_type_detail",
+        "as": "source_type_model_detail",
+    },
+    {
+        "joinaggregate": [
+            {
+                "op": "distinct",
+                "field": "source.id",
+                "as": "distinct_ids_per_source_name_type_model",
+            }
+        ],
+        "groupby": ["source.name", "source_type_model_detail"],
+    },
+    {
+        "calculate": "datum.source.version ? (datum.source_type_model_detail ? datum.source_type_model_detail + ' v' + datum.source.version : 'v' + datum.source.version) : datum.source_type_model_detail",
+        "as": "source_type_model_version_detail",
+    },
+    {
+        "joinaggregate": [
+            {
+                "op": "distinct",
+                "field": "source.id",
+                "as": "distinct_ids_per_source_name_type_model_version",
+            }
+        ],
+        "groupby": ["source.name", "source_type_model_version_detail"],
+    },
+    {
+        "calculate": "datum.distinct_ids_per_source_name == 1 ? datum.source.name : datum.distinct_ids_per_source_name_and_type == 1 && datum.source_type_detail ? datum.source.name + ' (' + datum.source_type_detail + ')' : datum.distinct_ids_per_source_name_type_model == 1 && datum.source_type_model_detail ? datum.source.name + ' (' + datum.source_type_model_detail + ')' : datum.source_type_model_version_detail ? datum.source.name + ' (' + datum.source_type_model_version_detail + ')' : datum.source.name",
+        "as": "source_legend_label",
     },
 ]

--- a/flexmeasures/data/models/data_sources.py
+++ b/flexmeasures/data/models/data_sources.py
@@ -465,9 +465,10 @@ class DataSource(db.Model, tb.BeliefSourceDBMixin):
         model_incl_version = self.model if self.model else ""
         if self.model and self.version:
             model_incl_version += f" (v{self.version})"
-        if "forecast" in self.type.lower():
+        raw_type = self.type or ""
+        if "forecast" in raw_type.lower():
             _type = "forecaster"  # e.g. 'forecaster' or 'forecasting script'
-        elif "schedul" in self.type.lower():  # e.g. 'scheduler' or 'scheduling script'
+        elif "schedul" in raw_type.lower():  # e.g. 'scheduler' or 'scheduling script'
             _type = "scheduler"
         else:
             _type = "other"
@@ -475,7 +476,10 @@ class DataSource(db.Model, tb.BeliefSourceDBMixin):
             id=self.id,
             name=self.name,
             model=model_incl_version,
+            version=self.version or "",
             type=_type,
+            raw_type=raw_type,
+            display_type=_type if _type != "other" else raw_type or "other",
             description=self.description,
         )
 

--- a/flexmeasures/data/models/data_sources.py
+++ b/flexmeasures/data/models/data_sources.py
@@ -462,9 +462,6 @@ class DataSource(db.Model, tb.BeliefSourceDBMixin):
 
     @cached_property
     def as_dict(self) -> dict:
-        model_incl_version = self.model if self.model else ""
-        if self.model and self.version:
-            model_incl_version += f" (v{self.version})"
         raw_type = self.type or ""
         if "forecast" in raw_type.lower():
             _type = "forecaster"  # e.g. 'forecaster' or 'forecasting script'
@@ -475,7 +472,7 @@ class DataSource(db.Model, tb.BeliefSourceDBMixin):
         return dict(
             id=self.id,
             name=self.name,
-            model=model_incl_version,
+            model=self.model or "",
             version=self.version or "",
             type=_type,
             raw_type=raw_type,

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -59,7 +59,10 @@ def _fixed_value_source_dict(
         id=_FLEX_SOURCE_IDS[flex_source],
         name=flex_source,
         model="",
+        version="",
         type="other",
+        raw_type=flex_source,
+        display_type=flex_source,
         description=f"Configured in the asset's {flex_source}",
     )
 
@@ -1244,7 +1247,12 @@ class GenericAsset(db.Model, AuthModelMixin):
                         sources_metadata[source_obj.id] = {
                             "name": source_dict.get("name", ""),
                             "model": source_dict.get("model", ""),
+                            "version": source_dict.get("version", ""),
                             "type": source_dict.get("type", "other"),
+                            "raw_type": source_dict.get("raw_type", ""),
+                            "display_type": source_dict.get(
+                                "display_type", source_dict.get("type", "other")
+                            ),
                             "description": source_dict.get("description", ""),
                         }
 

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -495,7 +495,12 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin, OrderByIdMixin):
                     sources_metadata[source_obj.id] = {
                         "name": source_dict.get("name", ""),
                         "model": source_dict.get("model", ""),
+                        "version": source_dict.get("version", ""),
                         "type": source_dict.get("type", "other"),
+                        "raw_type": source_dict.get("raw_type", ""),
+                        "display_type": source_dict.get(
+                            "display_type", source_dict.get("type", "other")
+                        ),
                         "description": source_dict.get("description", ""),
                     }
 

--- a/flexmeasures/data/tests/test_belief_charts.py
+++ b/flexmeasures/data/tests/test_belief_charts.py
@@ -366,6 +366,7 @@ def test_bar_chart_uses_source_legend_label_without_ids(battery_with_soc_flex_mo
     assert "source_name_and_id" in tooltip_fields
     assert "source.display_type" in tooltip_fields
     assert "source.model" in tooltip_fields
+    assert "source.version" in tooltip_fields
 
 
 def test_source_legend_label_transform_renders_short_non_id_labels():
@@ -678,12 +679,14 @@ def test_chart_data_json_preserves_display_source_type_for_labels(
     assert forecaster_metadata["type"] == "forecaster"
     assert forecaster_metadata["raw_type"] == "forecaster"
     assert forecaster_metadata["display_type"] == "forecaster"
+    assert forecaster_metadata["model"] == "TrainPredictPipeline"
     assert forecaster_metadata["version"] == "1"
 
     reporter_metadata = parsed["sources"][str(reporter_source.id)]
     assert reporter_metadata["type"] == "other"
     assert reporter_metadata["raw_type"] == "reporter"
     assert reporter_metadata["display_type"] == "reporter"
+    assert reporter_metadata["model"] == "PandasReporter"
     assert reporter_metadata["version"] == "1"
 
 

--- a/flexmeasures/data/tests/test_belief_charts.py
+++ b/flexmeasures/data/tests/test_belief_charts.py
@@ -11,6 +11,7 @@ The key scenarios checked here:
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta
 
 import pandas as pd
@@ -18,9 +19,70 @@ import pytest
 import pytz
 
 from flexmeasures import Sensor
+from flexmeasures.data.models.charts.utils import source_legend_label_transformation
 from flexmeasures.data.models.generic_assets import GenericAsset, GenericAssetType
 from flexmeasures.data.models.data_sources import DataSource
 from flexmeasures.data.models.time_series import TimedBelief
+
+
+def _walk_dicts(value):
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from _walk_dicts(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk_dicts(child)
+
+
+def _collect_scenegraph_texts(value) -> list[str]:
+    texts = []
+    if isinstance(value, dict):
+        if "text" in value:
+            texts.append(value["text"])
+        for child in value.values():
+            texts.extend(_collect_scenegraph_texts(child))
+    elif isinstance(value, list):
+        for child in value:
+            texts.extend(_collect_scenegraph_texts(child))
+    return texts
+
+
+def _chart_source(
+    source_id: int,
+    name: str,
+    display_type: str,
+    source_type: str = "other",
+    model: str = "",
+    version: str = "",
+    raw_type: str | None = None,
+) -> dict:
+    return {
+        "source": {
+            "id": source_id,
+            "name": name,
+            "display_type": display_type,
+            "raw_type": raw_type or display_type,
+            "type": source_type,
+            "model": model,
+            "version": version,
+        }
+    }
+
+
+def _render_source_legend_labels(values: list[dict]) -> list[str]:
+    vl_convert = pytest.importorskip("vl_convert")
+    spec = {
+        "$schema": "https://vega.github.io/schema/vega-lite/v6.json",
+        "data": {"values": values},
+        "transform": source_legend_label_transformation,
+        "mark": "text",
+        "encoding": {
+            "text": {"field": "source_legend_label", "type": "nominal"},
+            "y": {"field": "source.id", "type": "nominal", "axis": None},
+        },
+    }
+    return _collect_scenegraph_texts(vl_convert.vegalite_to_scenegraph(spec))
 
 
 @pytest.fixture(scope="function")
@@ -250,6 +312,182 @@ def test_fixed_value_sensor_unit_matches_flex_model(battery_with_soc_flex_model)
             )
 
 
+def test_bar_chart_uses_source_legend_label_without_ids(battery_with_soc_flex_model):
+    """Duplicate source-name labels should be distinguished without showing IDs."""
+    _, soc_sensor = battery_with_soc_flex_model
+
+    start = datetime(2015, 1, 1, tzinfo=pytz.utc)
+    end = datetime(2015, 1, 2, tzinfo=pytz.utc)
+
+    spec = soc_sensor.chart(
+        include_data=False,
+        event_starts_after=start,
+        event_ends_before=end,
+    )
+    data_layer = spec["layer"][0]
+    transforms = data_layer["transform"]
+
+    assert data_layer["encoding"]["color"]["field"] == "source_legend_label"
+    assert (
+        data_layer["encoding"]["stroke"]["condition"]["field"] == "source_legend_label"
+    )
+    display_type_transform = next(
+        transform
+        for transform in transforms
+        if transform.get("as") == "source_display_type"
+    )
+    assert "source.display_type" in display_type_transform["calculate"]
+    assert "source.raw_type" in display_type_transform["calculate"]
+    assert any(
+        transform.get("as") == "source_type_model_version_detail"
+        and "source.version" in transform["calculate"]
+        for transform in transforms
+    )
+
+    legend_label_transform = next(
+        transform
+        for transform in transforms
+        if transform.get("as") == "source_legend_label"
+    )
+    assert "ID:" not in legend_label_transform["calculate"]
+    assert "source.id" not in legend_label_transform["calculate"]
+
+    tooltip_id_transform = next(
+        transform
+        for transform in transforms
+        if transform.get("as") == "source_name_and_id"
+    )
+    assert "ID:" in tooltip_id_transform["calculate"]
+    tooltip_fields = [
+        tooltip["field"]
+        for tooltip in data_layer["encoding"]["tooltip"]
+        if tooltip is not None
+    ]
+    assert "source_name_and_id" in tooltip_fields
+    assert "source.display_type" in tooltip_fields
+    assert "source.model" in tooltip_fields
+
+
+def test_source_legend_label_transform_renders_short_non_id_labels():
+    values = [
+        _chart_source(1, "Unique", "user"),
+        _chart_source(
+            2,
+            "FlexMeasures",
+            "forecaster",
+            source_type="forecaster",
+            model="TrainPredictPipeline",
+            version="1",
+        ),
+        _chart_source(
+            3, "FlexMeasures", "reporter", model="PandasReporter", version="1"
+        ),
+        _chart_source(4, "Seita", "reporter", model="ModelA", version="1"),
+        _chart_source(5, "Seita", "reporter", model="ModelB", version="1"),
+        _chart_source(6, "Acme", "reporter", model="Shared", version="1"),
+        _chart_source(7, "Acme", "reporter", model="Shared", version="2"),
+    ]
+    texts = _render_source_legend_labels(values)
+
+    assert texts == [
+        "Unique",
+        "FlexMeasures (forecaster)",
+        "FlexMeasures (reporter)",
+        "Seita (reporter ModelA)",
+        "Seita (reporter ModelB)",
+        "Acme (reporter Shared v1)",
+        "Acme (reporter Shared v2)",
+    ]
+    assert "(" not in texts[0]
+    assert all("(" in text and ")" in text for text in texts[1:])
+    assert all("ID:" not in text for text in texts)
+
+
+def test_source_legend_label_transform_handles_sparse_source_metadata():
+    texts = _render_source_legend_labels(
+        [
+            _chart_source(1, "NoModel", "reporter", model="", version="1"),
+            _chart_source(2, "NoModel", "reporter", model="", version="2"),
+            _chart_source(
+                3,
+                "ModelOnly",
+                "",
+                source_type="",
+                raw_type="",
+                model="ModelA",
+            ),
+            _chart_source(
+                4,
+                "ModelOnly",
+                "",
+                source_type="",
+                raw_type="",
+                model="ModelB",
+            ),
+            {
+                "source": {
+                    "id": 5,
+                    "name": "OldData",
+                    "type": "scheduler",
+                    "model": "",
+                    "version": "",
+                }
+            },
+            {
+                "source": {
+                    "id": 6,
+                    "name": "OldData",
+                    "type": "other",
+                    "model": "",
+                    "version": "",
+                }
+            },
+            _chart_source(7, "NoDetails", "", source_type="", raw_type=""),
+            _chart_source(8, "NoDetails", "", source_type="", raw_type=""),
+        ]
+    )
+
+    assert texts == [
+        "NoModel (reporter v1)",
+        "NoModel (reporter v2)",
+        "ModelOnly (ModelA)",
+        "ModelOnly (ModelB)",
+        "OldData (scheduler)",
+        "OldData (other)",
+        "NoDetails",
+        "NoDetails",
+    ]
+    assert all("undefined" not in text for text in texts)
+    assert all("()" not in text for text in texts)
+    assert all("ID:" not in text for text in texts)
+
+
+def test_chart_styling_still_uses_normalized_source_type(battery_with_soc_flex_model):
+    """The new label field must not replace source.type for visual styling."""
+    battery, _ = battery_with_soc_flex_model
+
+    start = datetime(2015, 1, 1, tzinfo=pytz.utc)
+    end = datetime(2015, 1, 2, tzinfo=pytz.utc)
+
+    spec = battery.chart(
+        include_data=False,
+        event_starts_after=start,
+        event_ends_before=end,
+    )
+    stroke_dash_encodings = [
+        node["strokeDash"]
+        for node in _walk_dicts(spec)
+        if isinstance(node.get("strokeDash"), dict)
+    ]
+
+    assert any(
+        stroke_dash.get("field") == "source.type"
+        and stroke_dash.get("scale", {}).get("domain")
+        == ["forecaster", "scheduler", "other"]
+        for stroke_dash in stroke_dash_encodings
+    )
+
+
 # ---------------------------------------------------------------------------
 # Tests for the UI path: chart_data_json(compress_json=True)
 #
@@ -290,8 +528,6 @@ def test_chart_data_json_compressed_returns_expected_structure(
     start = datetime(2015, 1, 1, tzinfo=pytz.utc)
     end = datetime(2015, 1, 2, tzinfo=pytz.utc)
 
-    import json
-
     parsed = json.loads(
         battery.chart_data_json(
             compress_json=True,
@@ -314,8 +550,6 @@ def test_chart_data_json_compressed_includes_fixed_value_sensors(
 
     start = datetime(2015, 1, 1, tzinfo=pytz.utc)
     end = datetime(2015, 1, 2, tzinfo=pytz.utc)
-
-    import json
 
     parsed = json.loads(
         battery.chart_data_json(
@@ -343,8 +577,6 @@ def test_chart_data_json_compressed_fixed_value_records_are_correct(
 
     start = datetime(2015, 1, 1, tzinfo=pytz.utc)
     end = datetime(2015, 1, 2, tzinfo=pytz.utc)
-
-    import json
 
     parsed = json.loads(
         battery.chart_data_json(
@@ -382,8 +614,6 @@ def test_chart_data_json_compressed_source_references_flex_model(
     start = datetime(2015, 1, 1, tzinfo=pytz.utc)
     end = datetime(2015, 1, 2, tzinfo=pytz.utc)
 
-    import json
-
     parsed = json.loads(
         battery.chart_data_json(
             compress_json=True,
@@ -398,6 +628,63 @@ def test_chart_data_json_compressed_source_references_flex_model(
         "Source metadata must reference 'flex-model' for values from the flex_model; "
         f"got descriptions: {source_descriptions}"
     )
+
+
+def test_chart_data_json_preserves_display_source_type_for_labels(
+    battery_with_soc_flex_model,
+    fresh_db,
+):
+    """Chart data should preserve exact and label-friendly source type metadata."""
+    battery, soc_sensor = battery_with_soc_flex_model
+    start = datetime(2015, 1, 1, tzinfo=pytz.utc)
+    end = datetime(2015, 1, 2, tzinfo=pytz.utc)
+
+    forecaster_source = DataSource(
+        name="FlexMeasures",
+        type="forecaster",
+        model="TrainPredictPipeline",
+        version="1",
+    )
+    reporter_source = DataSource(
+        name="FlexMeasures",
+        type="reporter",
+        model="PandasReporter",
+        version="1",
+    )
+    fresh_db.session.add_all([forecaster_source, reporter_source])
+    fresh_db.session.flush()
+
+    for source, value in [(forecaster_source, 31), (reporter_source, 32)]:
+        fresh_db.session.add(
+            TimedBelief(
+                sensor=soc_sensor,
+                event_start=start,
+                event_value=value,
+                belief_horizon=timedelta(0),
+                source=source,
+            )
+        )
+    fresh_db.session.flush()
+
+    parsed = json.loads(
+        battery.chart_data_json(
+            compress_json=True,
+            event_starts_after=start,
+            event_ends_before=end,
+        )
+    )
+
+    forecaster_metadata = parsed["sources"][str(forecaster_source.id)]
+    assert forecaster_metadata["type"] == "forecaster"
+    assert forecaster_metadata["raw_type"] == "forecaster"
+    assert forecaster_metadata["display_type"] == "forecaster"
+    assert forecaster_metadata["version"] == "1"
+
+    reporter_metadata = parsed["sources"][str(reporter_source.id)]
+    assert reporter_metadata["type"] == "other"
+    assert reporter_metadata["raw_type"] == "reporter"
+    assert reporter_metadata["display_type"] == "reporter"
+    assert reporter_metadata["version"] == "1"
 
 
 def test_chart_data_json_skips_invalid_saved_asset_reference(
@@ -419,8 +706,6 @@ def test_chart_data_json_skips_invalid_saved_asset_reference(
 
     start = datetime(2015, 1, 1, tzinfo=pytz.utc)
     end = datetime(2015, 1, 2, tzinfo=pytz.utc)
-
-    import json
 
     parsed = json.loads(
         battery.chart_data_json(

--- a/flexmeasures/data/tests/test_belief_charts.py
+++ b/flexmeasures/data/tests/test_belief_charts.py
@@ -312,8 +312,10 @@ def test_fixed_value_sensor_unit_matches_flex_model(battery_with_soc_flex_model)
             )
 
 
-def test_bar_chart_uses_source_legend_label_without_ids(battery_with_soc_flex_model):
-    """Duplicate source-name labels should be distinguished without showing IDs."""
+def test_bar_chart_uses_source_legend_label_with_id_fallback(
+    battery_with_soc_flex_model,
+):
+    """Duplicate source-name labels should use IDs only as a last resort."""
     _, soc_sensor = battery_with_soc_flex_model
 
     start = datetime(2015, 1, 1, tzinfo=pytz.utc)
@@ -339,7 +341,7 @@ def test_bar_chart_uses_source_legend_label_without_ids(battery_with_soc_flex_mo
     assert "source.display_type" in display_type_transform["calculate"]
     assert "source.raw_type" in display_type_transform["calculate"]
     assert any(
-        transform.get("as") == "source_type_model_version_detail"
+        transform.get("as") == "source_version_detail"
         and "source.version" in transform["calculate"]
         for transform in transforms
     )
@@ -349,8 +351,8 @@ def test_bar_chart_uses_source_legend_label_without_ids(battery_with_soc_flex_mo
         for transform in transforms
         if transform.get("as") == "source_legend_label"
     )
-    assert "ID:" not in legend_label_transform["calculate"]
-    assert "source.id" not in legend_label_transform["calculate"]
+    assert "ID:" in legend_label_transform["calculate"]
+    assert "source.id" in legend_label_transform["calculate"]
 
     tooltip_id_transform = next(
         transform
@@ -394,10 +396,10 @@ def test_source_legend_label_transform_renders_short_non_id_labels():
         "Unique",
         "FlexMeasures (forecaster)",
         "FlexMeasures (reporter)",
-        "Seita (reporter ModelA)",
-        "Seita (reporter ModelB)",
-        "Acme (reporter Shared v1)",
-        "Acme (reporter Shared v2)",
+        "Seita (ModelA)",
+        "Seita (ModelB)",
+        "Acme (v1)",
+        "Acme (v2)",
     ]
     assert "(" not in texts[0]
     assert all("(" in text and ")" in text for text in texts[1:])
@@ -449,18 +451,18 @@ def test_source_legend_label_transform_handles_sparse_source_metadata():
     )
 
     assert texts == [
-        "NoModel (reporter v1)",
-        "NoModel (reporter v2)",
+        "NoModel (v1)",
+        "NoModel (v2)",
         "ModelOnly (ModelA)",
         "ModelOnly (ModelB)",
         "OldData (scheduler)",
         "OldData (other)",
-        "NoDetails",
-        "NoDetails",
+        "NoDetails (ID: 7)",
+        "NoDetails (ID: 8)",
     ]
     assert all("undefined" not in text for text in texts)
     assert all("()" not in text for text in texts)
-    assert all("ID:" not in text for text in texts)
+    assert all("ID:" not in text for text in texts[:-2])
 
 
 def test_chart_styling_still_uses_normalized_source_type(battery_with_soc_flex_model):

--- a/flexmeasures/data/tests/test_data_source.py
+++ b/flexmeasures/data/tests/test_data_source.py
@@ -183,6 +183,7 @@ def test_data_source_as_dict_keeps_raw_and_display_type(
 
     source_dict = source.as_dict
 
+    assert source_dict["model"] == "PandasReporter"
     assert source_dict["type"] == expected_type
     assert source_dict["raw_type"] == source_type
     assert source_dict["display_type"] == expected_display_type

--- a/flexmeasures/data/tests/test_data_source.py
+++ b/flexmeasures/data/tests/test_data_source.py
@@ -159,6 +159,36 @@ def test_data_generator_save_parameters(
     assert dg2._parameters["start"].isoformat() == parameters_2["start"]
 
 
+@pytest.mark.parametrize(
+    "source_type, expected_type, expected_display_type",
+    [
+        ("forecaster", "forecaster", "forecaster"),
+        ("forecasting script", "forecaster", "forecaster"),
+        ("scheduler", "scheduler", "scheduler"),
+        ("scheduling script", "scheduler", "scheduler"),
+        ("reporter", "other", "reporter"),
+        ("demo script", "other", "demo script"),
+        ("", "other", "other"),
+    ],
+)
+def test_data_source_as_dict_keeps_raw_and_display_type(
+    source_type: str, expected_type: str, expected_display_type: str
+):
+    source = DataSource(
+        name="FlexMeasures",
+        type=source_type,
+        model="PandasReporter",
+        version="1",
+    )
+
+    source_dict = source.as_dict
+
+    assert source_dict["type"] == expected_type
+    assert source_dict["raw_type"] == source_type
+    assert source_dict["display_type"] == expected_display_type
+    assert source_dict["version"] == "1"
+
+
 def test_keep_last_version():
     s1 = DataSource(
         id=1, name="s1", model="model 1", type="forecaster", version="0.1.0"

--- a/flexmeasures/ui/static/js/chart-data-utils.js
+++ b/flexmeasures/ui/static/js/chart-data-utils.js
@@ -51,10 +51,15 @@ export function decompressChartData(responseData) {
           asset_description: sensor.asset_description || "",
         },
         source: {
+          ...source,
           id: belief.src,
           name: source.name || "",
           model: source.model || "",
+          version: source.version || "",
           type: source.type || "other",
+          raw_type: source.raw_type || "",
+          display_type:
+            source.display_type || source.raw_type || source.type || "other",
           description: source.description || "",
         },
 


### PR DESCRIPTION
## Description

- [x] Preserve raw and display-friendly source type metadata alongside the normalized chart styling type.
- [x] Keep source metadata in compressed chart data and frontend decompression.
- [x] Distinguish duplicate source names in chart legends using the shortest available non-ID detail.
- [x] Format distinguishing legend details in brackets, e.g. `FlexMeasures (reporter)`.
- [x] Keep source IDs in tooltips, not legends.
- [x] Add regression coverage for source metadata, compressed chart data, sparse metadata, and rendered Vega legend labels.
- [x] added changelog entry.

## Look & Feel

Legend labels now render like:

```text
FlexMeasures (forecaster)
FlexMeasures (reporter)
Seita (reporter ModelA)
Acme (reporter Shared v1)
```
- Before:

<img width="874" height="380" alt="Screenshot from 2026-05-19 19-56-29" src="https://github.com/user-attachments/assets/2c3d4302-0725-4b32-b6e6-0d5f260b4835" />

- After: 

<img width="874" height="380" alt="Screenshot from 2026-05-19 19-55-43" src="https://github.com/user-attachments/assets/62ad73bb-0bf6-497e-92eb-e4117d6c8a62" />

...

## How to test

Manually, open an asset chart with multiple data sources sharing the same `source.name`. The legend should keep the source name and show only the distinguishing part in brackets, for example `FlexMeasures (forecaster)` and `FlexMeasures (reporter)`. Source IDs should not appear in the legend, but should still be visible in tooltips.

- Automated tests touched in this PR:

```bash
pytest flexmeasures/data/tests/test_data_source.py flexmeasures/data/tests/test_belief_charts.py -q
```

## Further Improvements

- If two data sources share the same name, type, model, and version, the legend still cannot distinguish them without showing IDs or adding another meaningful metadata field. we can maybe show id in that case ?

...

## Related Items

closes #2183

...

---

#### Sign-off

<!--
We ask contributors outside the FlexMeasures organisation to sign off on their contribution.
Please mark the below fields with an [x].
-->

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
