### PR TITLE
Fix: power capacity does not need to be mandatory

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -11,7 +11,7 @@ New features
 -------------
 * Floor off-clock API datetimes to a non-instantaneous sensor's resolution by default when ingesting sensor data, uploading sensor data, and handling scheduler flex-model timed events; configurable with the ``floor_datetimes_to_resolution`` sensor attribute [see `PR #2146 <https://www.github.com/FlexMeasures/flexmeasures/pull/2146>`_]
 * Sensor references in flex-model and flex-context support various ways of filtering by source [see `PR #2209 <https://www.github.com/FlexMeasures/flexmeasures/pull/2209>`_]
-* Let storage scheduling infer missing ``power-capacity`` from directional device capacities before falling back to site capacity, and default the missing opposite capacity to zero when only ``consumption-capacity`` or ``production-capacity`` is configured [see `PR #2222 <https://www.github.com/FlexMeasures/flexmeasures/pull/2222>`_]
+* Let storage scheduling infer missing ``power-capacity`` from directional device capacities before falling back to site capacity, and default the missing opposite capacity to zero when only a non-zero ``consumption-capacity`` or ``production-capacity`` is configured [see `PR #2222 <https://www.github.com/FlexMeasures/flexmeasures/pull/2222>`_]
 
 
 Infrastructure / Support

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -11,6 +11,7 @@ New features
 -------------
 * Floor off-clock API datetimes to a non-instantaneous sensor's resolution by default when ingesting sensor data, uploading sensor data, and handling scheduler flex-model timed events; configurable with the ``floor_datetimes_to_resolution`` sensor attribute [see `PR #2146 <https://www.github.com/FlexMeasures/flexmeasures/pull/2146>`_]
 * Sensor references in flex-model and flex-context support various ways of filtering by source [see `PR #2209 <https://www.github.com/FlexMeasures/flexmeasures/pull/2209>`_]
+* Let storage scheduling infer missing ``power-capacity`` from directional device capacities before falling back to site capacity, and default the missing opposite capacity to zero when only ``consumption-capacity`` or ``production-capacity`` is configured [see `PR #2222 <https://www.github.com/FlexMeasures/flexmeasures/pull/2222>`_]
 
 
 Infrastructure / Support
@@ -21,7 +22,6 @@ Infrastructure / Support
 
 Bugfixes
 -----------
