### PR TITLE
Feat: add configurable forecast post processing 

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,7 +13,7 @@ v1.0.0 | July XX, 2026
 New features
 -------------
 * In the UI, asset and sensor lists can be filtered by ID prefix through API-backed search fields [see `PR #2231 <https://www.github.com/FlexMeasures/flexmeasures/pull/2231>`_]
-* Support configurable lower and upper bounds and snapping for forecast output post-processing
+* Support configurable lower and upper bounds and snapping for forecast output post-processing [see `PR #2273 <https://www.github.com/FlexMeasures/flexmeasures/pull/2273>`_]
 * Floor off-clock API datetimes to a non-instantaneous sensor's resolution by default when ingesting sensor data, uploading sensor data, and handling scheduler flex-model timed events; configurable with the ``floor_datetimes_to_resolution`` sensor attribute [see `PR #2146 <https://www.github.com/FlexMeasures/flexmeasures/pull/2146>`_]
 * Sensor references in flex-model and flex-context support various ways of filtering by source [see `PR #2209 <https://www.github.com/FlexMeasures/flexmeasures/pull/2209>`_]
 * Let storage scheduling infer missing ``power-capacity`` from directional device capacities before falling back to site capacity, and default the missing opposite capacity to zero when only a non-zero ``consumption-capacity`` or ``production-capacity`` is configured [see `PR #2222 <https://www.github.com/FlexMeasures/flexmeasures/pull/2222>`_]

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,7 +13,7 @@ v1.0.0 | July XX, 2026
 New features
 -------------
 * In the UI, asset and sensor lists can be filtered by ID prefix through API-backed search fields [see `PR #2231 <https://www.github.com/FlexMeasures/flexmeasures/pull/2231>`_]
-* Support configurable lower and upper bounds and snapping for forecast output post-processing [see `PR #2273 <https://www.github.com/FlexMeasures/flexmeasures/pull/2273>`_]
+* Support configurable lower and upper bounds and snapping for forecast post-processing [see `PR #2273 <https://www.github.com/FlexMeasures/flexmeasures/pull/2273>`_]
 * Floor off-clock API datetimes to a non-instantaneous sensor's resolution by default when ingesting sensor data, uploading sensor data, and handling scheduler flex-model timed events; configurable with the ``floor_datetimes_to_resolution`` sensor attribute [see `PR #2146 <https://www.github.com/FlexMeasures/flexmeasures/pull/2146>`_]
 * Sensor references in flex-model and flex-context support various ways of filtering by source [see `PR #2209 <https://www.github.com/FlexMeasures/flexmeasures/pull/2209>`_]
 * Let storage scheduling infer missing ``power-capacity`` from directional device capacities before falling back to site capacity, and default the missing opposite capacity to zero when only a non-zero ``consumption-capacity`` or ``production-capacity`` is configured [see `PR #2222 <https://www.github.com/FlexMeasures/flexmeasures/pull/2222>`_]

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,6 +13,7 @@ v1.0.0 | July XX, 2026
 New features
 -------------
 * In the UI, asset and sensor lists can be filtered by ID prefix through API-backed search fields [see `PR #2231 <https://www.github.com/FlexMeasures/flexmeasures/pull/2231>`_]
+* Support configurable lower and upper bounds and snapping for forecast output post-processing
 * Floor off-clock API datetimes to a non-instantaneous sensor's resolution by default when ingesting sensor data, uploading sensor data, and handling scheduler flex-model timed events; configurable with the ``floor_datetimes_to_resolution`` sensor attribute [see `PR #2146 <https://www.github.com/FlexMeasures/flexmeasures/pull/2146>`_]
 * Sensor references in flex-model and flex-context support various ways of filtering by source [see `PR #2209 <https://www.github.com/FlexMeasures/flexmeasures/pull/2209>`_]
 * Let storage scheduling infer missing ``power-capacity`` from directional device capacities before falling back to site capacity, and default the missing opposite capacity to zero when only a non-zero ``consumption-capacity`` or ``production-capacity`` is configured [see `PR #2222 <https://www.github.com/FlexMeasures/flexmeasures/pull/2222>`_]

--- a/documentation/features/forecasting.rst
+++ b/documentation/features/forecasting.rst
@@ -62,7 +62,7 @@ Note that:
 ``forecast-frequency`` together with ``max-forecast-horizon`` determine how the forecasting cycles advance through time.
 ``train-period``, ``from-date`` and ``to-date`` allow precise control over the training and prediction windows in each cycle.
 
-Forecast output post-processing
+Forecast post-processing
 --------------------------------
 
 Forecaster configuration can clip and snap forecast values before they are stored.

--- a/documentation/features/forecasting.rst
+++ b/documentation/features/forecasting.rst
@@ -62,6 +62,27 @@ Note that:
 ``forecast-frequency`` together with ``max-forecast-horizon`` determine how the forecasting cycles advance through time.
 ``train-period``, ``from-date`` and ``to-date`` allow precise control over the training and prediction windows in each cycle.
 
+Forecast output post-processing
+--------------------------------
+
+Forecaster configuration can clip and snap forecast values before they are stored.
+Use ``lower`` and ``upper`` to clip values to bounds, and ``snap`` to replace values in a configured interval with a target value.
+Units are optional; unitless values are interpreted in the output sensor unit.
+
+For example, this configuration clips forecasts to the 0-20 kW range and snaps values between 0 kW and 4 kW to 0 kW:
+
+.. code-block:: json
+
+    {
+      "lower": "0 kW",
+      "snap": {
+        "0 kW": ["0 kW", "4 kW"]
+      },
+      "upper": "20 kW"
+    }
+
+Pass the same object as the API ``config`` payload, or place it in a JSON or YAML file and pass it to ``flexmeasures add forecasts`` with ``--config``.
+
 Forecasting via the UI
 -----------------------
 
@@ -142,4 +163,3 @@ If you want to take regressors into account, in addition to merely past measurem
 
 Including regressors can significantly improve forecasting accuracy, especially when they are highly correlated with the target variable. For example, using irradiation forecasts as regressors can substantially improve solar production predictions.
 In `this weather forecast plugin <https://github.com/flexmeasures/flexmeasures-weather>`_, we enable you to collect regressor data for ``["temperature", "wind speed", "cloud cover", "irradiance"]``, at a location you select.
-

