### PR TITLE
docs: improve docstring for asset copy endpoint

### DIFF
--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -1718,12 +1718,16 @@ class AssetAPI(FlaskView):
         post:
           summary: Copy an asset to a target account and/or parent.
           description: |
-            This endpoint creates a copy of an existing asset and optionally places it
-            under a `target` account and/or `parent` asset.
+            This endpoint creates a copy of an existing asset.
+
+            The asset copy will also have copies of child assets, including sensors and flex-configuration.
+            No beliefs will be copied.
+
+            The new asset can optionally be placed under a `target` account and/or `parent` asset.
 
             Resolution rules:
 
-            - If both are omitted, the copy remains in the same account and keeps the same parent.
+            - If both `target` and `account` are omitted, the copy remains in the same account and keeps the same parent as the original.
             - If `account` is provided and `parent` is omitted, parent defaults to `null`.
             - If `parent` is provided and `account` is omitted, account is derived from that parent.
             - If both are provided, it is possible to assign the copied asset to a different account than the parent.

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -2826,7 +2826,7 @@
     "/api/v3_0/assets/{id}/copy": {
       "post": {
         "summary": "Copy an asset to a target account and/or parent.",
-        "description": "This endpoint creates a copy of an existing asset and optionally places it\nunder a `target` account and/or `parent` asset.\n\nResolution rules:\n\n- If both are omitted, the copy remains in the same account and keeps the same parent.\n- If `account` is provided and `parent` is omitted, parent defaults to `null`.\n- If `parent` is provided and `account` is omitted, account is derived from that parent.\n- If both are provided, it is possible to assign the copied asset to a different account than the parent.\n",
+        "description": "This endpoint creates a copy of an existing asset.\n\nThe asset copy will also have copies of child assets, including sensors and flex-configuration.\nNo beliefs will be copied.\n\nThe new asset can optionally be placed under a `target` account and/or `parent` asset.\n\nResolution rules:\n\n- If both `target` and `account` are omitted, the copy remains in the same account and keeps the same parent as the original.\n- If `account` is provided and `parent` is omitted, parent defaults to `null`.\n- If `parent` is provided and `account` is omitted, account is derived from that parent.\n- If both are provided, it is possible to assign the copied asset to a different account than the parent.\n",
         "security": [
           {
             "ApiKeyAuth": []


### PR DESCRIPTION
The docstring now explains better what is being copied, not only where the copy will end up.

