### PR TITLE
Guard the shared checkout: block branch-switching git commands outside a worktree

### DIFF
--- a/.claude/hooks/worktree-guard.sh
+++ b/.claude/hooks/worktree-guard.sh
@@ -2,9 +2,18 @@
 # Blocking PreToolUse hook: the primary checkout is shared by multiple Claude
 # Code agents. Branch-mutating git commands (checkout/switch/merge/rebase/
 # reset/cherry-pick/stash) run there can switch the branch or rewrite history
-# out from under another agent. This hook blocks those commands unless we're
-# in a linked `git worktree` (or the command targets a directory outside the
-# project via `cd`), where mutating the branch only affects that worktree.
+# out from under another agent, and `git stash` silently pockets other agents'
+# uncommitted work. This hook blocks those commands when they target the
+# primary checkout, and allows them when they target a linked `git worktree`,
+# where mutating branch state only affects that worktree.
+#
+# Precision caveat: a PreToolUse hook does NOT run in the Bash tool's
+# persistent working directory — it runs in the project dir. So this guard is
+# "cwd + -C/--git-dir aware, not shell-state aware": if an agent ran
+# `cd <worktree>` in an earlier Bash call and then runs a bare `git switch`,
+# we evaluate against the primary checkout and block it. That is the safe
+# direction to fail (annoying, not dangerous) — use `git -C <worktree> ...`,
+# or `cd <worktree> && git ...` in the same command, to be recognised.
 #
 # Exit 2 = blocking error (Claude sees stderr and can course-correct).
 # Exit 0 = allow. Fails open (exit 0) on any parsing problem — never break
@@ -21,42 +30,98 @@ command="$(echo "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null ||
 
 # Self-filter: only act on git commands that could mutate branch/worktree
 # state. The settings-level "if" matcher is not honoured by all Claude Code
-# versions, so replicate the filter here.
-echo "$command" | grep -qE '(^|[;&|]|\bgit[[:space:]]+.*&&[[:space:]]*)git[[:space:]]+(checkout|switch|merge|rebase|reset|cherry-pick|stash)\b' || exit 0
+# versions, so replicate the filter here. Global options such as `-C <path>`,
+# `--git-dir=<path>` or `-c foo=bar` may sit between `git` and the verb, so
+# allow a run of option words (each optionally followed by its value) first.
+verb_re='\bgit[[:space:]]+(-[^[:space:]]*([[:space:]]+[^-[:space:];&|][^[:space:]]*)?[[:space:]]+)*(checkout|switch|merge|rebase|reset|cherry-pick|stash)\b'
+echo "$command" | grep -qE "$verb_re" || exit 0
 
 # `git checkout -- <path>` / `git checkout <ref> -- <path>` only restore
 # files from the index/a ref; they never move HEAD or the branch pointer.
 # Allow those explicitly even though they match the "checkout" verb above.
-if echo "$command" | grep -qE '\bgit[[:space:]]+checkout\b' && echo "$command" | grep -qE '\bgit[[:space:]]+checkout\b[^;&|]*--[[:space:]]'; then
+if echo "$command" | grep -qE '\bcheckout\b[^;&|]*[[:space:]]--[[:space:]]'; then
   exit 0
 fi
 
 project_dir="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
