### PR TITLE
refactor(ui): drive flex-context field types from UI_FLEX_CONTEXT_SCHEMA

### DIFF
--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -658,66 +658,100 @@ UI_FLEX_CONTEXT_SCHEMA: Dict[str, Dict[str, Any]] = {
     "aggregate-consumption": {
         "default": None,
         "description": rst_to_openapi(metadata.AGGREGATE_CONSUMPTION.description),
-        # todo: the field type is defined in asset_context.html in 3 places?
-        # "types": {
-        #     "backend": "typeTwo",
-        #     "ui": "A sensor which records the scheduled aggregate consumption.",
-        # },
+        "types": {
+            "backend": "typeTwo",
+            "ui": "One dynamic signal (via a sensor) only.",
+        },
         "example-units": EXAMPLE_UNIT_TYPES["power"],
     },
     "aggregate-production": {
         "default": None,
         "description": rst_to_openapi(metadata.AGGREGATE_PRODUCTION.description),
-        # todo: the field type is defined in asset_context.html in 3 places?
-        # "types": {
-        #     "backend": "typeTwo",
-        #     "ui": "A sensor which records the scheduled aggregate production.",
-        # },
+        "types": {
+            "backend": "typeTwo",
+            "ui": "One dynamic signal (via a sensor) only.",
+        },
         "example-units": EXAMPLE_UNIT_TYPES["power"],
     },
     "consumption-price": {
         "default": None,  # Refers to default value of the field
         "description": rst_to_openapi(metadata.CONSUMPTION_PRICE.description),
+        "types": {
+            "backend": "typeTwo",
+            "ui": "One dynamic signal (via a sensor) only.",
+        },
         "example-units": EXAMPLE_UNIT_TYPES["energy-price"],
     },
     "production-price": {
         "default": None,
         "description": rst_to_openapi(metadata.PRODUCTION_PRICE.description),
+        "types": {
+            "backend": "typeTwo",
+            "ui": "One dynamic signal (via a sensor) only.",
+        },
         "example-units": EXAMPLE_UNIT_TYPES["energy-price"],
     },
     "site-power-capacity": {
         "default": None,
         "description": rst_to_openapi(metadata.SITE_POWER_CAPACITY.description),
+        "types": {
+            "backend": "typeThree",
+            "ui": "One fixed value or a dynamic signal (via a sensor).",
+        },
         "example-units": ["kVA", "MVA"] + EXAMPLE_UNIT_TYPES["power"],
     },
     "site-production-capacity": {
         "default": None,
         "description": rst_to_openapi(metadata.SITE_PRODUCTION_CAPACITY.description),
+        "types": {
+            "backend": "typeThree",
+            "ui": "One fixed value or a dynamic signal (via a sensor).",
+        },
         "example-units": EXAMPLE_UNIT_TYPES["power"],
     },
     "site-consumption-capacity": {
         "default": None,
         "description": rst_to_openapi(metadata.SITE_CONSUMPTION_CAPACITY.description),
+        "types": {
+            "backend": "typeThree",
+            "ui": "One fixed value or a dynamic signal (via a sensor).",
+        },
         "example-units": EXAMPLE_UNIT_TYPES["power"],
     },
     "soc-minima-breach-price": {
         "default": None,
         "description": rst_to_openapi(metadata.SOC_MINIMA_BREACH_PRICE.description),
+        "types": {
+            "backend": "typeThree",
+            "ui": "One fixed value or a dynamic signal (via a sensor).",
+        },
         "example-units": EXAMPLE_UNIT_TYPES["energy-price"],
     },
     "soc-maxima-breach-price": {
         "default": None,
         "description": rst_to_openapi(metadata.SOC_MAXIMA_BREACH_PRICE.description),
+        "types": {
+            "backend": "typeThree",
+            "ui": "One fixed value or a dynamic signal (via a sensor).",
+        },
         "example-units": EXAMPLE_UNIT_TYPES["energy-price"],
     },
     "consumption-breach-price": {
         "default": None,
         "description": rst_to_openapi(metadata.CONSUMPTION_BREACH_PRICE.description),
+        "types": {
+            "backend": "typeThree",
+            "ui": "One fixed value or a dynamic signal (via a sensor).",
+        },
         "example-units": EXAMPLE_UNIT_TYPES["power-price"],
     },
     "production-breach-price": {
         "default": None,
         "description": rst_to_openapi(metadata.PRODUCTION_BREACH_PRICE.description),
+        "types": {
+            "backend": "typeThree",
+            "ui": "One fixed value or a dynamic signal (via a sensor).",
+        },
         "example-units": EXAMPLE_UNIT_TYPES["power-price"],
     },
     "site-consumption-breach-price": {
@@ -725,6 +759,10 @@ UI_FLEX_CONTEXT_SCHEMA: Dict[str, Dict[str, Any]] = {
         "description": rst_to_openapi(
             metadata.SITE_CONSUMPTION_BREACH_PRICE.description
         ),
+        "types": {
+            "backend": "typeThree",
+            "ui": "One fixed value or a dynamic signal (via a sensor).",
+        },
         "example-units": EXAMPLE_UNIT_TYPES["power-price"],
     },
     "site-production-breach-price": {
@@ -732,41 +770,73 @@ UI_FLEX_CONTEXT_SCHEMA: Dict[str, Dict[str, Any]] = {
         "description": rst_to_openapi(
             metadata.SITE_PRODUCTION_BREACH_PRICE.description
         ),
+        "types": {
+            "backend": "typeThree",
+            "ui": "One fixed value or a dynamic signal (via a sensor).",
+        },
         "example-units": EXAMPLE_UNIT_TYPES["power-price"],
     },
     "site-peak-consumption": {
         "default": None,
         "description": rst_to_openapi(metadata.SITE_PEAK_CONSUMPTION.description),
+        "types": {
+            "backend": "typeThree",
+            "ui": "One fixed value or a dynamic signal (via a sensor).",
+        },
         "example-units": EXAMPLE_UNIT_TYPES["power"],
     },
     "site-peak-production": {
         "default": None,
         "description": rst_to_openapi(metadata.SITE_PEAK_PRODUCTION.description),
+        "types": {
+            "backend": "typeThree",
+            "ui": "One fixed value or a dynamic signal (via a sensor).",
+        },
         "example-units": EXAMPLE_UNIT_TYPES["power"],
     },
     "site-peak-consumption-price": {
         "default": None,
         "description": rst_to_openapi(metadata.SITE_PEAK_CONSUMPTION_PRICE.description),
+        "types": {
+            "backend": "typeThree",
+            "ui": "One fixed value or a dynamic signal (via a sensor).",
+        },
         "example-units": EXAMPLE_UNIT_TYPES["power-price"],
     },
     "site-peak-production-price": {
         "default": None,
         "description": rst_to_openapi(metadata.SITE_PEAK_PRODUCTION_PRICE.description),
+        "types": {
+            "backend": "typeThree",
+            "ui": "One fixed value or a dynamic signal (via a sensor).",
+        },
         "example-units": EXAMPLE_UNIT_TYPES["power-price"],
     },
     "inflexible-device-sensors": {
         "default": [],
         "description": rst_to_openapi(metadata.INFLEXIBLE_DEVICE_SENSORS.description),
+        "types": {
+            "backend": "typeFour",
+            "ui": "A list of sensors.",
+        },
         "example-units": EXAMPLE_UNIT_TYPES["power"],
     },
     "commitments": {
         "default": None,
         "description": rst_to_openapi(metadata.COMMITMENTS.description),
+        "types": {
+            "backend": "typeThree",
+            "ui": "One fixed value or a dynamic signal (via a sensor).",
+        },
         "example-units": EXAMPLE_UNIT_TYPES["power"],
     },
     "aggregate-power": {
         "default": None,
         "description": rst_to_openapi(metadata.AGGREGATE_POWER.description),
+        "types": {
+            "backend": "typeTwo",
+            "ui": "One dynamic signal (via a sensor) only.",
+        },
         "example-units": EXAMPLE_UNIT_TYPES["power"],
     },
 }

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -658,100 +658,56 @@ UI_FLEX_CONTEXT_SCHEMA: Dict[str, Dict[str, Any]] = {
     "aggregate-consumption": {
         "default": None,
         "description": rst_to_openapi(metadata.AGGREGATE_CONSUMPTION.description),
-        "types": {
-            "backend": "typeTwo",
-            "ui": "One dynamic signal (via a sensor) only.",
-        },
         "example-units": EXAMPLE_UNIT_TYPES["power"],
     },
     "aggregate-production": {
         "default": None,
         "description": rst_to_openapi(metadata.AGGREGATE_PRODUCTION.description),
-        "types": {
-            "backend": "typeTwo",
-            "ui": "One dynamic signal (via a sensor) only.",
-        },
         "example-units": EXAMPLE_UNIT_TYPES["power"],
     },
     "consumption-price": {
         "default": None,  # Refers to default value of the field
         "description": rst_to_openapi(metadata.CONSUMPTION_PRICE.description),
-        "types": {
-            "backend": "typeTwo",
-            "ui": "One dynamic signal (via a sensor) only.",
-        },
         "example-units": EXAMPLE_UNIT_TYPES["energy-price"],
     },
     "production-price": {
         "default": None,
         "description": rst_to_openapi(metadata.PRODUCTION_PRICE.description),
-        "types": {
-            "backend": "typeTwo",
-            "ui": "One dynamic signal (via a sensor) only.",
-        },
         "example-units": EXAMPLE_UNIT_TYPES["energy-price"],
     },
     "site-power-capacity": {
         "default": None,
         "description": rst_to_openapi(metadata.SITE_POWER_CAPACITY.description),
-        "types": {
-            "backend": "typeThree",
-            "ui": "One fixed value or a dynamic signal (via a sensor).",
-        },
         "example-units": ["kVA", "MVA"] + EXAMPLE_UNIT_TYPES["power"],
     },
     "site-production-capacity": {
         "default": None,
         "description": rst_to_openapi(metadata.SITE_PRODUCTION_CAPACITY.description),
-        "types": {
-            "backend": "typeThree",
-            "ui": "One fixed value or a dynamic signal (via a sensor).",
-        },
         "example-units": EXAMPLE_UNIT_TYPES["power"],
     },
     "site-consumption-capacity": {
         "default": None,
         "description": rst_to_openapi(metadata.SITE_CONSUMPTION_CAPACITY.description),
-        "types": {
-            "backend": "typeThree",
-            "ui": "One fixed value or a dynamic signal (via a sensor).",
-        },
         "example-units": EXAMPLE_UNIT_TYPES["power"],
     },
     "soc-minima-breach-price": {
         "default": None,
         "description": rst_to_openapi(metadata.SOC_MINIMA_BREACH_PRICE.description),
-        "types": {
-            "backend": "typeThree",
-            "ui": "One fixed value or a dynamic signal (via a sensor).",
-        },
         "example-units": EXAMPLE_UNIT_TYPES["energy-price"],
     },
     "soc-maxima-breach-price": {
         "default": None,
         "description": rst_to_openapi(metadata.SOC_MAXIMA_BREACH_PRICE.description),
-        "types": {
-            "backend": "typeThree",
-            "ui": "One fixed value or a dynamic signal (via a sensor).",
-        },
         "example-units": EXAMPLE_UNIT_TYPES["energy-price"],
     },
     "consumption-breach-price": {
         "default": None,
         "description": rst_to_openapi(metadata.CONSUMPTION_BREACH_PRICE.description),
-        "types": {
-            "backend": "typeThree",
-            "ui": "One fixed value or a dynamic signal (via a sensor).",
-        },
         "example-units": EXAMPLE_UNIT_TYPES["power-price"],
     },
     "production-breach-price": {
         "default": None,
         "description": rst_to_openapi(metadata.PRODUCTION_BREACH_PRICE.description),
-        "types": {
-            "backend": "typeThree",
-            "ui": "One fixed value or a dynamic signal (via a sensor).",
-        },
         "example-units": EXAMPLE_UNIT_TYPES["power-price"],
     },
     "site-consumption-breach-price": {
@@ -759,10 +715,6 @@ UI_FLEX_CONTEXT_SCHEMA: Dict[str, Dict[str, Any]] = {
         "description": rst_to_openapi(
             metadata.SITE_CONSUMPTION_BREACH_PRICE.description
         ),
-        "types": {
-            "backend": "typeThree",
-            "ui": "One fixed value or a dynamic signal (via a sensor).",
-        },
         "example-units": EXAMPLE_UNIT_TYPES["power-price"],
     },
     "site-production-breach-price": {
@@ -770,73 +722,41 @@ UI_FLEX_CONTEXT_SCHEMA: Dict[str, Dict[str, Any]] = {
         "description": rst_to_openapi(
             metadata.SITE_PRODUCTION_BREACH_PRICE.description
         ),
-        "types": {
-            "backend": "typeThree",
-            "ui": "One fixed value or a dynamic signal (via a sensor).",
-        },
         "example-units": EXAMPLE_UNIT_TYPES["power-price"],
     },
     "site-peak-consumption": {
         "default": None,
         "description": rst_to_openapi(metadata.SITE_PEAK_CONSUMPTION.description),
-        "types": {
-            "backend": "typeThree",
-            "ui": "One fixed value or a dynamic signal (via a sensor).",
-        },
         "example-units": EXAMPLE_UNIT_TYPES["power"],
     },
     "site-peak-production": {
         "default": None,
         "description": rst_to_openapi(metadata.SITE_PEAK_PRODUCTION.description),
-        "types": {
-            "backend": "typeThree",
-            "ui": "One fixed value or a dynamic signal (via a sensor).",
-        },
         "example-units": EXAMPLE_UNIT_TYPES["power"],
     },
     "site-peak-consumption-price": {
         "default": None,
         "description": rst_to_openapi(metadata.SITE_PEAK_CONSUMPTION_PRICE.description),
-        "types": {
-            "backend": "typeThree",
-            "ui": "One fixed value or a dynamic signal (via a sensor).",
-        },
         "example-units": EXAMPLE_UNIT_TYPES["power-price"],
     },
     "site-peak-production-price": {
         "default": None,
         "description": rst_to_openapi(metadata.SITE_PEAK_PRODUCTION_PRICE.description),
-        "types": {
-            "backend": "typeThree",
-            "ui": "One fixed value or a dynamic signal (via a sensor).",
-        },
         "example-units": EXAMPLE_UNIT_TYPES["power-price"],
     },
     "inflexible-device-sensors": {
         "default": [],
         "description": rst_to_openapi(metadata.INFLEXIBLE_DEVICE_SENSORS.description),
-        "types": {
-            "backend": "typeFour",
-            "ui": "A list of sensors.",
-        },
         "example-units": EXAMPLE_UNIT_TYPES["power"],
     },
     "commitments": {
         "default": None,
         "description": rst_to_openapi(metadata.COMMITMENTS.description),
-        "types": {
-            "backend": "typeThree",
-            "ui": "One fixed value or a dynamic signal (via a sensor).",
-        },
         "example-units": EXAMPLE_UNIT_TYPES["power"],
     },
     "aggregate-power": {
         "default": None,
         "description": rst_to_openapi(metadata.AGGREGATE_POWER.description),
-        "types": {
-            "backend": "typeTwo",
-            "ui": "One dynamic signal (via a sensor) only.",
-        },
         "example-units": EXAMPLE_UNIT_TYPES["power"],
     },
 }
@@ -1132,6 +1052,55 @@ class DBFlexContextSchema(FlexContextSchema, NoTimeSeriesSpecs):
                 "Fixed prices are not currently supported for production-price in flex-context fields in the DB.",
                 field_name="production-price",
             )
+
+
+# One UI description per backend type token (same tokens as UI_FLEX_MODEL_SCHEMA uses).
+UI_TYPE_DESCRIPTIONS: Dict[str, str] = {
+    "typeOne": "One fixed value only.",
+    "typeTwo": "One dynamic signal (via a sensor) only.",
+    "typeThree": "One fixed value or a dynamic signal (via a sensor).",
+    "typeFour": "A list of sensors.",
+    "typeFive": "One fixed string value only.",
+    "typeSix": "A list of structured entries.",
+}
+
+
+def _derive_backend_type(schema_field: fields.Field) -> str:
+    """Derive the UI editor's backend type token from a marshmallow field."""
+    if isinstance(schema_field, fields.Bool):
+        return "typeOne"
+    if isinstance(schema_field, fields.List):
+        return "typeFour"
+    if isinstance(schema_field, fields.Nested):
+        return "typeSix" if schema_field.many else "typeTwo"
+    if isinstance(schema_field, VariableQuantityField):
+        return "typeThree"
+    if isinstance(schema_field, fields.Str):
+        return "typeFive"
+    raise NotImplementedError(
+        f"Cannot derive a UI type for field {schema_field.data_key}."
+    )
+
+
+# Fill in the "types" of each UI flex-context schema entry by deriving them
+# from the corresponding DBFlexContextSchema field, so the UI editor stays in
+# sync with what the DB schema actually accepts.
+_db_flex_context_fields: Dict[str, fields.Field] = {
+    schema_field.data_key or field_name: schema_field
+    for field_name, schema_field in DBFlexContextSchema().fields.items()
+}
+for _field_name, _entry in UI_FLEX_CONTEXT_SCHEMA.items():
+    _backend_type = _derive_backend_type(_db_flex_context_fields[_field_name])
+    if _field_name in ("consumption-price", "production-price", "aggregate-power"):
+        # Fixed prices are forbidden when storing the flex-context in the DB
+        # (see DBFlexContextSchema._forbid_fixed_prices), and aggregate-power
+        # must reference a sensor (see validate_aggregate_power_is_sensor),
+        # so the editor only offers a sensor for these fields.
+        _backend_type = "typeTwo"
+    _entry["types"] = {
+        "backend": _backend_type,
+        "ui": UI_TYPE_DESCRIPTIONS[_backend_type],
+    }
 
 
 class MultiSensorFlexModelSchema(Schema):

--- a/flexmeasures/ui/templates/assets/asset_context.html
+++ b/flexmeasures/ui/templates/assets/asset_context.html
@@ -335,6 +335,13 @@
     for (const [key, value] of Object.entries(schemaSpecs)) {
         assetFlexContextSchema[key] = value["default"];
     }
+
+    // Sensor-only fields offer no "Fixed value" tab in the editor.
+    // typeTwo = a single sensor reference, typeFour = a list of sensors.
+    function isSensorOnlyField(fieldName) {
+        const backendType = schemaSpecs[fieldName]?.["types"]?.["backend"];
+        return backendType === "typeTwo" || backendType === "typeFour";
+    }
     const [assetFlexContextRawJSON, extraFields] = processResourceRawJSON({ ...assetFlexContextSchema }, "{{ asset.flex_context | safe }}", true);
 
     const spinnerElement = document.getElementById('spinnerElement');
@@ -380,9 +387,8 @@
 
         setTimeout(() => {
             const card = document.getElementById(`${fieldName}-control`);
-            const isOnlySensorField = (fieldName === "inflexible-device-sensors" || fieldName === "consumption-price" || fieldName === "production-price" || fieldName === "aggregate-power" || fieldName === "aggregate-consumption" || fieldName === "aggregate-production");
             card.classList.add('border-on-click'); // Add border to the clicked card
-            flexOptionsContainer.appendChild(renderFlexInputOptions(fieldName, isOnlySensorField));
+            flexOptionsContainer.appendChild(renderFlexInputOptions(fieldName, isSensorOnlyField(fieldName)));
             handleFlexSelectChange(fieldName);
             setActiveCard(card);
 
@@ -608,8 +614,7 @@
             document.querySelectorAll(".card-highlight").forEach(el => el.classList.remove("border-on-click")); // Remove border from all cards
             card.classList.add("border-on-click"); // Add border to the clicked card
             handleFlexSelectChange(fieldName);
-            const isOnlySensorField = (fieldName === "inflexible-device-sensors" || fieldName === "consumption-price" || fieldName === "production-price" || fieldName === "aggregate-power" || fieldName === "aggregate-consumption" || fieldName === "aggregate-production");
-            flexOptionsContainer.appendChild(renderFlexInputOptions(fieldName, (isOnlySensorField)));
+            flexOptionsContainer.appendChild(renderFlexInputOptions(fieldName, isSensorOnlyField(fieldName)));
             setActiveCard(card);
             // Store active card in local storage
             localStorage.setItem('activeCard', fieldName);
@@ -720,10 +725,9 @@
         if (storedActiveCard && activeCard()) {
             const flexId = (activeCard() ? activeCard().id : null).slice(0, -8);
             if (assetFlexContext[storedActiveCard]) {
-                const isOnlySensorField = (flexId === "inflexible-device-sensors" || flexId === "consumption-price" || flexId === "production-price" || flexId === "aggregate-power" || flexId === "aggregate-consumption" || flexId === "aggregate-production");
                 setTimeout(() => {
                     flexOptionsContainer.innerHTML = "";
-                    flexOptionsContainer.appendChild(renderFlexInputOptions(flexId, isOnlySensorField));
+                    flexOptionsContainer.appendChild(renderFlexInputOptions(flexId, isSensorOnlyField(flexId)));
                     handleFlexSelectChange(flexId);
                     activeCard().classList.add('border-on-click'); // Add border to the clicked card
                     const renderedActiveCard = document.getElementById(`${flexId}-control`);


### PR DESCRIPTION
## Description

Groundwork for #2230 and #1572 (both add structured fields to the flex-context editor).

- [x] Add a `types` key to every `UI_FLEX_CONTEXT_SCHEMA` entry, following the `UI_FLEX_MODEL_SCHEMA` convention (`typeTwo` = single sensor reference, `typeThree` = fixed value or sensor, `typeFour` = list of sensors). This resolves the todo about the field type being hardcoded in `asset_context.html` in 3 places.
- [x] `asset_context.html` now derives its sensor-only check from the schema (`isSensorOnlyField`), replacing the three duplicated hardcoded field-name lists. Adding a context field to the UI now only requires a schema entry.
- [x] Changelog: none — no behaviour change.

## How to test

```
pytest flexmeasures/ui/tests flexmeasures/data/schemas
```

Manually: the asset context page renders and edits exactly as before (sensor-only tabs for prices/aggregates/inflexible sensors, fixed-or-sensor tabs elsewhere).

## Related Items

Prepares #2230 and #1572.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016MLCUiSdXDqDBmg8GbYp1B