--- a/documentation/features/forecasting.rst
+++ b/documentation/features/forecasting.rst
@@ -66,10 +66,10 @@ Forecast post-processing
 --------------------------------
 
 Forecaster configuration can clip and snap forecast values before they are stored.
-Use ``lower`` and ``upper`` to clip values to bounds, and ``snap`` to replace values in a configured interval with a target value.
+Use ``lower`` and ``upper`` to clip values to bounds, and ``snap`` to replace values inside a configured interval with a target value.
 Units are optional; unitless values are interpreted in the output sensor unit.
 
-For example, this configuration clips forecasts to the 0-20 kW range and snaps values between 0 kW and 4 kW to 0 kW:
+For example, this configuration clips forecasts to the 0-20 kW range and snaps values in ``[0 kW, 4 kW)`` to 0 kW:
 
 .. code-block:: json
 
@@ -80,6 +80,14 @@ For example, this configuration clips forecasts to the 0-20 kW range and snaps v
       },
       "upper": "20 kW"
     }
+
+Snapping is "traditional": the snap target must be one of the two interval bounds, so values always snap to a boundary rather than to a value outside the interval.
+The first bound is inclusive and the second is exclusive, so an interval reads as ``[first, second)``.
+Listing the bounds in reverse order flips the closed side: ``["10 kW", "4 kW"]`` means ``(4 kW, 10 kW]``.
+This keeps adjacent intervals unambiguous — a value on a shared boundary belongs to the interval that opens at it.
+For instance, given ``{"0 kW": ["0 kW", "4 kW"], "10 kW": ["4 kW", "10 kW"]}``, a forecast of exactly 4 kW snaps to 10 kW.
+
+Snapping runs first and clipping runs afterwards, so ``lower``/``upper`` always take precedence: a snap target outside the bounds is clipped back into range.
 
 Pass the same object as the API ``config`` payload, or place it in a JSON or YAML file and pass it to ``flexmeasures add forecasts`` with ``--config``.
 

--- a/documentation/features/forecasting.rst
+++ b/documentation/features/forecasting.rst
@@ -81,7 +81,7 @@ For example, this configuration clips forecasts to the 0-20 kW range and snaps v
       "upper": "20 kW"
     }
 
-Snapping is "traditional": the snap target must be one of the two interval bounds, so values always snap to a boundary rather than to a value outside the interval.
+The snap target must lie within its interval (on a bound or inside it), so values never snap to a value outside the interval. A target inside the interval snaps the whole band to that value, for example ``{"2 kW": ["0 kW", "4 kW"]}`` snaps everything in ``[0 kW, 4 kW)`` to 2 kW.
 The first bound is inclusive and the second is exclusive, so an interval reads as ``[first, second)``.
 Listing the bounds in reverse order flips the closed side: ``["10 kW", "4 kW"]`` means ``(4 kW, 10 kW]``.
 This keeps adjacent intervals unambiguous — a value on a shared boundary belongs to the interval that opens at it.

--- a/flexmeasures/data/models/forecasting/pipelines/predict.py
+++ b/flexmeasures/data/models/forecasting/pipelines/predict.py
@@ -13,7 +13,10 @@ from timely_beliefs import BeliefsDataFrame
 
 from flexmeasures import Sensor, Source
 from flexmeasures.data import db
-from flexmeasures.data.models.forecasting.utils import data_to_bdf
+from flexmeasures.data.models.forecasting.utils import (
+    apply_forecast_post_processing,
+    data_to_bdf,
+)
 from flexmeasures.data.models.forecasting.pipelines.base import BasePipeline
 from flexmeasures.data.utils import save_to_db
 
@@ -40,6 +43,7 @@ class PredictPipeline(BasePipeline):
         predict_end: datetime | None = None,
         data_source: Source = None,
         missing_threshold: float = 1.0,
+        post_processing_config: dict | None = None,
     ) -> None:
         """
         Initialize the PredictPipeline.
@@ -63,6 +67,7 @@ class PredictPipeline(BasePipeline):
         :param probabilistic: Whether to use a probabilistic model.
         :param sensor_to_save: Sensor to which the predictions will be attributed.
         :param missing_threshold: Max fraction of missing data allowed before failure. Missing data under the threshold will be filled with our interpolation methods.
+        :param post_processing_config: Optional clipping and snapping configuration for forecast values.
         """
         super().__init__(
             future_regressors=future_regressors,
@@ -88,6 +93,7 @@ class PredictPipeline(BasePipeline):
         self.sensor_to_save = sensor_to_save
         self.predict_start = predict_start
         self.predict_end = predict_end
+        self.post_processing_config = post_processing_config or {}
 
         self.sensor_resolution = self.target_sensor.event_resolution
         self.readable_resolution = duration_isoformat(self.sensor_resolution)
@@ -265,6 +271,12 @@ class PredictPipeline(BasePipeline):
             past_covariates_list=past_covariates_list,
             y_list=y_list,
             belief_timestamps_list=belief_timestamps_list,
+        )
+        df_pred = apply_forecast_post_processing(
+            data=df_pred,
+            horizon=self.max_forecast_horizon,
+            config=self.post_processing_config,
+            sensor_unit=self.sensor_to_save.unit,
         )
         logging.debug("Predictions ready to be saved")
 

--- a/flexmeasures/data/models/forecasting/pipelines/train_predict.py
+++ b/flexmeasures/data/models/forecasting/pipelines/train_predict.py
@@ -167,7 +167,7 @@ class TrainPredictPipeline(Forecaster):
             post_processing_config={
                 "lower": self._config.get("lower"),
                 "upper": self._config.get("upper"),
-                "snap": self._config.get("snap", {}),
+                "snap": self._config.get("snap"),
             },
         )
         logging.info(

--- a/flexmeasures/data/models/forecasting/pipelines/train_predict.py
+++ b/flexmeasures/data/models/forecasting/pipelines/train_predict.py
@@ -164,6 +164,11 @@ class TrainPredictPipeline(Forecaster):
             sensor_to_save=self._parameters["sensor_to_save"],
             data_source=self.data_source,
             missing_threshold=self._config.get("missing_threshold"),
+            post_processing_config={
+                "lower": self._config.get("lower"),
+                "upper": self._config.get("upper"),
+                "snap": self._config.get("snap", {}),
+            },
         )
         logging.info(
             f"Prediction cycle from {predict_start} to {predict_end} started ..."

--- a/flexmeasures/data/models/forecasting/utils.py
+++ b/flexmeasures/data/models/forecasting/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import numbers
 from typing import Any
 
@@ -59,6 +60,42 @@ def _quantity_to_sensor_value(value: Any, sensor_unit: str) -> float:
         ) from exc
 
 