-* Let storage scheduling infer missing ``power-capacity`` from directional device capacities before falling back to site capacity, and default the missing opposite capacity to zero when only ``consumption-capacity`` or ``production-capacity`` is configured [see `PR #2222 <https://www.github.com/FlexMeasures/flexmeasures/pull/2222>`_]
 
 
 v0.33.0 | June 1, 2026

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -21,6 +21,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
+* Let storage scheduling infer missing ``power-capacity`` from directional device capacities before falling back to site capacity [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
 
 
 v0.33.0 | June 1, 2026

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -21,7 +21,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
-* Let storage scheduling infer missing ``power-capacity`` from directional device capacities before falling back to site capacity [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
+* Let storage scheduling infer missing ``power-capacity`` from directional device capacities before falling back to site capacity [see `PR #2222 <https://www.github.com/FlexMeasures/flexmeasures/pull/2222>`_]
 
 
 v0.33.0 | June 1, 2026

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -21,7 +21,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
-* Let storage scheduling infer missing ``power-capacity`` from directional device capacities before falling back to site capacity [see `PR #2222 <https://www.github.com/FlexMeasures/flexmeasures/pull/2222>`_]
+* Let storage scheduling infer missing ``power-capacity`` from directional device capacities before falling back to site capacity, and default the missing opposite capacity to zero when only ``consumption-capacity`` or ``production-capacity`` is configured [see `PR #2222 <https://www.github.com/FlexMeasures/flexmeasures/pull/2222>`_]
 
 
 v0.33.0 | June 1, 2026

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -124,6 +124,10 @@ class MetaStorageScheduler(Scheduler):
         flex_model = self.flex_model.copy()
         if not isinstance(flex_model, list):
             flex_model = [flex_model]
+        else:
+            flex_model = [flex_model_d.copy() for flex_model_d in flex_model]
+        for flex_model_d in flex_model:
+            self._default_missing_directional_capacity_to_zero(flex_model_d)
 
         # total number of flexible devices D described in the flex-model
         num_flexible_devices = len(flex_model)
@@ -1493,7 +1497,7 @@ class MetaStorageScheduler(Scheduler):
             if fallback_capacity is not None:
                 current_app.logger.warning(
                     f"Missing 'power-capacity' on asset {asset.id}. "
-                    "Using the largest of consumption-capacity and production-capacity instead."
+                    "Using the largest configured directional capacity instead."
                 )
                 power_capacities.append(fallback_capacity)
                 continue
@@ -1521,6 +1525,17 @@ class MetaStorageScheduler(Scheduler):
             )
         return power_capacities
 
+    @staticmethod
+    def _default_missing_directional_capacity_to_zero(flex_model_d: dict) -> None:
+        """Default the missing opposite directional capacity to zero."""
+        has_consumption_capacity = flex_model_d.get("consumption_capacity") is not None
+        has_production_capacity = flex_model_d.get("production_capacity") is not None
+
+        if has_consumption_capacity and not has_production_capacity:
+            flex_model_d["production_capacity"] = ur.Quantity("0 MW")
+        elif has_production_capacity and not has_consumption_capacity:
+            flex_model_d["consumption_capacity"] = ur.Quantity("0 MW")
+
     def _get_largest_device_capacity(
         self,
         flex_model_d: dict,
@@ -1528,13 +1543,16 @@ class MetaStorageScheduler(Scheduler):
         resolution: timedelta,
         beliefs_before: datetime | None,
     ) -> Sensor | SensorReference | list[dict] | ur.Quantity | pd.Series | None:
-        """Return the largest directional capacity when both directions are configured."""
+        """Return the largest configured directional capacity, if any."""
         capacity_fields = ("consumption_capacity", "production_capacity")
-        if any(flex_model_d.get(field) is None for field in capacity_fields):
+        configured_capacity_fields = [
+            field for field in capacity_fields if flex_model_d.get(field) is not None
+        ]
+        if not configured_capacity_fields:
             return None
         capacities = [
             self._ensure_variable_quantity(flex_model_d[field], "MW")
-            for field in capacity_fields
+            for field in configured_capacity_fields
         ]
 
         capacity_series = [

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -1528,13 +1528,41 @@ class MetaStorageScheduler(Scheduler):
     @staticmethod
     def _default_missing_directional_capacity_to_zero(flex_model_d: dict) -> None:
         """Given a missing capacity opposite a non-zero directional capacity, default the missing capacity to zero."""
-        has_consumption_capacity = flex_model_d.get("consumption_capacity") is not None
-        has_production_capacity = flex_model_d.get("production_capacity") is not None
+        consumption_capacity = flex_model_d.get("consumption_capacity")
+        production_capacity = flex_model_d.get("production_capacity")
+        has_consumption_capacity = consumption_capacity is not None
+        has_production_capacity = production_capacity is not None
 
-        if has_consumption_capacity and not has_production_capacity:
+        if (
+            has_consumption_capacity
+            and not has_production_capacity
+            and MetaStorageScheduler._is_non_zero_capacity(consumption_capacity)
+        ):
             flex_model_d["production_capacity"] = ur.Quantity("0 MW")
-        elif has_production_capacity and not has_consumption_capacity:
+        elif (
+            has_production_capacity
+            and not has_consumption_capacity
+            and MetaStorageScheduler._is_non_zero_capacity(production_capacity)
+        ):
             flex_model_d["consumption_capacity"] = ur.Quantity("0 MW")
+
+    @staticmethod
+    def _is_non_zero_capacity(
+        capacity: str | int | float | ur.Quantity | Sensor | SensorReference | list
+    ) -> bool:
+        """Return whether a configured capacity should imply zero capacity in the opposite direction."""
+        if isinstance(capacity, (Sensor, SensorReference)):
+            return True
+        if isinstance(capacity, list):
+            return any(
+                MetaStorageScheduler._is_non_zero_capacity(event["value"])
+                for event in capacity
+            )
+        if isinstance(capacity, str):
+            capacity = ur.Quantity(capacity)
+        if isinstance(capacity, ur.Quantity):
+            return bool(np.any(capacity.magnitude != 0))
+        return capacity != 0
 
     def _get_largest_device_capacity(
         self,
@@ -1570,6 +1598,11 @@ class MetaStorageScheduler(Scheduler):
         ]
         largest_capacity = pd.concat(capacity_series, axis=1).max(axis=1)
         if largest_capacity.isna().all():
+            return None
+        if (
+            len(configured_capacity_fields) == 1
+            and largest_capacity.fillna(0).eq(0).all()
+        ):
             return None
         return largest_capacity
 

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -1548,7 +1548,7 @@ class MetaStorageScheduler(Scheduler):
 
     @staticmethod
     def _is_non_zero_capacity(
-        capacity: str | int | float | ur.Quantity | Sensor | SensorReference | list
+        capacity: str | int | float | ur.Quantity | Sensor | SensorReference | list,
     ) -> bool:
         """Return whether a configured capacity should imply zero capacity in the opposite direction."""
         if isinstance(capacity, (Sensor, SensorReference)):

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -1527,7 +1527,7 @@ class MetaStorageScheduler(Scheduler):
 
     @staticmethod
     def _default_missing_directional_capacity_to_zero(flex_model_d: dict) -> None:
-        """Default the missing opposite directional capacity to zero."""
+        """Given a missing capacity opposite a non-zero directional capacity, default the missing capacity to zero."""
         has_consumption_capacity = flex_model_d.get("consumption_capacity") is not None
         has_production_capacity = flex_model_d.get("production_capacity") is not None
 

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -176,8 +176,14 @@ class MetaStorageScheduler(Scheduler):
             "inflexible_device_sensors", []
         )
 
-        # Fetch the device's power capacity (required Sensor attribute)
-        power_capacity_in_mw = self._get_device_power_capacity(flex_model, assets)
+        # Fetch the device's power capacity (required to keep the optimization problem bounded)
+        power_capacity_in_mw = self._get_device_power_capacity(
+            flex_model,
+            assets,
+            query_window=(start, end),
+            resolution=resolution,
+            beliefs_before=belief_time,
+        )
 
         # Check for known prices or price forecasts
         up_deviation_prices = get_continuous_series_sensor_or_quantity(
@@ -1448,14 +1454,20 @@ class MetaStorageScheduler(Scheduler):
                     )
 
     def _get_device_power_capacity(
-        self, flex_model: list[dict], assets: list[Asset]
-    ) -> list[ur.Quantity]:
+        self,
+        flex_model: list[dict],
+        assets: list[Asset],
+        query_window: tuple[datetime, datetime],
+        resolution: timedelta,
+        beliefs_before: datetime | None,
+    ) -> list[Sensor | SensorReference | list[dict] | ur.Quantity | pd.Series]:
         """The device power capacity for each device must be known for the optimization problem to stay bounded.
 
         We search for the power capacity in the following order:
         1. Look for the power_capacity_in_mw field in the deserialized flex-model.
         2. Look for the power-capacity flex-model field of the asset.
-        3. Look for the site-power-capacity attribute of the asset.
+        3. Look for the greatest device consumption-capacity or production-capacity.
+        4. Look for the site-power-capacity attribute of the asset.
         """
         power_capacities = []
         for flex_model_d, asset in zip(flex_model, assets):
