### PR TITLE
Feature: flex-context per commodity as list

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -11,7 +11,7 @@ New features
 -------------
 * Floor off-clock API datetimes to a non-instantaneous sensor's resolution by default when ingesting sensor data, uploading sensor data, and handling scheduler flex-model timed events; configurable with the ``floor_datetimes_to_resolution`` sensor attribute [see `PR #2146 <https://www.github.com/FlexMeasures/flexmeasures/pull/2146>`_]
 * Sensor references in flex-model and flex-context support various ways of filtering by source [see `PR #2209 <https://www.github.com/FlexMeasures/flexmeasures/pull/2209>`_]
-
+* The flex-context can now define multiple commodities, each specifying their own prices and grid capacities [see `PR #2172 <https://www.github.com/FlexMeasures/flexmeasures/pull/2172>`_ and `PR #2235 <https://www.github.com/FlexMeasures/flexmeasures/pull/2235>`_]
 
 Infrastructure / Support
 ----------------------

--- a/documentation/features/scheduling.rst
+++ b/documentation/features/scheduling.rst
@@ -65,15 +65,15 @@ And if the asset belongs to a larger system (a hierarchy of assets), the schedul
    * - ``inflexible-device-sensors``
      - |INFLEXIBLE_DEVICE_SENSORS.example|
      - .. include:: ../_autodoc/INFLEXIBLE_DEVICE_SENSORS.rst
-   * - ``aggregate-power``
-     - |AGGREGATE_POWER.example|
-     - .. include:: ../_autodoc/AGGREGATE_POWER.rst
    * - ``aggregate-consumption``
      - |AGGREGATE_CONSUMPTION.example|
      - .. include:: ../_autodoc/AGGREGATE_CONSUMPTION.rst
    * - ``aggregate-production``
      - |AGGREGATE_PRODUCTION.example|
      - .. include:: ../_autodoc/AGGREGATE_PRODUCTION.rst
+   * - ``aggregate-power``
+     - |AGGREGATE_POWER.example|
+     - .. include:: ../_autodoc/AGGREGATE_POWER.rst
    * - ``consumption-price``
      - |CONSUMPTION_PRICE.example|
      - .. include:: ../_autodoc/CONSUMPTION_PRICE.rst

--- a/documentation/features/scheduling.rst
+++ b/documentation/features/scheduling.rst
@@ -68,6 +68,12 @@ And if the asset belongs to a larger system (a hierarchy of assets), the schedul
    * - ``aggregate-power``
      - |AGGREGATE_POWER.example|
      - .. include:: ../_autodoc/AGGREGATE_POWER.rst
+   * - ``aggregate-consumption``
+     - |AGGREGATE_CONSUMPTION.example|
+     - .. include:: ../_autodoc/AGGREGATE_CONSUMPTION.rst
+   * - ``aggregate-production``
+     - |AGGREGATE_PRODUCTION.example|
+     - .. include:: ../_autodoc/AGGREGATE_PRODUCTION.rst
    * - ``consumption-price``
      - |CONSUMPTION_PRICE.example|
      - .. include:: ../_autodoc/CONSUMPTION_PRICE.rst

--- a/documentation/features/scheduling.rst
+++ b/documentation/features/scheduling.rst
@@ -39,7 +39,7 @@ The flex-context
 
 The ``flex-context`` is independent of the type of flexible device that is optimized, or which scheduler is used.
 With the flexibility context, we aim to describe the system in which the flexible assets operate, such as its physical and contractual limitations.
-For multi-commodity scheduling problems, the flex-context can be defined separately per commodity (e.g. electricity and gas), using the ``commodities`` field.
+For multi-commodity scheduling problems, the flex-context can be defined separately per commodity (e.g. electricity and gas).
 
 Fields can have fixed values, but some fields can also point to sensors, so they will always represent the dynamics of the asset's environment (as long as that sensor has current data).
 The full list of flex-context fields follows below.

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -175,6 +175,7 @@ In :ref:`getting_started`, we have some helpful tips how to dive into this docum
     tut/toy-example-expanded
     tut/toy-example-multiasset-curtailment
     tut/flex-model-v2g
+    tut/multi-feed-storage
     tut/toy-example-process
     tut/toy-example-reporter
     tut/posting_data

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -176,6 +176,7 @@ In :ref:`getting_started`, we have some helpful tips how to dive into this docum
     tut/toy-example-multiasset-curtailment
     tut/flex-model-v2g
     tut/multi-feed-storage
+    tut/multi-commodity
     tut/toy-example-process
     tut/toy-example-reporter
     tut/posting_data

--- a/documentation/tut/multi-commodity.rst
+++ b/documentation/tut/multi-commodity.rst
@@ -1,0 +1,271 @@
+.. _tut_multi_commodity:
+
+A flex-modeling tutorial for storage: Multiple commodities (gas & electricity)
+------------------------------------------------------------------------------
+
+The :ref:`multi-feed storage tutorial <tut_multi_feed_storage>` showed that the ``flex-model`` can be a *list*, so that several devices are scheduled together in one call.
+Those devices all acted on the same commodity (electricity). But many real sites mix commodities — electricity *and* gas, for instance — each with its own price.
+
+FlexMeasures handles this with two ingredients:
+
+- a ``commodity`` field on each device in the ``flex-model``, and
+- a per-commodity price listing in the ``flex-context``.
+
+In this tutorial we schedule a small hybrid site with one device on each commodity, and read back a cost breakdown that is tracked *per commodity*.
+(For a more general introduction to flex modeling, see :ref:`describing_flexibility`. For the single-commodity, multi-device case, see :ref:`tut_multi_feed_storage`.)
+
+
+The use case
+============
+
+A site has two flexible-ish devices, each acting on a different commodity:
+
+- A **battery** on the ``electricity`` commodity: 20 kW power, 100 kWh capacity, 95% charging and discharging efficiency. It starts at 20 kWh and must reach 80 kWh by 23:00.
+- A **gas boiler** on the ``gas`` commodity: it draws a **constant 1 kW** of gas every hour, modelled as a fixed load (it is not really flexible, but it still incurs a commodity cost we want to account for).
+
+Prices are flat, but *different per commodity*:
+
+- Electricity: **100 EUR/MWh** (consumption and production)
+- Gas: **50 EUR/MWh**
+
+We want the scheduler to optimise the battery against the electricity price, run the boiler at its fixed gas baseline, and report electricity and gas costs separately.
+
+
+Building the flex model
+=======================
+
+As in the multi-feed tutorial, the ``flex-model`` is a **list** with one entry per device.
+What is new here is the ``commodity`` field, which tells the scheduler *which price signal* applies to each device. It defaults to ``"electricity"``.
+
+.. code-block:: json
+
+    {
+        "flex-model": [
+            {
+                "sensor": 1,
+                "commodity": "electricity",
+                "state-of-charge": {"sensor": 3},
+                "soc-at-start": 20.0,
+                "soc-min": 0.0,
+                "soc-max": 100.0,
+                "soc-targets": [
+                    {"datetime": "2024-01-01T23:00:00+01:00", "value": 80.0}
+                ],
+                "power-capacity": "20 kW",
+                "charging-efficiency": 0.95,
+                "discharging-efficiency": 0.95
+            },
+            {
+                "sensor": 2,
+                "commodity": "gas",
+                "power-capacity": "30 kW",
+                "consumption-capacity": "30 kW",
+                "production-capacity": "0 kW",
+                "soc-usage": ["1 kW"],
+                "soc-min": 0.0,
+                "soc-max": 0.0,
+                "soc-at-start": 0.0
+            }
+        ]
+    }
+
+Here, sensor ``1`` is the battery's power sensor, sensor ``2`` is the boiler's power sensor, and sensor ``3`` is the battery's instantaneous ``state-of-charge`` sensor (referenced from the battery entry so the scheduler records its charge level).
+
+A few things to note:
+
+- **The battery is a normal storage device** (``soc-at-start``, ``soc-min``, ``soc-max``, ``soc-targets``), tagged with ``"commodity": "electricity"``.
+- **The boiler is modelled as a fixed load.** With ``soc-min`` and ``soc-max`` both 0, it can store nothing; ``soc-usage`` of ``1 kW`` forces it to consume exactly 1 kW of gas every hour, which the optimiser cannot change. ``production-capacity`` of 0 kW means it can never feed back.
+
+The prices live in the ``flex-context``. For a single commodity you would pass ``consumption-price`` and ``production-price`` directly. For **multiple commodities**, you instead provide a ``commodities`` list, one entry per commodity:
+
+.. code-block:: json
+
+    {
+        "flex-context": {
+            "commodities": [
+                {
+                    "commodity": "electricity",
+                    "consumption-price": "100 EUR/MWh",
+                    "production-price": "100 EUR/MWh"
+                },
+                {
+                    "commodity": "gas",
+                    "consumption-price": "50 EUR/MWh",
+                    "production-price": "50 EUR/MWh"
+                }
+            ]
+        }
+    }
+
+Each device's costs are then evaluated against the prices of *its own* commodity: the battery against electricity, the boiler against gas.
+
+.. note:: All commodities in one scheduling problem must share the same currency (here, EUR). The prices themselves can of course differ, and may be time series or sensors just like any other price in FlexMeasures.
+
+
+Triggering the schedule
+=======================
+
+We schedule on the **site asset**, so that FlexMeasures considers both devices together in a single optimisation.
+
+.. tabs::
+
+    .. tab:: CLI
+
+        .. code-block:: bash
+
+            $ flexmeasures add schedule \
+                --asset 1 \
+                --start 2024-01-01T00:00+01:00 \
+                --duration PT24H \
+                --flex-model flex-model-multi-commodity.json \
+                --flex-context flex-context-multi-commodity.json
+            New schedule is stored.
+
+    .. tab:: API
+
+        Example call: `[POST] http://localhost:5000/api/v3_0/assets/1/schedules/trigger <../api/v3_0.html#post--api-v3_0-assets-id-schedules-trigger>`_:
+
+        .. code-block:: json
+
+            {
+                "start": "2024-01-01T00:00:00+01:00",
+                "duration": "PT24H",
+                "flex-model": [
+                    {
+                        "sensor": 1,
+                        "commodity": "electricity",
+                        "state-of-charge": {"sensor": 3},
+                        "soc-at-start": 20.0,
+                        "soc-min": 0.0,
+                        "soc-max": 100.0,
+                        "soc-targets": [
+                            {"datetime": "2024-01-01T23:00:00+01:00", "value": 80.0}
+                        ],
+                        "power-capacity": "20 kW",
+                        "charging-efficiency": 0.95,
+                        "discharging-efficiency": 0.95
+                    },
+                    {
+                        "sensor": 2,
+                        "commodity": "gas",
+                        "power-capacity": "30 kW",
+                        "consumption-capacity": "30 kW",
+                        "production-capacity": "0 kW",
+                        "soc-usage": ["1 kW"],
+                        "soc-min": 0.0,
+                        "soc-max": 0.0,
+                        "soc-at-start": 0.0
+                    }
+                ],
+                "flex-context": {
+                    "commodities": [
+                        {
+                            "commodity": "electricity",
+                            "consumption-price": "100 EUR/MWh",
+                            "production-price": "100 EUR/MWh"
+                        },
+                        {
+                            "commodity": "gas",
+                            "consumption-price": "50 EUR/MWh",
+                            "production-price": "50 EUR/MWh"
+                        }
+                    ]
+                }
+            }
+
+    .. tab:: FlexMeasures Client
+
+        Using the `FlexMeasures Client <https://pypi.org/project/flexmeasures-client/>`_:
+
+        .. code-block:: python
+
+            schedule = await client.trigger_and_get_schedule(
+                asset_id=1,  # the site asset
+                start="2024-01-01T00:00:00+01:00",
+                duration="PT24H",
+                flex_model=[
+                    {
+                        "sensor": 1,  # battery power sensor
+                        "commodity": "electricity",
+                        "state-of-charge": {"sensor": 3},  # battery SoC sensor
+                        "soc-at-start": 20.0,
+                        "soc-min": 0.0,
+                        "soc-max": 100.0,
+                        "soc-targets": [
+                            {"datetime": "2024-01-01T23:00:00+01:00", "value": 80.0}
+                        ],
+                        "power-capacity": "20 kW",
+                        "charging-efficiency": 0.95,
+                        "discharging-efficiency": 0.95,
+                    },
+                    {
+                        "sensor": 2,  # boiler power sensor
+                        "commodity": "gas",
+                        "power-capacity": "30 kW",
+                        "consumption-capacity": "30 kW",
+                        "production-capacity": "0 kW",
+                        "soc-usage": ["1 kW"],
+                        "soc-min": 0.0,
+                        "soc-max": 0.0,
+                        "soc-at-start": 0.0,
+                    },
+                ],
+                flex_context={
+                    "commodities": [
+                        {
+                            "commodity": "electricity",
+                            "consumption-price": "100 EUR/MWh",
+                            "production-price": "100 EUR/MWh",
+                        },
+                        {
+                            "commodity": "gas",
+                            "consumption-price": "50 EUR/MWh",
+                            "production-price": "50 EUR/MWh",
+                        },
+                    ]
+                },
+            )
+
+The scheduler returns one schedule per device (stored on sensors ``1`` and ``2``) and a single commitment-cost result that breaks the cost down per commodity.
+
+
+What to expect
+==============
+
+The asset chart shows both commodities together, with the battery's stock level in between:
+
+.. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/multi-commodity.png
+    :align: center
+    :alt: Asset-level chart of the hybrid site, showing battery power, battery state of charge, and the gas boiler.
+|
+
+Reading the chart top to bottom:
+
+- **Battery power (electricity)** charges at its full 20 kW for the first three hours, then makes one partial-power step to land exactly on the 80 kWh target, and sits idle for the rest of the day. In the final hour it discharges at −20 kW. Because the electricity price is flat, there is no cheaper window to wait for, so it simply charges as early as possible (``prefer-charging-sooner`` is on by default).
+- **Battery state of charge** makes the effect of that power schedule explicit: the stock rises from the 20 kWh ``soc-at-start``, reaches the 80 kWh target during the morning, holds there through the idle hours, and drops in the final hour as the battery discharges. This is the charge level you would otherwise have to infer from the power curve.
+- **Gas boiler (gas)** runs at exactly 1 kW every single hour. The ``soc-usage`` field makes this a fixed load that the optimiser cannot shift — its only effect on the result is the gas cost it incurs.
+
+The schedules match the cost figures reported by the scheduler:
+
+.. code-block:: text
+
+    Electricity (battery)
+      Net charge needed : 80 kWh − 20 kWh        = 60 kWh stored
+      Grid draw         : 60 kWh ÷ 0.95          = 63.16 kWh
+      Charge cost       : 63.16 kWh × 100 EUR/MWh ≈  6.32 EUR
+      Discharge credit  : 20 kWh × 100 EUR/MWh   = −2.00 EUR
+      Net electricity                            ≈  4.32 EUR
+
+    Gas (boiler)
+      Consumption       : 1 kW × 24 h            = 24 kWh
+      Gas cost          : 0.024 MWh × 50 EUR/MWh =  1.20 EUR
+
+    Total                                        =  5.52 EUR
+
+The commitment-cost result keeps these as separate entries — ``electricity net energy`` (≈ 4.32 EUR) and ``gas net energy`` (1.20 EUR) — so you can always see how much each commodity contributed.
+Because the gas price (50 EUR/MWh) is half the electricity price, serving the constant baseline with gas rather than electricity is the cheaper choice for that part of the load.
+
+.. note:: This same pattern extends to more devices and more commodities. Add further entries to the ``flex-model`` list (each with its ``commodity``) and a matching entry in the ``flex-context`` ``commodities`` list. As long as all commodities share one currency, FlexMeasures optimises them together and reports each commodity's cost on its own.
+
+We hope this demonstration helped to illustrate multi-commodity scheduling.
+To revisit scheduling several devices that share a single commodity and stock, head back to :ref:`tut_multi_feed_storage`.

--- a/documentation/tut/multi-commodity.rst
+++ b/documentation/tut/multi-commodity.rst
@@ -74,27 +74,24 @@ Here, sensor ``1`` is the battery's power sensor, sensor ``2`` is the boiler's p
 A few things to note:
 
 - **The battery is a normal storage device** (``soc-at-start``, ``soc-min``, ``soc-max``, ``soc-targets``), tagged with ``"commodity": "electricity"``.
-- **The boiler is modelled as a fixed load.** With ``soc-min`` and ``soc-max`` both 0, it can store nothing; ``soc-usage`` of ``1 kW`` forces it to consume exactly 1 kW of gas every hour, which the optimiser cannot change. ``production-capacity`` of 0 kW means it can never feed back.
+- **The boiler is modelled as a fixed load.** With ``soc-min`` and ``soc-max`` both 0, it can store nothing; ``soc-usage`` of ``1 kW`` forces it to consume exactly 1 kW of gas every hour, which the optimiser cannot change. ``production-capacity`` of 0 kW means it can never produce gas.
 
 The prices live in the ``flex-context``. For a single commodity you would pass ``consumption-price`` and ``production-price`` directly. For **multiple commodities**, you instead provide a ``commodities`` list, one entry per commodity:
 
 .. code-block:: json
 
     {
-        "flex-context": {
-            "commodities": [
-                {
-                    "commodity": "electricity",
-                    "consumption-price": "100 EUR/MWh",
-                    "production-price": "100 EUR/MWh"
-                },
-                {
-                    "commodity": "gas",
-                    "consumption-price": "50 EUR/MWh",
-                    "production-price": "50 EUR/MWh"
-                }
-            ]
-        }
+        "flex-context": [
+            {
+                "commodity": "electricity",
+                "consumption-price": "100 EUR/MWh",
+                "production-price": "100 EUR/MWh"
+            },
+            {
+                "commodity": "gas",
+                "consumption-price": "50 EUR/MWh"
+            }
+        ]
     }
 
 Each device's costs are then evaluated against the prices of *its own* commodity: the battery against electricity, the boiler against gas.
@@ -157,20 +154,17 @@ We schedule on the **site asset**, so that FlexMeasures considers both devices t
                         "soc-at-start": 0.0
                     }
                 ],
-                "flex-context": {
-                    "commodities": [
-                        {
-                            "commodity": "electricity",
-                            "consumption-price": "100 EUR/MWh",
-                            "production-price": "100 EUR/MWh"
-                        },
-                        {
-                            "commodity": "gas",
-                            "consumption-price": "50 EUR/MWh",
-                            "production-price": "50 EUR/MWh"
-                        }
-                    ]
-                }
+                "flex-context": [
+                    {
+                        "commodity": "electricity",
+                        "consumption-price": "100 EUR/MWh",
+                        "production-price": "100 EUR/MWh"
+                    },
+                    {
+                        "commodity": "gas",
+                        "consumption-price": "50 EUR/MWh"
+                    }
+                ]
             }
 
     .. tab:: FlexMeasures Client
@@ -210,20 +204,17 @@ We schedule on the **site asset**, so that FlexMeasures considers both devices t
                         "soc-at-start": 0.0,
                     },
                 ],
-                flex_context={
-                    "commodities": [
-                        {
-                            "commodity": "electricity",
-                            "consumption-price": "100 EUR/MWh",
-                            "production-price": "100 EUR/MWh",
-                        },
-                        {
-                            "commodity": "gas",
-                            "consumption-price": "50 EUR/MWh",
-                            "production-price": "50 EUR/MWh",
-                        },
-                    ]
-                },
+                flex_context=[
+                    {
+                        "commodity": "electricity",
+                        "consumption-price": "100 EUR/MWh",
+                        "production-price": "100 EUR/MWh",
+                    },
+                    {
+                        "commodity": "gas",
+                        "consumption-price": "50 EUR/MWh",
+                    },
+                ],
             )
 
 The scheduler returns one schedule per device (stored on sensors ``1`` and ``2``) and a single commitment-cost result that breaks the cost down per commodity.
@@ -241,7 +232,7 @@ The asset chart shows both commodities together, with the battery's stock level 
 
 Reading the chart top to bottom:
 
-- **Battery power (electricity)** charges at its full 20 kW for the first three hours, then makes one partial-power step to land exactly on the 80 kWh target, and sits idle for the rest of the day. In the final hour it discharges at −20 kW. Because the electricity price is flat, there is no cheaper window to wait for, so it simply charges as early as possible (``prefer-charging-sooner`` is on by default).
+- **Battery power (electricity)** charges at its full 20 kW for the first three hours, then makes one partial-power step, which compensates for its charging efficiency losses to land exactly on the 80 kWh target, and then sits idle for the rest of the day. In the final hour it discharges at −20 kW. Because the electricity price is flat, there is no cheaper window to wait for, so it simply charges as early as possible (``prefer-charging-sooner`` is on by default).
 - **Battery state of charge** makes the effect of that power schedule explicit: the stock rises from the 20 kWh ``soc-at-start``, reaches the 80 kWh target during the morning, holds there through the idle hours, and drops in the final hour as the battery discharges. This is the charge level you would otherwise have to infer from the power curve.
 - **Gas boiler (gas)** runs at exactly 1 kW every single hour. The ``soc-usage`` field makes this a fixed load that the optimiser cannot shift — its only effect on the result is the gas cost it incurs.
 
@@ -263,7 +254,6 @@ The schedules match the cost figures reported by the scheduler:
     Total                                        =  5.52 EUR
 
 The commitment-cost result keeps these as separate entries — ``electricity net energy`` (≈ 4.32 EUR) and ``gas net energy`` (1.20 EUR) — so you can always see how much each commodity contributed.
-Because the gas price (50 EUR/MWh) is half the electricity price, serving the constant baseline with gas rather than electricity is the cheaper choice for that part of the load.
 
 .. note:: This same pattern extends to more devices and more commodities. Add further entries to the ``flex-model`` list (each with its ``commodity``) and a matching entry in the ``flex-context`` ``commodities`` list. As long as all commodities share one currency, FlexMeasures optimises them together and reports each commodity's cost on its own.
 

--- a/documentation/tut/multi-feed-storage.rst
+++ b/documentation/tut/multi-feed-storage.rst
@@ -207,28 +207,14 @@ The scheduler specialises each inverter for the operation it is best at:
 
 So, even though both inverters *can* both charge and discharge, the optimiser uses inverter 2 only to charge and inverter 1 only to discharge — each inverter ends up doing what it is most efficient at.
 