-# Allow if the command explicitly `cd`s outside the project dir first — same
-# idea as the existing pre-commit-check.sh "target" logic: a `cd` elsewhere
-# means the git command isn't acting on this shared checkout.
-if echo "$command" | grep -qE '(^|[;&|])[[:space:]]*cd[[:space:]]+'; then
+# Work out which directory the git command actually targets, in priority
+# order: an explicit `-C <path>` / `--git-dir=<path>` on the git invocation
+# (the idiomatic way to drive another worktree without cd-ing), else a `cd`
+# earlier in the same command (same idea as pre-commit-check.sh's target
+# check), else the directory this hook runs in.
+target=""
+if echo "$command" | grep -qE '[[:space:]]-C[[:space:]]'; then
+  target="$(echo "$command" | grep -oE '[[:space:]]-C[[:space:]]+[^[:space:];&|]+' | head -n1 | sed -E 's/^[[:space:]]*-C[[:space:]]+//')"
+elif echo "$command" | grep -qE '\-\-git-dir[=[:space:]]'; then
+  target="$(echo "$command" | grep -oE '\-\-git-dir[=[:space:]][^[:space:];&|]+' | head -n1 | sed -E 's/^--git-dir[=[:space:]]//')"
+elif echo "$command" | grep -qE '(^|[;&|])[[:space:]]*cd[[:space:]]+'; then
   target="$(echo "$command" | grep -oE '(^|[;&|])[[:space:]]*cd[[:space:]]+[^;&|]+' | tail -n1 | sed -E 's/^[;&|]?[[:space:]]*cd[[:space:]]+//')"
-  target="$(eval echo "$target" 2>/dev/null || echo "$target")"
+fi
+
+# Strip surrounding quotes/whitespace and expand ~ where we safely can. Do the
+# expansion in a subshell with `set +u` so an unbound variable can't abort us.
+target="$(echo "$target" | sed -E "s/^[[:space:]]*['\"]?//; s/['\"]?[[:space:]]*$//")"
+if [ -n "$target" ]; then
   case "$target" in
