### PR TITLE
Fix: Fixed broken sorting on jobs table

### DIFF
--- a/flexmeasures/ui/templates/sensors/status.html
+++ b/flexmeasures/ui/templates/sensors/status.html
@@ -67,7 +67,7 @@ Sensors shown on this page are the ones relevant for correct functioning of the 
         <span class="fa fa-info" title="Resolution: ${sensor.resolution}, Asset: '${sensor.asset_name}', Reason: ${sensor.relation}" style="margin-left: 10px;"></span>`,
       source_type: sensor.source_type || "None",
       staleness_since: `
-        <psan title="${sensor.staleness_since ? sensor.staleness_since : 'Never'}"> 
+        <span title="${sensor.staleness_since ? sensor.staleness_since : 'Never'}"> 
           ${
             sensor.staleness_since ?
               getHumanFriendlyDeltaOrTimeStr(sensor.staleness_since) :
@@ -85,10 +85,11 @@ Sensors shown on this page are the ones relevant for correct functioning of the 
     const jobStatusMessage = job.err ? `${job.status}: ${job.err}` : job.status;
     const jobStatusIcon = job.status === "finished" ? "🟢" :
                           job.status === "failed" ? "🔴" : "🟡";
+    const createdAtTimestamp = job.enqueued_at ? Date.parse(job.enqueued_at) : 0;
     return {
-      created_at_timestamp: job.enqueued_at,
+      created_at_timestamp: createdAtTimestamp,
       created_at: `
-       <psan title="${job.enqueued_at? job.enqueued_at: 'Never'}"> 
+       <span title="${job.enqueued_at? job.enqueued_at: 'Never'}"> 
           ${
             job.enqueued_at ?
               getHumanFriendlyDeltaOrTimeStr(job.enqueued_at) :
@@ -226,13 +227,12 @@ Sensors shown on this page are the ones relevant for correct functioning of the 
     // JOBS TABLE
     const jobsTable = $("#jobsTable").DataTable({
       order: [[0, "desc"]],
-      columnDefs: [{ targets: 1, orderData: 0 }],
       searching: false,
       paging: false,
       info: false,
       columns: [
         { data: "created_at_timestamp", title: "Created At Timestamp", visible: false },
-        { data: "created_at", title: "Created At", orderable: true},
+        { data: "created_at", title: "Created At", orderable: true, orderData: 0 },
         { data: "queue", title: "Queue", orderable: true},
         { data: "entity", title: "Entity", orderable: false},
         { data: "status", title: "Status", className: "text-right", orderable: false},


### PR DESCRIPTION
## Description

In this Pr, the sorting based on "created at" was fixed on the "latest jobs" table found in the asset status page.

## Look & Feel

Before:
<img width="1602" height="752" alt="587635053-c9575abd-d04a-4904-8c18-5a741c5a77f4" src="https://github.com/user-attachments/assets/e8c098c0-eb9a-44b0-ac73-c35bca198c21" />

After:
<img width="1342" height="900" alt="Screenshot from 2026-06-02 11-17-58" src="https://github.com/user-attachments/assets/0090395b-4dc6-4eba-b321-c0a38e7f3ad5" />
<img width="1342" height="900" alt="Screenshot from 2026-06-02 11-17-53" src="https://github.com/user-attachments/assets/feedb4f0-38ff-4a40-a272-112255b23992" />

## How to test

make sure the asset has some jobs data, so the table is not empty.

Go to: http://localhost:5000/assets/<asset_id>/status

## Further Improvements

None
## Related Items

This PR closes: https://github.com/SeitaBV/ems/issues/213

#### Sign-off

<!--
We ask contributors outside the FlexMeasures organisation to sign off on their contribution.
Please mark the below fields with an [x].
-->

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