+def _parse_snap_intervals(
+    snap: dict, sensor_unit: str
+) -> list[tuple[float, float, float]]:
+    """Validate and parse a snap mapping into ``(target, first, second)`` triples.
+
+    Snapping is "traditional": each value that falls inside an interval is replaced
+    by a target that is itself one of the interval's boundaries. The first boundary
+    is treated as inclusive and the second as exclusive, so listing the boundaries in
+    reverse order flips which side is closed (``["4 kW", "10 kW"]`` means ``[4, 10)``
+    while ``["10 kW", "4 kW"]`` means ``(4, 10]``). This keeps adjacent intervals
+    unambiguous: a shared boundary belongs to whichever interval opens at it.
+    """
+    parsed = []
+    for target, interval in snap.items():
+        if not isinstance(interval, (list, tuple)) or len(interval) != 2:
+            raise ValueError(
+                "Forecast post-processing snap intervals must contain exactly two bounds."
+            )
+
+        target_value = _quantity_to_sensor_value(target, sensor_unit)
+        first = _quantity_to_sensor_value(interval[0], sensor_unit)
+        second = _quantity_to_sensor_value(interval[1], sensor_unit)
+        if math.isclose(first, second):
+            raise ValueError(
+                "Forecast post-processing snap interval bounds must differ."
+            )
+        if not (
+            math.isclose(target_value, first) or math.isclose(target_value, second)
+        ):
+            raise ValueError(
+                "Forecast post-processing snap target must equal one of its interval bounds."
+            )
+        parsed.append((target_value, first, second))
+    return parsed
+
+
 def apply_forecast_post_processing(
     data: pd.DataFrame,
     horizon: int,
@@ -66,6 +103,10 @@ def apply_forecast_post_processing(
     sensor_unit: str,
 ) -> pd.DataFrame:
     """Apply configured clipping and snapping to forecast horizon columns.
+
+    Snapping runs first, on the unmodified predictions, so intervals cannot cascade.
+    Clipping to ``lower``/``upper`` runs afterwards and always takes precedence, so a
+    snap target outside the bounds is still clipped back into range.
 
     :param data:        DataFrame containing one column per forecast horizon.
     :param horizon:     Maximum forecast horizon in time-steps.
@@ -75,7 +116,7 @@ def apply_forecast_post_processing(
     """
     lower = config.get("lower")
     upper = config.get("upper")
-    snap = config.get("snap", {})
+    snap = config.get("snap") or {}
 
     if lower is None and upper is None and not snap:
         return data
@@ -98,27 +139,18 @@ def apply_forecast_post_processing(
             "Forecast post-processing lower bound cannot be greater than upper bound."
         )
 
-    for target, interval in snap.items():
-        if not isinstance(interval, (list, tuple)) or len(interval) != 2:
-            raise ValueError(
-                "Forecast post-processing snap intervals must contain exactly two bounds."
-            )
+    snap_intervals = _parse_snap_intervals(snap, sensor_unit)
 
-        target_value = _quantity_to_sensor_value(target, sensor_unit)
-        interval_lower = _quantity_to_sensor_value(interval[0], sensor_unit)
-        interval_upper = _quantity_to_sensor_value(interval[1], sensor_unit)
-        if interval_lower > interval_upper:
-            raise ValueError(
-                "Forecast post-processing snap interval lower bound cannot be greater than upper bound."
-            )
-
-        for column in forecast_columns:
-            original_values = processed[column].copy()
-            mask = original_values.between(interval_lower, interval_upper)
-            if lower_value is not None:
-                mask &= original_values >= lower_value
-            if upper_value is not None:
-                mask &= original_values <= upper_value
+    for column in forecast_columns:
+        # Snap against the pre-snap predictions so intervals cannot chain into each other.
+        original_values = processed[column]
+        for target_value, first, second in snap_intervals:
+            if first <= second:
+                # First bound inclusive, second exclusive: [first, second).
+                mask = (original_values >= first) & (original_values < second)
+            else:
+                # Reversed order flips the closed side: (second, first].
+                mask = (original_values > second) & (original_values <= first)
             processed.loc[mask, column] = target_value
 
     processed[forecast_columns] = processed[forecast_columns].clip(

--- a/flexmeasures/data/models/forecasting/utils.py
+++ b/flexmeasures/data/models/forecasting/utils.py
@@ -59,12 +59,13 @@ def _parse_snap_intervals(
 ) -> list[tuple[float, float, float]]:
     """Validate and parse a snap mapping into ``(target, first, second)`` triples.
 
-    Snapping is "traditional": each value that falls inside an interval is replaced
-    by a target that is itself one of the interval's boundaries. The first boundary
-    is treated as inclusive and the second as exclusive, so listing the boundaries in
-    reverse order flips which side is closed (``["4 kW", "10 kW"]`` means ``[4, 10)``
-    while ``["10 kW", "4 kW"]`` means ``(4, 10]``). This keeps adjacent intervals
-    unambiguous: a shared boundary belongs to whichever interval opens at it.
+    Each value that falls inside an interval is replaced by a target that must lie
+    within that interval (on a bound or inside it), so values never snap to a value
+    outside their interval. The first boundary is treated as inclusive and the second
+    as exclusive, so listing the boundaries in reverse order flips which side is closed
+    (``["4 kW", "10 kW"]`` means ``[4, 10)`` while ``["10 kW", "4 kW"]`` means
+    ``(4, 10]``). This keeps adjacent intervals unambiguous: a shared boundary belongs
+    to whichever interval opens at it.
     """
     parsed = []
     for target, interval in snap.items():
@@ -80,11 +81,9 @@ def _parse_snap_intervals(
             raise ValueError(
                 "Forecast post-processing snap interval bounds must differ."
             )
-        if not (
-            math.isclose(target_value, first) or math.isclose(target_value, second)
-        ):
+        if not min(first, second) <= target_value <= max(first, second):
             raise ValueError(
-                "Forecast post-processing snap target must equal one of its interval bounds."
+                "Forecast post-processing snap target must lie within its interval bounds."
             )
         parsed.append((target_value, first, second))
     return parsed

--- a/flexmeasures/data/models/forecasting/utils.py
+++ b/flexmeasures/data/models/forecasting/utils.py
@@ -13,16 +13,11 @@ from flexmeasures.data.models.time_series import Sensor
 from datetime import datetime, timedelta
 
 from flexmeasures.data import db
-from flexmeasures.utils.unit_utils import ur
+from flexmeasures.utils.unit_utils import units_are_convertible, ur
 
 
 def negative_to_zero(x: np.ndarray) -> np.ndarray:
     return np.where(x < 0, 0, x)
-
-
-def _normalize_unit(unit: str | None) -> str:
-    """Normalize empty units for pint."""
-    return unit or "dimensionless"
 
 
 def _is_unitless(unit: str | None) -> bool:
@@ -32,8 +27,6 @@ def _is_unitless(unit: str | None) -> bool:
 
 def _quantity_to_sensor_value(value: Any, sensor_unit: str) -> float:
     """Parse a configured quantity and return its magnitude in the sensor unit."""
-    to_unit = _normalize_unit(sensor_unit)
-
     if isinstance(value, numbers.Real):
         return float(value)
 
@@ -49,15 +42,16 @@ def _quantity_to_sensor_value(value: Any, sensor_unit: str) -> float:
             f"Could not parse forecast post-processing value '{value}'."
         ) from exc
 
-    if _is_unitless(f"{quantity.units:~P}"):
+    from_unit = f"{quantity.units:~P}"
+    if _is_unitless(from_unit):
         return float(quantity.magnitude)
 
-    try:
-        return float(quantity.to(ur.Quantity(to_unit)).magnitude)
-    except Exception as exc:
+    to_unit = sensor_unit or "dimensionless"
+    if not units_are_convertible(from_unit, to_unit, duration_known=False):
         raise ValueError(
             f"Could not convert forecast post-processing value '{value}' to '{sensor_unit}'."
-        ) from exc
+        )
+    return float(quantity.to(to_unit).magnitude)
 
 
 def _parse_snap_intervals(

--- a/flexmeasures/data/models/forecasting/utils.py
+++ b/flexmeasures/data/models/forecasting/utils.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import numbers
+from typing import Any
+
 import numpy as np
 import pandas as pd
 import timely_beliefs as tb
@@ -9,10 +12,119 @@ from flexmeasures.data.models.time_series import Sensor
 from datetime import datetime, timedelta
 
 from flexmeasures.data import db
+from flexmeasures.utils.unit_utils import ur
 
 
 def negative_to_zero(x: np.ndarray) -> np.ndarray:
     return np.where(x < 0, 0, x)
+
+
+def _normalize_unit(unit: str | None) -> str:
+    """Normalize empty units for pint."""
+    return unit or "dimensionless"
+
+
+def _is_unitless(unit: str | None) -> bool:
+    """Check whether a parsed quantity carries no physical unit."""
+    return unit in (None, "", "dimensionless")
+
+
+def _quantity_to_sensor_value(value: Any, sensor_unit: str) -> float:
+    """Parse a configured quantity and return its magnitude in the sensor unit."""
+    to_unit = _normalize_unit(sensor_unit)
+
+    if isinstance(value, numbers.Real):
+        return float(value)
+
+    if not isinstance(value, str):
+        raise ValueError(
+            f"Forecast post-processing values must be numbers or quantity strings, not {type(value).__name__}."
+        )
+
+    try:
+        quantity = ur.Quantity(value)
+    except Exception as exc:
+        raise ValueError(
+            f"Could not parse forecast post-processing value '{value}'."
+        ) from exc
+
+    if _is_unitless(f"{quantity.units:~P}"):
+        return float(quantity.magnitude)
+
+    try:
+        return float(quantity.to(ur.Quantity(to_unit)).magnitude)
+    except Exception as exc:
+        raise ValueError(
+            f"Could not convert forecast post-processing value '{value}' to '{sensor_unit}'."
+        ) from exc
+
+
+def apply_forecast_post_processing(
+    data: pd.DataFrame,
+    horizon: int,
+    config: dict,
+    sensor_unit: str,
+) -> pd.DataFrame:
+    """Apply configured clipping and snapping to forecast horizon columns.
+
+    :param data:        DataFrame containing one column per forecast horizon.
+    :param horizon:     Maximum forecast horizon in time-steps.
+    :param config:      Forecaster config with optional ``lower``, ``upper`` and ``snap`` fields.
+    :param sensor_unit: Unit of the sensor to which forecasts will be saved.
+    :returns:           A DataFrame with post-processed forecast values.
+    """
+    lower = config.get("lower")
+    upper = config.get("upper")
+    snap = config.get("snap", {})
+
+    if lower is None and upper is None and not snap:
+        return data
+
+    processed = data.copy()
+    forecast_columns = [f"{h}h" for h in range(1, horizon + 1)]
+    lower_value = (
+        _quantity_to_sensor_value(lower, sensor_unit) if lower is not None else None
+    )
+    upper_value = (
+        _quantity_to_sensor_value(upper, sensor_unit) if upper is not None else None
+    )
+
+    if (
+        lower_value is not None
+        and upper_value is not None
+        and lower_value > upper_value
+    ):
+        raise ValueError(
+            "Forecast post-processing lower bound cannot be greater than upper bound."
+        )
+
+    for target, interval in snap.items():
+        if not isinstance(interval, (list, tuple)) or len(interval) != 2:
+            raise ValueError(
+                "Forecast post-processing snap intervals must contain exactly two bounds."
+            )
+
+        target_value = _quantity_to_sensor_value(target, sensor_unit)
+        interval_lower = _quantity_to_sensor_value(interval[0], sensor_unit)
+        interval_upper = _quantity_to_sensor_value(interval[1], sensor_unit)
+        if interval_lower > interval_upper:
+            raise ValueError(
+                "Forecast post-processing snap interval lower bound cannot be greater than upper bound."
+            )
+
+        for column in forecast_columns:
+            original_values = processed[column].copy()
+            mask = original_values.between(interval_lower, interval_upper)
+            if lower_value is not None:
+                mask &= original_values >= lower_value
+            if upper_value is not None:
+                mask &= original_values <= upper_value
+            processed.loc[mask, column] = target_value
+
+    processed[forecast_columns] = processed[forecast_columns].clip(
+        lower=lower_value, upper=upper_value, axis=None
+    )
+    return processed
 
 
 def data_to_bdf(

--- a/flexmeasures/data/schemas/forecasting/pipeline.py
+++ b/flexmeasures/data/schemas/forecasting/pipeline.py
@@ -138,7 +138,7 @@ class TrainPredictPipelineConfigSchema(Schema):
         required=False,
         load_default={},
         metadata={
-            "description": "Optional mapping from snap targets to [first, second] intervals. Values inside an interval are replaced by the snap target before storage. The target must be one of the two bounds. The first bound is inclusive and the second exclusive, so [first, second) by default; reverse the order to close the upper side instead.",
+            "description": "Optional mapping from snap targets to [first, second] intervals. Values inside an interval are replaced by the snap target before storage. The target must lie within the interval (on a bound or inside it). The first bound is inclusive and the second exclusive, so [first, second) by default; reverse the order to close the upper side instead.",
             "example": {"0 kW": ["0 kW", "4 kW"]},
         },
     )

--- a/flexmeasures/data/schemas/forecasting/pipeline.py
+++ b/flexmeasures/data/schemas/forecasting/pipeline.py
@@ -9,6 +9,7 @@ from isodate.duration import Duration
 from marshmallow import (
     fields,
     Schema,
+    validate,
     validates_schema,
     pre_load,
     post_load,
@@ -96,6 +97,34 @@ class TrainPredictPipelineConfigSchema(Schema):
             "cli": {
                 "option": "--ensure-positive",
             },
+        },
+    )
+    lower = fields.Raw(
+        required=False,
+        allow_none=True,
+        load_default=None,
+        metadata={
+            "description": "Optional lower bound for forecast values after prediction. Unitless values are interpreted in the output sensor unit.",
+            "example": "0 kW",
+        },
+    )
+    upper = fields.Raw(
+        required=False,
+        allow_none=True,
+        load_default=None,
+        metadata={
+            "description": "Optional upper bound for forecast values after prediction. Unitless values are interpreted in the output sensor unit.",
+            "example": "20 kW",
+        },
+    )
+    snap = fields.Dict(
+        keys=fields.Raw(),
+        values=fields.List(fields.Raw(), validate=validate.Length(equal=2)),
+        required=False,
+        load_default={},
+        metadata={
+            "description": "Optional mapping from snap targets to [lower, upper] intervals. Values inside an interval are replaced by the snap target before storage.",
+            "example": {"0 kW": ["0 kW", "4 kW"]},
         },
     )
     train_start = AwareDateTimeOrDateField(

--- a/flexmeasures/data/schemas/forecasting/pipeline.py
+++ b/flexmeasures/data/schemas/forecasting/pipeline.py
@@ -138,7 +138,7 @@ class TrainPredictPipelineConfigSchema(Schema):
         required=False,
         load_default={},
         metadata={
-            "description": "Optional mapping from snap targets to [lower, upper] intervals. Values inside an interval are replaced by the snap target before storage.",
+            "description": "Optional mapping from snap targets to [first, second] intervals. Values inside an interval are replaced by the snap target before storage. The target must be one of the two bounds. The first bound is inclusive and the second exclusive, so [first, second) by default; reverse the order to close the upper side instead.",
             "example": {"0 kW": ["0 kW", "4 kW"]},
         },
     )

--- a/flexmeasures/data/schemas/forecasting/pipeline.py
+++ b/flexmeasures/data/schemas/forecasting/pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import numbers
 import os
 
 from datetime import timedelta
@@ -25,6 +26,20 @@ from flexmeasures.data.schemas.times import (
 )
 from flexmeasures.data.models.forecasting.utils import floor_to_resolution
 from flexmeasures.utils.time_utils import server_now
+from flexmeasures.utils.unit_utils import ur
+
+
+def _is_parseable_quantity(value) -> bool:
+    """Whether a post-processing value is a number or a pint-parseable quantity string."""
+    if isinstance(value, numbers.Real):
+        return True
+    if not isinstance(value, str):
+        return False
+    try:
+        ur.Quantity(value)
+    except Exception:
+        return False
+    return True
 
 
 class TrainPredictPipelineConfigSchema(Schema):
@@ -205,6 +220,32 @@ class TrainPredictPipelineConfigSchema(Schema):
                 "(e.g. P365D, PT48H). Years and months are not supported.",
                 field_name="max_training_period",
             )