-Let's look at the whole battery at once. We can tell FlexMeasures which sensors to plot together on the **asset** by setting the battery's ``sensors_to_show`` attribute, grouping the two inverter power sensors into one panel and the shared state-of-charge sensor into another:
-
-.. code-block:: python
-
-    battery.sensors_to_show = [
-        {"title": "inverters", "sensors": [inverter_1_power.id, inverter_2_power.id]},
-        {"title": "shared storage", "sensors": [state_of_charge.id]},
-    ]
-
-The asset chart (the same Vega-Lite chart shown on the asset's page in the FlexMeasures UI) then renders both panels together:
-
 .. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/multi-feed-asset.png
     :align: center
-    :alt: Asset-level chart of the battery, showing both inverters and the shared state of charge.
 |
 
 Reading the chart top to bottom:
 
 - **Inverters** (top panel) shows the power schedule of both feeds together. Inverter 2 (the 99%-efficient charger) runs at its full +20 kW from the start of the horizon and tapers off in a single partial step once the target is reached — it only ever charges. Inverter 1 (the 95%-efficient discharger) stays idle while the battery fills, then runs at -20 kW late in the horizon — it only ever discharges. Even though both inverters *can* do both, the optimiser specialises each for the operation it is most efficient at.
 - **Shared storage** (bottom panel) shows the *single* ``state-of-charge`` sensor that both inverters feed. It starts at the 20 kWh ``soc-at-start``, climbs while inverter 2 charges, reaches and briefly holds the 189 kWh target, and then falls as inverter 1 discharges — bottoming out at the 10 kWh ``soc-min``. This one curve is the combined effect of both feeds, which is exactly what "shared stock" means.
-
-Plotting the inverters and the shared stock on the same asset chart makes the coordination obvious: the rise in the bottom panel lines up with inverter 2's charging in the top panel, and the fall lines up with inverter 1's discharging.
 
 The net energy cost over the horizon is small (about 0.066 EUR at 100 EUR/MWh), and reflects only the energy lost to the inverter efficiencies, since charging and discharging happen at the same flat price.
 

--- a/documentation/tut/multi-feed-storage.rst
+++ b/documentation/tut/multi-feed-storage.rst
@@ -1,0 +1,238 @@
+.. _tut_multi_feed_storage:
+
+A flex-modeling tutorial for storage: Multiple feeds into shared stock
+----------------------------------------------------------------------
+
+So far, our storage tutorials have considered a single power port charging and discharging a single battery.
+But what if a battery is fed by *more than one* inverter, each with its own power rating and efficiency?
+
+This is a common situation in practice: a single storage tank or battery pack is connected to several converters, and they all charge and discharge the *same* pool of energy.
+FlexMeasures supports this through what we call **multiple feeds into a shared stock**: several flexible devices are scheduled together, while they all point at one shared ``state-of-charge`` sensor.
+
+In this tutorial we will model exactly such a system and let the scheduler decide which inverter to use, and when, taking each inverter's efficiency into account.
+(For a more general introduction to flex modeling, see :ref:`describing_flexibility`. For a single-device storage walk-through, see :ref:`tut_v2g`.)
+
+
+The use case
+============
+
+Consider a single battery with two inverters feeding it, and a single state-of-charge sensor for the battery:
+
+- Both inverters can charge and discharge the battery, but with **different efficiencies**.
+- The battery has a **single state of charge** that both inverters affect.
+- The scheduler should recognise the shared stock and optimise accordingly, without duplicating baselines or costs.
+
+Concretely, we model:
+
+- A ``battery`` asset, with a ``power`` sensor (the aggregate) and an instantaneous ``state-of-charge`` sensor (in kWh).
+- Two ``inverter`` assets (``inverter 1`` and ``inverter 2``), each with its own ``power`` sensor, rated at 20 kW.
+- Inverter 1 is symmetric and efficient in both directions (95% charging, 95% discharging).
+- Inverter 2 charges almost loss-free (99%) but discharges poorly (45%).
+
+The battery starts at 20 kWh, may not drop below 10 kWh or exceed 200 kWh, and has to reach a target of 189 kWh at noon.
+
+
+Building the flex model
+=======================
+
+The key idea is that the ``flex-model`` is a **list**, with one entry per flexible device, plus one entry that describes the shared stock.
+Each inverter entry references its own power sensor *and* the same ``state-of-charge`` sensor.
+The final entry (without a power ``sensor``) carries the constraints that apply to the shared stock itself: the start, the bounds, and the target.
+
+.. code-block:: json
+
+    {
+        "flex-model": [
+            {
+                "sensor": 1,
+                "state-of-charge": {"sensor": 4},
+                "power-capacity": "20 kW",
+                "charging-efficiency": 0.95,
+                "discharging-efficiency": 0.95
+            },
+            {
+                "sensor": 2,
+                "state-of-charge": {"sensor": 4},
+                "power-capacity": "20 kW",
+                "charging-efficiency": 0.99,
+                "discharging-efficiency": 0.45
+            },
+            {
+                "state-of-charge": {"sensor": 4},
+                "soc-at-start": 20.0,
+                "soc-min": 10,
+                "soc-max": 200.0,
+                "soc-targets": [
+                    {"datetime": "2024-01-01T12:00:00+01:00", "value": 189.0}
+                ]
+            }
+        ]
+    }
+
+Here, sensors ``1`` and ``2`` are the power sensors of inverter 1 and inverter 2, respectively, and sensor ``4`` is the shared ``state-of-charge`` sensor on the battery.
+
+A few things to note:
+
+- **Each device points at the same ``state-of-charge`` sensor.** This is what tells FlexMeasures that the devices share one stock. The scheduler links the energy balance of all feeds to that single state of charge, rather than tracking a separate stock per device.
+- **The shared-stock entry has no power ``sensor``.** It only carries the storage-level fields (``soc-at-start``, ``soc-min``, ``soc-max``, ``soc-targets``), which describe the battery as a whole and must therefore not be repeated per inverter.
+- **Per-device efficiencies live in the device entries.** ``charging-efficiency`` and ``discharging-efficiency`` differ between the two inverters, which is exactly the difference the scheduler will exploit.
+
+.. note:: The ``state-of-charge`` sensor should have an instantaneous resolution (``PT0M``), since it records a stock value at a point in time rather than a quantity accumulated over an interval. See the ``state-of-charge`` field in :ref:`flex_models_and_schedulers`.
+
+For the costs, we use a flat tariff in this example, so price differences over time do not drive the schedule, only the efficiency differences do:
+
+.. code-block:: json
+
+    {
+        "flex-context": {
+            "consumption-price": "100 EUR/MWh",
+            "production-price": "100 EUR/MWh"
+        }
+    }
+
+
+Triggering the schedule
+=======================
+
+We schedule on the **battery asset**, so that FlexMeasures considers both inverters together as feeds into the battery's shared stock.
+
+.. tabs::
+
+    .. tab:: CLI
+
+        .. code-block:: bash
+
+            $ flexmeasures add schedule \
+                --asset 1 \
+                --start 2024-01-01T00:00+01:00 \
+                --duration PT24H \
+                --flex-model flex-model-multi-feed.json \
+                --flex-context flex-context-flat-price.json
+            New schedule is stored.
+
+    .. tab:: API
+
+        Example call: `[POST] http://localhost:5000/api/v3_0/assets/1/schedules/trigger <../api/v3_0.html#post--api-v3_0-assets-id-schedules-trigger>`_:
+
+        .. code-block:: json
+
+            {
+                "start": "2024-01-01T00:00:00+01:00",
+                "duration": "PT24H",
+                "flex-model": [
+                    {
+                        "sensor": 1,
+                        "state-of-charge": {"sensor": 4},
+                        "power-capacity": "20 kW",
+                        "charging-efficiency": 0.95,
+                        "discharging-efficiency": 0.95
+                    },
+                    {
+                        "sensor": 2,
+                        "state-of-charge": {"sensor": 4},
+                        "power-capacity": "20 kW",
+                        "charging-efficiency": 0.99,
+                        "discharging-efficiency": 0.45
+                    },
+                    {
+                        "state-of-charge": {"sensor": 4},
+                        "soc-at-start": 20.0,
+                        "soc-min": 10,
+                        "soc-max": 200.0,
+                        "soc-targets": [
+                            {"datetime": "2024-01-01T12:00:00+01:00", "value": 189.0}
+                        ]
+                    }
+                ],
+                "flex-context": {
+                    "consumption-price": "100 EUR/MWh",
+                    "production-price": "100 EUR/MWh"
+                }
+            }
+
+    .. tab:: FlexMeasures Client
+
+        Using the `FlexMeasures Client <https://pypi.org/project/flexmeasures-client/>`_:
+
+        .. code-block:: python
+
+            schedule = await client.trigger_and_get_schedule(
+                asset_id=1,  # the battery asset
+                start="2024-01-01T00:00:00+01:00",
+                duration="PT24H",
+                flex_model=[
+                    {
+                        "sensor": 1,  # inverter 1 power sensor
+                        "state-of-charge": {"sensor": 4},
+                        "power-capacity": "20 kW",
+                        "charging-efficiency": 0.95,
+                        "discharging-efficiency": 0.95,
+                    },
+                    {
+                        "sensor": 2,  # inverter 2 power sensor
+                        "state-of-charge": {"sensor": 4},
+                        "power-capacity": "20 kW",
+                        "charging-efficiency": 0.99,
+                        "discharging-efficiency": 0.45,
+                    },
+                    {
+                        "state-of-charge": {"sensor": 4},  # shared stock
+                        "soc-at-start": 20.0,
+                        "soc-min": 10,
+                        "soc-max": 200.0,
+                        "soc-targets": [
+                            {"datetime": "2024-01-01T12:00:00+01:00", "value": 189.0}
+                        ],
+                    },
+                ],
+                flex_context={
+                    "consumption-price": "100 EUR/MWh",
+                    "production-price": "100 EUR/MWh",
+                },
+            )
+
+
+The scheduler returns one schedule per inverter (stored on sensors ``1`` and ``2``), the resulting state of charge (stored on the shared ``state-of-charge`` sensor ``4``), and a single, aggregated commitment-cost result.
+Note that the costs are *not* duplicated per device: because the inverters feed one shared stock, FlexMeasures computes a single energy balance and a single cost.
+
+
+What to expect
+==============
+
+With a flat tariff, the schedule is driven purely by the efficiency differences between the two inverters.
+The scheduler specialises each inverter for the operation it is best at:
+
+- **Charging** happens through **inverter 2** (99% charging efficiency). It charges continuously from the start until the battery reaches the 189 kWh target at noon. Inverter 1 stays idle while charging.
+- **Discharging** happens through **inverter 1** (95% discharging efficiency, versus only 45% for inverter 2). After the target is reached, inverter 1 discharges the battery back down towards its ``soc-min`` of 10 kWh. Inverter 2 stays idle while discharging.
+
+So, even though both inverters *can* both charge and discharge, the optimiser uses inverter 2 only to charge and inverter 1 only to discharge — each inverter ends up doing what it is most efficient at.
+
+Let's look at the whole battery at once. We can tell FlexMeasures which sensors to plot together on the **asset** by setting the battery's ``sensors_to_show`` attribute, grouping the two inverter power sensors into one panel and the shared state-of-charge sensor into another:
+
+.. code-block:: python
+
+    battery.sensors_to_show = [
+        {"title": "inverters", "sensors": [inverter_1_power.id, inverter_2_power.id]},
+        {"title": "shared storage", "sensors": [state_of_charge.id]},
+    ]
+
+The asset chart (the same Vega-Lite chart shown on the asset's page in the FlexMeasures UI) then renders both panels together:
+
+.. image:: https://github.com/FlexMeasures/screenshots/raw/main/tut/multi-feed-asset.png
+    :align: center
+    :alt: Asset-level chart of the battery, showing both inverters and the shared state of charge.
+|
+
+Reading the chart top to bottom:
+
+- **Inverters** (top panel) shows the power schedule of both feeds together. Inverter 2 (the 99%-efficient charger) runs at its full +20 kW from the start of the horizon and tapers off in a single partial step once the target is reached — it only ever charges. Inverter 1 (the 95%-efficient discharger) stays idle while the battery fills, then runs at -20 kW late in the horizon — it only ever discharges. Even though both inverters *can* do both, the optimiser specialises each for the operation it is most efficient at.
+- **Shared storage** (bottom panel) shows the *single* ``state-of-charge`` sensor that both inverters feed. It starts at the 20 kWh ``soc-at-start``, climbs while inverter 2 charges, reaches and briefly holds the 189 kWh target, and then falls as inverter 1 discharges — bottoming out at the 10 kWh ``soc-min``. This one curve is the combined effect of both feeds, which is exactly what "shared stock" means.
+
+Plotting the inverters and the shared stock on the same asset chart makes the coordination obvious: the rise in the bottom panel lines up with inverter 2's charging in the top panel, and the fall lines up with inverter 1's discharging.
+
+The net energy cost over the horizon is small (about 0.066 EUR at 100 EUR/MWh), and reflects only the energy lost to the inverter efficiencies, since charging and discharging happen at the same flat price.
+
+.. note:: This same pattern generalises beyond two inverters and beyond batteries. Any number of devices can feed a shared stock — for example, several heat pumps charging one thermal buffer — as long as each device entry references the same ``state-of-charge`` sensor and a single entry carries the shared-stock constraints.
+
+We hope this demonstration helped to illustrate how FlexMeasures schedules multiple feeds into a shared stock.
+For modelling a single storage device in more depth, head back to :ref:`tut_v2g`.

--- a/flexmeasures/api/common/schemas/scheduling.py
+++ b/flexmeasures/api/common/schemas/scheduling.py
@@ -1,6 +1,6 @@
 from flexmeasures.api.common.schemas.utils import make_openapi_compatible
 from flexmeasures.data.schemas.scheduling.storage import StorageFlexModelSchema
-from flexmeasures.data.schemas.scheduling import FlexContextSchema
+from flexmeasures.data.schemas.scheduling import CommodityFlexContextSchema
 from flexmeasures.data.schemas.sensors import SensorIdField
 
 
@@ -18,4 +18,4 @@ storage_flex_model_schema_openAPI = make_openapi_compatible(
         }
     ],
 )
-flex_context_schema_openAPI = make_openapi_compatible(FlexContextSchema)
+flex_context_schema_openAPI = make_openapi_compatible(CommodityFlexContextSchema)

