### PR TITLE
fix(ci): checkout repo in pypi-smoke-test job

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -77,6 +77,8 @@ jobs:
       contents: read
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: "Set up Python"
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
## Summary
- `pypi-smoke-test` had no checkout step, so `.python-version` didn't exist in the runner workspace, breaking `actions/setup-python`'s `python-version-file` lookup.
- Adds `actions/checkout@v4` before the Python setup step, matching the other jobs in this workflow.

Fixes the failure seen at https://github.com/FlexMeasures/flexmeasures/actions/runs/28679603188/job/85065625900

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Qprz6PKnXkVE1TJ8d7PYe9