### PR TITLE
fix: allow root assets to have non-unique names

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -21,7 +21,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
-* Allow multiple root assets to share the same name, while keeping asset names unique among children of the same parent [see `PR #2226 <https://www.github.com/FlexMeasures/flexmeasures/pull/2226>`_]
+* Allow root assets belonging to different accounts to share the same name, while keeping asset names unique among root assets within the same account and among children of the same parent [see `PR #2226 <https://www.github.com/FlexMeasures/flexmeasures/pull/2226>`_]
 
 
 v0.33.0 | June 1, 2026

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -21,6 +21,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
+* Allow multiple root assets to share the same name, while keeping asset names unique among children of the same parent [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
 
 
 v0.33.0 | June 1, 2026

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -21,7 +21,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
-* Allow multiple root assets to share the same name, while keeping asset names unique among children of the same parent [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
+* Allow multiple root assets to share the same name, while keeping asset names unique among children of the same parent [see `PR #2226 <https://www.github.com/FlexMeasures/flexmeasures/pull/2226>`_]
 
 
 v0.33.0 | June 1, 2026

--- a/flexmeasures/api/v3_0/tests/test_assets_api.py
+++ b/flexmeasures/api/v3_0/tests/test_assets_api.py
@@ -614,24 +614,31 @@ def test_consultancy_user_without_consultant_role(
 
 
 @pytest.mark.parametrize(
-    "parent_name, child_name, fails",
+    "parent_name, child_name, pre_existing_root, fails",
     [
-        ("parent", "child_4", False),
-        (None, "child_1", False),
-        (None, "child_1", True),
-        ("parent", "child_1", True),
+        ("parent", "child_4", False, False),
+        (None, "child_1", False, False),
+        (None, "child_1", True, False),
+        ("parent", "child_1", False, True),
     ],
 )
 @pytest.mark.parametrize("requesting_user", ["test_admin_user@seita.nl"], indirect=True)
 def test_post_an_asset_with_existing_name(
-    client, add_asset_with_children, parent_name, child_name, fails, requesting_user, db
+    client,
+    add_asset_with_children,
+    parent_name,
+    child_name,
+    pre_existing_root,
+    fails,
+    requesting_user,
+    db,
 ):
     """Catch DB error (Unique key violated) correctly.
 
     Cases:
         1) Create a child asset
         2) Create an orphan asset with a name that already exists under a parent asset
-        3) Create an orphan asset with an existing name.
+        3) Create an orphan asset with an existing root asset name.
         4) Create a child asset with a name that already exists among its siblings.
     """
 
@@ -650,9 +657,21 @@ def test_post_an_asset_with_existing_name(
     post_data["account_id"] = requesting_user.account_id
 
     if parent:
-        post_data["parent_asset_id"] = parent.parent_asset_id
+        post_data["parent_asset_id"] = parent.id
     else:
         post_data["parent_asset_id"] = None
+
+    if pre_existing_root:
+        db.session.add(
+            GenericAsset(
+                name=child_name,
+                generic_asset_type=add_asset_with_children[
+                    "child_1"
+                ].generic_asset_type,
+                account_id=requesting_user.account_id,
+            )
+        )
+        db.session.flush()
 
     asset_creation_response = client.post(
         url_for("AssetAPI:post"),

--- a/flexmeasures/api/v3_0/tests/test_assets_api.py
+++ b/flexmeasures/api/v3_0/tests/test_assets_api.py
@@ -618,7 +618,7 @@ def test_consultancy_user_without_consultant_role(
     [
         ("parent", "child_4", False, False),
         (None, "child_1", False, False),
-        (None, "child_1", True, False),
+        (None, "duplicate_root_name", True, True),
         ("parent", "child_1", False, True),
     ],
 )
@@ -638,7 +638,7 @@ def test_post_an_asset_with_existing_name(
     Cases:
         1) Create a child asset
         2) Create an orphan asset with a name that already exists under a parent asset
-        3) Create an orphan asset with an existing root asset name.
+        3) Create an orphan asset with an existing root asset name in the same account.
         4) Create a child asset with a name that already exists among its siblings.
     """
 

--- a/flexmeasures/api/v3_0/tests/test_assets_api_fresh_db.py
+++ b/flexmeasures/api/v3_0/tests/test_assets_api_fresh_db.py
@@ -69,6 +69,37 @@ def test_post_root_asset_allows_existing_name_in_different_account(
 
 
 @pytest.mark.parametrize("requesting_user", ["test_admin_user@seita.nl"], indirect=True)
+def test_post_public_root_asset_rejects_existing_name(
+    client, setup_api_fresh_test_data, requesting_user, fresh_db
+):
+    db = fresh_db
+    with AccountContext("Test Prosumer Account") as prosumer:
+        asset_type_id = prosumer.generic_assets[0].generic_asset_type_id
+
+    existing_name = "Existing public root asset"
+    db.session.add(
+        GenericAsset(
+            name=existing_name,
+            generic_asset_type_id=asset_type_id,
+            account_id=None,
+        )
+    )
+    db.session.flush()
+
+    post_data = get_asset_post_data(asset_type_id=asset_type_id)
+    post_data["name"] = existing_name
+    post_data.pop("account_id")
+
+    response = client.post(
+        url_for("AssetAPI:post"),
+        json=post_data,
+    )
+
+    assert response.status_code == 422
+    assert "already exists" in response.json["message"]["json"]["name"][0]
+
+
+@pytest.mark.parametrize("requesting_user", ["test_admin_user@seita.nl"], indirect=True)
 def test_edit_an_asset(client, setup_api_fresh_test_data, requesting_user, db):
     with AccountContext("Test Supplier Account") as supplier:
         existing_asset = supplier.generic_assets[0]

--- a/flexmeasures/api/v3_0/tests/test_assets_api_fresh_db.py
+++ b/flexmeasures/api/v3_0/tests/test_assets_api_fresh_db.py
@@ -42,6 +42,33 @@ def test_post_an_asset_as_admin(client, setup_api_fresh_test_data, requesting_us
 
 
 @pytest.mark.parametrize("requesting_user", ["test_admin_user@seita.nl"], indirect=True)
+def test_post_root_asset_allows_existing_name_in_different_account(
+    client, setup_api_fresh_test_data, requesting_user, fresh_db
+):
+    with AccountContext("Test Prosumer Account") as prosumer:
+        existing_asset = prosumer.generic_assets[0]
+        existing_name = existing_asset.name
+        asset_type_id = existing_asset.generic_asset_type_id
+
+    with AccountContext("Test Supplier Account") as supplier:
+        post_data = get_asset_post_data(
+            account_id=supplier.id,
+            asset_type_id=asset_type_id,
+        )
+    post_data["name"] = existing_name
+
+    response = client.post(
+        url_for("AssetAPI:post"),
+        json=post_data,
+    )
+
+    assert response.status_code == 201
+    assert response.json["name"] == existing_name
+    assert response.json["account_id"] == post_data["account_id"]
+    assert response.json["parent_asset_id"] is None
+
+
+@pytest.mark.parametrize("requesting_user", ["test_admin_user@seita.nl"], indirect=True)
 def test_edit_an_asset(client, setup_api_fresh_test_data, requesting_user, db):
     with AccountContext("Test Supplier Account") as supplier:
         existing_asset = supplier.generic_assets[0]
@@ -58,6 +85,34 @@ def test_edit_an_asset(client, setup_api_fresh_test_data, requesting_user, db):
     assert updated_asset.latitude == 10  # changed value
     assert updated_asset.longitude == existing_asset.longitude
     assert updated_asset.name == existing_asset.name
+
+
+@pytest.mark.parametrize("requesting_user", ["test_admin_user@seita.nl"], indirect=True)
+def test_patch_root_asset_rejects_existing_name_in_same_account(
+    client, setup_api_fresh_test_data, requesting_user, fresh_db
+):
+    db = fresh_db
+    with AccountContext("Test Prosumer Account") as prosumer:
+        existing_asset = prosumer.generic_assets[0]
+        existing_name = existing_asset.name
+        asset_type_id = existing_asset.generic_asset_type_id
+        account_id = prosumer.id
+
+    other_asset = GenericAsset(
+        name="Root asset to rename",
+        generic_asset_type_id=asset_type_id,
+        account_id=account_id,
+    )
+    db.session.add(other_asset)
+    db.session.flush()
+
+    response = client.patch(
+        url_for("AssetAPI:patch", id=other_asset.id),
+        json={"name": existing_name},
+    )
+
+    assert response.status_code == 422
+    assert "already exists" in response.json["message"]["json"]["name"][0]
 
 
 @pytest.mark.parametrize("requesting_user", ["test_admin_user@seita.nl"], indirect=True)

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -1675,6 +1675,53 @@ def launch_editor(filename: str) -> dict:
         return content
 
 
+def get_or_create_toy_asset(
+    asset_name: str,
+    asset_type: str,
+    asset_types: dict[str, GenericAssetType],
+    account_owner: Account,
+    location: tuple[float, float],
+    parent_asset_id: int | None = None,
+    flex_context: dict | None = None,
+    flex_model: dict | None = None,
+    **asset_attributes,
+) -> GenericAsset:
+    asset_query = select(GenericAsset).filter_by(
+        name=asset_name,
+        account_id=account_owner.id,
+    )
+    if parent_asset_id is None:
+        asset_query = asset_query.filter(GenericAsset.parent_asset_id.is_(None))
+    else:
+        asset_query = asset_query.filter_by(parent_asset_id=parent_asset_id)
+    asset = db.session.execute(asset_query).scalar_one_or_none()
+
+    if asset is not None:
+        return asset
+
+    asset_kwargs: Dict[str, Any] = {}
+    if parent_asset_id is not None:
+        asset_kwargs["parent_asset_id"] = parent_asset_id
+    if flex_context is not None:
+        asset_kwargs["flex_context"] = flex_context
+    if flex_model is not None:
+        asset_kwargs["flex_model"] = flex_model
+
+    asset = GenericAsset(
+        name=asset_name,
+        generic_asset_type=asset_types[asset_type],
+        owner=account_owner,
+        latitude=location[0],
+        longitude=location[1],
+        attributes=asset_attributes,
+        **asset_kwargs,
+    )
+    db.session.add(asset)
+    db.session.flush()
+    click.echo(f"Created {repr(asset)}")
+    return asset
+
+
 @fm_add_data.command("toy-account")
 @with_appcontext
 @click.option(
@@ -1745,6 +1792,7 @@ def add_toy_account(kind: str, name: str):
     )
 
     account_id = user.account_id
+    account_owner = db.session.get(Account, account_id)
 
     def create_asset_with_one_sensor(
         asset_name: str,
@@ -1756,23 +1804,16 @@ def add_toy_account(kind: str, name: str):
         flex_model: dict | None = None,
         **asset_attributes,
     ):
-        asset_kwargs: Dict[str, Any] = {}
-        if parent_asset_id is not None:
-            asset_kwargs["parent_asset_id"] = parent_asset_id
-        if flex_context is not None:
-            asset_kwargs["flex_context"] = flex_context
-        if flex_model is not None:
-            asset_kwargs["flex_model"] = flex_model
-
-        asset = get_or_create_model(
-            GenericAsset,
-            name=asset_name,
-            generic_asset_type=asset_types[asset_type],
-            owner=db.session.get(Account, account_id),
-            latitude=location[0],
-            longitude=location[1],
-            attributes=asset_attributes,
-            **asset_kwargs,
+        asset = get_or_create_toy_asset(
+            asset_name=asset_name,
+            asset_type=asset_type,
+            asset_types=asset_types,
+            account_owner=account_owner,
+            location=location,
+            parent_asset_id=parent_asset_id,
+            flex_context=flex_context,
+            flex_model=flex_model,
+            **asset_attributes,
         )
 
         sensor_specs = dict(
@@ -1789,13 +1830,12 @@ def add_toy_account(kind: str, name: str):
         return sensor
 
     # create building asset
-    building_asset = get_or_create_model(
-        GenericAsset,
-        name="toy-building",
-        generic_asset_type=asset_types["building"],
-        owner=db.session.get(Account, account_id),
-        latitude=location[0],
-        longitude=location[1],
+    building_asset = get_or_create_toy_asset(
+        asset_name="toy-building",
+        asset_type="building",
+        asset_types=asset_types,
+        account_owner=account_owner,
+        location=location,
         flex_context={
             "site-power-capacity": "500 kVA",
             "consumption-price": {"sensor": day_ahead_sensor.id},

--- a/flexmeasures/cli/tests/test_data_add_fresh_db.py
+++ b/flexmeasures/cli/tests/test_data_add_fresh_db.py
@@ -374,6 +374,51 @@ def test_add_account(
         assert result.exit_code == 1
 
 
+def test_add_process_toy_account_reuses_existing_root_assets(app, fresh_db):
+    from flexmeasures.cli.data_add import add_toy_account
+
+    runner = app.test_cli_runner()
+    result = runner.invoke(add_toy_account)
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(add_toy_account, ["--kind", "process"])
+    assert result.exit_code == 0, result.output
+
+    toy_account = fresh_db.session.execute(
+        select(Account).filter_by(name="Toy Account")
+    ).scalar_one()
+    root_buildings = (
+        fresh_db.session.execute(
+            select(Asset).filter_by(
+                name="toy-building",
+                owner=toy_account,
+                parent_asset_id=None,
+            )
+        )
+        .scalars()
+        .all()
+    )
+    root_processes = (
+        fresh_db.session.execute(
+            select(Asset).filter_by(
+                name="toy-process",
+                owner=toy_account,
+                parent_asset_id=None,
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    assert len(root_buildings) == 1
+    assert len(root_processes) == 1
+    assert {sensor.name for sensor in root_processes[0].sensors} == {
+        "Power (Inflexible)",
+        "Power (Breakable)",
+        "Power (Shiftable)",
+    }
+
+
 @pytest.mark.parametrize("storage_power_capacity", ["sensor", "quantity", None])
 @pytest.mark.parametrize("storage_efficiency", ["sensor", "quantity", None])
 def test_add_storage_schedule(

--- a/flexmeasures/data/migrations/versions/c7b7f9019d4b_allow_duplicate_root_asset_names.py
+++ b/flexmeasures/data/migrations/versions/c7b7f9019d4b_allow_duplicate_root_asset_names.py
@@ -37,9 +37,18 @@ def upgrade():
         postgresql_where=sa.text("parent_asset_id IS NULL AND account_id IS NOT NULL"),
         sqlite_where=sa.text("parent_asset_id IS NULL AND account_id IS NOT NULL"),
     )
+    op.create_index(
+        "generic_asset_public_root_name_key",
+        "generic_asset",
+        ["name"],
+        unique=True,
+        postgresql_where=sa.text("parent_asset_id IS NULL AND account_id IS NULL"),
+        sqlite_where=sa.text("parent_asset_id IS NULL AND account_id IS NULL"),
+    )
 
 
 def downgrade():
+    op.drop_index("generic_asset_public_root_name_key", table_name="generic_asset")
     op.drop_index("generic_asset_root_account_id_name_key", table_name="generic_asset")
     op.drop_index("generic_asset_name_parent_asset_id_key", table_name="generic_asset")
     op.create_unique_constraint(

--- a/flexmeasures/data/migrations/versions/c7b7f9019d4b_allow_duplicate_root_asset_names.py
+++ b/flexmeasures/data/migrations/versions/c7b7f9019d4b_allow_duplicate_root_asset_names.py
@@ -1,0 +1,39 @@
+"""Allow duplicate root asset names.
+
+Revision ID: c7b7f9019d4b
+Revises: b2c3d4e5f6a7
+Create Date: 2026-06-05 12:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "c7b7f9019d4b"
+down_revision = "b2c3d4e5f6a7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint(
+        "generic_asset_name_parent_asset_id_key", "generic_asset", type_="unique"
+    )
+    op.create_index(
+        "generic_asset_name_parent_asset_id_key",
+        "generic_asset",
+        ["name", "parent_asset_id"],
+        unique=True,
+        postgresql_where=sa.text("parent_asset_id IS NOT NULL"),
+    )
+
+
+def downgrade():
+    op.drop_index("generic_asset_name_parent_asset_id_key", table_name="generic_asset")
+    op.create_unique_constraint(
+        "generic_asset_name_parent_asset_id_key",
+        "generic_asset",
+        ["name", "parent_asset_id"],
+    )