+
+    @validates_schema
+    def validate_post_processing(self, data: dict, **kwargs):
+        """Fail fast on unparseable post-processing values.
+
+        Unit compatibility with the sensor and interval semantics can only be
+        checked once the output sensor is known, so those run at forecast time.
+        """
+        errors: dict[str, list[str]] = {}
+        for field_name in ("lower", "upper"):
+            value = data.get(field_name)
+            if value is not None and not _is_parseable_quantity(value):
+                errors[field_name] = [
+                    "Must be a number or a parseable quantity string (e.g. 0 or '0 kW')."
+                ]
+
+        snap_errors = [
+            f"Snap entry '{target}' must use numbers or parseable quantity strings."
+            for target, interval in (data.get("snap") or {}).items()
+            if not all(_is_parseable_quantity(v) for v in (target, *interval))
+        ]
+        if snap_errors:
+            errors["snap"] = snap_errors
+
+        if errors:
+            raise ValidationError(errors)
 
     @post_load
     def resolve_config(self, data: dict, **kwargs) -> dict:  # noqa: C901

--- a/flexmeasures/data/schemas/tests/test_forecasting.py
+++ b/flexmeasures/data/schemas/tests/test_forecasting.py
@@ -676,3 +676,19 @@ def test_forecaster_config_schema_rejects_invalid_snap_interval_shape():
         )
 
     assert "snap" in exc.value.messages
