### PR TITLE
Fix: DST transition handling by supporting both datetime and pandas Timestamp objects

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -30,6 +30,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
+* Fix DST transition handling by supporting both native Python ``datetime`` and pandas ``Timestamp`` objects in time series segment processing, preventing ``AttributeError`` when processing segments with differing UTC offsets [see `PR #2197 <https://github.com/FlexMeasures/flexmeasures/pull/2197>`_]
 * Fix forecasting regressor filtering to use only regressor beliefs known at the forecast ``belief_time`` [see `PR #2134 <https://www.github.com/FlexMeasures/flexmeasures/pull/2134>`_]
 * Check read permissions for sensors referenced in forecasting and scheduling config payloads, and return a clearer 403 error when a referenced sensor is not readable [see `PR #2096 <https://www.github.com/FlexMeasures/flexmeasures/pull/2096>`_ and `PR #2125 <https://www.github.com/FlexMeasures/flexmeasures/pull/2125>`_]
 * Standardize resolution formatting across API endpoints for consistent response payloads [see `PR #2152 <https://www.github.com/FlexMeasures/flexmeasures/pull/2152>`_]

--- a/flexmeasures/data/models/planning/utils.py
+++ b/flexmeasures/data/models/planning/utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from packaging import version
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Literal
 
 from flask import current_app
@@ -428,8 +428,14 @@ def process_time_series_segments(
         # If start and end have different UTC offsets (like crossing DST),
         # normalize them by converting to UTC.
         if not same_offset:
-            start = pd.Timestamp(start).tz_convert("UTC")
-            end = pd.Timestamp(end).tz_convert("UTC")
+            if isinstance(start, datetime):
+                start = start.astimezone(timezone.utc)
+            else:
+                start = start.tz_convert("UTC")
+            if isinstance(end, datetime):
+                end = end.astimezone(timezone.utc)
+            else:
+                end = end.tz_convert("UTC")
         # Assign the value to the corresponding segment in the DataFrame
         time_series_segments.loc[start : end - resolution, segment] = value
 


### PR DESCRIPTION
## Description

This PR resolves an issue where the process_time_series_segments function would fail when processing time series segments with differing UTC offsets (e.g., crossing daylight saving time boundaries). The original implementation assumed start and end were always pandas Timestamp objects with a tz_convert() method, but these can also be native Python datetime objects which require astimezone() instead. The fix adds type checking to handle both cases: native datetime objects are converted using astimezone(timezone.utc), while pandas Timestamp objects continue to use tz_convert("UTC"). This ensures robust handling of DST transitions regardless of the input type, preventing AttributeError exceptions when working with mixed datetime representations


<!--
For changelog entries, please take into account the intended audience.

In our main changelog:
- The 'New features' section targets API / CLI / UI users.
- The 'Infrastructure / Support' section targets plugin developers and hosts.

Finally, please note that the API and CLI keep additional changelogs:
- `documentation/api/changelog.rst`
- `documentation/cli/changelog.rst`
-->

## Look & Feel

<!--
This section can contain example pictures for the UI, Input/Output for the CLI, Request / Response for an API endpoint, etc.
-->

...

## How to test

<!--
Steps to test it or name of the tests functions.

The library [flexmeasures-client](https://github.com/FlexMeasures/flexmeasures-client/) can be useful to showcase new features.
For example, it can be used to set some example data to be used in a new UI feature.
-->

...

## Further Improvements

<!--
Potential improvements to be done in the same PR or follow-up Issues/Discussions/PRs.
-->

...

## Related Items

<!--
Mention if this PR closes an Issue or Project.
-->

...

---

#### Sign-off

<!--
We ask contributors outside the FlexMeasures organisation to sign off on their contribution.
Please mark the below fields with an [x].
-->

- [ ] I agree to contribute to the project under Apache 2 License. 
- [ ] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