--- a/flexmeasures/data/migrations/versions/c7b7f9019d4b_allow_duplicate_root_asset_names.py
+++ b/flexmeasures/data/migrations/versions/c7b7f9019d4b_allow_duplicate_root_asset_names.py
@@ -27,10 +27,20 @@ def upgrade():
         ["name", "parent_asset_id"],
         unique=True,
         postgresql_where=sa.text("parent_asset_id IS NOT NULL"),
+        sqlite_where=sa.text("parent_asset_id IS NOT NULL"),
+    )
+    op.create_index(
+        "generic_asset_root_account_id_name_key",
+        "generic_asset",
+        ["account_id", "name"],
+        unique=True,
+        postgresql_where=sa.text("parent_asset_id IS NULL AND account_id IS NOT NULL"),
+        sqlite_where=sa.text("parent_asset_id IS NULL AND account_id IS NOT NULL"),
     )
 
 
 def downgrade():
+    op.drop_index("generic_asset_root_account_id_name_key", table_name="generic_asset")
     op.drop_index("generic_asset_name_parent_asset_id_key", table_name="generic_asset")
     op.create_unique_constraint(
         "generic_asset_name_parent_asset_id_key",

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -224,6 +224,13 @@ class GenericAsset(db.Model, AuthModelMixin):
             ),
             sqlite_where=db.text("parent_asset_id IS NULL AND account_id IS NOT NULL"),
         ),