-    "$project_dir"|"$project_dir"/*) : ;;
-    /*)
-      exit 0
+    *['$~']*)
+      # The path needs shell expansion. Only `~` is safe to expand here: a
+      # variable like `-C "$WT"` was set in an earlier Bash call, whose state
+      # this hook cannot see, so we cannot tell which checkout it points at.
+      expanded="$(set +u; eval "echo $target" 2>/dev/null || true)"
+      if [ -n "$expanded" ] && [ -d "$expanded" ]; then
+        target="$expanded"
+      else
+        # Block rather than guess — the safe direction, same as a bare
+        # `git switch` whose cwd we cannot see.
+        unresolved="$target"
+        target="$project_dir"
+      fi
       ;;
   esac
 fi
 
-# Only guard when running inside a git repo at all.
-git_dir="$(git rev-parse --git-dir 2>/dev/null || true)"
-[ -n "$git_dir" ] || exit 0
+if [ -n "$target" ]; then
+  # An absolute target outside the project dir entirely isn't our business.
+  case "$target" in
+    "$project_dir"|"$project_dir"/*) : ;;
+    /*) exit 0 ;;
+  esac
+else
+  target="$(pwd)"
+fi
 
-common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
-[ -n "$common_dir" ] || exit 0
+[ -d "$target" ] || exit 0
 
-# Normalize to absolute paths for a reliable comparison.
-git_dir_abs="$(cd "$(dirname "$git_dir")" 2>/dev/null && pwd)/$(basename "$git_dir")" || git_dir_abs="$git_dir"
-common_dir_abs="$(cd "$(dirname "$common_dir")" 2>/dev/null && pwd)/$(basename "$common_dir")" || common_dir_abs="$common_dir"
+if [ -n "${unresolved:-}" ]; then
+  cat >&2 <<EOF
+Blocked: cannot verify where this git command points. Its target path
+($unresolved) uses a shell variable this hook cannot see — a PreToolUse hook
+does not share your shell's state, so it may well be the shared primary
+checkout, where branch switching/merging clobbers other agents' sessions.
+
+Re-run it with a literal path, which this hook can check:
+  git -C /absolute/path/to/worktree <verb> ...
+EOF
+  exit 2
+fi
+
+# Only guard when the target is inside a git repo at all.
+git_dir="$(git -C "$target" rev-parse --git-dir 2>/dev/null || true)"
+common_dir="$(git -C "$target" rev-parse --git-common-dir 2>/dev/null || true)"
+{ [ -n "$git_dir" ] && [ -n "$common_dir" ]; } || exit 0
+
+# Normalize to absolute paths (git may return them relative to the target).
+abspath() {
+  local p="$1"
+  case "$p" in
+    /*) : ;;
+    *) p="$target/$p" ;;
+  esac
+  (cd "$(dirname "$p")" 2>/dev/null && echo "$(pwd)/$(basename "$p")") || echo "$p"
+}
+git_dir_abs="$(abspath "$git_dir")"
+common_dir_abs="$(abspath "$common_dir")"
 
 # In a linked worktree, --git-dir (.../.git/worktrees/<name>) differs from
 # --git-common-dir (.../.git). In the primary checkout they're the same.
@@ -66,18 +131,28 @@ if [ "$git_dir_abs" != "$common_dir_abs" ]; then
 fi
 
 cat >&2 <<'EOF'
-Blocked: this is the shared primary checkout — other agents may be working
-here right now. Do not switch branches, merge, rebase, reset, cherry-pick,
-or stash in it; doing so can yank the branch out from under another agent's
-session and litter the tree with leftovers.
+Blocked: this git command targets the shared primary checkout — other agents
+may be working there right now. Do not switch branches, merge, rebase, reset
+or cherry-pick in it: that yanks the branch out from under another agent's
+session and litters the tree with leftovers. `git stash` is blocked for the
+same reason — in a shared checkout it silently pockets *other agents'*
+uncommitted work.
 
 Create your own worktree and work there instead, e.g.:
   git worktree add --detach <scratchpad>/<name> <ref>
   # or, for a new branch:
   git worktree add -b <branch> <dir> <base>
 
-Then cd into that worktree and retry. Read-only git commands (status, log,
-diff, show, fetch, worktree, rev-parse, branch listing, etc.) and file-only
-`git checkout -- <path>` restores are fine to run here.
+Then target it explicitly — both of these forms are recognised:
+  git -C <worktree> switch <branch>
+  cd <worktree> && git merge main
+
+Note: this hook cannot see your shell's persistent working directory, so a
+bare `git switch` is always judged against the primary checkout even if you
+cd'd into a worktree in an earlier call. Use `git -C <worktree> ...`.
+
+Read-only git commands (status, log, diff, show, fetch, worktree, rev-parse,
+branch listing, etc.) and file-only `git checkout -- <path>` restores are
+fine to run here.
 EOF
 exit 2

--- a/.claude/hooks/worktree-guard.sh
+++ b/.claude/hooks/worktree-guard.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Blocking PreToolUse hook: the primary checkout is shared by multiple Claude
+# Code agents. Branch-mutating git commands (checkout/switch/merge/rebase/
+# reset/cherry-pick/stash) run there can switch the branch or rewrite history
+# out from under another agent. This hook blocks those commands unless we're
+# in a linked `git worktree` (or the command targets a directory outside the
+# project via `cd`), where mutating the branch only affects that worktree.
+#
+# Exit 2 = blocking error (Claude sees stderr and can course-correct).
+# Exit 0 = allow. Fails open (exit 0) on any parsing problem — never break
+# the user's shell over a malformed hook payload or a missing `jq`.
+
+set -euo pipefail
+
+payload="$(cat)"
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+command="$(echo "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
+[ -n "$command" ] || exit 0
+
+# Self-filter: only act on git commands that could mutate branch/worktree
+# state. The settings-level "if" matcher is not honoured by all Claude Code
+# versions, so replicate the filter here.
+echo "$command" | grep -qE '(^|[;&|]|\bgit[[:space:]]+.*&&[[:space:]]*)git[[:space:]]+(checkout|switch|merge|rebase|reset|cherry-pick|stash)\b' || exit 0
+
+# `git checkout -- <path>` / `git checkout <ref> -- <path>` only restore
+# files from the index/a ref; they never move HEAD or the branch pointer.
+# Allow those explicitly even though they match the "checkout" verb above.
+if echo "$command" | grep -qE '\bgit[[:space:]]+checkout\b' && echo "$command" | grep -qE '\bgit[[:space:]]+checkout\b[^;&|]*--[[:space:]]'; then
+  exit 0
+fi
+
+project_dir="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# Allow if the command explicitly `cd`s outside the project dir first — same
+# idea as the existing pre-commit-check.sh "target" logic: a `cd` elsewhere
+# means the git command isn't acting on this shared checkout.
+if echo "$command" | grep -qE '(^|[;&|])[[:space:]]*cd[[:space:]]+'; then
+  target="$(echo "$command" | grep -oE '(^|[;&|])[[:space:]]*cd[[:space:]]+[^;&|]+' | tail -n1 | sed -E 's/^[;&|]?[[:space:]]*cd[[:space:]]+//')"
+  target="$(eval echo "$target" 2>/dev/null || echo "$target")"
+  case "$target" in
+    "$project_dir"|"$project_dir"/*) : ;;
+    /*)
+      exit 0
+      ;;
+  esac
+fi
+
+# Only guard when running inside a git repo at all.
+git_dir="$(git rev-parse --git-dir 2>/dev/null || true)"
+[ -n "$git_dir" ] || exit 0
+
+common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+[ -n "$common_dir" ] || exit 0
+
+# Normalize to absolute paths for a reliable comparison.
+git_dir_abs="$(cd "$(dirname "$git_dir")" 2>/dev/null && pwd)/$(basename "$git_dir")" || git_dir_abs="$git_dir"
+common_dir_abs="$(cd "$(dirname "$common_dir")" 2>/dev/null && pwd)/$(basename "$common_dir")" || common_dir_abs="$common_dir"
+
+# In a linked worktree, --git-dir (.../.git/worktrees/<name>) differs from
+# --git-common-dir (.../.git). In the primary checkout they're the same.
+# Mutating git state is safe in a linked worktree, so allow it there.
+if [ "$git_dir_abs" != "$common_dir_abs" ]; then
+  exit 0
+fi
+
+cat >&2 <<'EOF'
+Blocked: this is the shared primary checkout — other agents may be working
+here right now. Do not switch branches, merge, rebase, reset, cherry-pick,
+or stash in it; doing so can yank the branch out from under another agent's
+session and litter the tree with leftovers.
+
+Create your own worktree and work there instead, e.g.:
+  git worktree add --detach <scratchpad>/<name> <ref>
+  # or, for a new branch:
+  git worktree add -b <branch> <dir> <base>
+
+Then cd into that worktree and retry. Read-only git commands (status, log,
+diff, show, fetch, worktree, rev-parse, branch listing, etc.) and file-only
+`git checkout -- <path>` restores are fine to run here.
+EOF
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -45,6 +45,12 @@
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/test-reminder.sh\"",
             "if": "Bash(git push:*)",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/worktree-guard.sh\"",
+            "if": "Bash(git:*)",
+            "timeout": 10
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,11 @@ repeatable lesson was learned — not after every session. When you do update on
   `.github/instructions/ui-terminology.instructions.md`.
 - **Docstrings/comments**: exactly one space after punctuation — see
   `.github/instructions/docstrings.instructions.md`.
+- **The primary checkout is shared** by multiple agent sessions. Never `git checkout`/`switch`/
+  `merge`/`rebase`/`reset`/`cherry-pick`/`stash` there — it can switch the branch or rewrite
+  history out from under another agent. Do your work in your own `git worktree` instead
+  (`git worktree add --detach <scratchpad>/<name> <ref>`). Read-only git commands are fine in the
+  primary checkout. A `PreToolUse` hook (`.claude/hooks/worktree-guard.sh`) enforces this.
 
 ## Session close checklist
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,9 +110,12 @@ repeatable lesson was learned — not after every session. When you do update on
   `.github/instructions/docstrings.instructions.md`.
 - **The primary checkout is shared** by multiple agent sessions. Never `git checkout`/`switch`/
   `merge`/`rebase`/`reset`/`cherry-pick`/`stash` there — it can switch the branch or rewrite
-  history out from under another agent. Do your work in your own `git worktree` instead
-  (`git worktree add --detach <scratchpad>/<name> <ref>`). Read-only git commands are fine in the
-  primary checkout. A `PreToolUse` hook (`.claude/hooks/worktree-guard.sh`) enforces this.
+  history out from under another agent, and `stash` pockets their uncommitted work. Do your work
+  in your own `git worktree` instead (`git worktree add --detach <scratchpad>/<name> <ref>`), and
+  target it with a **literal path**: `git -C /abs/path/to/worktree switch <branch>`. Read-only git
+  commands are fine in the primary checkout. A `PreToolUse` hook
+  (`.claude/hooks/worktree-guard.sh`) enforces this; it can't see your shell's cwd or variables,
+  so a bare `git switch` after an earlier `cd`, or a `-C "$VAR"`, is blocked on the safe side.
 
 ## Session close checklist
 

--- a/flexmeasures/api/v3_0/jobs.py
+++ b/flexmeasures/api/v3_0/jobs.py
@@ -141,9 +141,9 @@ class JobAPI(FlaskView):
                           constraint analysis (empty arrays when the flex model
                           defines no ``soc-minima``/``soc-maxima``, or when a
                           scheduler other than ``StorageScheduler`` was used).
-                         The ``num-beliefs`` field holds the total number of
-                         beliefs (scheduled values) saved to the database.
-                       nullable: true
+                          The ``num-beliefs`` field holds the total number of
+                          beliefs (scheduled values) saved to the database.
+                        nullable: true
                       func_name:
                         type: string
                         description: Fully-qualified name of the function executed by this job.

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -7,7 +7,7 @@
     },
     "termsOfService": null,
     "title": "FlexMeasures",
-    "version": "0.33.2"
+    "version": "1.0.0"
   },
   "externalDocs": {
     "description": "FlexMeasures runs on the open source FlexMeasures technology. Read the docs here.",
@@ -4270,7 +4270,7 @@
     "/api/v3_0/jobs/{uuid}": {
       "get": {
         "summary": "Get the status of a background job",
-        "description": "Look up a background job by its UUID and see whether it is\nqueued, running, finished, or failed.\n\nThe response includes a status message plus job metadata such\nas the queue name, function name, timestamps, and the job\nresult when available.\n\nFailed jobs also include traceback information when the worker\nstored it with the job result.\n\nFor a finished scheduling job, <code>result</code> is an object. For a\n<code>StorageScheduler</code> job it holds soft state-of-charge constraint\nanalysis: <code>unresolved</code> lists constraints the scheduler could not\nsatisfy, and <code>resolved</code> lists constraints that were satisfied\nwith some margin. Each device entry's <code>soc-minima</code>/<code>soc-maxima</code>\nvalue is a list, holding one entry per violated slot (for\n<code>unresolved</code>) or per met slot with its margin (for <code>resolved</code>),\nordered chronologically. Both arrays are empty when the flex model\ndefines no <code>soc-minima</code>/<code>soc-maxima</code>, or when a scheduler other\nthan <code>StorageScheduler</code> was used. This is the only place\nconstraint analysis is available \u2014 the sensor schedule endpoint\n(<code>GET /api/v3_0/sensors/<id>/schedules/<uuid></code>) returns power\nvalues only.\n",
+        "description": "Look up a background job by its UUID and see whether it is\nqueued, running, finished, or failed.\n\nThe response includes a status message plus job metadata such\nas the queue name, function name, timestamps, and the job\nresult when available.\n\nFailed jobs also include traceback information when the worker\nstored it with the job result.\n\nFor a finished scheduling job, <code>result</code> is an object. For a\n<code>StorageScheduler</code> job it holds soft state-of-charge constraint\nanalysis: <code>unresolved</code> lists constraints the scheduler could not\nsatisfy, and <code>resolved</code> lists constraints that were satisfied\nwith some margin. Each device entry's <code>soc-minima</code>/<code>soc-maxima</code>\nvalue is a list, holding one entry per violated slot (for\n<code>unresolved</code>) or per met slot with its margin (for <code>resolved</code>),\nordered chronologically. Both arrays are empty when the flex model\ndefines no <code>soc-minima</code>/<code>soc-maxima</code>, or when a scheduler other\nthan <code>StorageScheduler</code> was used. The <code>num-beliefs</code> field holds\nthe total number of beliefs (scheduled values) saved to the database.\nThis is the only place constraint analysis is available \u2014 the sensor\nschedule endpoint (<code>GET /api/v3_0/sensors/<id>/schedules/<uuid></code>)\nreturns power values only.\n",
         "security": [
           {
             "ApiKeyAuth": []
@@ -4315,7 +4315,7 @@
                       "description": "Human-readable description of the job status."
                     },
                     "result": {
-                      "description": "Return value of the job function, or null when not yet available. For a finished scheduling job, this is an object; a <code>StorageScheduler</code> job populates it with <code>unresolved</code>/<code>resolved</code> soft state-of-charge constraint analysis (empty arrays when the flex model defines no <code>soc-minima</code>/<code>soc-maxima</code>, or when a scheduler other than <code>StorageScheduler</code> was used).\n",
+                      "description": "Return value of the job function, or null when not yet available. For a finished scheduling job, this is an object; a <code>StorageScheduler</code> job populates it with <code>unresolved</code>/<code>resolved</code> soft state-of-charge constraint analysis (empty arrays when the flex model defines no <code>soc-minima</code>/<code>soc-maxima</code>, or when a scheduler other than <code>StorageScheduler</code> was used). The <code>num-beliefs</code> field holds the total number of beliefs (scheduled values) saved to the database.\n",
                       "nullable": true
                     },
                     "func_name": {
@@ -4387,7 +4387,8 @@
                             ]
                           }
                         ],
-                        "resolved": []
+                        "resolved": [],
+                        "num-beliefs": 96
                       },
                       "func_name": "flexmeasures.data.services.scheduling.create_schedule",
                       "origin": "scheduling",


### PR DESCRIPTION
## Motivation

Multiple Claude Code agents share the one primary FlexMeasures checkout. A recent session ran `git checkout` + `git merge` in it while other agents were working there, which switched the branch out from under them and littered the tree with merge leftovers. Branch-mutating git commands in the shared checkout are unsafe by construction — each agent should work in its own `git worktree`.

## What this adds

- **`.claude/hooks/worktree-guard.sh`** — a blocking `PreToolUse` hook wired into `.claude/settings.json` on `Bash(git:*)`, mirroring the conventions of the existing `pre-commit-check.sh` (payload on stdin, `jq -r '.tool_input.command // empty'`, self-filters on the command because the settings-level `if` matcher isn't honoured by all Claude Code versions, exit 2 = block with an actionable stderr message, exit 0 = allow).
- A short rule in **`AGENTS.md`** telling agents the checkout is shared and to work in a worktree.

### Blocked (only when the command targets the primary checkout)
`git checkout <ref>`, `switch`, `merge`, `rebase`, `reset`, `cherry-pick`, `stash`.

`git stash` is included because in a shared checkout it silently pockets *other agents'* uncommitted work — the block message says so, since the rule otherwise looks arbitrary.

### Allowed
- Anything targeting a **linked worktree**, detected by comparing `git rev-parse --git-dir` against `--git-common-dir` (they differ only in a linked worktree — more robust than string-matching `.git`).
- **`git -C <path> <verb>`** — the idiomatic way to drive another worktree without cd-ing. The hook parses `-C` / `--git-dir=` out of the invocation and runs the git-dir comparison against *that* path, not its own cwd. (Getting this wrong would have pushed agents back toward `cd`-ing into the shared checkout — the exact behaviour we want to discourage.)
- `cd <elsewhere> && git ...` in the same command.
- File-only restores: `git checkout -- <path>` and `git checkout <ref> -- <path>` — these never move HEAD or the branch pointer.
- All read-only git (`status`, `log`, `diff`, `show`, `fetch`, `worktree`, `rev-parse`, `branch` listing, …) — they simply don't match the guarded verb list.

### Precision caveat (worth a reviewer's eye)

A `PreToolUse` hook does **not** run in the Bash tool's persistent working directory — it runs in the project dir, and it cannot see the shell's variables. So the guard is **cwd + `-C`/`--git-dir` aware, not shell-state aware**. Two consequences, both deliberately erring on the safe side (annoying, not dangerous):

1. A bare `git switch` after an earlier `cd <worktree>` in a *previous* Bash call is judged against the primary checkout and blocked.
2. `git -C "$WT" switch main`, where `$WT` was exported in an earlier call, cannot be resolved, so it is blocked with a message asking for a literal path.

Both are documented in the hook's header comment, its block message, and `AGENTS.md`. The alternative (guessing, or failing open) risks the exact clobbering this PR exists to prevent.

## Testing

Piped realistic hook JSON payloads into the script, simulating "which directory the hook runs in" by `cd`-ing first. All 26 cases pass.

| Command | Target | Expected | Exit |
|---|---|---|---|
| `git -C <linked-worktree> switch main` | worktree | allow | 0 |
| `git -C <primary> switch main` | primary | block | 2 |
| `git -C <linked-worktree> merge main` | worktree | allow | 0 |
| `git -C <primary> merge main` | primary | block | 2 |
| `git -C "$WT" merge main` (unresolvable var) | unknown | block | 2 |
| `git --git-dir=<primary>/.git switch main` | primary | block | 2 |
| `git -C /some/other/repo switch main` | outside project | allow | 0 |
| `git -C ~ switch main` | outside project | allow | 0 |
| `git switch main` | primary (cwd) | block | 2 |
| `git switch main` | worktree (cwd) | allow | 0 |
| `git merge main` | worktree (cwd) | allow | 0 |
| `git rebase origin/main` | worktree (cwd) | allow | 0 |
| `git merge main` | primary | block | 2 |
| `git rebase -i HEAD~3` | primary | block | 2 |
| `git reset --hard origin/main` | primary | block | 2 |
| `git cherry-pick abc123` | primary | block | 2 |
| `git stash` | primary | block | 2 |
| `git checkout -- some/file.py` | primary | allow | 0 |
| `git checkout feature -- some/file.py` | primary | allow | 0 |
| `cd /tmp && git checkout main` | primary | allow | 0 |
| `git status` / `log` / `diff` / `fetch` / `branch -a` | primary | allow | 0 |
| `git worktree add -b x /tmp/x main` | primary | allow | 0 |
| `ls -la` (non-git) | primary | allow | 0 |
| malformed JSON / empty payload | — | fail open | 0 |

`jq . .claude/settings.json` confirms the settings file stays valid JSON, and `pre-commit run --all-files` passes.

## Other reviewer notes

- The hook fails open (exit 0) if `jq` is missing or the payload doesn't parse — intentional per "never break the user's shell", but it means a broken `jq` silently disables the guard.
- `git checkout` / `git merge` remain in `permissions.allow` in `.claude/settings.json`. That's the separate "don't prompt" list; the hook blocks them regardless, so no change was needed — but flagging it in case you'd like the two kept in sync.
- No `changelog.rst` entry for the hook itself — internal agent tooling, not user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G6LdvRHtFA6iacQQDE5eLS