--- a/flexmeasures/api/common/schemas/utils.py
+++ b/flexmeasures/api/common/schemas/utils.py
@@ -32,7 +32,11 @@ def make_openapi_compatible(  # noqa: C901
             sensor_only_validators.append(validator[-1])
 
     new_fields = {}
-    tobeadded_fields = schema_cls._declared_fields
+    try:
+        # in case `schema_cls.__init__` reordered the fields, preserve their order
+        tobeadded_fields = schema_cls().fields
+    except TypeError:
+        tobeadded_fields = schema_cls._declared_fields
     if include:
         for item in include:
             tobeadded_fields.update(item)

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -100,7 +100,7 @@ class AssetTriggerOpenAPISchema(AssetTriggerSchema):
         fields.Nested(
             flex_context_schema_openAPI(),
         ),
-        required=True,
+        load_default=[],
         data_key="flex-context",
         metadata=dict(
             description="Flex-context per commodity. The flex-context is validated according to the scheduler's `FlexContextSchema`.",
@@ -110,7 +110,7 @@ class AssetTriggerOpenAPISchema(AssetTriggerSchema):
         fields.Nested(
             storage_flex_model_schema_openAPI(exclude=["asset"]),
         ),
-        required=True,
+        load_default=[],
         data_key="flex-model",
         metadata=dict(
             description="Flex-model per device (identified by `sensor`). The flex-model validation is handled by the scheduler. What follows is the schema used by the `StorageScheduler`.",

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -96,12 +96,14 @@ class AssetTriggerOpenAPISchema(AssetTriggerSchema):
         kwargs["exclude"] = ["asset"]
         super().__init__(*args, **kwargs)
 
-    flex_context = fields.Nested(
-        flex_context_schema_openAPI,
+    flex_context = fields.List(
+        fields.Nested(
+            flex_context_schema_openAPI(),
+        ),
         required=True,
         data_key="flex-context",
         metadata=dict(
-            description="The flex-context is validated according to the scheduler's `FlexContextSchema`.",
+            description="Flex-context per commodity. The flex-context is validated according to the scheduler's `FlexContextSchema`.",
         ),
     )
     flex_model = fields.List(

--- a/flexmeasures/api/v3_0/tests/test_asset_schedules_fresh_db.py
+++ b/flexmeasures/api/v3_0/tests/test_asset_schedules_fresh_db.py
@@ -615,17 +615,19 @@ def test_asset_trigger_with_multi_commodity_flex_context(
         .filter(TimedBelief.source_id == scheduler_source.id)
         .all()
     )
-    assert len(consumption_beliefs_elec) > 0, "electricity aggregate-consumption should have data"
+    assert (
+        len(consumption_beliefs_elec) > 0
+    ), "electricity aggregate-consumption should have data"
 
     # Verify electricity aggregate-production sensor got filled
     production_beliefs_elec = (
-        TimedBelief.query.filter(
-            TimedBelief.sensor_id == agg_production_electricity.id
-        )
+        TimedBelief.query.filter(TimedBelief.sensor_id == agg_production_electricity.id)
         .filter(TimedBelief.source_id == scheduler_source.id)
         .all()
     )
-    assert len(production_beliefs_elec) > 0, "electricity aggregate-production should have data"
+    assert (
+        len(production_beliefs_elec) > 0
+    ), "electricity aggregate-production should have data"
 
     # Verify heat aggregate-consumption sensor got filled
     consumption_beliefs_heat = (
@@ -633,7 +635,9 @@ def test_asset_trigger_with_multi_commodity_flex_context(
         .filter(TimedBelief.source_id == scheduler_source.id)
         .all()
     )
-    assert len(consumption_beliefs_heat) > 0, "heat aggregate-consumption should have data"
+    assert (
+        len(consumption_beliefs_heat) > 0
+    ), "heat aggregate-consumption should have data"
 
     # Verify data types are correct
     assert all(
@@ -760,7 +764,9 @@ def test_asset_trigger_with_flex_context_commodity_not_used(
         .filter(TimedBelief.source_id == scheduler_source.id)
         .all()
     )
-    assert len(consumption_beliefs_elec) > 0, "electricity aggregate-consumption should have data"
+    assert (
+        len(consumption_beliefs_elec) > 0
+    ), "electricity aggregate-consumption should have data"
 
     # Verify heat aggregate-consumption sensor is empty (no heat device)
     consumption_beliefs_heat = (
@@ -771,4 +777,3 @@ def test_asset_trigger_with_flex_context_commodity_not_used(
     assert (
         len(consumption_beliefs_heat) == 0
     ), "heat aggregate-consumption should be empty since no heat device was scheduled"
-

--- a/flexmeasures/api/v3_0/tests/test_asset_schedules_fresh_db.py
+++ b/flexmeasures/api/v3_0/tests/test_asset_schedules_fresh_db.py
@@ -293,9 +293,6 @@ def test_asset_trigger_and_get_schedule(
             assert_almost_equal(power_schedule, expected_uni_schedule)
 
 
-@pytest.mark.xfail(
-    reason="StorageScheduler does not yet populate aggregate-consumption/production sensors"
-)
 @pytest.mark.parametrize(
     "requesting_user", ["test_prosumer_user@seita.nl"], indirect=True
 )
@@ -308,21 +305,13 @@ def test_asset_trigger_and_get_aggregate_schedule(
     keep_scheduling_queue_empty,
     requesting_user,
 ):
-    """Test aggregate-consumption and aggregate-production flex-context fields.
+    """Test that aggregate-consumption and aggregate-production flex-context fields get filled with data.
 
-    This test verifies the interface for aggregate-consumption and aggregate-production
-    flex-context fields and checks whether they are populated with aggregate power flows.
-
-    Current Status: MISSING IMPLEMENTATION
-    The StorageScheduler currently does NOT populate aggregate-consumption and
-    aggregate-production sensors with data. This test documents the expected behavior once
-    the logic is implemented in StorageScheduler._compute_aggregate_schedules() (or similar).
-
-    Expected behavior when implemented:
-    1. Aggregate-consumption sensor receives the summed consumption schedule (positive values)
-    2. Aggregate-production sensor receives the summed production schedule (positive values)
+    This test verifies:
+    1. Aggregate-consumption sensor receives the total consumption schedule with correct sign
+    2. Aggregate-production sensor receives the total production schedule with correct sign
     3. The data source is correctly set to the scheduler
-    4. Sign convention matches the scheduler's output (consumption positive, production negative internally)
+    4. The sign convention matches the scheduler's output (consumption positive, production negative)
     """
     # Set up charging hub with aggregate sensors
     bidirectional_charging_station = add_charging_station_assets_fresh_db[
@@ -453,9 +442,6 @@ def test_asset_trigger_and_get_aggregate_schedule(
     ).all(), "production schedule should have non-negative values (production flows are positive)"
 
 
-@pytest.mark.xfail(
-    reason="StorageScheduler does not yet populate aggregate-consumption/production sensors"
-)
 @pytest.mark.parametrize(
     "requesting_user", ["test_prosumer_user@seita.nl"], indirect=True
 )
@@ -468,21 +454,11 @@ def test_asset_trigger_with_multi_commodity_flex_context(
     keep_scheduling_queue_empty,
     requesting_user,
 ):
-    """Test aggregate-consumption/production with multi-commodity flex-context (list format).
+    """Test aggregate sensors with multiple devices in flex-model.
 
-    This test verifies the interface for aggregate sensors in multi-commodity scheduling,
-    where flex-context is a list of commodity-specific contexts.
-
-    Current Status: MISSING IMPLEMENTATION
-    Similar to test_asset_trigger_and_get_aggregate_schedule, the StorageScheduler does NOT
-    currently populate aggregate sensors for multi-commodity flex-contexts. This test documents
-    the expected behavior and verifies the infrastructure works correctly.
-
-    Expected behavior when implemented:
-    1. Aggregate-consumption and aggregate-production work with multi-commodity flex-context (list format)
-    2. Each commodity has its own aggregate sensors
-    3. Aggregate sensors for electricity correctly receive summed schedules
-    4. Aggregate sensors for heat correctly receive summed schedules (if applicable)
+    This test verifies that aggregate-consumption and aggregate-production sensors
+    correctly receive the summed output of multiple devices. The aggregation works
+    by summing schedules from all devices contributing to the same commodity.
     """
     # Set up charging hub
     bidirectional_cs = add_charging_station_assets_fresh_db[
@@ -490,86 +466,57 @@ def test_asset_trigger_with_multi_commodity_flex_context(
     ]
     charging_hub = bidirectional_cs.parent_asset
 
-    # Create aggregate sensors for electricity commodity
-    agg_consumption_electricity = Sensor(
-        name="aggregate-consumption-electricity",
+    # Create aggregate sensors
+    agg_consumption = Sensor(
+        name="aggregate-consumption-multi",
         generic_asset=charging_hub,
         unit="MW",
         event_resolution=pd.Timedelta(minutes=15),
     )
-    agg_production_electricity = Sensor(
-        name="aggregate-production-electricity",
+    agg_production = Sensor(
+        name="aggregate-production-multi",
         generic_asset=charging_hub,
         unit="MW",
         event_resolution=pd.Timedelta(minutes=15),
     )
-
-    # Create aggregate sensors for heat commodity
-    agg_consumption_heat = Sensor(
-        name="aggregate-consumption-heat",
-        generic_asset=charging_hub,
-        unit="MW",
-        event_resolution=pd.Timedelta(minutes=15),
-    )
-    agg_production_heat = Sensor(
-        name="aggregate-production-heat",
-        generic_asset=charging_hub,
-        unit="MW",
-        event_resolution=pd.Timedelta(minutes=15),
-    )
-    fresh_db.session.add(agg_consumption_electricity)
-    fresh_db.session.add(agg_production_electricity)
-    fresh_db.session.add(agg_consumption_heat)
-    fresh_db.session.add(agg_production_heat)
+    fresh_db.session.add(agg_consumption)
+    fresh_db.session.add(agg_production)
     fresh_db.session.flush()
 
     # Set up price sensors
     price_sensor_id = add_market_prices_fresh_db["epex_da"].id
 
-    # Get the charging stations
-    bidirectional_cs = add_charging_station_assets_fresh_db[
+    # Get both charging stations
+    charging_station_bi = add_charging_station_assets_fresh_db[
         "Test charging station (bidirectional)"
     ]
-    charging_station = add_charging_station_assets_fresh_db["Test charging station"]
+    charging_station_uni = add_charging_station_assets_fresh_db["Test charging station"]
 
-    sensor_1 = bidirectional_cs.sensors[0]
-    sensor_2 = charging_station.sensors[0]
-    bi_soc_sensor = add_charging_station_assets_fresh_db["bi-soc"]
-    uni_soc_sensor = add_charging_station_assets_fresh_db["uni-soc"]
+    sensor_bi = charging_station_bi.sensors[0]
+    sensor_uni = charging_station_uni.sensors[0]
+    soc_bi_sensor = add_charging_station_assets_fresh_db["bi-soc"]
+    soc_uni_sensor = add_charging_station_assets_fresh_db["uni-soc"]
 
-    # Build the message with multi-commodity flex-context (list of dicts)
+    # Build the message with multiple devices in flex-model
     message = message_for_trigger_schedule(resolution="PT30M")
+    message["flex-context"] = {
+        "consumption-price": {"sensor": price_sensor_id},
+        "production-price": {"sensor": price_sensor_id},
+        "site-power-capacity": "1 TW",
+        "aggregate-consumption": {"sensor": agg_consumption.id},
+        "aggregate-production": {"sensor": agg_production.id},
+    }
 
-    # Multi-commodity flex-context as a LIST of commodity contexts
-    message["flex-context"] = [
-        {
-            "commodity": "electricity",
-            "consumption-price": {"sensor": price_sensor_id},
-            "production-price": {"sensor": price_sensor_id},
-            "site-power-capacity": "1 TW",
-            "aggregate-consumption": {"sensor": agg_consumption_electricity.id},
-            "aggregate-production": {"sensor": agg_production_electricity.id},
-        },
-        {
-            "commodity": "heat",
-            "consumption-price": {"sensor": price_sensor_id},
-            "aggregate-consumption": {"sensor": agg_consumption_heat.id},
-            "aggregate-production": {"sensor": agg_production_heat.id},
-        },
-    ]
+    # Set up flex-models for both charging stations
+    flex_model_bi = message["flex-model"].copy()
+    flex_model_bi["state-of-charge"] = {"sensor": soc_bi_sensor.id}
+    flex_model_bi["sensor"] = sensor_bi.id
 
-    # Set up flex-models for both charging stations (both will use electricity commodity, but message allows multi-commodity)
-    CP_1_flex_model = message["flex-model"].copy()
-    CP_1_flex_model["state-of-charge"] = {"sensor": bi_soc_sensor.id}
-    CP_1_flex_model["sensor"] = sensor_1.id
-    CP_1_flex_model["commodity"] = "electricity"  # Explicitly set commodity
+    flex_model_uni = message["flex-model"].copy()
+    flex_model_uni["state-of-charge"] = {"sensor": soc_uni_sensor.id}
+    flex_model_uni["sensor"] = sensor_uni.id
 
-    CP_2_flex_model = message["flex-model"].copy()
-    CP_2_flex_model["state-of-charge"] = {"sensor": uni_soc_sensor.id}
-    CP_2_flex_model["sensor"] = sensor_2.id
-    CP_2_flex_model["commodity"] = "electricity"  # Explicitly set commodity
-
-    message["flex-model"] = [CP_1_flex_model, CP_2_flex_model]
+    message["flex-model"] = [flex_model_bi, flex_model_uni]
 
     # Trigger the schedule
     assert len(app.queues["scheduling"]) == 0
@@ -578,6 +525,8 @@ def test_asset_trigger_with_multi_commodity_flex_context(
             url_for("AssetAPI:trigger_schedule", id=charging_hub.id),
             json=message,
         )
+        if trigger_response.status_code != 200:
+            print(f"Error response: {trigger_response.json}")
         assert trigger_response.status_code == 200
         job_id = trigger_response.json["schedule"]
 
@@ -595,31 +544,25 @@ def test_asset_trigger_with_multi_commodity_flex_context(
     scheduler_source = get_data_source_for_job(scheduling_job)
     assert scheduler_source is not None
 
-    # Verify electricity aggregate-consumption sensor got filled with data
-    electricity_consumption_beliefs = (
-        TimedBelief.query.filter(
-            TimedBelief.sensor_id == agg_consumption_electricity.id
-        )
+    # Verify aggregate-consumption sensor got filled with data
+    consumption_beliefs = (
+        TimedBelief.query.filter(TimedBelief.sensor_id == agg_consumption.id)
         .filter(TimedBelief.source_id == scheduler_source.id)
         .all()
     )
-    assert (
-        len(electricity_consumption_beliefs) > 0
-    ), "electricity aggregate-consumption sensor should have data"
+    assert len(consumption_beliefs) > 0, "aggregate-consumption sensor should have data"
 
-    # Verify electricity aggregate-production sensor got filled with data
-    electricity_production_beliefs = (
-        TimedBelief.query.filter(TimedBelief.sensor_id == agg_production_electricity.id)
+    # Verify aggregate-production sensor got filled with data
+    production_beliefs = (
+        TimedBelief.query.filter(TimedBelief.sensor_id == agg_production.id)
         .filter(TimedBelief.source_id == scheduler_source.id)
         .all()
     )
-    assert (
-        len(electricity_production_beliefs) > 0
-    ), "electricity aggregate-production sensor should have data"
+    assert len(production_beliefs) > 0, "aggregate-production sensor should have data"
 
     # Verify data types are correct (should be numeric)
-    consumption_values = [v.event_value for v in electricity_consumption_beliefs]
-    production_values = [v.event_value for v in electricity_production_beliefs]
+    consumption_values = [v.event_value for v in consumption_beliefs]
+    production_values = [v.event_value for v in production_beliefs]
 
     assert all(
         isinstance(v, (int, float)) or v is None for v in consumption_values
@@ -628,5 +571,3 @@ def test_asset_trigger_with_multi_commodity_flex_context(
         isinstance(v, (int, float)) or v is None for v in production_values
     ), "production values should be numeric"
 
-    # Note: heat aggregate sensors may not have data if the scheduler doesn't compute aggregates for
-    # unused commodities, which is expected behavior. The test verifies the electricity commodity works.

--- a/flexmeasures/api/v3_0/tests/test_asset_schedules_fresh_db.py
+++ b/flexmeasures/api/v3_0/tests/test_asset_schedules_fresh_db.py
@@ -733,6 +733,8 @@ def test_asset_trigger_with_flex_context_commodity_not_used(
             url_for("AssetAPI:trigger_schedule", id=charging_hub.id),
             json=message,
         )
+        if trigger_response.status_code != 200:
+            print(f"Error response: {trigger_response.json}")
         assert trigger_response.status_code == 200
         job_id = trigger_response.json["schedule"]
 

--- a/flexmeasures/api/v3_0/tests/test_asset_schedules_fresh_db.py
+++ b/flexmeasures/api/v3_0/tests/test_asset_schedules_fresh_db.py
@@ -11,6 +11,7 @@ from rq.job import Job
 from flexmeasures import Sensor
 from flexmeasures.api.v3_0.tests.utils import message_for_trigger_schedule
 from flexmeasures.data.models.planning.tests.utils import check_constraints
+from flexmeasures.data.models.generic_assets import GenericAsset
 from flexmeasures.data.models.time_series import TimedBelief
 from flexmeasures.utils.job_utils import work_on_rq
 from flexmeasures.data.services.scheduling import (
@@ -454,69 +455,131 @@ def test_asset_trigger_with_multi_commodity_flex_context(
     keep_scheduling_queue_empty,
     requesting_user,
 ):
-    """Test aggregate sensors with multiple devices in flex-model.
+    """Test aggregate sensors with multi-commodity flex-context (electricity and heat).
 
-    This test verifies that aggregate-consumption and aggregate-production sensors
-    correctly receive the summed output of multiple devices. The aggregation works
-    by summing schedules from all devices contributing to the same commodity.
+    This test verifies that:
+    1. Multi-commodity flex-context (list format) works correctly
+    2. Each commodity has its own aggregate sensors
+    3. Devices with different commodities are scheduled together
+    4. Aggregate sensors correctly sum their respective commodity's power flows
     """
+    from flexmeasures.data.models.generic_assets import GenericAssetType
+
     # Set up charging hub
     bidirectional_cs = add_charging_station_assets_fresh_db[
         "Test charging station (bidirectional)"
     ]
     charging_hub = bidirectional_cs.parent_asset
 
-    # Create aggregate sensors
-    agg_consumption = Sensor(
-        name="aggregate-consumption-multi",
+    # Create a heat device (boiler) as a sibling to the charging stations
+    boiler_asset_type = GenericAssetType(name="boiler")
+    fresh_db.session.add(boiler_asset_type)
+    fresh_db.session.flush()
+
+    boiler = GenericAsset(
+        name="Test boiler",
+        owner=charging_hub.owner,
+        generic_asset_type=boiler_asset_type,
+        parent_asset=charging_hub,
+        latitude=10,
+        longitude=100,
+        attributes=dict(
+            is_consumer=True,
+            is_producer=False,
+            can_shift=True,
+        ),
+    )
+    boiler_power_sensor = Sensor(
+        name="power",
+        generic_asset=boiler,
+        unit="MW",
+        event_resolution=pd.Timedelta(minutes=15),
+    )
+    boiler_soc_sensor = Sensor(
+        name="heat-soc",
+        generic_asset=boiler,
+        unit="MWh",
+        event_resolution=pd.Timedelta(minutes=0),
+    )
+    fresh_db.session.add(boiler)
+    fresh_db.session.add(boiler_power_sensor)
+    fresh_db.session.add(boiler_soc_sensor)
+    fresh_db.session.flush()
+
+    # Create aggregate sensors for each commodity
+    agg_consumption_electricity = Sensor(
+        name="aggregate-consumption-electricity",
         generic_asset=charging_hub,
         unit="MW",
         event_resolution=pd.Timedelta(minutes=15),
     )
-    agg_production = Sensor(
-        name="aggregate-production-multi",
+    agg_production_electricity = Sensor(
+        name="aggregate-production-electricity",
         generic_asset=charging_hub,
         unit="MW",
         event_resolution=pd.Timedelta(minutes=15),
     )
-    fresh_db.session.add(agg_consumption)
-    fresh_db.session.add(agg_production)
+    agg_consumption_heat = Sensor(
+        name="aggregate-consumption-heat",
+        generic_asset=charging_hub,
+        unit="MW",
+        event_resolution=pd.Timedelta(minutes=15),
+    )
+    fresh_db.session.add(agg_consumption_electricity)
+    fresh_db.session.add(agg_production_electricity)
+    fresh_db.session.add(agg_consumption_heat)
     fresh_db.session.flush()
 
     # Set up price sensors
     price_sensor_id = add_market_prices_fresh_db["epex_da"].id
 
-    # Get both charging stations
-    charging_station_bi = add_charging_station_assets_fresh_db[
-        "Test charging station (bidirectional)"
-    ]
+    # Get the charging station
     charging_station_uni = add_charging_station_assets_fresh_db["Test charging station"]
-
-    sensor_bi = charging_station_bi.sensors[0]
     sensor_uni = charging_station_uni.sensors[0]
-    soc_bi_sensor = add_charging_station_assets_fresh_db["bi-soc"]
     soc_uni_sensor = add_charging_station_assets_fresh_db["uni-soc"]
 
-    # Build the message with multiple devices in flex-model
+    # Build the message with multi-commodity flex-context as a LIST
     message = message_for_trigger_schedule(resolution="PT30M")
-    message["flex-context"] = {
-        "consumption-price": {"sensor": price_sensor_id},
-        "production-price": {"sensor": price_sensor_id},
-        "site-power-capacity": "1 TW",
-        "aggregate-consumption": {"sensor": agg_consumption.id},
-        "aggregate-production": {"sensor": agg_production.id},
+
+    # Multi-commodity flex-context as a LIST of commodity contexts
+    message["flex-context"] = [
+        {
+            "commodity": "electricity",
+            "consumption-price": {"sensor": price_sensor_id},
+            "production-price": {"sensor": price_sensor_id},
+            "site-power-capacity": "1 TW",
+            "aggregate-consumption": {"sensor": agg_consumption_electricity.id},
+            "aggregate-production": {"sensor": agg_production_electricity.id},
+        },
+        {
+            "commodity": "heat",
+            "consumption-price": {"sensor": price_sensor_id},
+            "site-consumption-capacity": "100 kW",
+            "site-production-capacity": "0 kW",
+            "aggregate-consumption": {"sensor": agg_consumption_heat.id},
+        },
+    ]
+
+    # Set up flex-models for electricity (charging station) and heat (boiler)
+    flex_model_electricity = message["flex-model"].copy()
+    flex_model_electricity["state-of-charge"] = {"sensor": soc_uni_sensor.id}
+    flex_model_electricity["sensor"] = sensor_uni.id
+    flex_model_electricity["commodity"] = "electricity"
+
+    flex_model_heat = {
+        "sensor": boiler_power_sensor.id,
+        "commodity": "heat",
+        "state-of-charge": {"sensor": boiler_soc_sensor.id},
+        "soc-at-start": 10.0,
+        "soc-min": 0,
+        "soc-max": 20.0,
+        "soc-unit": "MWh",
+        "power-capacity": "1 MW",
+        "roundtrip-efficiency": "98%",
+        "storage-efficiency": "99.99%",
     }
 
-    # Set up flex-models for both charging stations
-    flex_model_bi = message["flex-model"].copy()
-    flex_model_bi["state-of-charge"] = {"sensor": soc_bi_sensor.id}
-    flex_model_bi["sensor"] = sensor_bi.id
-
-    flex_model_uni = message["flex-model"].copy()
-    flex_model_uni["state-of-charge"] = {"sensor": soc_uni_sensor.id}
-    flex_model_uni["sensor"] = sensor_uni.id
-
-    message["flex-model"] = [flex_model_bi, flex_model_uni]
+    message["flex-model"] = [flex_model_electricity, flex_model_heat]
 
     # Trigger the schedule
     assert len(app.queues["scheduling"]) == 0
@@ -544,30 +607,166 @@ def test_asset_trigger_with_multi_commodity_flex_context(
     scheduler_source = get_data_source_for_job(scheduling_job)
     assert scheduler_source is not None
 
-    # Verify aggregate-consumption sensor got filled with data
-    consumption_beliefs = (
-        TimedBelief.query.filter(TimedBelief.sensor_id == agg_consumption.id)
+    # Verify electricity aggregate-consumption sensor got filled
+    consumption_beliefs_elec = (
+        TimedBelief.query.filter(
+            TimedBelief.sensor_id == agg_consumption_electricity.id
+        )
         .filter(TimedBelief.source_id == scheduler_source.id)
         .all()
     )
-    assert len(consumption_beliefs) > 0, "aggregate-consumption sensor should have data"
+    assert len(consumption_beliefs_elec) > 0, "electricity aggregate-consumption should have data"
 
-    # Verify aggregate-production sensor got filled with data
-    production_beliefs = (
-        TimedBelief.query.filter(TimedBelief.sensor_id == agg_production.id)
+    # Verify electricity aggregate-production sensor got filled
+    production_beliefs_elec = (
+        TimedBelief.query.filter(
+            TimedBelief.sensor_id == agg_production_electricity.id
+        )
         .filter(TimedBelief.source_id == scheduler_source.id)
         .all()
     )
-    assert len(production_beliefs) > 0, "aggregate-production sensor should have data"
+    assert len(production_beliefs_elec) > 0, "electricity aggregate-production should have data"
 
-    # Verify data types are correct (should be numeric)
-    consumption_values = [v.event_value for v in consumption_beliefs]
-    production_values = [v.event_value for v in production_beliefs]
+    # Verify heat aggregate-consumption sensor got filled
+    consumption_beliefs_heat = (
+        TimedBelief.query.filter(TimedBelief.sensor_id == agg_consumption_heat.id)
+        .filter(TimedBelief.source_id == scheduler_source.id)
+        .all()
+    )
+    assert len(consumption_beliefs_heat) > 0, "heat aggregate-consumption should have data"
 
+    # Verify data types are correct
     assert all(
-        isinstance(v, (int, float)) or v is None for v in consumption_values
-    ), "consumption values should be numeric"
+        isinstance(v.event_value, (int, float)) or v.event_value is None
+        for v in consumption_beliefs_elec
+    ), "electricity consumption values should be numeric"
     assert all(
-        isinstance(v, (int, float)) or v is None for v in production_values
-    ), "production values should be numeric"
+        isinstance(v.event_value, (int, float)) or v.event_value is None
+        for v in consumption_beliefs_heat
+    ), "heat consumption values should be numeric"
+
+
+@pytest.mark.parametrize(
+    "requesting_user", ["test_prosumer_user@seita.nl"], indirect=True
+)
+def test_asset_trigger_with_flex_context_commodity_not_used(
+    app,
+    fresh_db,
+    add_market_prices_fresh_db,
+    setup_roles_users_fresh_db,
+    add_charging_station_assets_fresh_db,
+    keep_scheduling_queue_empty,
+    requesting_user,
+):
+    """Test multi-commodity flex-context where one commodity is not used by any device.
+
+    This test verifies that:
+    1. Commodities in flex-context but not used in flex-model don't cause errors
+    2. Aggregate sensors for unused commodities receive no data (which is expected)
+    3. Devices for other commodities are scheduled normally
+    """
+    # Set up charging hub
+    bidirectional_cs = add_charging_station_assets_fresh_db[
+        "Test charging station (bidirectional)"
+    ]
+    charging_hub = bidirectional_cs.parent_asset
+
+    # Create aggregate sensors for electricity and heat
+    agg_consumption_electricity = Sensor(
+        name="aggregate-consumption-elec-unused",
+        generic_asset=charging_hub,
+        unit="MW",
+        event_resolution=pd.Timedelta(minutes=15),
+    )
+    agg_consumption_heat = Sensor(
+        name="aggregate-consumption-heat-unused",
+        generic_asset=charging_hub,
+        unit="MW",
+        event_resolution=pd.Timedelta(minutes=15),
+    )
+    fresh_db.session.add(agg_consumption_electricity)
+    fresh_db.session.add(agg_consumption_heat)
+    fresh_db.session.flush()
+
+    # Set up price sensors
+    price_sensor_id = add_market_prices_fresh_db["epex_da"].id
+
+    # Get the charging station
+    charging_station_uni = add_charging_station_assets_fresh_db["Test charging station"]
+    sensor_uni = charging_station_uni.sensors[0]
+    soc_uni_sensor = add_charging_station_assets_fresh_db["uni-soc"]
+
+    # Build the message with multi-commodity flex-context
+    message = message_for_trigger_schedule(resolution="PT30M")
+
+    # Multi-commodity flex-context with both electricity and heat commodities
+    # But only electricity devices in flex-model
+    message["flex-context"] = [
+        {
+            "commodity": "electricity",
+            "consumption-price": {"sensor": price_sensor_id},
+            "production-price": {"sensor": price_sensor_id},
+            "site-power-capacity": "1 TW",
+            "aggregate-consumption": {"sensor": agg_consumption_electricity.id},
+        },
+        {
+            "commodity": "heat",
+            "consumption-price": {"sensor": price_sensor_id},
+            "site-consumption-capacity": "100 kW",
+            "site-production-capacity": "0 kW",
+            "aggregate-consumption": {"sensor": agg_consumption_heat.id},
+        },
+    ]
+
+    # Only electricity flex-model (no heat device)
+    flex_model_electricity = message["flex-model"].copy()
+    flex_model_electricity["state-of-charge"] = {"sensor": soc_uni_sensor.id}
+    flex_model_electricity["sensor"] = sensor_uni.id
+    flex_model_electricity["commodity"] = "electricity"
+
+    message["flex-model"] = [flex_model_electricity]
+
+    # Trigger the schedule
+    assert len(app.queues["scheduling"]) == 0
+    with app.test_client() as client:
+        trigger_response = client.post(
+            url_for("AssetAPI:trigger_schedule", id=charging_hub.id),
+            json=message,
+        )
+        assert trigger_response.status_code == 200
+        job_id = trigger_response.json["schedule"]
+
+    # Process the scheduling queue
+    scheduled_jobs = app.queues["scheduling"].jobs
+    scheduling_job = scheduled_jobs[0]
+    work_on_rq(app.queues["scheduling"], exc_handler=handle_scheduling_exception)
+    assert (
+        Job.fetch(job_id, connection=app.queues["scheduling"].connection).is_finished
+        is True
+    )
+
+    # Verify scheduler data source
+    scheduling_job.refresh()
+    scheduler_source = get_data_source_for_job(scheduling_job)
+    assert scheduler_source is not None
+
+    # Verify electricity aggregate-consumption sensor got filled
+    consumption_beliefs_elec = (
+        TimedBelief.query.filter(
+            TimedBelief.sensor_id == agg_consumption_electricity.id
+        )
+        .filter(TimedBelief.source_id == scheduler_source.id)
+        .all()
+    )
+    assert len(consumption_beliefs_elec) > 0, "electricity aggregate-consumption should have data"
+
+    # Verify heat aggregate-consumption sensor is empty (no heat device)
+    consumption_beliefs_heat = (
+        TimedBelief.query.filter(TimedBelief.sensor_id == agg_consumption_heat.id)
+        .filter(TimedBelief.source_id == scheduler_source.id)
+        .all()
+    )
+    assert (
+        len(consumption_beliefs_heat) == 0
+    ), "heat aggregate-consumption should be empty since no heat device was scheduled"
 

--- a/flexmeasures/api/v3_0/tests/test_asset_schedules_fresh_db.py
+++ b/flexmeasures/api/v3_0/tests/test_asset_schedules_fresh_db.py
@@ -11,6 +11,7 @@ from rq.job import Job
 from flexmeasures import Sensor
 from flexmeasures.api.v3_0.tests.utils import message_for_trigger_schedule
 from flexmeasures.data.models.planning.tests.utils import check_constraints
+from flexmeasures.data.models.time_series import TimedBelief
 from flexmeasures.utils.job_utils import work_on_rq
 from flexmeasures.data.services.scheduling import (
     handle_scheduling_exception,
@@ -290,3 +291,342 @@ def test_asset_trigger_and_get_schedule(
                 sum(power_schedule[cheapest_hour * 4 : (cheapest_hour + 1) * 4]) > 0
             ), "we expect to charge in the cheapest hour"
             assert_almost_equal(power_schedule, expected_uni_schedule)
+
+
+@pytest.mark.xfail(
+    reason="StorageScheduler does not yet populate aggregate-consumption/production sensors"
+)
+@pytest.mark.parametrize(
+    "requesting_user", ["test_prosumer_user@seita.nl"], indirect=True
+)
+def test_asset_trigger_and_get_aggregate_schedule(
+    app,
+    fresh_db,
+    add_market_prices_fresh_db,
+    setup_roles_users_fresh_db,
+    add_charging_station_assets_fresh_db,
+    keep_scheduling_queue_empty,
+    requesting_user,
+):
+    """Test aggregate-consumption and aggregate-production flex-context fields.
+
+    This test verifies the interface for aggregate-consumption and aggregate-production
+    flex-context fields and checks whether they are populated with aggregate power flows.
+
+    Current Status: MISSING IMPLEMENTATION
+    The StorageScheduler currently does NOT populate aggregate-consumption and
+    aggregate-production sensors with data. This test documents the expected behavior once
+    the logic is implemented in StorageScheduler._compute_aggregate_schedules() (or similar).
+
+    Expected behavior when implemented:
+    1. Aggregate-consumption sensor receives the summed consumption schedule (positive values)
+    2. Aggregate-production sensor receives the summed production schedule (positive values)
+    3. The data source is correctly set to the scheduler
+    4. Sign convention matches the scheduler's output (consumption positive, production negative internally)
+    """
+    # Set up charging hub with aggregate sensors
+    bidirectional_charging_station = add_charging_station_assets_fresh_db[
+        "Test charging station (bidirectional)"
+    ]
+    charging_hub = bidirectional_charging_station.parent_asset
+
+    # Create aggregate consumption and production sensors on the hub
+    aggregate_consumption_sensor = Sensor(
+        name="aggregate-consumption",
+        generic_asset=charging_hub,
+        unit="MW",
+        event_resolution=pd.Timedelta(minutes=15),
+    )
+    aggregate_production_sensor = Sensor(
+        name="aggregate-production",
+        generic_asset=charging_hub,
+        unit="MW",
+        event_resolution=pd.Timedelta(minutes=15),
+    )
+    fresh_db.session.add(aggregate_consumption_sensor)
+    fresh_db.session.add(aggregate_production_sensor)
+    fresh_db.session.flush()
+
+    # Set up price sensor
+    price_sensor_id = add_market_prices_fresh_db["epex_da"].id
+
+    # Create flex-model with both charging stations
+    bidirectional_charging_station = add_charging_station_assets_fresh_db[
+        "Test charging station (bidirectional)"
+    ]
+    charging_station = add_charging_station_assets_fresh_db["Test charging station"]
+
+    sensor_1 = bidirectional_charging_station.sensors[0]
+    sensor_2 = charging_station.sensors[0]
+    bi_soc_sensor = add_charging_station_assets_fresh_db["bi-soc"]
+    uni_soc_sensor = add_charging_station_assets_fresh_db["uni-soc"]
+
+    # Build the message with aggregate sensors in flex-context
+    message = message_for_trigger_schedule(resolution="PT30M")
+    message["flex-context"] = {
+        "consumption-price": {"sensor": price_sensor_id},
+        "production-price": {"sensor": price_sensor_id},
+        "site-power-capacity": "1 TW",
+        "aggregate-consumption": {"sensor": aggregate_consumption_sensor.id},
+        "aggregate-production": {"sensor": aggregate_production_sensor.id},
+    }
+
+    # Set up flex-models for both charging stations
+    CP_1_flex_model = message["flex-model"].copy()
+    CP_1_flex_model["state-of-charge"] = {"sensor": bi_soc_sensor.id}
+    CP_1_flex_model["sensor"] = sensor_1.id
+
+    CP_2_flex_model = message["flex-model"].copy()
+    CP_2_flex_model["state-of-charge"] = {"sensor": uni_soc_sensor.id}
+    CP_2_flex_model["sensor"] = sensor_2.id
+
+    message["flex-model"] = [CP_1_flex_model, CP_2_flex_model]
+
+    # Trigger the schedule
+    assert len(app.queues["scheduling"]) == 0
+    with app.test_client() as client:
+        trigger_response = client.post(
+            url_for("AssetAPI:trigger_schedule", id=charging_hub.id),
+            json=message,
+        )
+        assert trigger_response.status_code == 200
+        job_id = trigger_response.json["schedule"]
+
+    # Process the scheduling queue
+    scheduled_jobs = app.queues["scheduling"].jobs
+    scheduling_job = scheduled_jobs[0]
+    work_on_rq(app.queues["scheduling"], exc_handler=handle_scheduling_exception)
+    assert (
+        Job.fetch(job_id, connection=app.queues["scheduling"].connection).is_finished
+        is True
+    )
+
+    # Verify scheduler data source was created
+    scheduling_job.refresh()
+    scheduler_source = get_data_source_for_job(scheduling_job)
+    assert scheduler_source is not None
+
+    # Verify aggregate-consumption sensor got filled with data
+    consumption_beliefs = (
+        TimedBelief.query.filter(
+            TimedBelief.sensor_id == aggregate_consumption_sensor.id
+        )
+        .filter(TimedBelief.source_id == scheduler_source.id)
+        .all()
+    )
+    assert len(consumption_beliefs) > 0, "aggregate-consumption sensor should have data"
+
+    # Extract consumption schedule (consumption is positive in the scheduler)
+    consumption_schedule = pd.Series(
+        [
+            -v.event_value for v in consumption_beliefs
+        ],  # Negate because DB stores consumption as negative
+        index=pd.DatetimeIndex([v.event_start for v in consumption_beliefs]),
+    )
+
+    # Verify aggregate-production sensor got filled with data
+    production_beliefs = (
+        TimedBelief.query.filter(
+            TimedBelief.sensor_id == aggregate_production_sensor.id
+        )
+        .filter(TimedBelief.source_id == scheduler_source.id)
+        .all()
+    )
+    assert len(production_beliefs) > 0, "aggregate-production sensor should have data"
+
+    # Extract production schedule (production is negative in the scheduler, but stored as positive in DB for production sensors)
+    production_schedule = pd.Series(
+        [v.event_value for v in production_beliefs],
+        index=pd.DatetimeIndex([v.event_start for v in production_beliefs]),
+    )
+
+    # Verify sign conventions: some values should be positive (consumption), some negative (production)
+    # At least one consumption value should be positive
+    assert (
+        consumption_schedule > 0
+    ).any(), "consumption schedule should have some positive values"
+
+    # For a test with charging, we might not have discharge, so production could be all zeros
+    # But we still verify the schedule structure is correct
+    assert (
+        production_schedule >= 0
+    ).all(), "production schedule should have non-negative values (production flows are positive)"
+
+
+@pytest.mark.xfail(
+    reason="StorageScheduler does not yet populate aggregate-consumption/production sensors"
+)
+@pytest.mark.parametrize(
+    "requesting_user", ["test_prosumer_user@seita.nl"], indirect=True
+)
+def test_asset_trigger_with_multi_commodity_flex_context(
+    app,
+    fresh_db,
+    add_market_prices_fresh_db,
+    setup_roles_users_fresh_db,
+    add_charging_station_assets_fresh_db,
+    keep_scheduling_queue_empty,
+    requesting_user,
+):
+    """Test aggregate-consumption/production with multi-commodity flex-context (list format).
+
+    This test verifies the interface for aggregate sensors in multi-commodity scheduling,
+    where flex-context is a list of commodity-specific contexts.
+
+    Current Status: MISSING IMPLEMENTATION
+    Similar to test_asset_trigger_and_get_aggregate_schedule, the StorageScheduler does NOT
+    currently populate aggregate sensors for multi-commodity flex-contexts. This test documents
+    the expected behavior and verifies the infrastructure works correctly.
+
+    Expected behavior when implemented:
+    1. Aggregate-consumption and aggregate-production work with multi-commodity flex-context (list format)
+    2. Each commodity has its own aggregate sensors
+    3. Aggregate sensors for electricity correctly receive summed schedules
+    4. Aggregate sensors for heat correctly receive summed schedules (if applicable)
+    """
+    # Set up charging hub
+    bidirectional_cs = add_charging_station_assets_fresh_db[
+        "Test charging station (bidirectional)"
+    ]
+    charging_hub = bidirectional_cs.parent_asset
+
+    # Create aggregate sensors for electricity commodity
+    agg_consumption_electricity = Sensor(
+        name="aggregate-consumption-electricity",
+        generic_asset=charging_hub,
+        unit="MW",
+        event_resolution=pd.Timedelta(minutes=15),
+    )
+    agg_production_electricity = Sensor(
+        name="aggregate-production-electricity",
+        generic_asset=charging_hub,
+        unit="MW",
+        event_resolution=pd.Timedelta(minutes=15),
+    )
+
+    # Create aggregate sensors for heat commodity
+    agg_consumption_heat = Sensor(
+        name="aggregate-consumption-heat",
+        generic_asset=charging_hub,
+        unit="MW",
+        event_resolution=pd.Timedelta(minutes=15),
+    )
+    agg_production_heat = Sensor(
+        name="aggregate-production-heat",
+        generic_asset=charging_hub,
+        unit="MW",
+        event_resolution=pd.Timedelta(minutes=15),
+    )
+    fresh_db.session.add(agg_consumption_electricity)
+    fresh_db.session.add(agg_production_electricity)
+    fresh_db.session.add(agg_consumption_heat)
+    fresh_db.session.add(agg_production_heat)
+    fresh_db.session.flush()
+
+    # Set up price sensors
+    price_sensor_id = add_market_prices_fresh_db["epex_da"].id
+
+    # Get the charging stations
+    bidirectional_cs = add_charging_station_assets_fresh_db[
+        "Test charging station (bidirectional)"
+    ]
+    charging_station = add_charging_station_assets_fresh_db["Test charging station"]
+
+    sensor_1 = bidirectional_cs.sensors[0]
+    sensor_2 = charging_station.sensors[0]
+    bi_soc_sensor = add_charging_station_assets_fresh_db["bi-soc"]
+    uni_soc_sensor = add_charging_station_assets_fresh_db["uni-soc"]
+
+    # Build the message with multi-commodity flex-context (list of dicts)
+    message = message_for_trigger_schedule(resolution="PT30M")
+
+    # Multi-commodity flex-context as a LIST of commodity contexts
+    message["flex-context"] = [
+        {
+            "commodity": "electricity",
+            "consumption-price": {"sensor": price_sensor_id},
+            "production-price": {"sensor": price_sensor_id},
+            "site-power-capacity": "1 TW",
+            "aggregate-consumption": {"sensor": agg_consumption_electricity.id},
+            "aggregate-production": {"sensor": agg_production_electricity.id},
+        },
+        {
+            "commodity": "heat",
+            "consumption-price": {"sensor": price_sensor_id},
+            "aggregate-consumption": {"sensor": agg_consumption_heat.id},
+            "aggregate-production": {"sensor": agg_production_heat.id},
+        },
+    ]
+
+    # Set up flex-models for both charging stations (both will use electricity commodity, but message allows multi-commodity)
+    CP_1_flex_model = message["flex-model"].copy()
+    CP_1_flex_model["state-of-charge"] = {"sensor": bi_soc_sensor.id}
+    CP_1_flex_model["sensor"] = sensor_1.id
+    CP_1_flex_model["commodity"] = "electricity"  # Explicitly set commodity
+
+    CP_2_flex_model = message["flex-model"].copy()
+    CP_2_flex_model["state-of-charge"] = {"sensor": uni_soc_sensor.id}
+    CP_2_flex_model["sensor"] = sensor_2.id
+    CP_2_flex_model["commodity"] = "electricity"  # Explicitly set commodity
+
+    message["flex-model"] = [CP_1_flex_model, CP_2_flex_model]
+
+    # Trigger the schedule
+    assert len(app.queues["scheduling"]) == 0
+    with app.test_client() as client:
+        trigger_response = client.post(
+            url_for("AssetAPI:trigger_schedule", id=charging_hub.id),
+            json=message,
+        )
+        assert trigger_response.status_code == 200
+        job_id = trigger_response.json["schedule"]
+
+    # Process the scheduling queue
+    scheduled_jobs = app.queues["scheduling"].jobs
+    scheduling_job = scheduled_jobs[0]
+    work_on_rq(app.queues["scheduling"], exc_handler=handle_scheduling_exception)
+    assert (
+        Job.fetch(job_id, connection=app.queues["scheduling"].connection).is_finished
+        is True
+    )
+
+    # Verify scheduler data source
+    scheduling_job.refresh()
+    scheduler_source = get_data_source_for_job(scheduling_job)
+    assert scheduler_source is not None
+
+    # Verify electricity aggregate-consumption sensor got filled with data
+    electricity_consumption_beliefs = (
+        TimedBelief.query.filter(
+            TimedBelief.sensor_id == agg_consumption_electricity.id
+        )
+        .filter(TimedBelief.source_id == scheduler_source.id)
+        .all()
+    )
+    assert (
+        len(electricity_consumption_beliefs) > 0
+    ), "electricity aggregate-consumption sensor should have data"
+
+    # Verify electricity aggregate-production sensor got filled with data
+    electricity_production_beliefs = (
+        TimedBelief.query.filter(TimedBelief.sensor_id == agg_production_electricity.id)
+        .filter(TimedBelief.source_id == scheduler_source.id)
+        .all()
+    )
+    assert (
+        len(electricity_production_beliefs) > 0
+    ), "electricity aggregate-production sensor should have data"
+
+    # Verify data types are correct (should be numeric)
+    consumption_values = [v.event_value for v in electricity_consumption_beliefs]
+    production_values = [v.event_value for v in electricity_production_beliefs]
+
+    assert all(
+        isinstance(v, (int, float)) or v is None for v in consumption_values
+    ), "consumption values should be numeric"
+    assert all(
+        isinstance(v, (int, float)) or v is None for v in production_values
+    ), "production values should be numeric"
+
+    # Note: heat aggregate sensors may not have data if the scheduler doesn't compute aggregates for
+    # unused commodities, which is expected behavior. The test verifies the electricity commodity works.

--- a/flexmeasures/data/models/planning/__init__.py
+++ b/flexmeasures/data/models/planning/__init__.py
@@ -14,7 +14,7 @@ from flask import current_app
 from flexmeasures.data import db
 from flexmeasures.data.models.time_series import Sensor
 from flexmeasures.data.models.generic_assets import GenericAsset as Asset
-from flexmeasures.utils.coding_utils import deprecated
+from flexmeasures.utils.coding_utils import deprecated, merge_or_append
 from .exceptions import WrongEntityException
 
 
@@ -220,8 +220,19 @@ class Scheduler:
             asset = self.asset
         else:
             asset = self.sensor.generic_asset
+
+        # Merge the passed flex_context with the db_flex_context by matching commodities
         db_flex_context = asset.get_flex_context()
-        self.flex_context = {**db_flex_context, **self.flex_context}
+        if isinstance(self.flex_context, dict):
+            self.flex_context = {**db_flex_context, **self.flex_context}
+        elif isinstance(self.flex_context, list):
+            # Currently, db_flex_context is always a dict describing only electricity
+            merge_or_append(
+                db_flex_context,
+                self.flex_context,
+                match_key="commodity",
+                match_value="electricity",
+            )
 
         # Merge the passed flex_model with the db_flex_model by matching asset IDs
         db_flex_model = asset.get_flex_model()

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -1301,6 +1301,8 @@ class MetaStorageScheduler(Scheduler):
             for d, flex_model_d in enumerate(flex_model):
                 commitment = FlowCommitment(
                     device=d,
+                    # todo: is flex_model_d guaranteed to have "commodity? Consider defaulting the device commodity to "electricity"
+                    # todo: should there not be something matching the "commodity" from the commitment_spec (default to "electricity") to the device commodity?
                     device_group=flex_model_d["commodity"],
                     **commitment_spec,
                 )

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -32,6 +32,7 @@ from flexmeasures.data.models.planning.utils import (
 from flexmeasures.data.models.planning.exceptions import InfeasibleProblemException
 from flexmeasures.data.schemas.scheduling.storage import StorageFlexModelSchema
 from flexmeasures.data.schemas.scheduling import (
+    CommodityFlexContextSchema,
     FlexContextSchema,
     MultiSensorFlexModelSchema,
 )
@@ -1337,8 +1338,20 @@ class MetaStorageScheduler(Scheduler):
             self.flex_model = {}
 
         self.collect_flex_config()
-        self.flex_context = FlexContextSchema().load(self.flex_context)
-
+        if isinstance(self.flex_context, dict):
+            # One flex-context for electricity
+            self.flex_context = FlexContextSchema().load(self.flex_context)
+        elif isinstance(self.flex_context, list):
+            # A flex-context per commodity -> nest it under the commodity_contexts field
+            for g, commodity_flex_context in enumerate(self.flex_context):
+                self.flex_context[g] = CommodityFlexContextSchema().load(
+                    commodity_flex_context
+                )
+            self.flex_context = dict(commodity_contexts=self.flex_context)
+        else:
+            raise TypeError(
+                f"Unsupported type of flex-context: '{type(self.flex_context)}'"
+            )
         if isinstance(self.flex_model, dict):
             if self.sensor.generic_asset.asset_type.name in storage_asset_types:
                 self.ensure_soc_at_start()

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -2318,11 +2318,12 @@ class StorageScheduler(MetaStorageScheduler):
         aggregate_power_sensor = self.flex_context.get("aggregate_power", None)
         if isinstance(aggregate_power_sensor, Sensor):
             storage_schedule[aggregate_power_sensor] = pd.concat(
-                ems_schedule, axis=1  # todo: select only electric devices (flexible and inflexible)
+                ems_schedule,
+                axis=1,  # todo: select only electric devices (flexible and inflexible)
             ).sum(axis=1)
         # Compute per-commodity aggregate power flows for aggregate-consumption and aggregate-production sensors
         self._compute_commodity_aggregate_schedules(
-            storage_schedule, ems_schedule#, sensors
+            storage_schedule, ems_schedule  # , sensors
         )
 
         # Convert each device schedule to the unit of the device's power sensor

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -1340,6 +1340,10 @@ class MetaStorageScheduler(Scheduler):
             self.flex_model = {}
 
         self.collect_flex_config()
+        self._deserialize_flex_context()
+        self._deserialize_flex_model()
+
+    def _deserialize_flex_context(self):
         if isinstance(self.flex_context, dict):
             # Load the one flex-context for electricity
             self.flex_context = FlexContextSchema().load(self.flex_context)
@@ -1376,6 +1380,8 @@ class MetaStorageScheduler(Scheduler):
             raise TypeError(
                 f"Unsupported type of flex-context: '{type(self.flex_context)}'"
             )
+
+    def _deserialize_flex_model(self):
         if isinstance(self.flex_model, dict):
             if self.sensor.generic_asset.asset_type.name in storage_asset_types:
                 self.ensure_soc_at_start()

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -8,7 +8,7 @@ from typing import Type
 import pandas as pd
 import numpy as np
 from flask import current_app
-
+from marshmallow import ValidationError
 
 from flexmeasures import Asset, Sensor
 from flexmeasures.data import db
@@ -1339,15 +1339,37 @@ class MetaStorageScheduler(Scheduler):
 
         self.collect_flex_config()
         if isinstance(self.flex_context, dict):
-            # One flex-context for electricity
+            # Load the one flex-context for electricity
             self.flex_context = FlexContextSchema().load(self.flex_context)
         elif isinstance(self.flex_context, list):
-            # A flex-context per commodity -> nest it under the commodity_contexts field
+            # Load each flex-context per commodity
             for g, commodity_flex_context in enumerate(self.flex_context):
                 self.flex_context[g] = CommodityFlexContextSchema().load(
                     commodity_flex_context
                 )
-            self.flex_context = dict(commodity_contexts=self.flex_context)
+
+            # Ensure all flex-contexts share the same currency unit
+            # todo: move this into a validator for FlexContextSchema.commodity_contexts?
+            shared_currency_unit = None
+            for commodity_flex_context in self.flex_context:
+                shared_currency_unit = commodity_flex_context["shared_currency_unit"]
+                if shared_currency_unit is None:
+                    shared_currency_unit = commodity_flex_context[
+                        "shared_currency_unit"
+                    ]
+                elif (
+                    commodity_flex_context["shared_currency_unit"]
+                    != shared_currency_unit
+                ):
+                    raise ValidationError(
+                        f"All prices in the flex-context must share the same currency unit (in this case: '{shared_currency_unit}')."
+                    )
+
+            # Nest the flex-contexts per commodity under the commodity_contexts field
+            self.flex_context = dict(
+                commodity_contexts=self.flex_context,
+                shared_currency_unit=shared_currency_unit,
+            )
         else:
             raise TypeError(
                 f"Unsupported type of flex-context: '{type(self.flex_context)}'"

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -2122,6 +2122,128 @@ class StorageScheduler(MetaStorageScheduler):
                 )
         return schedules
 
+    def _compute_commodity_aggregate_schedules(
+        self,
+        storage_schedule: dict,
+        ems_schedule: pd.DataFrame,
+        # sensors: list[Sensor | None],
+    ) -> None:
+        """Compute per-commodity aggregate power flows for aggregate-consumption and aggregate-production sensors.
+
+        This method populates the storage_schedule dict with aggregate schedules for each commodity
+        that defines aggregate-consumption and/or aggregate-production sensors in its commodity context.
+
+        The sign convention and split logic follows the same pattern as _build_consumption_production_schedules:
+        - Only aggregate-consumption defined: full aggregate schedule (consumption +, production -)
+        - Only aggregate-production defined: full aggregate schedule (consumption +, production -)
+          (sign will be flipped by make_schedule based on consumption_is_positive=False)
+        - Both defined: consumption sensor gets non-negative part, production sensor gets non-positive part
+          (sign will be flipped for production by make_schedule)
+
+        For backwards compatibility, when no commodity_contexts are defined, all devices are treated
+        as electricity devices and use the top-level flex-context fields.
+
+        :param storage_schedule: Dict to populate with aggregate schedules (will be modified in-place)
+        :param ems_schedule:     DataFrame of per-device power schedules in MW (consumption positive)
+        :param sensors:          List of sensors corresponding to device indices
+        """
+        # Get the device models to reconstruct commodity_to_devices mapping
+        flex_model = getattr(self, "_device_models", None)
+        if flex_model is None:
+            # Fallback: reconstruct if not available (shouldn't happen in normal flow)
+            flex_model = (
+                self.flex_model.copy()
+                if isinstance(self.flex_model, dict)
+                else [fm for fm in self.flex_model if fm.get("sensor") is not None]
+            )
+        if not isinstance(flex_model, list):
+            flex_model = [flex_model]
+
+        # Reconstruct commodity_to_devices mapping
+        commodity_to_devices = {}
+        for d, flex_model_d in enumerate(flex_model):
+            commodity = flex_model_d.get("commodity", "electricity")
+            commodity_to_devices.setdefault(commodity, []).append(d)
+
+        # Add inflexible devices to electricity commodity
+        inflexible_device_sensors = self.flex_context.get(
+            "inflexible_device_sensors", []
+        )
+        number_flexible_devices = len(flex_model)
+        commodity_to_devices.setdefault("electricity", []).extend(
+            list(
+                range(
+                    number_flexible_devices,
+                    number_flexible_devices + len(inflexible_device_sensors),
+                )
+            )
+        )
+
+        # Get commodity contexts (handles backwards compatibility)
+        commodity_contexts = self._get_commodity_contexts()
+
+        # Process each commodity
+        for commodity, devices in commodity_to_devices.items():
+            commodity_context = commodity_contexts.get(commodity, {})
+
+            # Get aggregate sensors for this commodity
+            aggregate_consumption_field = commodity_context.get("aggregate_consumption")
+            aggregate_production_field = commodity_context.get("aggregate_production")
+
+            # Extract sensor objects
+            aggregate_consumption_sensor = (
+                aggregate_consumption_field.get("sensor")
+                if isinstance(aggregate_consumption_field, dict)
+                and "sensor" in aggregate_consumption_field
+                else None
+            )
+            aggregate_production_sensor = (
+                aggregate_production_field.get("sensor")
+                if isinstance(aggregate_production_field, dict)
+                and "sensor" in aggregate_production_field
+                else None
+            )
+
+            # Skip if no aggregate sensors defined for this commodity
+            if (
+                aggregate_consumption_sensor is None
+                and aggregate_production_sensor is None
+            ):
+                continue
+
+            # Sum the schedules for all devices in this commodity
+            # ems_schedule is a list of Series, one per device
+            commodity_aggregate = sum(
+                ems_schedule[d] for d in devices if d < len(ems_schedule)
+            )
+
+            # Apply split logic based on which sensors are defined
+            if (
+                aggregate_consumption_sensor is not None
+                and aggregate_production_sensor is None
+            ):
+                # Only consumption sensor: full aggregate schedule
+                # (consumption positive, production negative)
+                storage_schedule[aggregate_consumption_sensor] = commodity_aggregate
+
+            elif (
+                aggregate_production_sensor is not None
+                and aggregate_consumption_sensor is None
+            ):
+                # Only production sensor: full aggregate schedule in native convention
+                # make_schedule will flip the sign via consumption_is_positive=False
+                storage_schedule[aggregate_production_sensor] = commodity_aggregate
+
+            else:
+                # Both sensors defined: split into consumption (>=0) and production (<=0) parts
+                # make_schedule will flip the sign for production sensor via consumption_is_positive=False
+                storage_schedule[aggregate_consumption_sensor] = (
+                    commodity_aggregate.clip(lower=0)
+                )
+                storage_schedule[aggregate_production_sensor] = (
+                    commodity_aggregate.clip(upper=0)
+                )
+
     def compute(self, skip_validation: bool = False) -> SchedulerOutputType:
         """Schedule a battery or Charge Point based directly on the latest beliefs regarding market prices within the specified time window.
         For the resulting consumption schedule, consumption is defined as positive values.
@@ -2176,8 +2298,12 @@ class StorageScheduler(MetaStorageScheduler):
         aggregate_power_sensor = self.flex_context.get("aggregate_power", None)
         if isinstance(aggregate_power_sensor, Sensor):
             storage_schedule[aggregate_power_sensor] = pd.concat(
-                ems_schedule, axis=1
+                ems_schedule, axis=1  # todo: select only electric devices (flexible and inflexible)
             ).sum(axis=1)
+        # Compute per-commodity aggregate power flows for aggregate-consumption and aggregate-production sensors
+        self._compute_commodity_aggregate_schedules(
+            storage_schedule, ems_schedule#, sensors
+        )
 
         # Convert each device schedule to the unit of the device's power sensor
         storage_schedule = {

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -2233,9 +2233,14 @@ class StorageScheduler(MetaStorageScheduler):
 
             # Sum the schedules for all devices in this commodity
             # ems_schedule is a list of Series, one per device
-            commodity_aggregate = sum(
-                ems_schedule[d] for d in devices if d < len(ems_schedule)
-            )
+            device_indices = [d for d in devices if d < len(ems_schedule)]
+
+            # If no devices contribute to this commodity's aggregate, skip it
+            # (e.g., heat commodity with no heat devices)
+            if not device_indices:
+                continue
+
+            commodity_aggregate = sum(ems_schedule[d] for d in device_indices)
 
             # Apply split logic based on which sensors are defined
             if (

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -2165,19 +2165,39 @@ class StorageScheduler(MetaStorageScheduler):
             commodity = flex_model_d.get("commodity", "electricity")
             commodity_to_devices.setdefault(commodity, []).append(d)
 
-        # Add inflexible devices to electricity commodity
+        # Add inflexible devices to commodities, mirroring _prepare()'s device
+        # enumeration so the device indices line up with ems_schedule:
+        #   - top-level inflexible-device-sensors go to electricity (backwards compat),
+        #   - then each commodity context's own inflexible-device-sensors are appended to
+        #     that commodity, in the order the commodity contexts are given.
+        # Without step 2 below, a commodity's inflexible demand (e.g. a heat load) is left
+        # out of its aggregate schedule, so an aggregate-consumption sensor only reflects
+        # the flexible devices of that commodity.
         inflexible_device_sensors = self.flex_context.get(
             "inflexible_device_sensors", []
         )
         number_flexible_devices = len(flex_model)
         commodity_to_devices.setdefault("electricity", []).extend(
-            list(
-                range(
-                    number_flexible_devices,
-                    number_flexible_devices + len(inflexible_device_sensors),
-                )
+            range(
+                number_flexible_devices,
+                number_flexible_devices + len(inflexible_device_sensors),
             )
         )
+
+        # Per-commodity inflexible devices, enumerated after the top-level ones.
+        num_devices = number_flexible_devices + len(inflexible_device_sensors)
+        for commodity_context in self.flex_context.get("commodity_contexts", []):
+            commodity = commodity_context["commodity"]
+            commodity_inflexible_device_sensors = commodity_context.get(
+                "inflexible_device_sensors", []
+            )
+            commodity_to_devices.setdefault(commodity, []).extend(
+                range(
+                    num_devices,
+                    num_devices + len(commodity_inflexible_device_sensors),
+                )
+            )
+            num_devices += len(commodity_inflexible_device_sensors)
 
         # Get commodity contexts (handles backwards compatibility)
         commodity_contexts = self._get_commodity_contexts()

--- a/flexmeasures/data/models/planning/tests/test_commitments.py
+++ b/flexmeasures/data/models/planning/tests/test_commitments.py
@@ -763,20 +763,18 @@ def test_mixed_gas_and_electricity_assets(app, db):
         },
     ]
 
-    flex_context = {
-        "commodities": [
-            {
-                "commodity": "electricity",
-                "consumption-price": "100 EUR/MWh",  # electricity price
-                "production-price": "100 EUR/MWh",
-            },
-            {
-                "commodity": "gas",
-                "consumption-price": "50 EUR/MWh",  # gas price
-                "production-price": "50 EUR/MWh",
-            },
-        ]
-    }
+    flex_context = [
+        {
+            "commodity": "electricity",
+            "consumption-price": "100 EUR/MWh",  # electricity price
+            "production-price": "100 EUR/MWh",
+        },
+        {
+            "commodity": "gas",
+            "consumption-price": "50 EUR/MWh",  # gas price
+            "production-price": "50 EUR/MWh",
+        },
+    ]
 
     scheduler = StorageScheduler(
         asset_or_sensor=battery,

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -396,6 +396,42 @@ class FlexContextSchema(SharedSchema):
         if not isinstance(aggregate_power, Sensor):
             raise ValidationError("The `aggregate-power` field can only be a Sensor.")
 
+    @validates("commodity_contexts")
+    def validate_commodity_contexts_shared_currency(
+        self, commodity_contexts: list[dict], **kwargs
+    ):
+        """Validate that all prices across commodity contexts share the same currency."""
+        if not commodity_contexts:
+            return
+
+        shared_currency_unit = None
+
+        for context in commodity_contexts:
+            # Check all price fields in this context
+            for field_name, field_value in context.items():
+                if field_name.endswith("_price") and field_value is not None:
+                    # Get the price unit
+                    if hasattr(field_value, "units"):
+                        price_unit = str(field_value.units)
+                    elif isinstance(field_value, ur.Quantity):
+                        price_unit = str(field_value.units)
+                    else:
+                        continue
+
+                    # Extract currency from the price unit
+                    # Price units are typically like "EUR/MWh" or "USD/MW"
+                    # Split by "/" and take first part as currency
+                    currency_unit = price_unit.split("/")[0].strip()
+
+                    if shared_currency_unit is None:
+                        shared_currency_unit = str(
+                            ur.Quantity(currency_unit).to_base_units().units
+                        )
+                    elif not units_are_convertible(currency_unit, shared_currency_unit):
+                        raise ValidationError(
+                            "all prices in the flex-context must share the same currency unit"
+                        )
+
     @validates_schema(pass_original=True)
     def check_prices(self, data: dict, original_data: dict, **kwargs):
         """Check assumptions about prices.

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -247,6 +247,58 @@ class SharedSchema(Schema):
         metadata=metadata.INFLEXIBLE_DEVICE_SENSORS.to_dict(),
     )
 
+    @validates_schema(pass_original=True)
+    def _try_to_convert_price_units(self, data: dict, original_data: dict, **kwargs):
+        """Convert price units to the same unit and scale if they can (incl. same currency)."""
+
+        shared_currency_unit = None
+        previous_field_name = None
+        for field in self.declared_fields:
+            if field[-5:] == "price" and field in data:
+                price_field = self.declared_fields[field]
+                price_unit = price_field._get_unit(data[field])
+                currency_unit = str(
+                    (
+                        ur.Quantity(price_unit) / ur.Quantity(f"1{price_field.to_unit}")
+                    ).units
+                )
+
+                if shared_currency_unit is None:
+                    shared_currency_unit = str(
+                        ur.Quantity(currency_unit).to_base_units().units
+                    )
+                    previous_field_name = price_field.data_key
+                if not units_are_convertible(currency_unit, shared_currency_unit):
+                    field_name = price_field.data_key
+                    original_price_unit = price_field._get_original_unit(
+                        original_data[field_name], data[field]
+                    )
+                    error_message = f"Invalid unit. A valid unit would be, for example, '{shared_currency_unit + price_field.to_unit}' (this example uses '{shared_currency_unit}', because '{previous_field_name}' used that currency). However, you passed an incompatible price ('{original_price_unit}') for the '{field_name}' field."
+                    if shared_currency_unit not in price_unit:
+                        error_message += f" Also note that all prices in the flex-context must share the same currency unit (in this case: '{shared_currency_unit}')."
+                    raise ValidationError(error_message, field_name=field_name)
+        if shared_currency_unit is not None:
+            data["shared_currency_unit"] = shared_currency_unit
+        elif sensor := data.get("consumption_price_sensor"):
+            data["shared_currency_unit"] = self._to_currency_per_mwh(sensor.unit)
+        elif sensor := data.get("production_price_sensor"):
+            data["shared_currency_unit"] = self._to_currency_per_mwh(sensor.unit)
+        else:
+            data["shared_currency_unit"] = "EUR"
+        return data
+
+    @staticmethod
+    def _to_currency_per_mwh(price_unit: str) -> str:
+        """Convert a price unit to a base currency used to express that price per MWh.
+
+        >>> FlexContextSchema()._to_currency_per_mwh("EUR/MWh")
+        'EUR'
+        >>> FlexContextSchema()._to_currency_per_mwh("EUR/kWh")
+        'EUR'
+        """
+        currency = str(ur.Quantity(price_unit + " * MWh").to_base_units().units)
+        return currency
+
 
 class CommodityFlexContextSchema(SharedSchema):
     commodity = fields.Str(
@@ -422,7 +474,6 @@ class FlexContextSchema(SharedSchema):
         # make sure that the prices fields are valid price units
 
         # All prices must share the same unit
-        data = self._try_to_convert_price_units(data, original_data)
         shared_currency = ur.Quantity(data["shared_currency_unit"])
 
         # Fill in default soc breach prices when asked to relax SoC constraints, unless already set explicitly.
@@ -465,57 +516,6 @@ class FlexContextSchema(SharedSchema):
             )
 
         return data
-
-    def _try_to_convert_price_units(self, data: dict, original_data: dict):
-        """Convert price units to the same unit and scale if they can (incl. same currency)."""
-
-        shared_currency_unit = None
-        previous_field_name = None
-        for field in self.declared_fields:
-            if field[-5:] == "price" and field in data:
-                price_field = self.declared_fields[field]
-                price_unit = price_field._get_unit(data[field])
-                currency_unit = str(
-                    (
-                        ur.Quantity(price_unit) / ur.Quantity(f"1{price_field.to_unit}")
-                    ).units
-                )
-
-                if shared_currency_unit is None:
-                    shared_currency_unit = str(
-                        ur.Quantity(currency_unit).to_base_units().units
-                    )
-                    previous_field_name = price_field.data_key
-                if not units_are_convertible(currency_unit, shared_currency_unit):
-                    field_name = price_field.data_key
-                    original_price_unit = price_field._get_original_unit(
-                        original_data[field_name], data[field]
-                    )
-                    error_message = f"Invalid unit. A valid unit would be, for example, '{shared_currency_unit + price_field.to_unit}' (this example uses '{shared_currency_unit}', because '{previous_field_name}' used that currency). However, you passed an incompatible price ('{original_price_unit}') for the '{field_name}' field."
-                    if shared_currency_unit not in price_unit:
-                        error_message += f" Also note that all prices in the flex-context must share the same currency unit (in this case: '{shared_currency_unit}')."
-                    raise ValidationError(error_message, field_name=field_name)
-        if shared_currency_unit is not None:
-            data["shared_currency_unit"] = shared_currency_unit
-        elif sensor := data.get("consumption_price_sensor"):
-            data["shared_currency_unit"] = self._to_currency_per_mwh(sensor.unit)
-        elif sensor := data.get("production_price_sensor"):
-            data["shared_currency_unit"] = self._to_currency_per_mwh(sensor.unit)
-        else:
-            data["shared_currency_unit"] = "EUR"
-        return data
-
-    @staticmethod
-    def _to_currency_per_mwh(price_unit: str) -> str:
-        """Convert a price unit to a base currency used to express that price per MWh.
-
-        >>> FlexContextSchema()._to_currency_per_mwh("EUR/MWh")
-        'EUR'
-        >>> FlexContextSchema()._to_currency_per_mwh("EUR/kWh")
-        'EUR'
-        """
-        currency = str(ur.Quantity(price_unit + " * MWh").to_base_units().units)
-        return currency
 
 
 EXAMPLE_UNIT_TYPES: Dict[str, list[str]] = {

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -592,6 +592,24 @@ EXAMPLE_UNIT_TYPES: Dict[str, list[str]] = {
 }
 
 UI_FLEX_CONTEXT_SCHEMA: Dict[str, Dict[str, Any]] = {
+    "aggregate-consumption": {
+        "default": None,
+        "description": rst_to_openapi(metadata.AGGREGATE_CONSUMPTION.description),
+        "types": {
+            "backend": "typeTwo",
+            "ui": "A sensor which records the scheduled aggregate consumption.",
+        },
+        "example-units": EXAMPLE_UNIT_TYPES["power"],
+    },
+    "aggregate-production": {
+        "default": None,
+        "description": rst_to_openapi(metadata.AGGREGATE_PRODUCTION.description),
+        "types": {
+            "backend": "typeTwo",
+            "ui": "A sensor which records the scheduled aggregate production.",
+        },
+        "example-units": EXAMPLE_UNIT_TYPES["power"],
+    },
     "consumption-price": {
         "default": None,  # Refers to default value of the field
         "description": rst_to_openapi(metadata.CONSUMPTION_PRICE.description),

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -250,7 +250,8 @@ class SharedSchema(Schema):
 
 class CommodityFlexContextSchema(SharedSchema):
     commodity = fields.Str(
-        required=True,
+        required=False,
+        load_default="electricity",
         data_key="commodity",
         metadata=metadata.COMMODITY_FLEX_CONTEXT.to_dict(),
     )

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -1128,7 +1128,7 @@ class AssetTriggerSchema(Schema):
         data_key="flex-model",
         load_default=[],
     )
-    flex_context = fields.Dict(
+    flex_context = fields.Raw(
         required=False,
         data_key="flex-context",
         load_default={},
@@ -1146,6 +1146,37 @@ class AssetTriggerSchema(Schema):
             description="If True, this bypasses the cache that the server keeps for results of scheduling jobs. This cache helps prevents redundant computation when schedules with the exact same request parameters are triggered.",
         ),
     )
+
+    @pre_load
+    def normalize_flex_context_format(self, data, **kwargs):
+        """Normalize flex_context to always be a dict.
+
+        Accepts both:
+        - Single commodity dict: {"commodity": "electricity", ...}
+        - List of commodity dicts: [{"commodity": "electricity", ...}, {"commodity": "heat", ...}]
+        - MultiDict with multiple 'flex-context' entries (when JSON list is parsed by webargs)
+
+        If a list is provided, it is wrapped under the 'commodities' field.
+        If a dict is provided, it is kept as-is.
+        This ensures downstream code always sees a dict structure.
+        """
+        if "flex-context" in data:
+            raw_flex_context = data.get("flex-context")
+
+            # Check if data is a MultiDict with multiple 'flex-context' entries
+            # This happens when JSON contains a list which webargs converts to multiple entries
+            if hasattr(data, "getlist"):
+                # MultiDict case - get all values for 'flex-context'
+                flex_contexts = data.getlist("flex-context")
+                if len(flex_contexts) > 1:
+                    # Multiple commodities: wrap in a dict with commodity_contexts field
+                    data["flex-context"] = {"commodities": flex_contexts}
+                # If only 1 entry, leave as-is (it's already a dict)
+            elif isinstance(raw_flex_context, list):
+                # Regular list case
+                data["flex-context"] = {"commodities": raw_flex_context}
+            # else: already a dict, leave as-is
+        return data
 
     @validates_schema
     def check_flex_model_sensors(self, data, **kwargs):

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -23,6 +23,7 @@ from flexmeasures.data.schemas.sensors import (
     VariableQuantityField,
     SensorIdField,
     SensorReference,
+    SensorReferenceSchema,
 )
 from flexmeasures.data.schemas.scheduling import metadata
 from flexmeasures.data.schemas.units import UnitField
@@ -143,6 +144,8 @@ class DBCommitmentSchema(CommitmentSchema, NoTimeSeriesSpecs):
 
 
 class SharedSchema(Schema):
+    """Shared schema for fields common across commodities in flex-context and commodity-context."""
+
     consumption_price = VariableQuantityField(
         "/MWh",
         required=False,
@@ -233,103 +236,7 @@ class SharedSchema(Schema):
         metadata=metadata.SITE_PEAK_PRODUCTION_PRICE.to_dict(),
     )
 
-    commitments = fields.Nested(
-        CommitmentSchema,
-        data_key="commitments",
-        required=False,
-        many=True,
-        metadata=metadata.COMMITMENTS.to_dict(),
-    )
-
-    inflexible_device_sensors = fields.List(
-        SensorIdField(),
-        data_key="inflexible-device-sensors",
-        metadata=metadata.INFLEXIBLE_DEVICE_SENSORS.to_dict(),
-    )
-
-    @validates_schema(pass_original=True)
-    def _try_to_convert_price_units(self, data: dict, original_data: dict, **kwargs):
-        """Convert price units to the same unit and scale if they can (incl. same currency)."""
-
-        shared_currency_unit = None
-        previous_field_name = None
-        for field in self.declared_fields:
-            if field[-5:] == "price" and field in data:
-                price_field = self.declared_fields[field]
-                price_unit = price_field._get_unit(data[field])
-                currency_unit = str(
-                    (
-                        ur.Quantity(price_unit) / ur.Quantity(f"1{price_field.to_unit}")
-                    ).units
-                )
-
-                if shared_currency_unit is None:
-                    shared_currency_unit = str(
-                        ur.Quantity(currency_unit).to_base_units().units
-                    )
-                    previous_field_name = price_field.data_key
-                if not units_are_convertible(currency_unit, shared_currency_unit):
-                    field_name = price_field.data_key
-                    original_price_unit = price_field._get_original_unit(
-                        original_data[field_name], data[field]
-                    )
-                    error_message = f"Invalid unit. A valid unit would be, for example, '{shared_currency_unit + price_field.to_unit}' (this example uses '{shared_currency_unit}', because '{previous_field_name}' used that currency). However, you passed an incompatible price ('{original_price_unit}') for the '{field_name}' field."
-                    if shared_currency_unit not in price_unit:
-                        error_message += f" Also note that all prices in the flex-context must share the same currency unit (in this case: '{shared_currency_unit}')."
-                    raise ValidationError(error_message, field_name=field_name)
-        if shared_currency_unit is not None:
-            data["shared_currency_unit"] = shared_currency_unit
-        elif sensor := data.get("consumption_price_sensor"):
-            data["shared_currency_unit"] = self._to_currency_per_mwh(sensor.unit)
-        elif sensor := data.get("production_price_sensor"):
-            data["shared_currency_unit"] = self._to_currency_per_mwh(sensor.unit)
-        else:
-            data["shared_currency_unit"] = "EUR"
-        return data
-
-    @staticmethod
-    def _to_currency_per_mwh(price_unit: str) -> str:
-        """Convert a price unit to a base currency used to express that price per MWh.
-
-        >>> FlexContextSchema()._to_currency_per_mwh("EUR/MWh")
-        'EUR'
-        >>> FlexContextSchema()._to_currency_per_mwh("EUR/kWh")
-        'EUR'
-        """
-        currency = str(ur.Quantity(price_unit + " * MWh").to_base_units().units)
-        return currency
-
-
-class CommodityFlexContextSchema(SharedSchema):
-    commodity = fields.Str(
-        required=False,
-        load_default="electricity",
-        data_key="commodity",
-        metadata=metadata.COMMODITY_FLEX_CONTEXT.to_dict(),
-    )
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        commodity_field = self.fields.pop("commodity")
-        self.fields = OrderedDict(
-            [("commodity", commodity_field), *self.fields.items()]
-        )
-
-
-class FlexContextSchema(SharedSchema):
-    """This schema defines fields that provide context to the portfolio to be optimized."""
-
-    commodity_contexts = fields.Nested(
-        CommodityFlexContextSchema,
-        data_key="commodities",
-        required=False,
-        many=True,
-        metadata=dict(
-            description="For multi-commodity scheduling problems, the above fields can be set here per commodity.",
-        ),
-    )
-    # Device commitments
+    # Breach prices for device capacity constraints
     consumption_breach_price = VariableQuantityField(
         "/MW",
         data_key="consumption-breach-price",
@@ -358,12 +265,13 @@ class FlexContextSchema(SharedSchema):
         value_validator=validate.Range(min=0),
         metadata=metadata.SOC_MAXIMA_BREACH_PRICE.to_dict(),
     )
+
+    # Relaxation fields
     relax_constraints = fields.Bool(
         data_key="relax-constraints",
         load_default=False,
         metadata=metadata.RELAX_CONSTRAINTS.to_dict(),
     )
-    # Dev fields
     relax_soc_constraints = fields.Bool(
         data_key="relax-soc-constraints",
         load_default=False,
@@ -380,17 +288,32 @@ class FlexContextSchema(SharedSchema):
         metadata=metadata.RELAX_SITE_CAPACITY_CONSTRAINTS.to_dict(),
     )
 
-    # Energy commitments
-    # todo: deprecated since flexmeasures==0.23
-    consumption_price_sensor = SensorIdField(data_key="consumption-price-sensor")
-    production_price_sensor = SensorIdField(data_key="production-price-sensor")
-
-    # todo: group by month start (MS), something like a commitment resolution, or a list of datetimes representing splits of the commitments
-    aggregate_power = VariableQuantityField(
-        to_unit="MW",
-        data_key="aggregate-power",
+    commitments = fields.Nested(
+        CommitmentSchema,
+        data_key="commitments",
         required=False,
-        metadata=metadata.AGGREGATE_POWER.to_dict(),
+        many=True,
+        metadata=metadata.COMMITMENTS.to_dict(),
+    )
+
+    inflexible_device_sensors = fields.List(
+        SensorIdField(),
+        data_key="inflexible-device-sensors",
+        metadata=metadata.INFLEXIBLE_DEVICE_SENSORS.to_dict(),
+    )
+
+    # Aggregate output sensors
+    aggregate_consumption = fields.Nested(
+        SensorReferenceSchema,
+        required=False,
+        data_key="aggregate-consumption",
+        metadata=metadata.AGGREGATE_CONSUMPTION.to_dict(),
+    )
+    aggregate_production = fields.Nested(
+        SensorReferenceSchema,
+        required=False,
+        data_key="aggregate-production",
+        metadata=metadata.AGGREGATE_PRODUCTION.to_dict(),
     )
 
     def set_default_breach_prices(
@@ -408,6 +331,57 @@ class FlexContextSchema(SharedSchema):
                 + self.declared_fields[field].to_unit.split("/")[-1]
             )
         return data
+
+
+class CommodityFlexContextSchema(SharedSchema):
+    commodity = fields.Str(
+        required=False,
+        load_default="electricity",
+        data_key="commodity",
+        metadata=metadata.COMMODITY_FLEX_CONTEXT.to_dict(),
+    )
+
+    # For flex-context listings (per commodity), default relax_constraints to True
+    relax_constraints = fields.Bool(
+        data_key="relax-constraints",
+        load_default=True,
+        metadata=metadata.RELAX_CONSTRAINTS.to_dict(),
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        commodity_field = self.fields.pop("commodity")
+        self.fields = OrderedDict(
+            [("commodity", commodity_field), *self.fields.items()]
+        )
+
+
+class FlexContextSchema(SharedSchema):
+    """This schema defines fields that provide context to the portfolio to be optimized."""
+
+    commodity_contexts = fields.Nested(
+        CommodityFlexContextSchema,
+        data_key="commodities",
+        required=False,
+        many=True,
+        metadata=dict(
+            description="For multi-commodity scheduling problems, the above fields can be set here per commodity.",
+        ),
+    )
+
+    # Energy commitments
+    # todo: deprecated since flexmeasures==0.23
+    consumption_price_sensor = SensorIdField(data_key="consumption-price-sensor")
+    production_price_sensor = SensorIdField(data_key="production-price-sensor")
+
+    # todo: group by month start (MS), something like a commitment resolution, or a list of datetimes representing splits of the commitments
+    aggregate_power = VariableQuantityField(
+        to_unit="MW",
+        data_key="aggregate-power",
+        required=False,
+        metadata=metadata.AGGREGATE_POWER.to_dict(),
+    )
 
     @validates("aggregate_power")
     def validate_aggregate_power_is_sensor(
@@ -516,6 +490,58 @@ class FlexContextSchema(SharedSchema):
             )
 
         return data
+
+    @validates_schema(pass_original=True)
+    def _try_to_convert_price_units(self, data: dict, original_data: dict, **kwargs):
+        """Convert price units to the same unit and scale if they can (incl. same currency)."""
+
+        shared_currency_unit = None
+        previous_field_name = None
+        for field in self.declared_fields:
+            if field[-5:] == "price" and field in data:
+                price_field = self.declared_fields[field]
+                price_unit = price_field._get_unit(data[field])
+                currency_unit = str(
+                    (
+                        ur.Quantity(price_unit) / ur.Quantity(f"1{price_field.to_unit}")
+                    ).units
+                )
+
+                if shared_currency_unit is None:
+                    shared_currency_unit = str(
+                        ur.Quantity(currency_unit).to_base_units().units
+                    )
+                    previous_field_name = price_field.data_key
+                if not units_are_convertible(currency_unit, shared_currency_unit):
+                    field_name = price_field.data_key
+                    original_price_unit = price_field._get_original_unit(
+                        original_data[field_name], data[field]
+                    )
+                    error_message = f"Invalid unit. A valid unit would be, for example, '{shared_currency_unit + price_field.to_unit}' (this example uses '{shared_currency_unit}', because '{previous_field_name}' used that currency). However, you passed an incompatible price ('{original_price_unit}') for the '{field_name}' field."
+                    if shared_currency_unit not in price_unit:
+                        error_message += f" Also note that all prices in the flex-context must share the same currency unit (in this case: '{shared_currency_unit}')."
+                    raise ValidationError(error_message, field_name=field_name)
+        if shared_currency_unit is not None:
+            data["shared_currency_unit"] = shared_currency_unit
+        elif sensor := data.get("consumption_price_sensor"):
+            data["shared_currency_unit"] = self._to_currency_per_mwh(sensor.unit)
+        elif sensor := data.get("production_price_sensor"):
+            data["shared_currency_unit"] = self._to_currency_per_mwh(sensor.unit)
+        else:
+            data["shared_currency_unit"] = "EUR"
+        return data
+
+    @staticmethod
+    def _to_currency_per_mwh(price_unit: str) -> str:
+        """Convert a price unit to a base currency used to express that price per MWh.
+
+        >>> FlexContextSchema()._to_currency_per_mwh("EUR/MWh")
+        'EUR'
+        >>> FlexContextSchema()._to_currency_per_mwh("EUR/kWh")
+        'EUR'
+        """
+        currency = str(ur.Quantity(price_unit + " * MWh").to_base_units().units)
+        return currency
 
 
 EXAMPLE_UNIT_TYPES: Dict[str, list[str]] = {

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -332,6 +332,58 @@ class SharedSchema(Schema):
             )
         return data
 
+    @validates_schema(pass_original=True)
+    def _try_to_convert_price_units(self, data: dict, original_data: dict, **kwargs):
+        """Convert price units to the same unit and scale if they can (incl. same currency)."""
+
+        shared_currency_unit = None
+        previous_field_name = None
+        for field in self.declared_fields:
+            if field[-5:] == "price" and field in data:
+                price_field = self.declared_fields[field]
+                price_unit = price_field._get_unit(data[field])
+                currency_unit = str(
+                    (
+                        ur.Quantity(price_unit) / ur.Quantity(f"1{price_field.to_unit}")
+                    ).units
+                )
+
+                if shared_currency_unit is None:
+                    shared_currency_unit = str(
+                        ur.Quantity(currency_unit).to_base_units().units
+                    )
+                    previous_field_name = price_field.data_key
+                if not units_are_convertible(currency_unit, shared_currency_unit):
+                    field_name = price_field.data_key
+                    original_price_unit = price_field._get_original_unit(
+                        original_data[field_name], data[field]
+                    )
+                    error_message = f"Invalid unit. A valid unit would be, for example, '{shared_currency_unit + price_field.to_unit}' (this example uses '{shared_currency_unit}', because '{previous_field_name}' used that currency). However, you passed an incompatible price ('{original_price_unit}') for the '{field_name}' field."
+                    if shared_currency_unit not in price_unit:
+                        error_message += f" Also note that all prices in the flex-context must share the same currency unit (in this case: '{shared_currency_unit}')."
+                    raise ValidationError(error_message, field_name=field_name)
+        if shared_currency_unit is not None:
+            data["shared_currency_unit"] = shared_currency_unit
+        elif sensor := data.get("consumption_price_sensor"):
+            data["shared_currency_unit"] = self._to_currency_per_mwh(sensor.unit)
+        elif sensor := data.get("production_price_sensor"):
+            data["shared_currency_unit"] = self._to_currency_per_mwh(sensor.unit)
+        else:
+            data["shared_currency_unit"] = "EUR"
+        return data
+
+    @staticmethod
+    def _to_currency_per_mwh(price_unit: str) -> str:
+        """Convert a price unit to a base currency used to express that price per MWh.
+
+        >>> FlexContextSchema()._to_currency_per_mwh("EUR/MWh")
+        'EUR'
+        >>> FlexContextSchema()._to_currency_per_mwh("EUR/kWh")
+        'EUR'
+        """
+        currency = str(ur.Quantity(price_unit + " * MWh").to_base_units().units)
+        return currency
+
 
 class CommodityFlexContextSchema(SharedSchema):
     commodity = fields.Str(
@@ -484,6 +536,7 @@ class FlexContextSchema(SharedSchema):
         # make sure that the prices fields are valid price units
 
         # All prices must share the same unit
+        self._try_to_convert_price_units(data, original_data)
         shared_currency = ur.Quantity(data["shared_currency_unit"])
 
         # Fill in default soc breach prices when asked to relax SoC constraints, unless already set explicitly.
@@ -526,58 +579,6 @@ class FlexContextSchema(SharedSchema):
             )
 
         return data
-
-    @validates_schema(pass_original=True)
-    def _try_to_convert_price_units(self, data: dict, original_data: dict, **kwargs):
-        """Convert price units to the same unit and scale if they can (incl. same currency)."""
-
-        shared_currency_unit = None
-        previous_field_name = None
-        for field in self.declared_fields:
-            if field[-5:] == "price" and field in data:
-                price_field = self.declared_fields[field]
-                price_unit = price_field._get_unit(data[field])
-                currency_unit = str(
-                    (
-                        ur.Quantity(price_unit) / ur.Quantity(f"1{price_field.to_unit}")
-                    ).units
-                )
-
-                if shared_currency_unit is None:
-                    shared_currency_unit = str(
-                        ur.Quantity(currency_unit).to_base_units().units
-                    )
-                    previous_field_name = price_field.data_key
-                if not units_are_convertible(currency_unit, shared_currency_unit):
-                    field_name = price_field.data_key
-                    original_price_unit = price_field._get_original_unit(
-                        original_data[field_name], data[field]
-                    )
-                    error_message = f"Invalid unit. A valid unit would be, for example, '{shared_currency_unit + price_field.to_unit}' (this example uses '{shared_currency_unit}', because '{previous_field_name}' used that currency). However, you passed an incompatible price ('{original_price_unit}') for the '{field_name}' field."
-                    if shared_currency_unit not in price_unit:
-                        error_message += f" Also note that all prices in the flex-context must share the same currency unit (in this case: '{shared_currency_unit}')."
-                    raise ValidationError(error_message, field_name=field_name)
-        if shared_currency_unit is not None:
-            data["shared_currency_unit"] = shared_currency_unit
-        elif sensor := data.get("consumption_price_sensor"):
-            data["shared_currency_unit"] = self._to_currency_per_mwh(sensor.unit)
-        elif sensor := data.get("production_price_sensor"):
-            data["shared_currency_unit"] = self._to_currency_per_mwh(sensor.unit)
-        else:
-            data["shared_currency_unit"] = "EUR"
-        return data
-
-    @staticmethod
-    def _to_currency_per_mwh(price_unit: str) -> str:
-        """Convert a price unit to a base currency used to express that price per MWh.
-
-        >>> FlexContextSchema()._to_currency_per_mwh("EUR/MWh")
-        'EUR'
-        >>> FlexContextSchema()._to_currency_per_mwh("EUR/kWh")
-        'EUR'
-        """
-        currency = str(ur.Quantity(price_unit + " * MWh").to_base_units().units)
-        return currency
 
 
 EXAMPLE_UNIT_TYPES: Dict[str, list[str]] = {

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -536,7 +536,7 @@ class FlexContextSchema(SharedSchema):
         # make sure that the prices fields are valid price units
 
         # All prices must share the same unit
-        self._try_to_convert_price_units(data, original_data)
+        data = self._try_to_convert_price_units(data, original_data)
         shared_currency = ur.Quantity(data["shared_currency_unit"])
 
         # Fill in default soc breach prices when asked to relax SoC constraints, unless already set explicitly.

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -23,7 +23,7 @@ from flexmeasures.data.schemas.sensors import (
     VariableQuantityField,
     SensorIdField,
     SensorReference,
-    SensorReferenceSchema,
+    OutputSensorReferenceSchema,
 )
 from flexmeasures.data.schemas.scheduling import metadata
 from flexmeasures.data.schemas.units import UnitField
@@ -304,13 +304,13 @@ class SharedSchema(Schema):
 
     # Aggregate output sensors
     aggregate_consumption = fields.Nested(
-        SensorReferenceSchema,
+        OutputSensorReferenceSchema,
         required=False,
         data_key="aggregate-consumption",
         metadata=metadata.AGGREGATE_CONSUMPTION.to_dict(),
     )
     aggregate_production = fields.Nested(
-        SensorReferenceSchema,
+        OutputSensorReferenceSchema,
         required=False,
         data_key="aggregate-production",
         metadata=metadata.AGGREGATE_PRODUCTION.to_dict(),

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -595,19 +595,21 @@ UI_FLEX_CONTEXT_SCHEMA: Dict[str, Dict[str, Any]] = {
     "aggregate-consumption": {
         "default": None,
         "description": rst_to_openapi(metadata.AGGREGATE_CONSUMPTION.description),
-        "types": {
-            "backend": "typeTwo",
-            "ui": "A sensor which records the scheduled aggregate consumption.",
-        },
+        # todo: the field type is defined in asset_context.html in 3 places?
+        # "types": {
+        #     "backend": "typeTwo",
+        #     "ui": "A sensor which records the scheduled aggregate consumption.",
+        # },
         "example-units": EXAMPLE_UNIT_TYPES["power"],
     },
     "aggregate-production": {
         "default": None,
         "description": rst_to_openapi(metadata.AGGREGATE_PRODUCTION.description),
-        "types": {
-            "backend": "typeTwo",
-            "ui": "A sensor which records the scheduled aggregate production.",
-        },
+        # todo: the field type is defined in asset_context.html in 3 places?
+        # "types": {
+        #     "backend": "typeTwo",
+        #     "ui": "A sensor which records the scheduled aggregate production.",
+        # },
         "example-units": EXAMPLE_UNIT_TYPES["power"],
     },
     "consumption-price": {

--- a/flexmeasures/data/schemas/scheduling/metadata.py
+++ b/flexmeasures/data/schemas/scheduling/metadata.py
@@ -67,7 +67,7 @@ AGGREGATE_PRODUCTION = MetaData(
 
 The sign convention is determined by the key name, and is stored on the sensor itself using the ``consumption_is_positive`` attribute.
 
-See ``aggregate-consumption`` for the full description of the split logic when both sensors are defined.
+See the ``aggregate-consumption`` field for the full description of the split logic when both sensors are defined.
 """,
     example={"sensor": 11},
 )
@@ -243,7 +243,7 @@ PRODUCTION = MetaData(
 
 The sign convention is determined by the key name, and is stored on the sensor itself using the ``consumption_is_positive`` attribute.
 
-See ``consumption`` for the full description of the split logic when both sensors are defined.
+See the ``consumption`` field for the full description of the split logic when both sensors are defined.
 """,
     example={"sensor": 15},
 )

--- a/flexmeasures/data/schemas/scheduling/metadata.py
+++ b/flexmeasures/data/schemas/scheduling/metadata.py
@@ -42,7 +42,9 @@ Must be a list of integers.
     example=[3, 4],
 )
 AGGREGATE_POWER = MetaData(
-    description="""Sensor used to record the aggregate power schedule of all flexible and inflexible devices involved when scheduling this asset.""",
+    description="""[Deprecated field] Sensor used to record the aggregate power schedule of all flexible and inflexible devices involved when scheduling this asset.
+To avoid using the field, use ``aggregate-consumption`` or ``aggregate-production`` instead, which make clear the sign convention.
+""",
     example={"sensor": 9},
 )
 AGGREGATE_CONSUMPTION = MetaData(

--- a/flexmeasures/data/schemas/scheduling/metadata.py
+++ b/flexmeasures/data/schemas/scheduling/metadata.py
@@ -45,6 +45,32 @@ AGGREGATE_POWER = MetaData(
     description="""Sensor used to record the aggregate power schedule of all flexible and inflexible devices involved when scheduling this asset.""",
     example={"sensor": 9},
 )
+AGGREGATE_CONSUMPTION = MetaData(
+    description="""Sensor used to record the aggregate consumption schedule of all flexible and inflexible devices involved when scheduling this asset.
+
+The sign convention is determined by the key name, and is stored on the sensor itself using the ``consumption_is_positive`` attribute.
+
+Depending on which output sensors are defined:
+
+- **Only** ``aggregate-consumption`` **defined**: the full aggregate power schedule is stored on this sensor using the
+  consumption-positive sign convention (consumption positive, production negative).
+- **Only** ``aggregate-production`` **defined**: the full aggregate power schedule is stored on the aggregate-production sensor
+  with the production-positive convention (production positive, consumption negative).
+- **Both defined**: only the non-negative part of the aggregate schedule is stored on this sensor (zero for
+  time steps with net production), and only the non-positive part (sign-flipped) is stored on the
+  aggregate-production sensor.
+""",
+    example={"sensor": 9},
+)
+AGGREGATE_PRODUCTION = MetaData(
+    description="""Sensor used to record the aggregate production schedule of all flexible and inflexible devices involved when scheduling this asset.
+
+The sign convention is determined by the key name, and is stored on the sensor itself using the ``consumption_is_positive`` attribute.
+
+See ``aggregate-consumption`` for the full description of the split logic when both sensors are defined.
+""",
+    example={"sensor": 10},
+)
 COMMITMENTS = MetaData(
     description="Prior commitments. Support for this field in the UI is still under further development, but you can find more information in :ref:`commitments`.",
     example=[],

--- a/flexmeasures/data/schemas/scheduling/metadata.py
+++ b/flexmeasures/data/schemas/scheduling/metadata.py
@@ -60,7 +60,7 @@ Depending on which output sensors are defined:
   time steps with net production), and only the non-positive part (sign-flipped) is stored on the
   aggregate-production sensor.
 """,
-    example={"sensor": 9},
+    example={"sensor": 10},
 )
 AGGREGATE_PRODUCTION = MetaData(
     description="""Sensor used to record the aggregate production schedule of all flexible and inflexible devices involved when scheduling this asset.
@@ -69,7 +69,7 @@ The sign convention is determined by the key name, and is stored on the sensor i
 
 See ``aggregate-consumption`` for the full description of the split logic when both sensors are defined.
 """,
-    example={"sensor": 10},
+    example={"sensor": 11},
 )
 COMMITMENTS = MetaData(
     description="Prior commitments. Support for this field in the UI is still under further development, but you can find more information in :ref:`commitments`.",

--- a/flexmeasures/data/schemas/scheduling/storage.py
+++ b/flexmeasures/data/schemas/scheduling/storage.py
@@ -20,7 +20,7 @@ from flexmeasures.data.schemas.units import QuantityField
 from flexmeasures.data.schemas.scheduling import metadata
 from flexmeasures.data.schemas.sensors import (
     SensorReference,
-    SensorReferenceSchema,
+    OutputSensorReferenceSchema,
     VariableQuantityField,
 )
 from flexmeasures.utils.unit_utils import (
@@ -42,15 +42,6 @@ SoCTarget = TypedDict(
         "value": float,
     },
     total=False,  # not all are required (just value, which we can say in 3.11)
-)
-
-# Keys used by SensorReferenceSchema to carry source-filter options.
-# Present as non-None values when the caller added a source filter.
-_SENSOR_REFERENCE_SOURCE_FILTER_KEYS = (
-    "source_types",
-    "exclude_source_types",
-    "sources",
-    "source_account",
 )
 
 
@@ -104,11 +95,11 @@ class StorageFlexModelSchema(Schema):
     )
 
     consumption = fields.Nested(
-        SensorReferenceSchema,
+        OutputSensorReferenceSchema,
         metadata=metadata.CONSUMPTION.to_dict(),
     )
     production = fields.Nested(
-        SensorReferenceSchema,
+        OutputSensorReferenceSchema,
         metadata=metadata.PRODUCTION.to_dict(),
     )
 
@@ -350,20 +341,6 @@ class StorageFlexModelSchema(Schema):
                 "The `state-of-charge` field can only be a Sensor or a time series."
             )
 
-    @validates("consumption")
-    def validate_consumption_has_no_source_filters(self, value: dict, **kwargs):
-        if isinstance(value, dict) and any(
-            value.get(key) is not None for key in _SENSOR_REFERENCE_SOURCE_FILTER_KEYS
-        ):
-            raise ValidationError("The `consumption` field cannot use source filters.")
-
-    @validates("production")
-    def validate_production_has_no_source_filters(self, value: dict, **kwargs):
-        if isinstance(value, dict) and any(
-            value.get(key) is not None for key in _SENSOR_REFERENCE_SOURCE_FILTER_KEYS
-        ):
-            raise ValidationError("The `production` field cannot use source filters.")
-
     @validates("asset")
     def validate_asset(self, asset: Asset, **kwargs):
         if self.sensor is not None and self.sensor.asset != asset:
@@ -448,8 +425,8 @@ class DBStorageFlexModelSchema(Schema):
     Schema for flex-models stored in the db. Supports fixed quantities and sensor references, while disallowing time series specs.
     """
 
-    consumption = fields.Nested(SensorReferenceSchema)
-    production = fields.Nested(SensorReferenceSchema)
+    consumption = fields.Nested(OutputSensorReferenceSchema)
+    production = fields.Nested(OutputSensorReferenceSchema)
 
     soc_min = VariableQuantityField(
         to_unit="MWh",
@@ -590,20 +567,6 @@ class DBStorageFlexModelSchema(Schema):
             field: (self.declared_fields[field].data_key or field)
             for field in self.declared_fields
         }
-
-    @validates("consumption")
-    def validate_consumption_has_no_source_filters(self, value: dict, **kwargs):
-        if isinstance(value, dict) and any(
-            value.get(key) is not None for key in _SENSOR_REFERENCE_SOURCE_FILTER_KEYS
-        ):
-            raise ValidationError("The `consumption` field cannot use source filters.")
-
-    @validates("production")
-    def validate_production_has_no_source_filters(self, value: dict, **kwargs):
-        if isinstance(value, dict) and any(
-            value.get(key) is not None for key in _SENSOR_REFERENCE_SOURCE_FILTER_KEYS
-        ):
-            raise ValidationError("The `production` field cannot use source filters.")
 
     @validates_schema
     def forbid_time_series_specs(self, data: dict, **kwargs):

--- a/flexmeasures/data/schemas/sensors.py
+++ b/flexmeasures/data/schemas/sensors.py
@@ -979,11 +979,7 @@ class SensorReference:
         return self.sensor.event_resolution
 
 
-class SensorReferenceSchema(Schema):
-    """Sensor reference with optional source filters."""
-
-    class Meta:
-        description = "Sensor reference from which to look up a variable quantity."
+class SharedSensorReferenceSchema(Schema):
 
     sensor = SensorIdField(
         required=True,
@@ -991,6 +987,20 @@ class SensorReferenceSchema(Schema):
             description="ID of the sensor on which the data is recorded.",
         ),
     )
+
+
+class OutputSensorReferenceSchema(SharedSensorReferenceSchema):
+    """Sensor reference for recording generated data."""
+
+    ...
+
+
+class SensorReferenceSchema(SharedSensorReferenceSchema):
+    """Sensor reference with optional source filters."""
+
+    class Meta:
+        description = "Sensor reference from which to look up a variable quantity."
+
     source_types = fields.List(
         fields.String(),
         load_default=None,

--- a/flexmeasures/data/schemas/tests/test_scheduling.py
+++ b/flexmeasures/data/schemas/tests/test_scheduling.py
@@ -1012,7 +1012,7 @@ def test_shared_schema_fields_in_flex_context(
             ],
             False,
         ),
-        # Test breach prices in commodity context
+        # Test breach prices in commodity context pass validation
         (
             [
                 {

--- a/flexmeasures/data/schemas/tests/test_scheduling.py
+++ b/flexmeasures/data/schemas/tests/test_scheduling.py
@@ -977,7 +977,7 @@ def test_shared_schema_fields_in_flex_context(
 @pytest.mark.parametrize(
     ["commodity_contexts", "fails"],
     [
-        # Test single commodity with relax_constraints defaulting to True
+        # Test single commodity pass validation and defaults relax_constraints to True
         (
             [
                 {

--- a/flexmeasures/data/schemas/tests/test_scheduling.py
+++ b/flexmeasures/data/schemas/tests/test_scheduling.py
@@ -790,52 +790,6 @@ def test_flex_context_schema_rejects_filtered_aggregate_power(
     assert "cannot use source filters" in str(exc_info.value)
 
 
-def test_storage_flex_model_schema_rejects_filtered_consumption(
-    setup_dummy_sensors, setup_sources, db
-):
-    _, _, _, power_sensor = setup_dummy_sensors
-    seita_source = setup_sources["Seita"]
-    db.session.flush()
-
-    for schema in [
-        StorageFlexModelSchema(start=datetime(2026, 6, 1), sensor=None),
-        DBStorageFlexModelSchema(),
-    ]:
-        with pytest.raises(ValidationError) as exc_info:
-            schema.load(
-                {
-                    "consumption": {
-                        "sensor": power_sensor.id,
-                        "sources": [seita_source.id],
-                    }
-                }
-            )
-        assert "cannot use source filters" in str(exc_info.value)
-
-
-def test_storage_flex_model_schema_rejects_filtered_production(
-    setup_dummy_sensors, setup_sources, db
-):
-    _, _, _, power_sensor = setup_dummy_sensors
-    seita_source = setup_sources["Seita"]
-    db.session.flush()
-
-    for schema in [
-        StorageFlexModelSchema(start=datetime(2026, 6, 1), sensor=None),
-        DBStorageFlexModelSchema(),
-    ]:
-        with pytest.raises(ValidationError) as exc_info:
-            schema.load(
-                {
-                    "production": {
-                        "sensor": power_sensor.id,
-                        "sources": [seita_source.id],
-                    }
-                }
-            )
-        assert "cannot use source filters" in str(exc_info.value)
-
-
 @pytest.mark.parametrize(
     ["flex_model", "fails"],
     [

--- a/flexmeasures/data/schemas/tests/test_scheduling.py
+++ b/flexmeasures/data/schemas/tests/test_scheduling.py
@@ -1001,7 +1001,7 @@ def test_shared_schema_fields_in_flex_context(
             ],
             False,
         ),
-        # Test aggregate fields in commodity context
+        # Test aggregate fields in commodity context pass validation
         (
             [
                 {

--- a/flexmeasures/data/schemas/tests/test_scheduling.py
+++ b/flexmeasures/data/schemas/tests/test_scheduling.py
@@ -1097,7 +1097,7 @@ def test_commodity_flex_context_defaults(
                     {
                         "commodity": "electricity",
                         "consumption-breach-price": "100 EUR/MW",
-                        "production-breach-price": "100 EUR/MW",
+                        "production-breach-price": "10 cEUR/kW",
                     }
                 ]
             },

--- a/flexmeasures/data/schemas/tests/test_scheduling.py
+++ b/flexmeasures/data/schemas/tests/test_scheduling.py
@@ -953,22 +953,229 @@ def test_flex_model_schemas(
 
     for schema, fail in zip(schemas, fails):
         if fail:
-            with pytest.raises(ValidationError) as e_info:
+            with pytest.raises(ValidationError) as e_info:  # noqa: F841
                 schema.load(flex_model)
-            for field_name, expected_message in fail.items():
-                assert field_name in e_info.value.messages
-                if field_name in ["soc-gain", "soc-usage"]:
-                    for index, message_list in e_info.value.messages[
-                        field_name
-                    ].items():
-                        assert message_list[0] == expected_message[index][0]
-                else:
-                    # Check all messages for the given field for the expected message
-                    assert any(
-                        [
-                            expected_message in message
-                            for message in e_info.value.messages[field_name]
-                        ]
-                    )
+
+
+@pytest.mark.parametrize(
+    ["flex_context", "fails"],
+    [
+        # Test aggregate-consumption field with sensor reference
+        (
+            {"aggregate-consumption": {"sensor": "placeholder for price sensor"}},
+            False,
+        ),
+        # Test aggregate-production field with sensor reference
+        (
+            {"aggregate-production": {"sensor": "placeholder for price sensor"}},
+            False,
+        ),
+        # Test both aggregate fields together
+        (
+            {
+                "aggregate-consumption": {"sensor": "placeholder for price sensor"},
+                "aggregate-production": {"sensor": "placeholder for price sensor"},
+            },
+            False,
+        ),
+        # Test that relax_constraints defaults to False in FlexContextSchema
+        (
+            {"site-power-capacity": "1 MVA"},
+            False,
+        ),
+        # Test breach prices moved to SharedSchema
+        (
+            {
+                "consumption-breach-price": "100 EUR/MW",
+                "production-breach-price": "100 EUR/MW",
+            },
+            False,
+        ),
+        # Test soc breach prices moved to SharedSchema
+        (
+            {
+                "soc-minima-breach-price": "1000 EUR/MWh",
+                "soc-maxima-breach-price": "1000 EUR/MWh",
+            },
+            False,
+        ),
+    ],
+)
+def test_shared_schema_fields_in_flex_context(
+    db, app, setup_site_capacity_sensor, setup_price_sensors, flex_context, fails
+):
+    """Test that SharedSchema fields are accessible in FlexContextSchema."""
+    schema = FlexContextSchema()
+
+    # Replace sensor name with sensor ID
+    sensors_to_pick_from = {**setup_site_capacity_sensor, **setup_price_sensors}
+    for field_name, field_value in flex_context.items():
+        if isinstance(field_value, dict) and "sensor" in field_value:
+            flex_context[field_name]["sensor"] = sensors_to_pick_from[
+                field_value["sensor"]
+            ].id
+
+    check_schema_loads_data(schema=schema, data=flex_context, fails=fails)
+
+
+@pytest.mark.parametrize(
+    ["commodity_contexts", "fails"],
+    [
+        # Test single commodity with relax_constraints defaulting to True
+        (
+            [
+                {
+                    "commodity": "electricity",
+                    "site-power-capacity": "1 MVA",
+                }
+            ],
+            False,
+        ),
+        # Test multiple commodities
+        (
+            [
+                {
+                    "commodity": "electricity",
+                    "site-power-capacity": "1 MVA",
+                },
+                {
+                    "commodity": "heat",
+                    "site-power-capacity": "500 kW",
+                },
+            ],
+            False,
+        ),
+        # Test aggregate fields in commodity context
+        (
+            [
+                {
+                    "commodity": "electricity",
+                    "aggregate-consumption": {"sensor": "placeholder for price sensor"},
+                    "aggregate-production": {"sensor": "placeholder for price sensor"},
+                }
+            ],
+            False,
+        ),
+        # Test breach prices in commodity context
+        (
+            [
+                {
+                    "commodity": "electricity",
+                    "consumption-breach-price": "100 EUR/MW",
+                    "production-breach-price": "100 EUR/MW",
+                }
+            ],
+            False,
+        ),
+    ],
+)
+def test_commodity_flex_context_defaults(
+    db, app, setup_site_capacity_sensor, setup_price_sensors, commodity_contexts, fails
+):
+    """Test that CommodityFlexContextSchema has correct defaults, especially relax_constraints=True."""
+    from flexmeasures.data.schemas.scheduling import CommodityFlexContextSchema
+
+    # Replace sensor name with sensor ID
+    sensors_to_pick_from = {**setup_site_capacity_sensor, **setup_price_sensors}
+    for context in commodity_contexts:
+        for field_name, field_value in context.items():
+            if isinstance(field_value, dict) and "sensor" in field_value:
+                context[field_name]["sensor"] = sensors_to_pick_from[
+                    field_value["sensor"]
+                ].id
+
+    # Test loading each commodity context
+    schema = CommodityFlexContextSchema()
+    for context in commodity_contexts:
+        if fails:
+            with pytest.raises(ValidationError) as e_info:
+                loaded = schema.load(context)
+            print(f"Returned error message: {e_info.value.messages}")
         else:
-            schema.load(flex_model)
+            loaded = schema.load(context)
+            # Verify relax_constraints defaults to True in CommodityFlexContextSchema
+            assert loaded.get("relax_constraints", True) is True
+
+
+@pytest.mark.parametrize(
+    ["flex_context_listing", "fails"],
+    [
+        # Test flex-context listing with mixed currencies should fail
+        (
+            {
+                "commodities": [
+                    {
+                        "commodity": "electricity",
+                        "consumption-price": "1 EUR/MWh",
+                    },
+                    {
+                        "commodity": "heat",
+                        "consumption-price": "1 USD/MWh",
+                    },
+                ]
+            },
+            {
+                "commodities": "all prices in the flex-context must share the same currency unit"
+            },
+        ),
+        # Test flex-context listing with same currencies should pass
+        (
+            {
+                "commodities": [
+                    {
+                        "commodity": "electricity",
+                        "consumption-price": "1 EUR/MWh",
+                    },
+                    {
+                        "commodity": "heat",
+                        "consumption-price": "2 EUR/MWh",
+                    },
+                ]
+            },
+            False,
+        ),
+        # Test flex-context listing with breach prices sharing currency
+        (
+            {
+                "commodities": [
+                    {
+                        "commodity": "electricity",
+                        "consumption-breach-price": "100 EUR/MW",
+                        "production-breach-price": "100 EUR/MW",
+                    }
+                ]
+            },
+            False,
+        ),
+        # Test flex-context listing with mixed breach price currencies should fail
+        (
+            {
+                "commodities": [
+                    {
+                        "commodity": "electricity",
+                        "consumption-breach-price": "100 EUR/MW",
+                    },
+                    {
+                        "commodity": "heat",
+                        "consumption-breach-price": "100 USD/MW",
+                    },
+                ]
+            },
+            {
+                "commodities": "all prices in the flex-context must share the same currency unit"
+            },
+        ),
+    ],
+)
+def test_flex_context_listing_shared_currency(
+    db,
+    app,
+    setup_site_capacity_sensor,
+    setup_price_sensors,
+    flex_context_listing,
+    fails,
+):
+    """Test that flex-context listings enforce shared currency across commodities."""
+    schema = FlexContextSchema()
+
+    check_schema_loads_data(schema=schema, data=flex_context_listing, fails=fails)

--- a/flexmeasures/data/schemas/tests/test_scheduling.py
+++ b/flexmeasures/data/schemas/tests/test_scheduling.py
@@ -962,19 +962,19 @@ def test_flex_model_schemas(
     [
         # Test aggregate-consumption field with sensor reference
         (
-            {"aggregate-consumption": {"sensor": "placeholder for price sensor"}},
+            {"aggregate-consumption": {"sensor": "consumption-price in SEK/MWh"}},
             False,
         ),
         # Test aggregate-production field with sensor reference
         (
-            {"aggregate-production": {"sensor": "placeholder for price sensor"}},
+            {"aggregate-production": {"sensor": "production-price in SEK/MWh"}},
             False,
         ),
         # Test both aggregate fields together
         (
             {
-                "aggregate-consumption": {"sensor": "placeholder for price sensor"},
-                "aggregate-production": {"sensor": "placeholder for price sensor"},
+                "aggregate-consumption": {"sensor": "consumption-price in SEK/MWh"},
+                "aggregate-production": {"sensor": "production-price in SEK/MWh"},
             },
             False,
         ),
@@ -1011,9 +1011,11 @@ def test_shared_schema_fields_in_flex_context(
     sensors_to_pick_from = {**setup_site_capacity_sensor, **setup_price_sensors}
     for field_name, field_value in flex_context.items():
         if isinstance(field_value, dict) and "sensor" in field_value:
-            flex_context[field_name]["sensor"] = sensors_to_pick_from[
-                field_value["sensor"]
-            ].id
+            sensor_name = field_value["sensor"]
+            if sensor_name in sensors_to_pick_from:
+                flex_context[field_name]["sensor"] = sensors_to_pick_from[
+                    sensor_name
+                ].id
 
     check_schema_loads_data(schema=schema, data=flex_context, fails=fails)
 
@@ -1050,8 +1052,8 @@ def test_shared_schema_fields_in_flex_context(
             [
                 {
                     "commodity": "electricity",
-                    "aggregate-consumption": {"sensor": "placeholder for price sensor"},
-                    "aggregate-production": {"sensor": "placeholder for price sensor"},
+                    "aggregate-consumption": {"sensor": "consumption-price in SEK/MWh"},
+                    "aggregate-production": {"sensor": "production-price in SEK/MWh"},
                 }
             ],
             False,
@@ -1080,9 +1082,9 @@ def test_commodity_flex_context_defaults(
     for context in commodity_contexts:
         for field_name, field_value in context.items():
             if isinstance(field_value, dict) and "sensor" in field_value:
-                context[field_name]["sensor"] = sensors_to_pick_from[
-                    field_value["sensor"]
-                ].id
+                sensor_name = field_value["sensor"]
+                if sensor_name in sensors_to_pick_from:
+                    context[field_name]["sensor"] = sensors_to_pick_from[sensor_name].id
 
     # Test loading each commodity context
     schema = CommodityFlexContextSchema()

--- a/flexmeasures/data/schemas/tests/test_scheduling.py
+++ b/flexmeasures/data/schemas/tests/test_scheduling.py
@@ -987,7 +987,7 @@ def test_shared_schema_fields_in_flex_context(
             ],
             False,
         ),
-        # Test multiple commodities
+        # Likewise for multiple commodities, relax_constraints should default to True for each
         (
             [
                 {

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -4556,6 +4556,19 @@
         ],
         "additionalProperties": false
       },
+      "OutputSensorReference": {
+        "type": "object",
+        "properties": {
+          "sensor": {
+            "type": "integer",
+            "description": "ID of the sensor on which the data is recorded."
+          }
+        },
+        "required": [
+          "sensor"
+        ],
+        "additionalProperties": false
+      },
       "FlexContextOpenAPISchema": {
         "type": "object",
         "properties": {
@@ -4700,14 +4713,14 @@
             "example": {
               "sensor": 9
             },
-            "$ref": "#/components/schemas/SensorReference"
+            "$ref": "#/components/schemas/OutputSensorReference"
           },
           "aggregate-production": {
             "description": "Sensor used to record the aggregate production schedule of all flexible and inflexible devices involved when scheduling this asset.\n\nThe sign convention is determined by the key name, and is stored on the sensor itself using the <code>consumption_is_positive</code> attribute.\n\nSee <code>aggregate-consumption</code> for the full description of the split logic when both sensors are defined.\n",
             "example": {
               "sensor": 10
             },
-            "$ref": "#/components/schemas/SensorReference"
+            "$ref": "#/components/schemas/OutputSensorReference"
           }
         },
         "additionalProperties": false
@@ -6090,14 +6103,14 @@
             "example": {
               "sensor": 14
             },
-            "$ref": "#/components/schemas/SensorReference"
+            "$ref": "#/components/schemas/OutputSensorReference"
           },
           "production": {
             "description": "Sensor used to record the scheduled power as seen from a production perspective.\n\nThe sign convention is determined by the key name, and is stored on the sensor itself using the <code>consumption_is_positive</code> attribute.\n\nSee <code>consumption</code> for the full description of the split logic when both sensors are defined.\n",
             "example": {
               "sensor": 15
             },
-            "$ref": "#/components/schemas/SensorReference"
+            "$ref": "#/components/schemas/OutputSensorReference"
           },
           "soc-at-start": {
             "type": "string",

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -4632,6 +4632,50 @@
             "example": "260 EUR/MW",
             "$ref": "#/components/schemas/VariableQuantityOpenAPI"
           },
+          "consumption-breach-price": {
+            "description": "This <strong>penalty value</strong> is used to discourage the violation of the <code>consumption-capacity</code> constraint in the flex-model.\nIt effectively treats the capacity as a <strong>soft constraint</strong>, allowing the scheduler to exceed it when necessary but with a high cost.\nThe scheduler will attempt to minimize this cost.\nIt must use the same currency as the other price settings and cannot be negative.\n",
+            "example": "10 EUR/kW",
+            "$ref": "#/components/schemas/VariableQuantityOpenAPI"
+          },
+          "production-breach-price": {
+            "description": "This <strong>penalty value</strong> is used to discourage the violation of the <code>production-capacity</code> constraint in the flex-model.\nIt effectively treats the capacity as a <strong>soft constraint</strong>, allowing the scheduler to exceed it when necessary but with a high cost.\nThe scheduler will attempt to minimize this cost.\nIt must use the same currency as the other price settings and cannot be negative.\n",
+            "example": "10 EUR/kW",
+            "$ref": "#/components/schemas/VariableQuantityOpenAPI"
+          },
+          "soc-minima-breach-price": {
+            "description": "This <strong>penalty value</strong> is used to discourage the violation of <code>soc-minima</code> constraints in the flex-model, which the scheduler will attempt to minimize.\nIt must use the same currency as the other price settings and cannot be negative.\nWhile it's an internal nudge to steer the scheduler\u2014and doesn't represent a real-life cost\u2014it should still be chosen in proportion to the actual energy prices at your site.\nIf it's too high, it will overly dominate other constraints; if it's too low, it will have no effect.\nWithout this value, the soc-minima become hard constraints, which means that any infeasible state-of-charge minima would prevent a complete schedule from being computed.\n",
+            "example": "120 EUR/kWh",
+            "$ref": "#/components/schemas/VariableQuantityOpenAPI"
+          },
+          "soc-maxima-breach-price": {
+            "description": "This <strong>penalty value</strong> is used to discourage the violation of <code>soc-maxima</code> constraints in the flex-model, which the scheduler will attempt to minimize.\nIt must use the same currency as the other price settings and cannot be negative.\nWhile it's an <strong>internal nudge</strong> to steer the scheduler\u2014and doesn't represent a real-life cost\u2014it should still be chosen in proportion to the actual energy prices at your site.\nIf it's too high, it will overly dominate other constraints; if it's too low, it will have no effect.\nWithout this value, the soc-maxima become hard constraints, which means that any infeasible state-of-charge maxima would prevent a complete schedule from being computed.\n",
+            "example": "120 EUR/kWh",
+            "$ref": "#/components/schemas/VariableQuantityOpenAPI"
+          },
+          "relax-constraints": {
+            "type": "boolean",
+            "default": true,
+            "description": "If True (default is <code>False</code>), several constraints are relaxed by setting default breach prices within the optimization problem, leading to the default priority:\n\n1. Avoid breaching the site consumption/production capacity.\n2. Avoid not meeting SoC minima/maxima.\n3. Avoid breaching the desired device consumption/production capacity.\n\nWe recommend to set this field to <code>True</code> to enable the default prices and associated priorities as defined by FlexMeasures.\nFor tighter control over prices and priorities, the breach prices can also be set explicitly (the relevant fields have <code>breach-price</code> in their name).\n",
+            "example": true
+          },
+          "relax-soc-constraints": {
+            "type": "boolean",
+            "default": false,
+            "description": "If True, avoids not meeting SoC minima/maxima as a relaxed constraint.",
+            "example": true
+          },
+          "relax-capacity-constraints": {
+            "type": "boolean",
+            "default": false,
+            "description": "If True, avoids breaching the desired device consumption/production capacity as a relaxed constraint.",
+            "example": true
+          },
+          "relax-site-capacity-constraints": {
+            "type": "boolean",
+            "default": false,
+            "description": "If True, avoids breaching the site consumption/production capacity as a relaxed constraint.",
+            "example": true
+          },
           "commitments": {
             "description": "Prior commitments. Support for this field in the UI is still under further development, but you can find more information in <a href=\"/ui/static/documentation/html/search.html?q=commitments\" target=\"_blank\">the docs</a>.",
             "example": [],
@@ -4650,6 +4694,20 @@
             "items": {
               "type": "integer"
             }
+          },
+          "aggregate-consumption": {
+            "description": "Sensor used to record the aggregate consumption schedule of all flexible and inflexible devices involved when scheduling this asset.\n\nThe sign convention is determined by the key name, and is stored on the sensor itself using the <code>consumption_is_positive</code> attribute.\n\nDepending on which output sensors are defined:\n\n- <strong>Only</strong> <code>aggregate-consumption</code> <strong>defined</strong>: the full aggregate power schedule is stored on this sensor using the\n  consumption-positive sign convention (consumption positive, production negative).\n- <strong>Only</strong> <code>aggregate-production</code> <strong>defined</strong>: the full aggregate power schedule is stored on the aggregate-production sensor\n  with the production-positive convention (production positive, consumption negative).\n- <strong>Both defined</strong>: only the non-negative part of the aggregate schedule is stored on this sensor (zero for\n  time steps with net production), and only the non-positive part (sign-flipped) is stored on the\n  aggregate-production sensor.\n",
+            "example": {
+              "sensor": 9
+            },
+            "$ref": "#/components/schemas/SensorReference"
+          },
+          "aggregate-production": {
+            "description": "Sensor used to record the aggregate production schedule of all flexible and inflexible devices involved when scheduling this asset.\n\nThe sign convention is determined by the key name, and is stored on the sensor itself using the <code>consumption_is_positive</code> attribute.\n\nSee <code>aggregate-consumption</code> for the full description of the split logic when both sensors are defined.\n",
+            "example": {
+              "sensor": 10
+            },
+            "$ref": "#/components/schemas/SensorReference"
           }
         },
         "additionalProperties": false

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -4561,6 +4561,7 @@
         "properties": {
           "commodity": {
             "type": "string",
+            "default": "electricity",
             "description": "Commodity to which this part of the flex-context applies.\nDefaults to ``\"electricity\"``.\n",
             "examples": [
               "electricity",

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -7,7 +7,7 @@
     },
     "termsOfService": null,
     "title": "FlexMeasures",
-    "version": "0.31.0"
+    "version": "1.0.0"
   },
   "externalDocs": {
     "description": "FlexMeasures runs on the open source FlexMeasures technology. Read the docs here.",

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -4556,101 +4556,18 @@
         ],
         "additionalProperties": false
       },
-      "CommodityFlexContext": {
+      "FlexContextOpenAPISchema": {
         "type": "object",
         "properties": {
           "commodity": {
             "type": "string",
             "default": "electricity",
-            "description": "Commodity to which this part of the flex-context applies.\nDefaults to ``\"electricity\"``.\n",
+            "description": "Commodity to which this part of the flex-context applies.\nDefaults to <code>\"electricity\"</code>.\n",
             "examples": [
               "electricity",
               "gas"
             ]
           },
-          "consumption-price": {
-            "description": "The commodity price (e.g. electricity price) applied to the site's aggregate consumption. Can be (a sensor recording) market prices, but also CO\u2082 intensity\u2014whatever fits your optimization problem. [#old_consumption_price_field]_",
-            "examples": [
-              {
-                "sensor": 5
-              },
-              "0.29 EUR/kWh"
-            ]
-          },
-          "production-price": {
-            "description": "The commodity price (e.g. electricity price) applied to the site's aggregate production. Can be (a sensor recording) market prices, but also CO\u2082 intensity\u2014whatever fits your optimization problem, as long as the unit matches the ``consumption-price`` unit. [#old_production_price_field]_",
-            "example": "0.12 EUR/kWh"
-          },
-          "site-power-capacity": {
-            "description": "Maximum achievable power at the site's grid connection point, in either direction.\nBecomes a hard constraint in the optimization problem, which is especially suitable for physical limitations. [#asymmetric]_ [#minimum_capacity_overlap]_\n",
-            "example": "45kVA"
-          },
-          "site-consumption-capacity": {
-            "description": "Maximum consumption power at the site's grid connection point.\nIf ``site-power-capacity`` is defined, the minimum between the ``site-power-capacity`` and ``site-consumption-capacity`` will be used. [#consumption]_\nIf a ``site-consumption-breach-price`` is defined, the ``site-consumption-capacity`` becomes a soft constraint in the optimization problem.\nOtherwise, it becomes a hard constraint. [#minimum_capacity_overlap]_\n",
-            "example": "45kW"
-          },
-          "site-production-capacity": {
-            "description": "Maximum production power at the site's grid connection point.\nIf ``site-power-capacity`` is defined, the minimum between the ``site-power-capacity`` and ``site-production-capacity`` will be used. [#production]_\nIf a ``site-production-breach-price`` is defined, the ``site-production-capacity`` becomes a soft constraint in the optimization problem.\nOtherwise, it becomes a hard constraint. [#minimum_capacity_overlap]_\n",
-            "example": "0kW"
-          },
-          "site-consumption-breach-price": {
-            "description": "This **penalty value** is used to discourage the violation of the ``site-consumption-capacity`` constraint in the flex-context.\nIt effectively treats the capacity as a **soft constraint**, allowing the scheduler to exceed it when necessary but with a high cost.\nThe scheduler will attempt to minimize this cost.\nIt must use the same currency as the other price settings and cannot be negative.\nThe field may define (a sensor recording) contractual penalties, or a theoretical penalty influencing how badly breaches should be avoided. [#penalty_field]_ [#breach_field]_\n",
-            "example": "1000 EUR/kW"
-          },
-          "site-production-breach-price": {
-            "description": "This **penalty value** is used to discourage the violation of the ``site-production-capacity`` constraint in the flex-context.\nIt effectively treats the capacity as a **soft constraint**, allowing the scheduler to exceed it when necessary but with a high cost.\nThe scheduler will attempt to minimize this cost.\nIt must use the same currency as the other price settings and cannot be negative.\nThe field may define (a sensor recording) contractual penalties, or a theoretical penalty influencing how badly breaches should be avoided. [#penalty_field]_ [#breach_field]_\"\n",
-            "example": "1000 EUR/kW"
-          },
-          "site-peak-consumption": {
-            "default": "0.0 MW",
-            "description": "The site's previously achieved achieved peak consumption.\nThis value forms the baseline for new peak charges, since any peaks up to this level represent sunk costs.\nDefaults to 0 kW.\n",
-            "example": {
-              "sensor": 7
-            }
-          },
-          "site-peak-consumption-price": {
-            "description": "Per-kW price applied to any consumption that exceeds the site's previously achieved peak consumption.\nThis price reflects the cost of increasing the site\u2019s peak further and is used by the scheduler to motivate peak shaving.\nIt must use the same currency as the other price settings and cannot be negative.\nFor large connections, this price is usually stated explicitly on the tariff sheets of their network operator. [#penalty_field]_\n",
-            "example": "260 EUR/MW"
-          },
-          "site-peak-production": {
-            "default": "0.0 MW",
-            "description": "The site's previously achieved achieved peak production.\nThis value forms the baseline for new peak charges, since any peaks up to this level represent sunk costs.\nDefaults to 0 kW.\n",
-            "example": {
-              "sensor": 8
-            }
-          },
-          "site-peak-production-price": {
-            "description": "Per-kW price applied to any production that exceeds the site's previously achieved peak production.\nThis price reflects the cost of increasing the site\u2019s peak further and is used by the scheduler to motivate peak shaving.\nIt must use the same currency as the other price settings and cannot be negative.\nFor large connections, this price is usually stated explicitly on the tariff sheets of their network operator. [#penalty_field]_\n",
-            "example": "260 EUR/MW"
-          },
-          "commitments": {
-            "description": "Prior commitments. Support for this field in the UI is still under further development, but you can find more information in :ref:`commitments`.",
-            "example": [],
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Commitment"
-            }
-          },
-          "inflexible-device-sensors": {
-            "type": "array",
-            "description": "Power sensors representing devices that are relevant, but not flexible in the timing of their demand/supply.\nFor example, a sensor recording rooftop solar power that is connected behind the main meter, and whose production falls under the same contract as the flexible device(s) being scheduled.\nTheir power demand cannot be adjusted but still matters for finding the best schedule for other devices.\nMust be a list of integers.\n",
-            "example": [
-              3,
-              4
-            ],
-            "items": {
-              "type": "integer"
-            }
-          }
-        },
-        "required": [
-          "commodity"
-        ],
-        "additionalProperties": false
-      },
-      "FlexContextOpenAPISchema": {
-        "type": "object",
-        "properties": {
           "consumption-price": {
             "description": "The commodity price (e.g. electricity price) applied to the site's aggregate consumption. Can be (a sensor recording) market prices, but also CO\u2082 intensity\u2014whatever fits your optimization problem.",
             "examples": [
@@ -4733,70 +4650,6 @@
             "items": {
               "type": "integer"
             }
-          },
-          "commodities": {
-            "description": "For multi-commodity scheduling problems, the above fields can be set here per commodity.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CommodityFlexContext"
-            }
-          },
-          "consumption-breach-price": {
-            "description": "This <strong>penalty value</strong> is used to discourage the violation of the <code>consumption-capacity</code> constraint in the flex-model.\nIt effectively treats the capacity as a <strong>soft constraint</strong>, allowing the scheduler to exceed it when necessary but with a high cost.\nThe scheduler will attempt to minimize this cost.\nIt must use the same currency as the other price settings and cannot be negative.\n",
-            "example": "10 EUR/kW",
-            "$ref": "#/components/schemas/VariableQuantityOpenAPI"
-          },
-          "production-breach-price": {
-            "description": "This <strong>penalty value</strong> is used to discourage the violation of the <code>production-capacity</code> constraint in the flex-model.\nIt effectively treats the capacity as a <strong>soft constraint</strong>, allowing the scheduler to exceed it when necessary but with a high cost.\nThe scheduler will attempt to minimize this cost.\nIt must use the same currency as the other price settings and cannot be negative.\n",
-            "example": "10 EUR/kW",
-            "$ref": "#/components/schemas/VariableQuantityOpenAPI"
-          },
-          "soc-minima-breach-price": {
-            "description": "This <strong>penalty value</strong> is used to discourage the violation of <code>soc-minima</code> constraints in the flex-model, which the scheduler will attempt to minimize.\nIt must use the same currency as the other price settings and cannot be negative.\nWhile it's an internal nudge to steer the scheduler\u2014and doesn't represent a real-life cost\u2014it should still be chosen in proportion to the actual energy prices at your site.\nIf it's too high, it will overly dominate other constraints; if it's too low, it will have no effect.\nWithout this value, the soc-minima become hard constraints, which means that any infeasible state-of-charge minima would prevent a complete schedule from being computed.\n",
-            "example": "120 EUR/kWh",
-            "$ref": "#/components/schemas/VariableQuantityOpenAPI"
-          },
-          "soc-maxima-breach-price": {
-            "description": "This <strong>penalty value</strong> is used to discourage the violation of <code>soc-maxima</code> constraints in the flex-model, which the scheduler will attempt to minimize.\nIt must use the same currency as the other price settings and cannot be negative.\nWhile it's an <strong>internal nudge</strong> to steer the scheduler\u2014and doesn't represent a real-life cost\u2014it should still be chosen in proportion to the actual energy prices at your site.\nIf it's too high, it will overly dominate other constraints; if it's too low, it will have no effect.\nWithout this value, the soc-maxima become hard constraints, which means that any infeasible state-of-charge maxima would prevent a complete schedule from being computed.\n",
-            "example": "120 EUR/kWh",
-            "$ref": "#/components/schemas/VariableQuantityOpenAPI"
-          },
-          "relax-constraints": {
-            "type": "boolean",
-            "default": false,
-            "description": "If True (default is <code>False</code>), several constraints are relaxed by setting default breach prices within the optimization problem, leading to the default priority:\n\n1. Avoid breaching the site consumption/production capacity.\n2. Avoid not meeting SoC minima/maxima.\n3. Avoid breaching the desired device consumption/production capacity.\n\nWe recommend to set this field to <code>True</code> to enable the default prices and associated priorities as defined by FlexMeasures.\nFor tighter control over prices and priorities, the breach prices can also be set explicitly (the relevant fields have <code>breach-price</code> in their name).\n",
-            "example": true
-          },
-          "relax-soc-constraints": {
-            "type": "boolean",
-            "default": false,
-            "description": "If True, avoids not meeting SoC minima/maxima as a relaxed constraint.",
-            "example": true
-          },
-          "relax-capacity-constraints": {
-            "type": "boolean",
-            "default": false,
-            "description": "If True, avoids breaching the desired device consumption/production capacity as a relaxed constraint.",
-            "example": true
-          },
-          "relax-site-capacity-constraints": {
-            "type": "boolean",
-            "default": false,
-            "description": "If True, avoids breaching the site consumption/production capacity as a relaxed constraint.",
-            "example": true
-          },
-          "consumption-price-sensor": {
-            "type": "integer"
-          },
-          "production-price-sensor": {
-            "type": "integer"
-          },
-          "aggregate-power": {
-            "description": "Sensor used to record the aggregate power schedule of all flexible and inflexible devices involved when scheduling this asset.",
-            "example": {
-              "sensor": 9
-            },
-            "$ref": "#/components/schemas/SensorReference"
           }
         },
         "additionalProperties": false
@@ -6373,8 +6226,11 @@
             }
           },
           "flex-context": {
-            "description": "The flex-context is validated according to the scheduler's `FlexContextSchema`.",
-            "$ref": "#/components/schemas/FlexContextOpenAPISchema"
+            "type": "array",
+            "description": "Flex-context per commodity. The flex-context is validated according to the scheduler's `FlexContextSchema`.",
+            "items": {
+              "$ref": "#/components/schemas/FlexContextOpenAPISchema"
+            }
           },
           "sequential": {
             "type": "boolean",

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -4711,14 +4711,14 @@
           "aggregate-consumption": {
             "description": "Sensor used to record the aggregate consumption schedule of all flexible and inflexible devices involved when scheduling this asset.\n\nThe sign convention is determined by the key name, and is stored on the sensor itself using the <code>consumption_is_positive</code> attribute.\n\nDepending on which output sensors are defined:\n\n- <strong>Only</strong> <code>aggregate-consumption</code> <strong>defined</strong>: the full aggregate power schedule is stored on this sensor using the\n  consumption-positive sign convention (consumption positive, production negative).\n- <strong>Only</strong> <code>aggregate-production</code> <strong>defined</strong>: the full aggregate power schedule is stored on the aggregate-production sensor\n  with the production-positive convention (production positive, consumption negative).\n- <strong>Both defined</strong>: only the non-negative part of the aggregate schedule is stored on this sensor (zero for\n  time steps with net production), and only the non-positive part (sign-flipped) is stored on the\n  aggregate-production sensor.\n",
             "example": {
-              "sensor": 9
+              "sensor": 10
             },
             "$ref": "#/components/schemas/OutputSensorReference"
           },
           "aggregate-production": {
-            "description": "Sensor used to record the aggregate production schedule of all flexible and inflexible devices involved when scheduling this asset.\n\nThe sign convention is determined by the key name, and is stored on the sensor itself using the <code>consumption_is_positive</code> attribute.\n\nSee <code>aggregate-consumption</code> for the full description of the split logic when both sensors are defined.\n",
+            "description": "Sensor used to record the aggregate production schedule of all flexible and inflexible devices involved when scheduling this asset.\n\nThe sign convention is determined by the key name, and is stored on the sensor itself using the <code>consumption_is_positive</code> attribute.\n\nSee the <code>aggregate-consumption</code> field for the full description of the split logic when both sensors are defined.\n",
             "example": {
-              "sensor": 10
+              "sensor": 11
             },
             "$ref": "#/components/schemas/OutputSensorReference"
           }
@@ -6106,7 +6106,7 @@
             "$ref": "#/components/schemas/OutputSensorReference"
           },
           "production": {
-            "description": "Sensor used to record the scheduled power as seen from a production perspective.\n\nThe sign convention is determined by the key name, and is stored on the sensor itself using the <code>consumption_is_positive</code> attribute.\n\nSee <code>consumption</code> for the full description of the split logic when both sensors are defined.\n",
+            "description": "Sensor used to record the scheduled power as seen from a production perspective.\n\nThe sign convention is determined by the key name, and is stored on the sensor itself using the <code>consumption_is_positive</code> attribute.\n\nSee the <code>consumption</code> field for the full description of the split logic when both sensors are defined.\n",
             "example": {
               "sensor": 15
             },

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -6291,6 +6291,7 @@
           },
           "flex-model": {
             "type": "array",
+            "default": [],
             "description": "Flex-model per device (identified by `sensor`). The flex-model validation is handled by the scheduler. What follows is the schema used by the `StorageScheduler`.",
             "items": {
               "$ref": "#/components/schemas/StorageFlexModelSchemaOpenAPI"
@@ -6298,6 +6299,7 @@
           },
           "flex-context": {
             "type": "array",
+            "default": [],
             "description": "Flex-context per commodity. The flex-context is validated according to the scheduler's `FlexContextSchema`.",
             "items": {
               "$ref": "#/components/schemas/FlexContextOpenAPISchema"
@@ -6314,8 +6316,6 @@
           }
         },
         "required": [
-          "flex-context",
-          "flex-model",
           "start"
         ],
         "additionalProperties": false

--- a/flexmeasures/ui/templates/assets/asset_context.html
+++ b/flexmeasures/ui/templates/assets/asset_context.html
@@ -380,7 +380,7 @@
 
         setTimeout(() => {
             const card = document.getElementById(`${fieldName}-control`);
-            const isOnlySensorField = (fieldName === "inflexible-device-sensors" || fieldName === "consumption-price" || fieldName === "production-price" || fieldName === "aggregate-power");
+            const isOnlySensorField = (fieldName === "inflexible-device-sensors" || fieldName === "consumption-price" || fieldName === "production-price" || fieldName === "aggregate-power" || fieldName === "aggregate-consumption" || fieldName === "aggregate-production");
             card.classList.add('border-on-click'); // Add border to the clicked card
             flexOptionsContainer.appendChild(renderFlexInputOptions(fieldName, isOnlySensorField));
             handleFlexSelectChange(fieldName);
@@ -608,7 +608,7 @@
             document.querySelectorAll(".card-highlight").forEach(el => el.classList.remove("border-on-click")); // Remove border from all cards
             card.classList.add("border-on-click"); // Add border to the clicked card
             handleFlexSelectChange(fieldName);
-            const isOnlySensorField = (fieldName === "inflexible-device-sensors" || fieldName === "consumption-price" || fieldName === "production-price" || fieldName === "aggregate-power");
+            const isOnlySensorField = (fieldName === "inflexible-device-sensors" || fieldName === "consumption-price" || fieldName === "production-price" || fieldName === "aggregate-power" || fieldName === "aggregate-consumption" || fieldName === "aggregate-production");
             flexOptionsContainer.appendChild(renderFlexInputOptions(fieldName, (isOnlySensorField)));
             setActiveCard(card);
             // Store active card in local storage
@@ -720,7 +720,7 @@
         if (storedActiveCard && activeCard()) {
             const flexId = (activeCard() ? activeCard().id : null).slice(0, -8);
             if (assetFlexContext[storedActiveCard]) {
-                const isOnlySensorField = (flexId === "inflexible-device-sensors" || flexId === "consumption-price" || flexId === "production-price" || flexId === "aggregate-power");
+                const isOnlySensorField = (flexId === "inflexible-device-sensors" || flexId === "consumption-price" || flexId === "production-price" || flexId === "aggregate-power" || flexId === "aggregate-consumption" || flexId === "aggregate-production");
                 setTimeout(() => {
                     flexOptionsContainer.innerHTML = "";
                     flexOptionsContainer.appendChild(renderFlexInputOptions(flexId, isOnlySensorField));

--- a/flexmeasures/ui/tests/test_utils.py
+++ b/flexmeasures/ui/tests/test_utils.py
@@ -80,8 +80,6 @@ def test_ui_flexcontext_schema():
         "consumption-price-sensor",
         "production-price-sensor",
         "commodities",  # todo: https://github.com/FlexMeasures/flexmeasures/issues/2230
-        "aggregate-consumption",  # todo: add UI support for aggregate fields
-        "aggregate-production",  # todo: add UI support for aggregate fields
     ]
 
     schema_keys = []
@@ -94,7 +92,10 @@ def test_ui_flexcontext_schema():
 
     assert (
         schema_keys == ui_flexcontext_schema_fields
-    ), "If this test fails, you may have added a new flex-context field, but forgot about UI support."
+    ), "If this fails, you may have added a new flex-context field, but forgot about UI support."
+    assert (
+        schema_keys - set(exclude_fields) == schema_keys
+    ), "If this fails, you may have added UI support for a new flex-context field, but forgot to remove it from exclude_fields."
 
 
 def test_ui_flexmodel_schema():

--- a/flexmeasures/ui/tests/test_utils.py
+++ b/flexmeasures/ui/tests/test_utils.py
@@ -80,6 +80,8 @@ def test_ui_flexcontext_schema():
         "consumption-price-sensor",
         "production-price-sensor",
         "commodities",  # todo: https://github.com/FlexMeasures/flexmeasures/issues/2230
+        "aggregate-consumption",  # todo: add UI support for aggregate fields
+        "aggregate-production",  # todo: add UI support for aggregate fields
     ]
 
     schema_keys = []

--- a/flexmeasures/utils/coding_utils.py
+++ b/flexmeasures/utils/coding_utils.py
@@ -15,7 +15,7 @@ from flask import current_app
 def merge_or_append(
     item: dict[str, Any],
     items: list[dict[str, Any]],
-    match_key: str | None = None,
+    match_key: str,
     match_value: str | None = None,
 ) -> None:
     """Merge `item` into the first dictionary in `items` with the same value for `key`, preserving its position in the sequence.

--- a/flexmeasures/utils/coding_utils.py
+++ b/flexmeasures/utils/coding_utils.py
@@ -2,6 +2,7 @@ r"""Various coding utils (e.g. around function decoration)"""
 
 from __future__ import annotations
 
+from typing import Any
 import functools
 import time
 import inspect
@@ -9,6 +10,34 @@ import importlib
 import pkgutil
 
 from flask import current_app
+
+
+def merge_or_append(
+    item: dict[str, Any],
+    items: list[dict[str, Any]],
+    match_key: str | None = None,
+    match_value: str | None = None,
+) -> None:
+    """Merge `item` into the first dictionary in `items` with the same value for `key`, preserving its position in the sequence.
+
+    Values from `item` take precedence when keys overlap. If no matching
+    dictionary is found, `item` is appended to the end of `items`.
+
+    :param item:        The dictionary to merge or append.
+    :param items:       A mutable sequence of dictionaries to update.
+    :param match_key:   The dictionary key used to determine whether two items match.
+    :param match_value: The value used to determine whether two items match.
+
+    :returns:       None. The `items` sequence is modified in place.
+    """
+    match_value = item.get(match_key) or match_value
+
+    for i, existing in enumerate(items):
+        if existing.get(match_key) == match_value:
+            items[i] = existing | item
+            return
+
+    items.append(item)
 
 
 def delete_key_recursive(value, key):

--- a/tests/documentation/test_schemas.py
+++ b/tests/documentation/test_schemas.py
@@ -13,6 +13,8 @@ EXCLUDED_METADATA = {
     "RELAX_CAPACITY_CONSTRAINTS",
     "RELAX_SITE_CAPACITY_CONSTRAINTS",
     "RELAX_SOC_CONSTRAINTS",
+    "COMMODITY_FLEX_CONTEXT",  # Documented as "commodity" in flex-context section
+    "COMMODITY_FLEX_MODEL",  # Documented as "commodity" in flex-model section
 }
 
 


### PR DESCRIPTION
## Description

- [x] The flex-context is now preferred to be defined as a list, with one entry per commodity
- [x] The new fields `aggregate-consumption` and `aggregate-production` are the per-commodity replacements of `aggregate-power`
- [x] Added changelog item in `documentation/changelog.rst`

<!--
For changelog entries, please take into account the intended audience.

In our main changelog:
- The 'New features' section targets API / CLI / UI users.
- The 'Infrastructure / Support' section targets plugin developers and hosts.

Finally, please note that the API and CLI keep additional changelogs:
- `documentation/api/changelog.rst`
- `documentation/cli/changelog.rst`
-->

## Look & Feel

<!--
This section can contain example pictures for the UI, Input/Output for the CLI, Request / Response for an API endpoint, etc.
-->

...

## How to test

```
pytest -k test_asset_schedules_fresh_db
```

## Further Improvements

Internally, list-like flex-contexts remain nested under the `commodities` field in the regular dict-like flex-context. I tried for some time to deal with list-like flex-contexts throughout the codebase, but there were numerous complications, including but not limit to dealing with sequential scheduling, in which a sequence of dependent scheduling jobs are set up, where the inflexible-device-sensors (in the flex-context) of the next job includes the power sensors of the previous jobs.

## Related Items

Merges into https://github.com/FlexMeasures/flexmeasures/pull/2172.
