### PR TITLE
Chore/avoid autouse fixtures

### DIFF
--- a/flexmeasures/api/tests/conftest.py
+++ b/flexmeasures/api/tests/conftest.py
@@ -6,7 +6,7 @@ from flask_security import SQLAlchemySessionUserDatastore
 from flask_security.utils import hash_password
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="module")
 def setup_api_test_data(db, setup_accounts, setup_roles_users):
     """
     Adding the task-runner

--- a/flexmeasures/api/tests/test_task_runs.py
+++ b/flexmeasures/api/tests/test_task_runs.py
@@ -16,7 +16,9 @@ from flexmeasures.auth.error_handling import (
 @pytest.mark.parametrize(
     "requesting_user", ["test_prosumer_user@seita.nl"], indirect=True
 )
-def test_api_task_run_post_unauthorized_wrong_role(client, requesting_user):
+def test_api_task_run_post_unauthorized_wrong_role(
+    client, setup_api_test_data, requesting_user
+):
     url = url_for("flexmeasures_api_ops.post_task_run")
     auth_token = get_auth_token(client, "test_prosumer_user@seita.nl", "testtest")
     post_req_params = dict(

--- a/flexmeasures/data/models/planning/tests/conftest.py
+++ b/flexmeasures/data/models/planning/tests/conftest.py
@@ -29,7 +29,7 @@ def app_with_each_solver(app, request):
     app.config["FLEXMEASURES_LP_SOLVER"] = original_solver
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="module")
 def setup_planning_test_data(db, add_market_prices, add_charging_station_assets):
     """
     Set up data for all planning tests.

--- a/flexmeasures/data/models/planning/tests/test_process.py
+++ b/flexmeasures/data/models/planning/tests/test_process.py
@@ -17,7 +17,12 @@ resolution = timedelta(hours=1)
     [("INFLEXIBLE", datetime(2015, 1, 2, 0)), ("SHIFTABLE", datetime(2015, 1, 2, 8))],
 )
 def test_process_scheduler(
-    add_battery_assets, process, process_type, optimal_start, db
+    setup_planning_test_data,
+    add_battery_assets,
+    process,
+    process_type,
+    optimal_start,
+    db,
 ):
     """
     Test scheduling a process of 4kW of power that last 4h using the ProcessScheduler
@@ -145,7 +150,9 @@ def test_process_scheduler_time_restrictions(add_battery_assets, process, db):
     assert (schedule[time_restrictions] == 0).all()
 
 
-def test_breakable_scheduler_time_restrictions(add_battery_assets, process, db):
+def test_breakable_scheduler_time_restrictions(
+    setup_planning_test_data, add_battery_assets, process, db
+):
     """
     Test BREAKABLE process_type of ProcessScheduler by introducing four 1-hour restrictions
     interspaced by 1 hour. The equivalent mask would be the following: [0,...,0,1,0,1,0,1,0,1,0, ...,0].

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -80,6 +80,7 @@ def test_storage_loss_function(
 @pytest.mark.parametrize("use_inflexible_device", [False, True])
 @pytest.mark.parametrize("battery_name", ["Test battery", "Test small battery"])
 def test_battery_solver_day_1(
+    setup_planning_test_data,
     add_battery_assets,
     add_inflexible_device_forecasts,
     use_inflexible_device,
@@ -126,7 +127,11 @@ def test_battery_solver_day_1(
     ],
 )
 def test_battery_solver_day_2(
-    add_battery_assets, roundtrip_efficiency: float, storage_efficiency: float, db
+    setup_planning_test_data,
+    add_battery_assets,
+    roundtrip_efficiency: float,
+    storage_efficiency: float,
+    db,
 ):
     """Check battery scheduling results for day 2, which is set up with
     8 expensive, then 8 cheap, then again 8 expensive hours.
@@ -306,7 +311,9 @@ def run_test_charge_discharge_sign(
     return schedule.tz_convert(tz), soc_schedule.tz_convert(tz)
 
 
-def test_battery_solver_day_3(add_battery_assets, add_inflexible_device_forecasts, db):
+def test_battery_solver_day_3(
+    setup_planning_test_data, add_battery_assets, add_inflexible_device_forecasts, db
+):
     """Check battery scheduling results for day 3, which is set up with
     8 hours with negative prices, followed by 16 expensive hours.
 


### PR DESCRIPTION
## Description

- [x] Remove two `autouse=True` fixtures.
- [x] No changelog entry; internal refactoring.

## Look & Feel

Only three `autouse=True` fixtures remain, which make sense to keep imo:

1. `conftest.error_endpoints`: Adds endpoints only for testing, which "can only be done *before* the first request
    so scope=session and autouse=True are required."
2. `api.conftest.patch_check_token`:  "Without this patch, API tests that use token authentication fail with 401."
3. `ui.tests.conftest.setup_ui_test_data`: Makes sure the UI has something to view, and there is someone to view it (an admin).

## How to test

...

## Further Improvements

...

## Related Items

Closes #137.