+        db.Index(
+            "generic_asset_public_root_name_key",
+            "name",
+            unique=True,
+            postgresql_where=db.text("parent_asset_id IS NULL AND account_id IS NULL"),
+            sqlite_where=db.text("parent_asset_id IS NULL AND account_id IS NULL"),
+        ),
         db.UniqueConstraint(
             "account_id",
             "external_id",

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -214,6 +214,16 @@ class GenericAsset(db.Model, AuthModelMixin):
             postgresql_where=db.text("parent_asset_id IS NOT NULL"),
             sqlite_where=db.text("parent_asset_id IS NOT NULL"),
         ),
+        db.Index(
+            "generic_asset_root_account_id_name_key",
+            "account_id",
+            "name",
+            unique=True,
+            postgresql_where=db.text(
+                "parent_asset_id IS NULL AND account_id IS NOT NULL"
+            ),
+            sqlite_where=db.text("parent_asset_id IS NULL AND account_id IS NOT NULL"),
+        ),
         db.UniqueConstraint(
             "account_id",
             "external_id",

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -206,10 +206,13 @@ class GenericAsset(db.Model, AuthModelMixin):
         db.CheckConstraint(
             "parent_asset_id != id", name="generic_asset_self_reference_ck"
         ),
-        db.UniqueConstraint(
+        db.Index(
+            "generic_asset_name_parent_asset_id_key",
             "name",
             "parent_asset_id",
-            name="generic_asset_name_parent_asset_id_key",
+            unique=True,
+            postgresql_where=db.text("parent_asset_id IS NOT NULL"),
+            sqlite_where=db.text("parent_asset_id IS NOT NULL"),
         ),
         db.UniqueConstraint(
             "account_id",

--- a/flexmeasures/data/models/planning/tests/conftest.py
+++ b/flexmeasures/data/models/planning/tests/conftest.py
@@ -105,7 +105,7 @@ def building(db, setup_accounts, setup_markets) -> GenericAsset:
         building_type = GenericAssetType(name="building")
     db.session.add(building_type)
     building = GenericAsset(
-        name="building",
+        name="planning building",
         generic_asset_type=building_type,
         owner=setup_accounts["Prosumer"],
         flex_context={

--- a/flexmeasures/data/schemas/generic_assets.py
+++ b/flexmeasures/data/schemas/generic_assets.py
@@ -340,9 +340,8 @@ class GenericAssetSchema(ma.SQLAlchemySchema):
         which usually is at creation time.
         """
 
-        if "name" in data:
-            parent_id = data.get("parent_asset_id", None)
-
+        parent_id = data.get("parent_asset_id")
+        if "name" in data and parent_id is not None:
             query = select(GenericAsset).filter_by(
                 name=data["name"],
                 parent_asset_id=parent_id,

--- a/flexmeasures/data/schemas/generic_assets.py
+++ b/flexmeasures/data/schemas/generic_assets.py
@@ -337,7 +337,7 @@ class GenericAssetSchema(ma.SQLAlchemySchema):
         Validate that name is unique in its asset context.
         For child assets, names are unique among siblings.
         For account-owned root assets, names are unique within the account.
-        Public root assets are exempt.
+        For public root assets, names are unique globally.
         This is also checked by db indexes.
         Here, we can only check if we have all information (a full form),
         which usually is at creation time or when the existing asset is in context.
@@ -370,17 +370,25 @@ class GenericAssetSchema(ma.SQLAlchemySchema):
                 "account_id", getattr(current_asset, "account_id", None)
             )
             if account_id is None:
-                return
-
-            query = select(GenericAsset).filter_by(
-                name=name,
-                account_id=account_id,
-                parent_asset_id=None,
-            )
-            err_msg = (
-                f"An asset with the name '{name}' already exists as a top-level asset "
-                f"in account {account_id}"
-            )
+                query = select(GenericAsset).filter_by(
+                    name=name,
+                    account_id=None,
+                    parent_asset_id=None,
+                )
+                err_msg = (
+                    f"An asset with the name '{name}' already exists as a public "
+                    "top-level asset"
+                )
+            else:
+                query = select(GenericAsset).filter_by(
+                    name=name,
+                    account_id=account_id,
+                    parent_asset_id=None,
+                )
+                err_msg = (
+                    f"An asset with the name '{name}' already exists as a top-level "
+                    f"asset in account {account_id}"
+                )
 
         if current_editing_id is not None:
             query = query.filter(GenericAsset.id != current_editing_id)

--- a/flexmeasures/data/schemas/generic_assets.py
+++ b/flexmeasures/data/schemas/generic_assets.py
@@ -334,29 +334,61 @@ class GenericAssetSchema(ma.SQLAlchemySchema):
     @validates_schema(skip_on_field_errors=False)
     def validate_name_is_unique_under_parent(self, data, **kwargs):
         """
-        Validate that name is unique among siblings.
-        This is also checked by a db constraint.
+        Validate that name is unique in its asset context.
+        For child assets, names are unique among siblings.
+        For account-owned root assets, names are unique within the account.
+        Public root assets are exempt.
+        This is also checked by db indexes.
         Here, we can only check if we have all information (a full form),
-        which usually is at creation time.
+        which usually is at creation time or when the existing asset is in context.
         """
 
-        parent_id = data.get("parent_asset_id")
-        if "name" in data and parent_id is not None:
+        context = getattr(self, "context", {})
+        current_asset = context.get("asset")
+        name = data.get("name", getattr(current_asset, "name", None))
+        if name is None:
+            return
+
+        parent_id = data.get(
+            "parent_asset_id", getattr(current_asset, "parent_asset_id", None)
+        )
+        current_editing_id = context.get("asset_id") or getattr(
+            current_asset, "id", None
+        )
+
+        if parent_id is not None:
             query = select(GenericAsset).filter_by(
-                name=data["name"],
+                name=name,
                 parent_asset_id=parent_id,
             )
+            err_msg = (
+                f"An asset with the name '{name}' already exists under parent asset "
+                f"{parent_id}"
+            )
+        else:
+            account_id = data.get(
+                "account_id", getattr(current_asset, "account_id", None)
+            )
+            if account_id is None:
+                return
 
-            current_editing_id = getattr(self, "context", {}).get("asset_id")
+            query = select(GenericAsset).filter_by(
+                name=name,
+                account_id=account_id,
+                parent_asset_id=None,
+            )
+            err_msg = (
+                f"An asset with the name '{name}' already exists as a top-level asset "
+                f"in account {account_id}"
+            )
 
-            if current_editing_id is not None:
-                query = query.filter(GenericAsset.id != current_editing_id)
+        if current_editing_id is not None:
+            query = query.filter(GenericAsset.id != current_editing_id)
 
-            existing_asset = db.session.scalars(query).first()
+        existing_asset = db.session.scalars(query).first()
 
-            if existing_asset:
-                err_msg = f"An asset with the name '{data['name']}' already exists under parent asset {data.get('parent_asset_id')}"
-                raise ValidationError(err_msg, "name")
+        if existing_asset:
+            raise ValidationError(err_msg, "name")
 
     @validates("generic_asset_type_id")
     def validate_generic_asset_type(self, generic_asset_type_id: int, **kwargs):

--- a/flexmeasures/data/tests/test_generic_assets.py
+++ b/flexmeasures/data/tests/test_generic_assets.py
@@ -1,5 +1,8 @@
 from datetime import timedelta
 
+import pytest
+from sqlalchemy.exc import IntegrityError
+
 from flexmeasures.data.services.generic_assets import format_json_field_change
 from flexmeasures.data.models.generic_assets import GenericAsset
 from flexmeasures.data.models.time_series import Sensor
@@ -76,6 +79,48 @@ class NewAssetWithSensors:
         self.db.session.delete(self.price_sensor2)
         self.db.session.delete(self.test_battery)
         self.db.session.commit()
+
+
+def test_duplicate_root_asset_names_are_allowed(db, setup_generic_asset_types):
+    asset_type = setup_generic_asset_types["battery"]
+    root_assets = [
+        GenericAsset(name="Shared root name", generic_asset_type=asset_type),
+        GenericAsset(name="Shared root name", generic_asset_type=asset_type),
+    ]
+
+    db.session.add_all(root_assets)
+    db.session.flush()
+
+    assert root_assets[0].id != root_assets[1].id
+    assert root_assets[0].parent_asset_id is None
+    assert root_assets[1].parent_asset_id is None
+
+
+def test_duplicate_sibling_asset_names_are_rejected(db, setup_generic_asset_types):
+    asset_type = setup_generic_asset_types["battery"]
+    parent = GenericAsset(name="Parent asset", generic_asset_type=asset_type)
+    db.session.add(parent)
+    db.session.flush()
+
+    db.session.add_all(
+        [
+            GenericAsset(
+                name="Shared child name",
+                generic_asset_type=asset_type,
+                parent_asset_id=parent.id,
+            ),
+            GenericAsset(
+                name="Shared child name",
+                generic_asset_type=asset_type,
+                parent_asset_id=parent.id,
+            ),
+        ]
+    )
+
+    with pytest.raises(IntegrityError):
+        db.session.flush()
+
+    db.session.rollback()
 
 
 def test_format_json_field_change_reports_nested_flex_model_changes():

--- a/flexmeasures/data/tests/test_generic_assets.py
+++ b/flexmeasures/data/tests/test_generic_assets.py
@@ -81,8 +81,11 @@ class NewAssetWithSensors:
         self.db.session.commit()
 
 
-def test_duplicate_root_asset_names_are_allowed(db, setup_generic_asset_types):
-    asset_type = setup_generic_asset_types["battery"]
+def test_duplicate_public_root_asset_names_are_allowed(
+    fresh_db, setup_generic_asset_types_fresh_db
+):
+    db = fresh_db
+    asset_type = setup_generic_asset_types_fresh_db["battery"]
     root_assets = [
         GenericAsset(name="Shared root name", generic_asset_type=asset_type),
         GenericAsset(name="Shared root name", generic_asset_type=asset_type),
@@ -96,8 +99,64 @@ def test_duplicate_root_asset_names_are_allowed(db, setup_generic_asset_types):
     assert root_assets[1].parent_asset_id is None
 
 
-def test_duplicate_sibling_asset_names_are_rejected(db, setup_generic_asset_types):
-    asset_type = setup_generic_asset_types["battery"]
+def test_duplicate_root_asset_names_in_different_accounts_are_allowed(
+    fresh_db, setup_generic_asset_types_fresh_db, setup_accounts_fresh_db
+):
+    db = fresh_db
+    asset_type = setup_generic_asset_types_fresh_db["battery"]
+    root_assets = [
+        GenericAsset(
+            name="Shared account root name",
+            generic_asset_type=asset_type,
+            owner=setup_accounts_fresh_db["Prosumer"],
+        ),
+        GenericAsset(
+            name="Shared account root name",
+            generic_asset_type=asset_type,
+            owner=setup_accounts_fresh_db["Supplier"],
+        ),
+    ]
+
+    db.session.add_all(root_assets)
+    db.session.flush()
+
+    assert root_assets[0].id != root_assets[1].id
+    assert root_assets[0].account_id != root_assets[1].account_id
+    assert root_assets[0].parent_asset_id is None
+    assert root_assets[1].parent_asset_id is None
+
+
+def test_duplicate_root_asset_names_in_same_account_are_rejected(
+    fresh_db, setup_generic_asset_types_fresh_db, setup_accounts_fresh_db
+):
+    db = fresh_db
+    asset_type = setup_generic_asset_types_fresh_db["battery"]
+    root_assets = [
+        GenericAsset(
+            name="Conflicting account root name",
+            generic_asset_type=asset_type,
+            owner=setup_accounts_fresh_db["Prosumer"],
+        ),
+        GenericAsset(
+            name="Conflicting account root name",
+            generic_asset_type=asset_type,
+            owner=setup_accounts_fresh_db["Prosumer"],
+        ),
+    ]
+
+    db.session.add_all(root_assets)
+
+    with pytest.raises(IntegrityError):
+        db.session.flush()
+
+    db.session.rollback()
+
+
+def test_duplicate_sibling_asset_names_are_rejected(
+    fresh_db, setup_generic_asset_types_fresh_db
+):
+    db = fresh_db
+    asset_type = setup_generic_asset_types_fresh_db["battery"]
     parent = GenericAsset(name="Parent asset", generic_asset_type=asset_type)
     db.session.add(parent)
     db.session.flush()

--- a/flexmeasures/data/tests/test_generic_assets.py
+++ b/flexmeasures/data/tests/test_generic_assets.py
@@ -81,7 +81,7 @@ class NewAssetWithSensors:
         self.db.session.commit()
 
 
-def test_duplicate_public_root_asset_names_are_allowed(
+def test_duplicate_public_root_asset_names_are_rejected(
     fresh_db, setup_generic_asset_types_fresh_db
 ):
     db = fresh_db
@@ -92,11 +92,9 @@ def test_duplicate_public_root_asset_names_are_allowed(
     ]
 
     db.session.add_all(root_assets)
-    db.session.flush()
 
-    assert root_assets[0].id != root_assets[1].id
-    assert root_assets[0].parent_asset_id is None
-    assert root_assets[1].parent_asset_id is None
+    with pytest.raises(IntegrityError):
+        db.session.flush()
 
 
 def test_duplicate_root_asset_names_in_different_accounts_are_allowed(


### PR DESCRIPTION
## Description

We added a constraint that a parent can not have two child assets with the same name.
However, if the parent is `None` (root assets), this constraint also matched. This PR removes that shortcoming.

- [x] Update db constraint
- [x] Update in-code schema check, as well
- [x] Added changelog item in `documentation/changelog.rst`

