### PR TITLE
fix(ci): fetch full git history in QA workflow so server reports real version

### DIFF
--- a/.github/workflows/docker-qa.yml
+++ b/.github/workflows/docker-qa.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout flexmeasures
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history + tags, required for hatch-vcs to resolve the version
 
       - name: Checkout flexmeasures-client
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Follow-up to #2262. The manual QA workflow now gets much further but fails at "Run the HEMS example against the running stack" with `InsufficientServerVersionError: ... Current server has version 0.1.dev1+g7c0934dea.d20260703`.
- `Dockerfile` bakes `.git` into the image specifically so `hatch-vcs` can derive the real package version, but `docker-qa.yml`'s "Checkout flexmeasures" step used the default shallow, tag-less clone, so `hatch-vcs` had nothing to compute a version from and fell back to `0.1.dev1+...` — below flexmeasures-client's `0.31.0` minimum.
- Fix: add `fetch-depth: 0` to that checkout step, matching the identical fix already in place in `docker-publish.yml` for the same reason.

## Test plan
- [ ] Re-run the manual QA workflow (`workflow_dispatch`) and confirm the server reports a real `0.33.x`-derived dev version and the HEMS example's min-version check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qprz6PKnXkVE1TJ8d7PYe9