### PR TITLE
feat: CLI option to add/edit an account attribute

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -11,6 +11,7 @@ New features
 -------------
 * Floor off-clock API datetimes to a non-instantaneous sensor's resolution by default when ingesting sensor data, uploading sensor data, and handling scheduler flex-model timed events; configurable with the ``floor_datetimes_to_resolution`` sensor attribute [see `PR #2146 <https://www.github.com/FlexMeasures/flexmeasures/pull/2146>`_]
 * Sensor references in flex-model and flex-context support various ways of filtering by source [see `PR #2209 <https://www.github.com/FlexMeasures/flexmeasures/pull/2209>`_]
+* CLI support for adding/editing account attributes [see `PR #2242 <https://www.github.com/FlexMeasures/flexmeasures/pull/2242>`_]
 
 
 Infrastructure / Support

--- a/flexmeasures/cli/data_edit.py
+++ b/flexmeasures/cli/data_edit.py
@@ -21,7 +21,7 @@ from flexmeasures.data.schemas.attributes import validate_special_attributes
 from flexmeasures.data.schemas import AssetIdField
 from flexmeasures.data.schemas.sensors import SensorIdField
 from flexmeasures.data.models.generic_assets import GenericAsset
-from flexmeasures.data.models.audit_log import AssetAuditLog
+from flexmeasures.data.models.audit_log import AssetAuditLog, AuditLog
 from flexmeasures.data.models.time_series import TimedBelief
 from flexmeasures.data.utils import save_to_db
 from flexmeasures.cli.utils import (
@@ -40,6 +40,18 @@ def fm_edit_data():
 
 @fm_edit_data.command("attribute", cls=DeprecatedOptionsCommand)
 @with_appcontext
+@click.option(
+    "--account",
+    "--account-id",
+    "accounts",
+    required=False,
+    multiple=True,
+    type=AccountIdField(),
+    cls=DeprecatedOption,
+    deprecated=["--asset-id"],
+    preferred="--asset",
+    help="Add/edit attribute to this account. Follow up with the account's ID.",
+)
 @click.option(
     "--asset",
     "--asset-id",
@@ -122,6 +134,7 @@ def fm_edit_data():
 )
 def edit_attribute(
     attribute_key: str,
+    accounts: list[Account],
     assets: list[GenericAsset],
     sensors: list[Sensor],
     attribute_null_value: bool,
@@ -134,8 +147,10 @@ def edit_attribute(
 ):
     """Edit (or add) an asset attribute or sensor attribute."""
 
-    if not assets and not sensors:
-        raise ValueError("Missing flag: pass at least one --asset-id or --sensor-id.")
+    if not accounts and not assets and not sensors:
+        raise ValueError(
+            "Missing flag: pass at least one --account, --asset or --sensor."
+        )
 
     # Parse attribute value
     attribute_value = parse_attribute_value(
@@ -152,6 +167,12 @@ def edit_attribute(
     validate_special_attributes(attribute_key, attribute_value)
 
     # Set attribute
+    for account in accounts:
+        AuditLog.add_record_for_attribute_update(
+            attribute_key, attribute_value, "account", account
+        )
+        account.attributes[attribute_key] = attribute_value
+        db.session.add(account)
     for asset in assets:
         AssetAuditLog.add_record_for_attribute_update(
             attribute_key, attribute_value, "asset", asset

--- a/flexmeasures/cli/data_edit.py
+++ b/flexmeasures/cli/data_edit.py
@@ -165,19 +165,19 @@ def edit_attribute(
     # Set attribute
     for account in accounts:
         AuditLog.add_record_for_attribute_update(
-            attribute_key, attribute_value, "account", account
+            attribute_key, attribute_value, account
         )
         account.attributes[attribute_key] = attribute_value
         db.session.add(account)
     for asset in assets:
         AssetAuditLog.add_record_for_attribute_update(
-            attribute_key, attribute_value, "asset", asset
+            attribute_key, attribute_value, asset
         )
         asset.attributes[attribute_key] = attribute_value
         db.session.add(asset)
     for sensor in sensors:
         AssetAuditLog.add_record_for_attribute_update(
-            attribute_key, attribute_value, "sensor", sensor
+            attribute_key, attribute_value, sensor
         )
         sensor.attributes[attribute_key] = attribute_value
         db.session.add(sensor)

--- a/flexmeasures/cli/data_edit.py
+++ b/flexmeasures/cli/data_edit.py
@@ -38,18 +38,14 @@ def fm_edit_data():
     """FlexMeasures: Edit data."""
 
 
-@fm_edit_data.command("attribute", cls=DeprecatedOptionsCommand)
+@fm_edit_data.command("attribute")
 @with_appcontext
 @click.option(
     "--account",
-    "--account-id",
     "accounts",
     required=False,
     multiple=True,
     type=AccountIdField(),
-    cls=DeprecatedOption,
-    deprecated=["--asset-id"],
-    preferred="--asset",
     help="Add/edit attribute to this account. Follow up with the account's ID.",
 )
 @click.option(

--- a/flexmeasures/cli/tests/test_data_edit.py
+++ b/flexmeasures/cli/tests/test_data_edit.py
@@ -4,6 +4,7 @@ import pandas as pd
 import timely_beliefs as tb
 from sqlalchemy import select
 
+from flexmeasures import Account, Asset, Sensor
 from flexmeasures.cli.tests.utils import check_command_ran_without_error, to_flags
 from flexmeasures.data.models.audit_log import AssetAuditLog, AuditLog
 from flexmeasures.data.models.time_series import TimedBelief
@@ -43,6 +44,12 @@ def test_add_one_sensor_attribute(app, db, setup_markets):
     n_attributes_after = len(sensor.attributes)
 
     assert n_attributes_after == n_attributes_before + 1
+    assert (
+        db.session.execute(select(Sensor).filter_by(id=sensor.id))
+        .scalar_one_or_none()
+        .attributes["some new attribute"]
+        == 3
+    )
 
 
 def test_update_one_asset_attribute(app, db, setup_generic_assets):
@@ -70,6 +77,12 @@ def test_update_one_asset_attribute(app, db, setup_generic_assets):
             active_user_name=None,
         )
     ).scalar_one_or_none()
+    assert (
+        db.session.execute(select(Asset).filter_by(id=asset.id))
+        .scalar_one_or_none()
+        .attributes["some-attribute"]
+        == "some-new-value"
+    )
 
 
 def test_update_one_account_attribute(app, db, setup_generic_assets):
@@ -97,6 +110,12 @@ def test_update_one_account_attribute(app, db, setup_generic_assets):
             active_user_name=None,
         )
     ).scalar_one_or_none()
+    assert (
+        db.session.execute(select(Account).filter_by(id=account.id))
+        .scalar_one_or_none()
+        .attributes["some-attribute"]
+        == "some-new-value"
+    )
 
 
 @pytest.mark.parametrize(

--- a/flexmeasures/cli/tests/test_data_edit.py
+++ b/flexmeasures/cli/tests/test_data_edit.py
@@ -5,7 +5,7 @@ import timely_beliefs as tb
 from sqlalchemy import select
 
 from flexmeasures.cli.tests.utils import check_command_ran_without_error, to_flags
-from flexmeasures.data.models.audit_log import AssetAuditLog
+from flexmeasures.data.models.audit_log import AssetAuditLog, AuditLog
 from flexmeasures.data.models.time_series import TimedBelief
 from flexmeasures.cli.tests.utils import get_click_commands
 from flexmeasures.tests.utils import get_test_sensor
@@ -65,6 +65,33 @@ def test_update_one_asset_attribute(app, db, setup_generic_assets):
     assert db.session.execute(
         select(AssetAuditLog).filter_by(
             affected_asset_id=asset.id,
+            event=event,
+            active_user_id=None,
+            active_user_name=None,
+        )
+    ).scalar_one_or_none()
+
+
+def test_update_one_account_attribute(app, db, setup_generic_assets):
+    from flexmeasures.cli.data_edit import edit_attribute
+
+    db.session.flush()
+    account = setup_generic_assets["test_battery"].owner
+    cli_input = {
+        "account": account.id,
+        "attribute": "some-attribute",
+        "str": "some-new-value",
+    }
+
+    runner = app.test_cli_runner()
+    result = runner.invoke(edit_attribute, to_flags(cli_input))
+    check_command_ran_without_error(result)
+    assert "Success" in result.output, result.exception
+
+    event = f"Updated account '{account.name}': {account.id}; Attr 'some-attribute' To some-new-value From None"
+    assert db.session.execute(
+        select(AuditLog).filter_by(
+            affected_account_id=account.id,
             event=event,
             active_user_id=None,
             active_user_name=None,

--- a/flexmeasures/cli/tests/test_data_edit.py
+++ b/flexmeasures/cli/tests/test_data_edit.py
@@ -4,11 +4,10 @@ import pandas as pd
 import timely_beliefs as tb
 from sqlalchemy import select
 
-from flexmeasures import Account, Asset, Sensor
 from flexmeasures.cli.tests.utils import check_command_ran_without_error, to_flags
 from flexmeasures.data.models.audit_log import AssetAuditLog, AuditLog
 from flexmeasures.data.models.time_series import TimedBelief
-from flexmeasures.cli.tests.utils import get_click_commands
+from flexmeasures.cli.tests.utils import check_attribute_is_stored, get_click_commands
 from flexmeasures.tests.utils import get_test_sensor
 
 
@@ -44,12 +43,7 @@ def test_add_one_sensor_attribute(app, db, setup_markets):
     n_attributes_after = len(sensor.attributes)
 
     assert n_attributes_after == n_attributes_before + 1
-    assert (
-        db.session.execute(select(Sensor).filter_by(id=sensor.id))
-        .scalar_one_or_none()
-        .attributes["some new attribute"]
-        == 3
-    )
+    check_attribute_is_stored(sensor, "some new attribute", 3)
 
 
 def test_update_one_asset_attribute(app, db, setup_generic_assets):
@@ -77,12 +71,7 @@ def test_update_one_asset_attribute(app, db, setup_generic_assets):
             active_user_name=None,
         )
     ).scalar_one_or_none()
-    assert (
-        db.session.execute(select(Asset).filter_by(id=asset.id))
-        .scalar_one_or_none()
-        .attributes["some-attribute"]
-        == "some-new-value"
-    )
+    check_attribute_is_stored(asset, "some-attribute", "some-new-value")
 
 
 def test_update_one_account_attribute(app, db, setup_generic_assets):
@@ -110,12 +99,7 @@ def test_update_one_account_attribute(app, db, setup_generic_assets):
             active_user_name=None,
         )
     ).scalar_one_or_none()
-    assert (
-        db.session.execute(select(Account).filter_by(id=account.id))
-        .scalar_one_or_none()
-        .attributes["some-attribute"]
-        == "some-new-value"
-    )
+    check_attribute_is_stored(account, "some-attribute", "some-new-value")
 
 
 @pytest.mark.parametrize(

--- a/flexmeasures/cli/tests/utils.py
+++ b/flexmeasures/cli/tests/utils.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import Any, Callable
 from traceback import print_tb
 
 from click.core import Command as ClickCommand
+from sqlalchemy import select
+
+from flexmeasures import Account, Asset, Sensor, User
+from flexmeasures.data import db
 
 
 def check_command_ran_without_error(result):
@@ -11,6 +15,17 @@ def check_command_ran_without_error(result):
     assert result.exit_code == 0, print_tb(
         result.exc_info[2]
     )  # run command without errors
+
+
+def check_attribute_is_stored(
+    db_object: Account | Asset | Sensor | User, attribute: str, value: Any
+):
+    assert (
+        db.session.execute(select(type(db_object)).filter_by(id=db_object.id))
+        .scalar_one_or_none()
+        .attributes[attribute]
+        == value
+    )
 
 
 def to_flags(cli_input: dict) -> list:

--- a/flexmeasures/data/models/audit_log.py
+++ b/flexmeasures/data/models/audit_log.py
@@ -69,22 +69,13 @@ class AuditLog(db.Model, AuthModelMixin):
         attribute_key: str,
         attribute_value: float | int | bool | str | list | dict | None,
         account_or_user: Account | User,
-        entity_type: str | None = None,
     ) -> None:
         """Add audit log record about account or user attribute update.
 
         :param attribute_key:   attribute key to update
         :param attribute_value: new attribute value
         :param account_or_user: account or user object
-        :param entity_type:     [deprecated]
         """
-        if entity_type is not None:
-            warnings.warn(
-                "'entity_type' is deprecated and will be removed in a future release. "
-                "The type is now inferred from 'account_or_user'.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         current_user_id, current_user_name = get_current_user_id_name()
 
         old_value = account_or_user.attributes.get(attribute_key)

--- a/flexmeasures/data/models/audit_log.py
+++ b/flexmeasures/data/models/audit_log.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import warnings
+
 from flask_security import current_user
 from flask_security.core import AnonymousUser
 from sqlalchemy import DateTime, Column, Integer, String, ForeignKey
@@ -66,27 +68,34 @@ class AuditLog(db.Model, AuthModelMixin):
         cls,
         attribute_key: str,
         attribute_value: float | int | bool | str | list | dict | None,
-        entity_type: str,
         account_or_user: Account | User,
+        entity_type: str | None = None,
     ) -> None:
         """Add audit log record about account or user attribute update.
 
-        :param attribute_key: attribute key to update
+        :param attribute_key:   attribute key to update
         :param attribute_value: new attribute value
-        :param entity_type: 'account' or 'user'
         :param account_or_user: account or user object
+        :param entity_type:     [deprecated]
         """
+        if entity_type is not None:
+            warnings.warn(
+                "'entity_type' is deprecated and will be removed in a future release. "
+                "The type is now inferred from 'account_or_user'.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         current_user_id, current_user_name = get_current_user_id_name()
 
         old_value = account_or_user.attributes.get(attribute_key)
-        if entity_type == "user":
+        if isinstance(account_or_user, User):
             event = f"Updated user '{account_or_user.name}': {account_or_user.id}; "
             affected_account_id = (account_or_user.account_id,)
-        elif entity_type == "account":
+        elif isinstance(account_or_user, Account):
             event = f"Updated account '{account_or_user.name}': {account_or_user.id}; "
             affected_account_id = account_or_user.id
         else:
-            raise ValueError(f"Unknown entity type '{entity_type}'")
+            raise TypeError(f"Expected Account or User, got {type(account_or_user)!r}")
         event += f"Attr '{attribute_key}' To {attribute_value} From {old_value}"
 
         audit_log = cls(
@@ -191,27 +200,34 @@ class AssetAuditLog(db.Model, AuthModelMixin):
         cls,
         attribute_key: str,
         attribute_value: float | int | bool | str | list | dict | None,
-        entity_type: str,
         asset_or_sensor: GenericAsset | Sensor,
+        entity_type: str | None = None,
     ) -> None:
         """Add audit log record about asset or sensor attribute update.
 
-        :param attribute_key: attribute key to update
+        :param attribute_key:   attribute key to update
         :param attribute_value: new attribute value
-        :param entity_type: 'asset' or 'sensor'
         :param asset_or_sensor: asset or sensor object
+        :param entity_type:     [deprecated]
         """
+        if entity_type is not None:
+            warnings.warn(
+                "'entity_type' is deprecated and will be removed in a future release. "
+                "The type is now inferred from 'asset_or_sensor'.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         current_user_id, current_user_name = get_current_user_id_name()
 
         old_value = asset_or_sensor.attributes.get(attribute_key)
-        if entity_type == "sensor":
+        if isinstance(asset_or_sensor, Sensor):
             event = f"Updated sensor '{asset_or_sensor.name}': {asset_or_sensor.id}; "
             affected_asset_id = (asset_or_sensor.generic_asset_id,)
-        elif entity_type == "asset":
+        elif isinstance(asset_or_sensor, GenericAsset):
             event = f"Updated asset '{asset_or_sensor.name}': {asset_or_sensor.id}; "
             affected_asset_id = asset_or_sensor.id
         else:
-            raise ValueError(f"Unknown entity type '{entity_type}'")
+            raise TypeError(f"Expected Asset or Sensor, got {type(asset_or_sensor)!r}")
         event += f"Attr '{attribute_key}' To {attribute_value} From {old_value}"
 
         audit_log = cls(

--- a/flexmeasures/data/models/audit_log.py
+++ b/flexmeasures/data/models/audit_log.py
@@ -82,9 +82,11 @@ class AuditLog(db.Model, AuthModelMixin):
         if entity_type == "user":
             event = f"Updated user '{account_or_user.name}': {account_or_user.id}; "
             affected_account_id = (account_or_user.account_id,)
-        else:
+        elif entity_type == "account":
             event = f"Updated account '{account_or_user.name}': {account_or_user.id}; "
             affected_account_id = account_or_user.id
+        else:
+            raise ValueError(f"Unknown entity type '{entity_type}'")
         event += f"Attr '{attribute_key}' To {attribute_value} From {old_value}"
 
         audit_log = cls(
@@ -205,9 +207,11 @@ class AssetAuditLog(db.Model, AuthModelMixin):
         if entity_type == "sensor":
             event = f"Updated sensor '{asset_or_sensor.name}': {asset_or_sensor.id}; "
             affected_asset_id = (asset_or_sensor.generic_asset_id,)
-        else:
+        elif entity_type == "asset":
             event = f"Updated asset '{asset_or_sensor.name}': {asset_or_sensor.id}; "
             affected_asset_id = asset_or_sensor.id
+        else:
+            raise ValueError(f"Unknown entity type '{entity_type}'")
         event += f"Attr '{attribute_key}' To {attribute_value} From {old_value}"
 
         audit_log = cls(

--- a/flexmeasures/data/models/audit_log.py
+++ b/flexmeasures/data/models/audit_log.py
@@ -62,6 +62,43 @@ class AuditLog(db.Model, AuthModelMixin):
     )
 
     @classmethod
+    def add_record_for_attribute_update(
+        cls,
+        attribute_key: str,
+        attribute_value: float | int | bool | str | list | dict | None,
+        entity_type: str,
+        account_or_user: Account | User,
+    ) -> None:
+        """Add audit log record about account or user attribute update.
+
+        :param attribute_key: attribute key to update
+        :param attribute_value: new attribute value
+        :param entity_type: 'account' or 'user'
+        :param account_or_user: account or user object
+        """
+        current_user_id, current_user_name = get_current_user_id_name()
+
+        old_value = account_or_user.attributes.get(attribute_key)
+        if entity_type == "user":
+            event = f"Updated user '{account_or_user.name}': {account_or_user.id}; "
+            affected_account_id = (account_or_user.account_id,)
+        else:
+            event = f"Updated account '{account_or_user.name}': {account_or_user.id}; "
+            affected_account_id = account_or_user.id
+        event += f"Attr '{attribute_key}' To {attribute_value} From {old_value}"
+
+        audit_log = cls(
+            event_datetime=server_now(),
+            event=truncate_string(
+                event, 500
+            ),  # we truncate the event string if it exceeds 500 characters by adding ellipses in the middle
+            active_user_id=current_user_id,
+            active_user_name=current_user_name,
+            affected_account_id=affected_account_id,
+        )
+        db.session.add(audit_log)
+
+    @classmethod
     def user_table_acl(cls, user: User):
         """
         Table-level access rules for user-affecting audit logs. Use directly in check_access or in @permission_required_for_context with pass_ctx_to_loader, ctx_loader=AuditLog.user_acl.


### PR DESCRIPTION
## Description

- [x] Add missing CLI functionality to edit an account attribute
- [x] Prepare util function for user attributes
- [x] Added changelog item in `documentation/changelog.rst`

## Look & Feel

...

## How to test

- New test: `pytest -k test_update_one_account_attribute`

## Further Improvements

...

## Related Items

...