+
+
+def test_forecaster_config_schema_rejects_unparseable_bound():
+    with pytest.raises(ValidationError) as exc:
+        TrainPredictPipelineConfigSchema().load({"lower": "not a quantity"})
+
+    assert "lower" in exc.value.messages
+
+
+def test_forecaster_config_schema_rejects_unparseable_snap_value():
+    with pytest.raises(ValidationError) as exc:
+        TrainPredictPipelineConfigSchema().load(
+            {"snap": {"0 kW": ["0 kW", "not a quantity"]}}
+        )
+
+    assert "snap" in exc.value.messages

--- a/flexmeasures/data/schemas/tests/test_forecasting.py
+++ b/flexmeasures/data/schemas/tests/test_forecasting.py
@@ -643,3 +643,36 @@ def test_timing_parameters_of_forecaster_config_schema(
         # Convert kebab-case key to snake_case to match data dictionary keys returned by schema
         snake_key = kebab_to_snake(k)
         assert data[snake_key] == v, f"{k} did not match expectations."
+
+
+def test_forecaster_config_schema_loads_forecast_post_processing_options():
+    data = TrainPredictPipelineConfigSchema().load(
+        {
+            "lower": "0 kW",
+            "upper": 20,
+            "snap": {"0 kW": ["0 kW", "4 kW"]},
+        }
+    )
+
+    assert data["lower"] == "0 kW"
+    assert data["upper"] == 20
+    assert data["snap"] == {"0 kW": ["0 kW", "4 kW"]}
+
+
+def test_forecaster_config_schema_defaults_forecast_post_processing_to_disabled():
+    data = TrainPredictPipelineConfigSchema().load({})
+
+    assert data["lower"] is None
+    assert data["upper"] is None
+    assert data["snap"] == {}
+
+
+def test_forecaster_config_schema_rejects_invalid_snap_interval_shape():
+    with pytest.raises(ValidationError) as exc:
+        TrainPredictPipelineConfigSchema().load(
+            {
+                "snap": {"0 kW": ["0 kW"]},
+            }
+        )
+
+    assert "snap" in exc.value.messages

--- a/flexmeasures/data/tests/test_forecasting_pipeline.py
+++ b/flexmeasures/data/tests/test_forecasting_pipeline.py
@@ -11,6 +11,9 @@ from marshmallow import ValidationError
 from flexmeasures.data.models.forecasting.custom_models.lgbm_model import CustomLGBM
 from flexmeasures.data.models.data_sources import DataSource
 from flexmeasures.data.models.forecasting.exceptions import NotEnoughDataException
+from flexmeasures.data.models.forecasting.utils import (
+    apply_forecast_post_processing,
+)
 from flexmeasures.data.models.forecasting.pipelines.base import BasePipeline
 from flexmeasures.data.models.forecasting.pipelines.train import derive_daily_lag_steps
 from flexmeasures.data.models.generic_assets import (
@@ -87,6 +90,72 @@ def test_derive_daily_lag_steps_requires_divisible_resolution(caplog):
     assert any(
         "does not evenly divide one day" in message for message in caplog.messages
     )
+
+
+def test_forecast_post_processing_clips_and_snaps_values():
+    df = pd.DataFrame(
+        {
+            "1h": [-2.0, 2.0, 8.5, 11.5, 21.0],
+            "2h": [0.5, 3.5, 10.5, 12.5, 25.0],
+        }
+    )
+
+    processed = apply_forecast_post_processing(
+        data=df,
+        horizon=2,
+        config={
+            "lower": "0 kW",
+            "snap": {
+                "0 kW": ["0 kW", "4 kW"],
+                "8 kW": ["8 kW", "11 kW"],
+                "12 kW": ["11 kW", "12 kW"],
+            },
+            "upper": "20 kW",
+        },
+        sensor_unit="kW",
+    )
+
+    pd.testing.assert_frame_equal(
+        processed,
+        pd.DataFrame(
+            {
+                "1h": [0.0, 0.0, 8.0, 12.0, 20.0],
+                "2h": [0.0, 0.0, 8.0, 12.5, 20.0],
+            }
+        ),
+    )
+
+
+def test_forecast_post_processing_interprets_unitless_values_in_sensor_unit():
+    df = pd.DataFrame({"1h": [0.5, 1.3, 2.5]})
+
+    processed = apply_forecast_post_processing(
+        data=df,
+        horizon=1,
+        config={
+            "lower": 1,
+            "snap": {"1500 W": ["1.2 kW", "1.8 kW"]},
+            "upper": "2 kW",
+        },
+        sensor_unit="kW",
+    )
+
+    pd.testing.assert_frame_equal(
+        processed,
+        pd.DataFrame({"1h": [1.0, 1.5, 2.0]}),
+    )
+
+
+def test_forecast_post_processing_rejects_inconsistent_bounds():
+    df = pd.DataFrame({"1h": [1.0]})
+
+    with pytest.raises(ValueError, match="lower bound cannot be greater"):
+        apply_forecast_post_processing(
+            data=df,
+            horizon=1,
+            config={"lower": "2 kW", "upper": "1 kW"},
+            sensor_unit="kW",
+        )
 
 
 @pytest.mark.parametrize(

--- a/flexmeasures/data/tests/test_forecasting_pipeline.py
+++ b/flexmeasures/data/tests/test_forecasting_pipeline.py
@@ -162,6 +162,22 @@ def test_forecast_post_processing_interprets_unitless_snap_in_sensor_unit():
     )
 
 
+def test_forecast_post_processing_converts_snap_units_to_sensor_unit():
+    df = pd.DataFrame({"1h": [1.1, 1.5, 1.9]})
+
+    processed = apply_forecast_post_processing(
+        data=df,
+        horizon=1,
+        config={"snap": {"1000 W": ["1200 W", "1800 W"]}},
+        sensor_unit="kW",
+    )
+
+    pd.testing.assert_frame_equal(
+        processed,
+        pd.DataFrame({"1h": [1.1, 1.0, 1.9]}),
+    )
+
+
 def test_forecast_post_processing_rejects_inconsistent_bounds():
     df = pd.DataFrame({"1h": [1.0]})
 

--- a/flexmeasures/data/tests/test_forecasting_pipeline.py
+++ b/flexmeasures/data/tests/test_forecasting_pipeline.py
@@ -134,7 +134,7 @@ def test_forecast_post_processing_interprets_unitless_values_in_sensor_unit():
         horizon=1,
         config={
             "lower": 1,
-            "snap": {"1500 W": ["1.2 kW", "1.8 kW"]},
+            "snap": {"1.2 kW": ["1.2 kW", "1.8 kW"]},
             "upper": "2 kW",
         },
         sensor_unit="kW",
@@ -142,7 +142,7 @@ def test_forecast_post_processing_interprets_unitless_values_in_sensor_unit():
 
     pd.testing.assert_frame_equal(
         processed,
-        pd.DataFrame({"1h": [1.0, 1.5, 2.0]}),
+        pd.DataFrame({"1h": [1.0, 1.2, 2.0]}),
     )
 
 
@@ -168,13 +168,90 @@ def test_forecast_post_processing_converts_snap_units_to_sensor_unit():
     processed = apply_forecast_post_processing(
         data=df,
         horizon=1,
-        config={"snap": {"1000 W": ["1200 W", "1800 W"]}},
+        config={"snap": {"1200 W": ["1200 W", "1800 W"]}},
         sensor_unit="kW",
     )
 
     pd.testing.assert_frame_equal(
         processed,
-        pd.DataFrame({"1h": [1.1, 1.0, 1.9]}),
+        pd.DataFrame({"1h": [1.1, 1.2, 1.9]}),
+    )
+
+
+def test_forecast_post_processing_snap_bounds_are_half_open():
+    """The first bound is inclusive, the second exclusive: [first, second)."""
+    df = pd.DataFrame({"1h": [0.0, 2.0, 4.0]})
+
+    processed = apply_forecast_post_processing(
+        data=df,
+        horizon=1,
+        config={"snap": {"0 kW": ["0 kW", "4 kW"]}},
+        sensor_unit="kW",
+    )
+
+    # 0 is included and snaps to 0; 4 is excluded and is left untouched.
+    pd.testing.assert_frame_equal(
+        processed,
+        pd.DataFrame({"1h": [0.0, 0.0, 4.0]}),
+    )
+
+
+def test_forecast_post_processing_reversed_snap_bounds_close_the_upper_side():
+    """Listing bounds in reverse order snaps the closed side: (second, first]."""
+    df = pd.DataFrame({"1h": [4.0, 7.0, 10.0]})
+
+    processed = apply_forecast_post_processing(
+        data=df,
+        horizon=1,
+        config={"snap": {"10 kW": ["10 kW", "4 kW"]}},
+        sensor_unit="kW",
+    )
+
+    # 4 is excluded, 10 is included; both 7 and 10 snap up to 10.
+    pd.testing.assert_frame_equal(
+        processed,
+        pd.DataFrame({"1h": [4.0, 10.0, 10.0]}),
+    )
+
+
+def test_forecast_post_processing_adjacent_intervals_share_a_boundary_unambiguously():
+    """A value on a shared boundary belongs to the interval that opens at it."""
+    df = pd.DataFrame({"1h": [3.0, 4.0, 9.0]})
+
+    processed = apply_forecast_post_processing(
+        data=df,
+        horizon=1,
+        config={
+            "snap": {
+                "0 kW": ["0 kW", "4 kW"],
+                "10 kW": ["4 kW", "10 kW"],
+            }
+        },
+        sensor_unit="kW",
+    )
+
+    # 3 -> 0 ([0, 4)), 4 -> 10 ([4, 10)), 9 -> 10 ([4, 10)).
+    pd.testing.assert_frame_equal(
+        processed,
+        pd.DataFrame({"1h": [0.0, 10.0, 10.0]}),
+    )
+
+
+def test_forecast_post_processing_clip_takes_precedence_over_snap():
+    """A snap target outside the clip bounds is still clipped back into range."""
+    df = pd.DataFrame({"1h": [-3.0]})
+
+    processed = apply_forecast_post_processing(
+        data=df,
+        horizon=1,
+        config={"lower": "0 kW", "snap": {"-5 kW": ["-5 kW", "-1 kW"]}},
+        sensor_unit="kW",
+    )
+
+    # -3 snaps to -5, which is then clipped up to the lower bound of 0.
+    pd.testing.assert_frame_equal(
+        processed,
+        pd.DataFrame({"1h": [0.0]}),
     )
 
 
@@ -186,6 +263,18 @@ def test_forecast_post_processing_rejects_inconsistent_bounds():
             data=df,
             horizon=1,
             config={"lower": "2 kW", "upper": "1 kW"},
+            sensor_unit="kW",
+        )
+
+
+def test_forecast_post_processing_rejects_snap_target_off_the_interval():
+    df = pd.DataFrame({"1h": [1.0]})
+
+    with pytest.raises(ValueError, match="snap target must equal one of its interval"):
+        apply_forecast_post_processing(
+            data=df,
+            horizon=1,
+            config={"snap": {"11 kW": ["13 kW", "15 kW"]}},
             sensor_unit="kW",
         )
 

--- a/flexmeasures/data/tests/test_forecasting_pipeline.py
+++ b/flexmeasures/data/tests/test_forecasting_pipeline.py
@@ -279,6 +279,18 @@ def test_forecast_post_processing_rejects_snap_target_off_the_interval():
         )
 
 
