### PR TITLE
Stamp LatestTaskRun at insertion time, not at import time (follow-up to #2303)

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -44,6 +44,7 @@ Bugfixes
 * Show why a CLI option was rejected (e.g. "No account found with id 9999") instead of only echoing the offending value [see `PR #2303 <https://www.github.com/FlexMeasures/flexmeasures/pull/2303>`_]
 * Fix the task detail page returning a 500 for jobs whose meta data is not JSON-serializable [see `PR #2303 <https://www.github.com/FlexMeasures/flexmeasures/pull/2303>`_]
 * Roll back before retrying the query behind ``[GET] /api/ops/getLatestTaskRun``, which otherwise reports an aborted transaction instead of the original database error [see `PR #2303 <https://www.github.com/FlexMeasures/flexmeasures/pull/2303>`_]
+* Stamp a ``LatestTaskRun`` with the time it is recorded, rather than with the time the FlexMeasures process started [see `PR #2304 <https://www.github.com/FlexMeasures/flexmeasures/pull/2304>`_]
 * Let storage scheduling treat missing constant SoC bounds as unconstrained lower or upper bounds [see `PR #2221 <https://www.github.com/FlexMeasures/flexmeasures/pull/2221>`_]
 * Allow root assets belonging to different accounts to share the same name, while keeping asset names unique among root assets within the same account and among children of the same parent [see `PR #2226 <https://www.github.com/FlexMeasures/flexmeasures/pull/2226>`_]
 * Fix queued train-predict forecasting jobs losing their resolved forecast window or failing on detached database objects in workers [see `PR #2035 <https://www.github.com/FlexMeasures/flexmeasures/pull/2035>`_]

--- a/flexmeasures/data/models/task_runs.py
+++ b/flexmeasures/data/models/task_runs.py
@@ -13,7 +13,12 @@ class LatestTaskRun(db.Model):
     """
 
     name = db.Column(db.String(80), primary_key=True)
-    datetime = db.Column(db.DateTime(timezone=True), default=datetime.now(timezone.utc))
+    # NB pass a callable, so the default is the time of insertion.
+    # (Calling datetime.now() here would evaluate it once, at import time, stamping
+    # every task run with the time the process started.)
+    datetime = db.Column(
+        db.DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
     status = db.Column(db.Boolean, default=True)
 
     def __repr__(self):


### PR DESCRIPTION
## Description

Follow-up to #2303, which was merged ~22 minutes before its final commit landed — so this one fix (of the nine) never reached `main`.

```python
# flexmeasures/data/models/task_runs.py  (current main)
datetime = db.Column(db.DateTime(timezone=True), default=datetime.now(timezone.utc))
```

`datetime.now(timezone.utc)` is **called once, when the module is imported**, so its *value* becomes the column default for the entire process lifetime. Every `LatestTaskRun` inserted without an explicit timestamp is therefore stamped with **the time the FlexMeasures process started** — the wrong answer for a table whose only purpose is to record when a task last ran.

Fixed by passing a callable, so the default is evaluated per insertion.

## Impact

Latent rather than active: both production call sites (`LatestTaskRun.record_run()` and the `postLatestTaskRun` endpoint) assign `.datetime` immediately after constructing the row, so the stale default is overwritten in practice. But any other code — a plugin, or a future call site — that creates a `LatestTaskRun` without setting the timestamp silently gets process-start time, and `flexmeasures monitor latest-run` would then judge staleness against the wrong instant.

It also leaves a test failing on `main` right now:

```
$ pytest flexmeasures/data/tests/ flexmeasures/api/tests/test_task_runs.py
FAILED flexmeasures/api/tests/test_task_runs.py::test_api_task_run_get_recent_entry
1 failed, 187 passed
```

The test asserts the recorded run is less than 2 minutes old. Because the default is fixed at import time, the assertion drifts out of range once the test session has been running longer than that — which is why it passes in an `api/`-only run and fails once `data/tests/` (≈3 minutes) runs first. With this fix:

```
188 passed
```

Refs #2302

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rbix8k1JfeUWNXEmHEZVpX