### PR TITLE
Catch 404 errors in Sentry interation without exc_info as well

### DIFF
--- a/.github/agents/test-specialist.md
+++ b/.github/agents/test-specialist.md
@@ -653,3 +653,7 @@ After each assignment:
 
 - **Model layer coverage gap**: The PR added `account_id` parameter to three model methods: `Sensor.search_beliefs`, `TimedBelief.search`, and `GenericAsset.search_beliefs`. Tests covered only the first two. When a parameter is added to multiple model-layer methods, each method must be tested independently — especially when they use different code paths (e.g., `GenericAsset.search_beliefs` delegates through `Sensor.search_beliefs` but may not if the delegation chain changes). Add a checklist item: "When a filter/param is added to `search_beliefs` across multiple models, ensure at least one test exercises each model class."
 - **Empty-list edge case**: `account_id=[]` is schema-valid but semantically means "match nothing" (SQL `IN ()` returns zero rows). Tests should include this edge case and assert the expected empty result rather than letting it pass as a valid no-op.
+
+**Session 2026-05-31 (Sentry `before_send` filtering)**:
+
+- **Integration hint shape coverage**: When testing Sentry `before_send` or filter behavior, cover the real hint shapes the SDK emits, especially `log_record` versus `exc_info`. Flask error handlers may log handled HTTP errors, and Sentry's logging integration captures those as log events rather than exception events.

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -60,6 +60,7 @@ Bugfixes
 * Distinguish data sources with duplicate names in chart legends without showing source IDs [see `PR #2185 <https://www.github.com/FlexMeasures/flexmeasures/pull/2185>`_]
 * Fix broken API endpoint links in Read the Docs output by post-processing both known API index layouts and rewriting ``(id)`` anchors [see `PR #1753 <https://www.github.com/FlexMeasures/flexmeasures/pull/1753>`_]
 * Wrap Darts training ``ValueError`` about no common feature times as a clearer ``NotEnoughDataException`` when there is insufficient history for the requested forecast horizon [see `PR #2192 <https://www.github.com/FlexMeasures/flexmeasures/pull/2192>`_]
+* Make Sentry also ignore 404 events, if we only log them without exc_info [`PR #2212 <https://www.github.com/FlexMeasures/flexmeasures/pull/2212>`_]
 
 
 v0.32.3 | May 15, 2026

--- a/flexmeasures/utils/app_utils.py
+++ b/flexmeasures/utils/app_utils.py
@@ -38,6 +38,15 @@ def _sentry_filter_notfound(event, hint):
         exc_type, exc_value, _tb = hint["exc_info"]
         if isinstance(exc_value, NotFound):
             return None
+    # FlexMeasures logs handled 404s with verbose=False to keep automated
+    # scans for hackable URLs from overwhelming log files. Sentry receives
+    # those as logging events, so the NotFound exception is only visible in
+    # the LogRecord message rather than in hint["exc_info"].
+    log_record = hint.get("log_record")
+    if log_record is not None:
+        message = log_record.getMessage()
+        if message.startswith("NotFound - URL was: "):
+            return None
     return event
 
 

