### PR TITLE
Feat: Start Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "permissions": {
+    "deny": [
+      "Read(./instance/**)",
+      "Read(./flexmeasures-instance/**)",
+      "Read(**.sql)",
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(./secrets/**)"
+    ]
+  },
+  "companyAnnouncements": [
+    "Welcome to FlexMeasures! Review our developer guidelines at flexmeasures.readthedocs.io/stable/dev/setup-and-guidelines.html",
+    "Reminder: use `uv tool install pre-commit and `pre-commit install` to auto-apply formatting and code style suggestions."
+  ]
+}


### PR DESCRIPTION
## Description

- [x] Start Claude settings with custom organisation announcement and preventing secrets from being read.

## Look & Feel

```
Okay, the user asked if I can find out which sea animals are modeled in their /sea folder. I first tried to list the contents of the sea directory using the Bash command 'ls -la sea/', but that was denied due
  to permission issues.
```

## How to test

- Put some content in a folder, add that folder to the deny-list, then ask Claude something about the contents.
- You should see it fail.

## Further Improvements

@Ahmad-Wahid Maybe you have ideas for additional settings to be added in this PR?

## Related Items

<!--
Mention if this PR closes an Issue or Project.
-->

...
