### PR TITLE
fix(ci): scope QA workflow's uv cache glob, install uv before docker compose up

### DIFF
--- a/.github/workflows/docker-qa.yml
+++ b/.github/workflows/docker-qa.yml
@@ -54,6 +54,18 @@ jobs:
                 - ${{ github.workspace }}/flexmeasures-client/examples/HEMS/configs:/hems-configs:ro
           EOF
 
+      # Runs before the docker compose stack comes up, since `docker compose up`
+      # bind-mounts docker-compose-data/dev-db, which the dev-db container then
+      # locks down to its own uid. setup-uv's cache-dependency-glob walks the
+      # whole workspace by default and would hit EACCES scanning that directory
+      # if this step ran later.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.10.9"
+          enable-cache: true
+          cache-dependency-glob: "flexmeasures-client/**/pyproject.toml"
+
       - name: Build and start the docker compose stack
         run: docker compose up --build --detach --wait --wait-timeout 300
 
@@ -77,12 +89,6 @@ jobs:
           ACCOUNT_ID=$(echo "$OUTPUT" | grep -oP '(?<=ID: )\d+')
           docker compose exec -T server bash -c \
             "printf 'admin\nadmin\n' | flexmeasures add user --username admin --email admin@admin.com --account $ACCOUNT_ID --roles admin"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: "0.10.9"
-          enable-cache: true
 
       - name: Run the HEMS example against the running stack
         working-directory: flexmeasures-client


### PR DESCRIPTION
## Summary
- The manually-triggered `docker-qa.yml` workflow failed on its first real run at the "Install uv" step with `EACCES: permission denied, scandir '.../docker-compose-data/dev-db'`.
- `setup-uv`'s default cache-dependency-glob walks the whole workspace; once `docker compose up` starts the `dev-db` container, it locks `docker-compose-data/dev-db` down to its own uid, making it unreadable by the runner user.
- Fix: install uv before bringing up the docker compose stack, and scope `cache-dependency-glob` to `flexmeasures-client/**/pyproject.toml` (the only project the workflow actually `uv sync`s) as defense-in-depth.

## Test plan
- [ ] Re-run the manual QA workflow (`workflow_dispatch`) and confirm the "Install uv" step succeeds and the job proceeds to the HEMS/tutorial steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qprz6PKnXkVE1TJ8d7PYe9