--- a/flexmeasures/utils/error_utils.py
+++ b/flexmeasures/utils/error_utils.py
@@ -78,7 +78,7 @@ def error_handling_router(error: HTTPException):
         log_error(
             error,
             error.name,
-            verbose=False,
+            verbose=False,  # not interesting
         )
     elif http_error_code in (401, 403, 410) or isinstance(error, SecurityError):
         log_error(

--- a/flexmeasures/utils/tests/test_app_utils.py
+++ b/flexmeasures/utils/tests/test_app_utils.py
@@ -1,6 +1,26 @@
-from werkzeug.exceptions import NotFound, InternalServerError
+import logging
+
+import sentry_sdk
+from flask import Flask
+from sentry_sdk.integrations.flask import FlaskIntegration
+from sentry_sdk.transport import Transport
+from werkzeug.exceptions import InternalServerError, NotFound
 
 from flexmeasures.utils.app_utils import _sentry_filter_notfound
+from flexmeasures.utils.error_utils import add_basic_error_handlers
+
+
+class RecordingTransport(Transport):
+    """Sentry transport that records events instead of sending them."""
+
+    def __init__(self, options=None):
+        super().__init__(options)
+        self.events = []
+
+    def capture_envelope(self, envelope):
+        event = envelope.get_event()
+        if event is not None:
+            self.events.append(event)
 
 
 def make_hint(exc):
@@ -14,7 +34,7 @@ def make_hint(exc):
 
 
 def test_sentry_filter_drops_notfound():
-    """404 NotFound errors should be filtered out (return None) before reaching Sentry."""
+    """404 NotFound errors should be filtered out before reaching Sentry."""
     event = {"message": "Not Found"}
     hint = make_hint(NotFound())
     assert _sentry_filter_notfound(event, hint) is None
@@ -32,3 +52,61 @@ def test_sentry_filter_passes_events_without_exc_info():
     event = {"message": "some log message"}
     hint = {}
     assert _sentry_filter_notfound(event, hint) is event
+
+
+def test_sentry_filter_drops_flexmeasures_notfound_log_record():
+    """FlexMeasures logs handled 404s without exc_info."""
+    event = {"message": "Not Found"}
+    log_record = app_logger_record('NotFound - URL was: /missing - "Not Found"')
+    hint = {"log_record": log_record}
+    assert _sentry_filter_notfound(event, hint) is None
+
+
+def test_sentry_filter_passes_other_log_records():
+    """Other logging events should be passed through unchanged."""
+    event = {"message": "some log message"}
+    log_record = app_logger_record("NotFound in unrelated background task")
+    hint = {"log_record": log_record}
+    assert _sentry_filter_notfound(event, hint) is event
+
+
+def test_sentry_filter_drops_flask_404_logging_event():
+    """The Flask error handler logs 404s with a LogRecord hint."""
+    app = Flask(__name__)
+    add_basic_error_handlers(app)
+    transport = RecordingTransport()
+    hints_seen = []
+    previous_client = sentry_sdk.get_client()
+
+    def before_send(event, hint):
+        hints_seen.append(hint)
+        return _sentry_filter_notfound(event, hint)
+
+    sentry_sdk.init(
+        dsn="https://public@example.com/1",
+        integrations=[FlaskIntegration()],
+        before_send=before_send,
+        transport=transport,
+    )
+    try:
+        response = app.test_client().get("/api/missing")
+    finally:
+        sentry_sdk.flush()
+        sentry_sdk.get_client().close()
+        sentry_sdk.get_global_scope().set_client(previous_client)
+
+    assert response.status_code == 404
+    assert transport.events == []
+    assert any("log_record" in hint for hint in hints_seen)
+
+
+def app_logger_record(message):
+    return logging.LogRecord(
+        "flexmeasures",
+        logging.ERROR,
+        pathname=__file__,
+        lineno=1,
+        msg=message,
+        args=(),
+        exc_info=None,
+    )


### PR DESCRIPTION
## Description

We added _sentry_filter_not_found so that 404 errors are not sent to Sentry (and our event limit doesn't get used up by those events).

The unit test seems to work nicely, but in practice (on the production aserver)  the 404s are being sent.
I checked on the production server, and the config contains `FLEXMEASURES_DO_NOT_SEND_NOTFOUND_TO_SENTRY = True`. 

So in this PR we attempt to fix that.

The root cause seems to be that the existing test only covered Sentry exception events with `hint["exc_info"]`. In production, FlexMeasures’ 404 handler logs the handled 404 with `current_app.logger.error(...)` but with no `exc_info` (as we set `verbose=False` for 404s (see /utils/error_utils.py line 61), and Sentry captures that through its logging integration as a hint["log_record"] event. The old filter passed those through.

- [x] `_sentry_filter_notfound()` now also drops FlexMeasures handled-404 log records.
- [x] added documentation explaining intentions behind verbose=False and our need to do this
- [x] expand tests
- [x] Added changelog item in `documentation/changelog.rst`


## How to test

Codex claims it instrumented Sentry’s `before_send` locally and looked at the actual hint Sentry passed in for a Flask 404 handled by FlexMeasures’ error handler. It verified his thesis with a local Flask app, calling ´app.test_client().get("/api/missing")`. 