+def test_forecast_post_processing_rejects_incompatible_units():
+    df = pd.DataFrame({"1h": [1.0]})
+
+    with pytest.raises(ValueError, match="Could not convert"):
+        apply_forecast_post_processing(
+            data=df,
+            horizon=1,
+            config={"lower": "5 m"},
+            sensor_unit="kW",
+        )
+
+
 @pytest.mark.parametrize(
     ["config", "params", "as_job", "expected_error"],
     [

--- a/flexmeasures/data/tests/test_forecasting_pipeline.py
+++ b/flexmeasures/data/tests/test_forecasting_pipeline.py
@@ -146,6 +146,22 @@ def test_forecast_post_processing_interprets_unitless_values_in_sensor_unit():
     )
 
 
+def test_forecast_post_processing_interprets_unitless_snap_in_sensor_unit():
+    df = pd.DataFrame({"1h": [0.5, 2.5, 5.0]})
+
+    processed = apply_forecast_post_processing(
+        data=df,
+        horizon=1,
+        config={"snap": {"0": [0, 4]}},
+        sensor_unit="kW",
+    )
+
+    pd.testing.assert_frame_equal(
+        processed,
+        pd.DataFrame({"1h": [0.0, 0.0, 5.0]}),
+    )
+
+
 def test_forecast_post_processing_rejects_inconsistent_bounds():
     df = pd.DataFrame({"1h": [1.0]})
 

--- a/flexmeasures/data/tests/test_forecasting_pipeline.py
+++ b/flexmeasures/data/tests/test_forecasting_pipeline.py
@@ -134,7 +134,7 @@ def test_forecast_post_processing_interprets_unitless_values_in_sensor_unit():
         horizon=1,
         config={
             "lower": 1,
-            "snap": {"1.2 kW": ["1.2 kW", "1.8 kW"]},
+            "snap": {"1500 W": ["1.2 kW", "1.8 kW"]},
             "upper": "2 kW",
         },
         sensor_unit="kW",
@@ -142,7 +142,7 @@ def test_forecast_post_processing_interprets_unitless_values_in_sensor_unit():
 
     pd.testing.assert_frame_equal(
         processed,
-        pd.DataFrame({"1h": [1.0, 1.2, 2.0]}),
+        pd.DataFrame({"1h": [1.0, 1.5, 2.0]}),
     )
 
 
@@ -267,10 +267,28 @@ def test_forecast_post_processing_rejects_inconsistent_bounds():
         )
 
 
