### PR TITLE
docs: recommend and explain TRUSTED_HOSTS

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -22,6 +22,7 @@ Infrastructure / Support
 * Prepare the ``device_scheduler`` to deal with commitments per device group [see `PR #1934 <https://www.github.com/FlexMeasures/flexmeasures/pull/1934>`_]
 * Documentation section on the modelling choice for recording measurements, forecasts and schedules under one or multiple sensors [see `PR #2217 <https://www.github.com/FlexMeasures/flexmeasures/pull/2217>`_]
 * Document suggested cloud architecture [see `PR #2245 <https://www.github.com/FlexMeasures/flexmeasures/pull/2245>`_]
+* Document the ``TRUSTED_HOSTS`` setting to safeguard against host poisoning from clients [see `PR #2246 <https://www.github.com/FlexMeasures/flexmeasures/pull/2246>`_]
 
 Bugfixes
 -----------

--- a/documentation/concepts/security_auth.rst
+++ b/documentation/concepts/security_auth.rst
@@ -3,6 +3,14 @@
 Security aspects
 ====================================
 
+This page explains how security is handled in FlexMeasures. This deals with encryption, authentication and authorization.
+For hosts, we also provide some best practices.
+
+.. contents::
+    :local:
+    :depth: 1
+
+
 Data
 -------
 
@@ -10,7 +18,7 @@ A FlexMeasures server handles two types of data in its Postgres database - struc
 
 How these Postgres and Redis databases are set up and protected is up to the host. 
 
-More crucial to this documentation is that each FlexMeasures server connects to the Postgres database according to strict authentication and authorization rules, for reading and writing data. The remainder of this page describes how this is implemented.
+More crucial to this documentation is that each FlexMeasures server reads from and writes to the Postgres database according to strict authentication and authorization rules. Much of the remainder of this page describes how this is implemented.
 
 Finally, when sending data back and forth between clients (e.g. browsers) and the server, the FlexMeasures application communicates all data with HTTPS, the Hypertext Transfer Protocol encrypted by Transport Layer Security. This is used even if the application is accessed via ``http://``.
 
@@ -106,3 +114,14 @@ We plan to introduce some editing/creation capabilities in the future.
 
 Setting an account as the consultancy account is something only admins can do. 
 It is possible via the ``/accounts`` PATCH endpoint, but also in the UI. You can also specify a consultancy account when creating a client account, which for now happens only in the CLI: ``flexmeasures add account --name "Account2" --consultancy 1`` makes account 1 the consultancy account for account 2.
+
+
+.. _security-best-practices-for-hosts:
+
+Best security-practices for hosts
+-----------------------------
+
+* Use the ``TRUSTED_HOSTS`` setting (see the Flask docs on `the configuration <https://flask.palletsprojects.com/en/stable/config/#TRUSTED_HOSTS>`_ and on `the topic of host header validation <https://flask.palletsprojects.com/en/stable/web-security/#host-header-validation>`_) to specify on which hosts the platform is actually being provided.
+  As an example for why this is valuable: FlexMeasures constructs URLs, e.g. for password reset links. Client code could set its own ``Host`` request header to make these URLs lead to a different server.
+  If the client "poisons" the URLs for its own users this way, they are using the user's trust in the FlexMeasures host platform to hack them.
+  List your own domain in this setting, but also the IP of your load balancer, if you are using one.

--- a/documentation/configuration.rst
+++ b/documentation/configuration.rst
@@ -574,6 +574,14 @@ When ``FLEXMEASURES_ENFORCE_SECURE_CONTENT_POLICY`` is set to ``True``, the ``<m
 Default: ``False``
 
 
+TRUSTED_HOSTS
+^^^^^^^^^^^^^^
+
+A Flask setting you should use to prevent host header poisoning. Read more at :ref:`security-best-practices-for-hosts`.
+
+Default: ``None``
+
+
 .. _mail-config:
 
 Mail

--- a/documentation/host/installation.rst
+++ b/documentation/host/installation.rst
@@ -460,3 +460,5 @@ If your data structure is good, you should think about (continually) adding meas
 Then, you probably want to use FlexMeasures to generate forecasts and schedules! For this, read further in :ref:`tut_forecasting_scheduling`.
 
 One more consideration is to run FlexMeasures in a more professional way as a web service. Head on to :ref:`deployment`.
+
+Be sure to also read about :ref:`security-best-practices-for-hosts`!


### PR DESCRIPTION
## Description

Hosting FlexMeasures properly means to set TRUSTED_HOSTS, to prevent host poisoning attacks by clients on password reset emails.

- [x] document TRUSTED_HOSTS on the security page
- [x] link to it from configuration page and hosts/installation page 
- [x] Added changelog item in `documentation/changelog.rst`