@@ -1472,6 +1484,21 @@ class MetaStorageScheduler(Scheduler):
                 continue
 
             # 3
+            fallback_capacity = self._get_largest_device_capacity(
+                flex_model_d=flex_model_d,
+                query_window=query_window,
+                resolution=resolution,
+                beliefs_before=beliefs_before,
+            )
+            if fallback_capacity is not None:
+                current_app.logger.warning(
+                    f"Missing 'power-capacity' on asset {asset.id}. "
+                    "Using the largest of consumption-capacity and production-capacity instead."
+                )
+                power_capacities.append(fallback_capacity)
+                continue
+
+            # 4
             site_power_capacity = asset.get_attribute("site-power-capacity")
             if site_power_capacity is not None:
                 current_app.logger.warning(
@@ -1494,14 +1521,47 @@ class MetaStorageScheduler(Scheduler):
             )
         return power_capacities
 
+    def _get_largest_device_capacity(
+        self,
+        flex_model_d: dict,
+        query_window: tuple[datetime, datetime],
+        resolution: timedelta,
+        beliefs_before: datetime | None,
+    ) -> Sensor | SensorReference | list[dict] | ur.Quantity | pd.Series | None:
+        """Return the largest directional capacity when both directions are configured."""
+        capacity_fields = ("consumption_capacity", "production_capacity")
+        if any(flex_model_d.get(field) is None for field in capacity_fields):
+            return None
+        capacities = [
+            self._ensure_variable_quantity(flex_model_d[field], "MW")
+            for field in capacity_fields
+        ]
+
+        capacity_series = [
+            get_continuous_series_sensor_or_quantity(
+                variable_quantity=capacity,
+                unit="MW",
+                query_window=query_window,
+                resolution=resolution,
+                beliefs_before=beliefs_before,
+                min_value=0,
+                resolve_overlaps="min",
+            )
+            for capacity in capacities
+        ]
+        largest_capacity = pd.concat(capacity_series, axis=1).max(axis=1)
+        if largest_capacity.isna().all():
+            return None
+        return largest_capacity
+
     def _ensure_variable_quantity(
-        self, value: str | int | float | ur.Quantity, unit: str
-    ) -> Sensor | SensorReference | list[dict] | ur.Quantity:
+        self, value: str | int | float | ur.Quantity | pd.Series, unit: str
+    ) -> Sensor | SensorReference | list[dict] | ur.Quantity | pd.Series:
         if isinstance(value, str):
             q = ur.Quantity(value).to(unit)
         elif isinstance(value, (float, int)):
             q = ur.Quantity(f"{value} {unit}")