-def test_forecast_post_processing_rejects_snap_target_off_the_interval():
+def test_forecast_post_processing_allows_snap_target_inside_the_interval():
+    """The snap target may lie inside the interval, not only on a bound."""
+    df = pd.DataFrame({"1h": [0.5, 3.9, 4.0]})
+
+    processed = apply_forecast_post_processing(
+        data=df,
+        horizon=1,
+        config={"snap": {"2 kW": ["0 kW", "4 kW"]}},
+        sensor_unit="kW",
+    )
+
+    # Everything in [0, 4) collapses to the interior target 2; 4 is excluded.
+    pd.testing.assert_frame_equal(
+        processed,
+        pd.DataFrame({"1h": [2.0, 2.0, 4.0]}),
+    )
+
+
+def test_forecast_post_processing_rejects_snap_target_outside_the_interval():
     df = pd.DataFrame({"1h": [1.0]})
 
-    with pytest.raises(ValueError, match="snap target must equal one of its interval"):
+    with pytest.raises(ValueError, match="snap target must lie within its interval"):
         apply_forecast_post_processing(
             data=df,
             horizon=1,

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -4781,7 +4781,7 @@
           "snap": {
             "type": "object",
             "default": {},
-            "description": "Optional mapping from snap targets to [first, second] intervals. Values inside an interval are replaced by the snap target before storage. The target must be one of the two bounds. The first bound is inclusive and the second exclusive, so [first, second) by default; reverse the order to close the upper side instead.",
+            "description": "Optional mapping from snap targets to [first, second] intervals. Values inside an interval are replaced by the snap target before storage. The target must lie within the interval (on a bound or inside it). The first bound is inclusive and the second exclusive, so [first, second) by default; reverse the order to close the upper side instead.",
             "example": {
               "0 kW": [
                 "0 kW",

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -4781,7 +4781,7 @@
           "snap": {
             "type": "object",
             "default": {},
-            "description": "Optional mapping from snap targets to [lower, upper] intervals. Values inside an interval are replaced by the snap target before storage.",
+            "description": "Optional mapping from snap targets to [first, second] intervals. Values inside an interval are replaced by the snap target before storage. The target must be one of the two bounds. The first bound is inclusive and the second exclusive, so [first, second) by default; reverse the order to close the upper side instead.",
             "example": {
               "0 kW": [
                 "0 kW",

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -4767,6 +4767,33 @@
             "default": false,
             "description": "Whether to clip negative values in forecasts. Defaults to None (disabled).",
             "example": true
+          },
+          "lower": {
+            "default": null,
+            "description": "Optional lower bound for forecast values after prediction. Unitless values are interpreted in the output sensor unit.",
+            "example": "0 kW"
+          },
+          "upper": {
+            "default": null,
+            "description": "Optional upper bound for forecast values after prediction. Unitless values are interpreted in the output sensor unit.",
+            "example": "20 kW"
+          },
+          "snap": {
+            "type": "object",
+            "default": {},
+            "description": "Optional mapping from snap targets to [lower, upper] intervals. Values inside an interval are replaced by the snap target before storage.",
+            "example": {
+              "0 kW": [
+                "0 kW",
+                "4 kW"
+              ]
+            },
+            "additionalProperties": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "items": {}
+            }
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
## Description

- [x] Add configurable forecast output post-processing through forecaster config fields:
  - `lower`: clip forecast values below this bound
  - `upper`: clip forecast values above this bound
  - `snap`: replace forecast values inside configured intervals with a target value
- [x] Interpret unitless post-processing values in the output sensor unit.
- [x] Keep existing `ensure-positive` behavior unchanged for backwards compatibility.
- [x] Apply post-processing after prediction and before storing forecasts.
- [x] Add tests for clipping, snapping, unit conversion, unitless values, schema loading, and schema defaults.
- [x] Update generated OpenAPI specs and forecasting documentation.
- [x] Add changelog entry.


## How to test

Automated tests:

```bash
uv run pytest flexmeasures/data/tests/test_forecasting_pipeline.py -k "forecast_post_processing" -q
uv run pytest flexmeasures/data/schemas/tests/test_forecasting.py -k "forecast_post_processing or snap_interval" -q
```

Manual test:

1. Create a forecaster config file, for example `/tmp/forecast-post-processing.yml`:

```yaml
lower: "0 kW"
snap:
  "0 kW": ["0 kW", "4 kW"]
upper: "20 kW"
```

2. Run a forecast for a `kW` sensor with enough historical data:

```bash
flexmeasures add forecasts \
  --sensor <SENSOR_ID> \
  --from-date "2025-01-09T00:00:00+00:00" \
  --to-date "2025-01-09T06:00:00+00:00" \
  --max-forecast-horizon "PT1H" \
  --forecast-frequency "PT1H" \
  --config /tmp/forecast-post-processing.yml
```

3. Verify the stored forecast values for that run:
   - values below `0 kW` are stored as `0 kW`
   - values above `20 kW` are stored as `20 kW`
   - values between `0 kW` and `4 kW` are stored as `0 kW`

Alternative unit-conversion check:

```yaml
lower: 0
upper: "20000 W"
```

Expected result: forecasts above `20 kW` are clipped to `20 kW`.

Unitless snap check:

If the output sensor unit is `kW`, this config:

```yaml
snap:
  "0": [0, 4]
```

is interpreted as:

```yaml
snap:
  "0 kW": ["0 kW", "4 kW"]
```

I manually tested this with a temporary `kW` sensor trained on constant `2.5 kW` values. The stored forecast values were:

```text
[0.0, 0.0, 0.0]
```

## Further Improvements

- Validation of unit compatibility and `lower <= upper` currently happens when post-processing runs. We may move this earlier into schema/parameter validation.
- Overlapping snap intervals are order-dependent; this PR documents and tests the main intended non-overlapping use case.

## Related Items

Closes #2270

## Sign-off

- [x] I agree to contribute this code under Apache 2 License.
- [x] To the best of my knowledge, I have the right to submit this work under this license.