-        elif isinstance(value, (Sensor, SensorReference, list, ur.Quantity)):
+        elif isinstance(value, (Sensor, SensorReference, list, ur.Quantity, pd.Series)):
             q = value
         else:
             raise TypeError(

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -1563,7 +1563,8 @@ class MetaStorageScheduler(Scheduler):
                 resolution=resolution,
                 beliefs_before=beliefs_before,
                 min_value=0,
-                resolve_overlaps="min",
+                # Normally, we'd resolve overlapping time series segments for capacities with "min", but here our goal is to find the maximum capacity.
+                resolve_overlaps="max",
             )
             for capacity in capacities
         ]

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -1391,6 +1391,51 @@ def test_capacity(
 
 
 @pytest.mark.parametrize(
+    "production_capacity, consumption_capacity, expected_capacity",
+    [
+        ("300 kW", "700 kW", 0.7),
+        ("1.1 MW", "200 kW", 1.1),
+    ],
+)
+def test_device_power_capacity_uses_greatest_directional_capacity_before_site_fallback(
+    db,
+    add_battery_assets,
+    production_capacity,
+    consumption_capacity,
+    expected_capacity,
+):
+    _, battery = get_sensors_from_db(db, add_battery_assets)
+
+    start = pytz.timezone("Europe/Amsterdam").localize(datetime(2015, 1, 2))
+    end = pytz.timezone("Europe/Amsterdam").localize(datetime(2015, 1, 3))
+    resolution = timedelta(minutes=15)
+    scheduler = StorageScheduler(
+        asset_or_sensor=battery,
+        start=start,
+        end=end,
+        resolution=resolution,
+        flex_model={
+            "soc-at-start": 0,
+            "soc-min": 0,
+            "soc-max": 5,
+            "production-capacity": production_capacity,
+            "consumption-capacity": consumption_capacity,
+        },
+    )
+    scheduler.deserialize_config()
+
+    power_capacity = scheduler._get_device_power_capacity(
+        [scheduler.flex_model],
+        [battery.generic_asset],
+        query_window=(start, end),
+        resolution=resolution,
+        beliefs_before=scheduler.belief_time,
+    )[0]
+
+    assert np.allclose(power_capacity.values, expected_capacity)
+
+
+@pytest.mark.parametrize(
     ["soc_values", "log_message", "expected_num_targets"],
     [
         (

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -1391,18 +1391,31 @@ def test_capacity(
 
 
 @pytest.mark.parametrize(
-    "production_capacity, consumption_capacity, expected_capacity",
+    "configured_capacities, expected_capacity, expected_derivative_min, expected_derivative_max",
     [
-        ("300 kW", "700 kW", 0.7),
-        ("1.1 MW", "200 kW", 1.1),
+        (
+            {"production-capacity": "300 kW", "consumption-capacity": "700 kW"},
+            0.7,
+            -0.3,
+            0.7,
+        ),
+        (
+            {"production-capacity": "1.1 MW", "consumption-capacity": "200 kW"},
+            1.1,
+            -1.1,
+            0.2,
+        ),
+        ({"consumption-capacity": "700 kW"}, 0.7, 0, 0.7),
+        ({"production-capacity": "300 kW"}, 0.3, -0.3, 0),
     ],
 )
-def test_device_power_capacity_uses_greatest_directional_capacity_before_site_fallback(
+def test_device_power_capacity_uses_directional_capacity_before_site_fallback(
     db,
     add_battery_assets,
-    production_capacity,
-    consumption_capacity,
+    configured_capacities,
     expected_capacity,
+    expected_derivative_min,
+    expected_derivative_max,
 ):
     _, battery = get_sensors_from_db(db, add_battery_assets)
 
@@ -1418,9 +1431,9 @@ def test_device_power_capacity_uses_greatest_directional_capacity_before_site_fa
             "soc-at-start": 0,
             "soc-min": 0,
             "soc-max": 5,
-            "production-capacity": production_capacity,
-            "consumption-capacity": consumption_capacity,
+            **configured_capacities,
         },
+        flex_context={"consumption-price": "1 EUR/MWh"},
     )
     scheduler.deserialize_config()
 
@@ -1433,6 +1446,11 @@ def test_device_power_capacity_uses_greatest_directional_capacity_before_site_fa
     )[0]
 
     assert np.allclose(power_capacity.values, expected_capacity)
+
+    device_constraints = scheduler._prepare(skip_validation=True)[5]
+
+    assert np.allclose(device_constraints[0]["derivative min"], expected_derivative_min)
+    assert np.allclose(device_constraints[0]["derivative max"], expected_derivative_max)
 
 
 @pytest.mark.parametrize(
@@ -1552,7 +1570,7 @@ def test_build_device_soc_values(caplog, soc_values, log_message, expected_num_t
             True,
             None,
             None,
-            # from the power sensor attribute 'consumption_capacity'
+            # from the power sensor attribute 'production_capacity'
             [-8] * 24 * 4,
             # from the flex model field 'consumption-capacity' (a sensor),
             # and when absent, defaulting to the max value from the power sensor attribute capacity_in_mw
@@ -1618,8 +1636,8 @@ def test_build_device_soc_values(caplog, soc_values, log_message, expected_num_t
             None,
             # from the flex model field 'production-capacity' (a quantity)
             -0.01,
-            # from the asset attribute 'capacity_in_mw'
-            2,
+            # missing consumption-capacity defaults to zero when production-capacity is provided
+            0,
             False,
             False,
             -1.1,
@@ -1871,6 +1889,7 @@ def test_battery_stock_delta_sensor(
         "roundtrip-efficiency": 1,
         "storage-efficiency": 1,
         "production-capacity": "0kW",
+        "consumption-capacity": f"{capacity}MW",
         "soc-at-start": 0,
     }
     if stock_delta_sensor is not None:
@@ -2062,6 +2081,7 @@ def test_battery_storage_efficiency_sensor(
             "roundtrip-efficiency": 1,
             "storage-efficiency": {"sensor": storage_efficiency_sensor_obj.id},
             "production-capacity": "0kW",
+            "consumption-capacity": "2MW",
             "soc-at-start": 0,
         },
     )
@@ -2143,6 +2163,7 @@ def test_add_storage_constraint_from_sensor(
         "soc-min": 0,
         "roundtrip-efficiency": 1,
         "production-capacity": "0kW",
+        "consumption-capacity": "2MW",
         "soc-at-start": soc_at_start,
     }
 

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -1407,6 +1407,8 @@ def test_capacity(
         ),
         ({"consumption-capacity": "700 kW"}, 0.7, 0, 0.7),
         ({"production-capacity": "300 kW"}, 0.3, -0.3, 0),
+        ({"consumption-capacity": "0 kW"}, 2, -2, 0),
+        ({"production-capacity": "0 kW"}, 2, 0, 2),
     ],
 )
 def test_device_power_capacity_uses_directional_capacity_before_site_fallback(
@@ -1445,7 +1447,11 @@ def test_device_power_capacity_uses_directional_capacity_before_site_fallback(
         beliefs_before=scheduler.belief_time,
     )[0]
 
-    assert np.allclose(power_capacity.values, expected_capacity)
+    if isinstance(power_capacity, ur.Quantity):
+        actual_capacity = power_capacity.to("MW").magnitude
+    else:
+        actual_capacity = power_capacity.values
+    assert np.allclose(actual_capacity, expected_capacity)
 
     device_constraints = scheduler._prepare(skip_validation=True)[5]
 
@@ -1889,7 +1895,6 @@ def test_battery_stock_delta_sensor(
         "roundtrip-efficiency": 1,
         "storage-efficiency": 1,
         "production-capacity": "0kW",
-        "consumption-capacity": f"{capacity}MW",
         "soc-at-start": 0,
     }
     if stock_delta_sensor is not None:
@@ -2081,7 +2086,6 @@ def test_battery_storage_efficiency_sensor(
             "roundtrip-efficiency": 1,
             "storage-efficiency": {"sensor": storage_efficiency_sensor_obj.id},
             "production-capacity": "0kW",
-            "consumption-capacity": "2MW",
             "soc-at-start": 0,
         },
     )
@@ -2163,7 +2167,6 @@ def test_add_storage_constraint_from_sensor(
         "soc-min": 0,
         "roundtrip-efficiency": 1,
         "production-capacity": "0kW",
-        "consumption-capacity": "2MW",
         "soc-at-start": soc_at_start,
     }
 

--- a/flexmeasures/data/schemas/scheduling/metadata.py
+++ b/flexmeasures/data/schemas/scheduling/metadata.py
@@ -337,7 +337,8 @@ Boolean option only.
 )
 POWER_CAPACITY = MetaData(
     description="""Symmetric device-level power constraint. How much power can be applied to this asset in either direction.
-If omitted, the scheduler infers this limit from the greatest of ``consumption-capacity`` and ``production-capacity`` when either is configured, before falling back to ``site-power-capacity``. [#minimum_overlap]_""",
+If omitted, the scheduler infers this limit from the greatest of ``consumption-capacity`` and ``production-capacity`` when either is configured, before falling back to ``site-power-capacity``.
+When exactly one of ``consumption-capacity`` or ``production-capacity`` is configured, the missing opposite capacity defaults to zero. [#minimum_overlap]_""",
     example="50 kVA",
 )
 CONSUMPTION_CAPACITY = MetaData(

--- a/flexmeasures/data/schemas/scheduling/metadata.py
+++ b/flexmeasures/data/schemas/scheduling/metadata.py
@@ -342,7 +342,7 @@ When exactly one of ``consumption-capacity`` or ``production-capacity`` is confi
     example="50 kVA",
 )
 CONSUMPTION_CAPACITY = MetaData(
-    description="""Device-level power constraint on consumption. How much power can be drawn by this asset. [#minimum_overlap]_""",
+    description="Device-level power constraint on consumption. How much power can be drawn by this asset. [#minimum_overlap]_",
     example={"sensor": 56},
 )
 PRODUCTION_CAPACITY = MetaData(

--- a/flexmeasures/data/schemas/scheduling/metadata.py
+++ b/flexmeasures/data/schemas/scheduling/metadata.py
@@ -341,8 +341,7 @@ If omitted, the scheduler infers this limit from the greatest of ``consumption-c
     example="50 kVA",
 )
 CONSUMPTION_CAPACITY = MetaData(
-    description="""Device-level power constraint on consumption. How much power can be drawn by this asset.
-If ``power-capacity`` is omitted and ``production-capacity`` is also configured, this field contributes to the inferred symmetric device-level power limit. [#minimum_overlap]_""",
+    description="""Device-level power constraint on consumption. How much power can be drawn by this asset. [#minimum_overlap]_""",
     example={"sensor": 56},
 )
 PRODUCTION_CAPACITY = MetaData(

--- a/flexmeasures/data/schemas/scheduling/metadata.py
+++ b/flexmeasures/data/schemas/scheduling/metadata.py
@@ -337,7 +337,7 @@ Boolean option only.
 )
 POWER_CAPACITY = MetaData(
     description="""Symmetric device-level power constraint. How much power can be applied to this asset in either direction.
-If omitted, the scheduler infers this limit from the greatest of ``consumption-capacity`` and ``production-capacity`` when both are configured, before falling back to ``site-power-capacity``. [#minimum_overlap]_""",
+If omitted, the scheduler infers this limit from the greatest of ``consumption-capacity`` and ``production-capacity`` when either is configured, before falling back to ``site-power-capacity``. [#minimum_overlap]_""",
     example="50 kVA",
 )
 CONSUMPTION_CAPACITY = MetaData(

--- a/flexmeasures/data/schemas/scheduling/metadata.py
+++ b/flexmeasures/data/schemas/scheduling/metadata.py
@@ -338,7 +338,7 @@ Boolean option only.
 POWER_CAPACITY = MetaData(
     description="""Symmetric device-level power constraint. How much power can be applied to this asset in either direction.
 If omitted, the scheduler infers this limit from the greatest of ``consumption-capacity`` and ``production-capacity`` when either is configured, before falling back to ``site-power-capacity``.
-When exactly one of ``consumption-capacity`` or ``production-capacity`` is configured, the missing opposite capacity defaults to zero. [#minimum_overlap]_""",
+When exactly one of ``consumption-capacity`` or ``production-capacity`` is configured to non-zero capacity, the missing opposite capacity defaults to zero. [#minimum_overlap]_""",
     example="50 kVA",
 )
 CONSUMPTION_CAPACITY = MetaData(

--- a/flexmeasures/data/schemas/scheduling/metadata.py
+++ b/flexmeasures/data/schemas/scheduling/metadata.py
@@ -336,16 +336,19 @@ Boolean option only.
     example=True,
 )
 POWER_CAPACITY = MetaData(
-    description="Device-level power constraint. How much power can be applied to this asset. [#minimum_overlap]_",
+    description="""Symmetric device-level power constraint. How much power can be applied to this asset in either direction.
+If omitted, the scheduler infers this limit from the greatest of ``consumption-capacity`` and ``production-capacity`` when both are configured, before falling back to ``site-power-capacity``. [#minimum_overlap]_""",
     example="50 kVA",
 )
 CONSUMPTION_CAPACITY = MetaData(
-    description="Device-level power constraint on consumption. How much power can be drawn by this asset. [#minimum_overlap]_",
+    description="""Device-level power constraint on consumption. How much power can be drawn by this asset.
+If ``power-capacity`` is omitted and ``production-capacity`` is also configured, this field contributes to the inferred symmetric device-level power limit. [#minimum_overlap]_""",
     example={"sensor": 56},
 )
 PRODUCTION_CAPACITY = MetaData(
     description="""Device-level power constraint on production.
 How much power can be supplied by this asset.
+If ``power-capacity`` is omitted and ``consumption-capacity`` is also configured, this field contributes to the inferred symmetric device-level power limit.
 For :abbr:`PV (photovoltaic solar panels)` curtailment, set this to reference your sensor containing PV power forecasts. [#minimum_overlap]_
 """,
     example="0 kW",

--- a/flexmeasures/data/schemas/scheduling/metadata.py
+++ b/flexmeasures/data/schemas/scheduling/metadata.py
@@ -347,7 +347,6 @@ CONSUMPTION_CAPACITY = MetaData(
 PRODUCTION_CAPACITY = MetaData(
     description="""Device-level power constraint on production.
 How much power can be supplied by this asset.
-If ``power-capacity`` is omitted and ``consumption-capacity`` is also configured, this field contributes to the inferred symmetric device-level power limit.
 For :abbr:`PV (photovoltaic solar panels)` curtailment, set this to reference your sensor containing PV power forecasts. [#minimum_overlap]_
 """,
     example="0 kW",

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -6094,7 +6094,7 @@
             "example": "7 kWh"
           },
           "power-capacity": {
-            "description": "Device-level power constraint. How much power can be applied to this asset.",
+            "description": "Symmetric device-level power constraint. How much power can be applied to this asset in either direction.\nIf omitted, the scheduler infers this limit from the greatest of <code>consumption-capacity</code> and <code>production-capacity</code> when either is configured, before falling back to <code>site-power-capacity</code>.\nWhen exactly one of <code>consumption-capacity</code> or <code>production-capacity</code> is configured to non-zero capacity, the missing opposite capacity defaults to zero.",
             "example": "50 kVA",
             "$ref": "#/components/schemas/VariableQuantityOpenAPI"
           },


### PR DESCRIPTION
## Description

- [x] Let storage scheduling continue when a flex-model omits `power-capacity`.
- [x] Infer the symmetric device-level power limit from the greatest of `consumption-capacity` and `production-capacity` when both directional capacities are configured.
- [x] Keep the existing `site-power-capacity` fallback after the directional-capacity fallback.
- [x] Clarified the scheduling metadata for `power-capacity`, `consumption-capacity`, and `production-capacity`.
- [x] Added changelog entry.

## Look & Feel

N/A. This is scheduler behavior and documentation only.

## How to test


```bash
pytest -k "device_power_capacity_uses_greatest_directional_capacity_before_site_fallback"
```


Manual check:

- With no `power-capacity`, `production_capacity = 300 kW`, and `consumption_capacity = 700 kW`, `_get_device_power_capacity` returned a 96-step capacity series whose values are close to `0.7 MW`.
- The method logged the expected missing `power-capacity` warning instead of raising the previous error.


## Related Items

Closes SeitaBV/ems#210

---

#### Sign-off

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
