### PR TITLE
Chore: check on startup if the db schema is on alembic head 

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -39,6 +39,7 @@ Infrastructure / Support
 * Automate Docker Hub image publishing and a PyPI install smoke test on release, add a manually-triggered QA workflow that runs the toy tutorials and HEMS walkthrough against a local Docker Compose stack, and add a helper script to list merged PRs since the last tag [see `PR #2260 <https://www.github.com/FlexMeasures/flexmeasures/pull/2260>`_]
 * Make toy tutorials robust against pre-existing IDs [see `PR #2269 <https://www.github.com/FlexMeasures/flexmeasures/pull/2269>`_]
 * Document multi-tenancy and consultancy tenant structures for hosts [see `PR #2176 <https://www.github.com/FlexMeasures/flexmeasures/pull/2176>`_]
+* Warn hosts when the database schema is not at the latest migration, and skip startup template provisioning until migrations are applied [see `PR #2309 <https://www.github.com/FlexMeasures/flexmeasures/pull/2309>`_]
 
 Bugfixes
 -----------

--- a/flexmeasures/app.py
+++ b/flexmeasures/app.py
@@ -47,10 +47,10 @@ def create(  # noqa C901
     )
     from flexmeasures.utils.app_utils import (
         init_sentry,
+        provision_default_template_assets_on_startup,
     )
     from flexmeasures.utils.error_utils import add_basic_error_handlers
     from flexmeasures.utils.secrets_utils import set_secret_key, set_totp_secrets
-    from sqlalchemy.exc import OperationalError, ProgrammingError
 
     configure_logging()  # do this first, see https://flask.palletsprojects.com/en/2.0.x/logging
     cfg_location = find_flexmeasures_cfg()  # Find flexmeasures.cfg location
@@ -210,23 +210,7 @@ def create(  # noqa C901
 
     register_ui_at(app)
 
-    if (
-        app.config.get("FLEXMEASURES_CREATE_TEMPLATE_ASSETS_ON_STARTUP", False)
-        and not app.testing
-        and app.config.get("FLEXMEASURES_ENV") != "documentation"
-    ):
-        from flexmeasures.data import db
-        from flexmeasures.data.scripts.data_gen import (
-            provision_default_template_assets,
-        )
-
-        try:
-            with app.app_context():
-                provision_default_template_assets(db)
-        except (OperationalError, ProgrammingError) as exc:
-            app.logger.warning(
-                f"Skipping startup template provisioning due to an error: {exc}"
-            )
+    provision_default_template_assets_on_startup(app)
 
     # Global template variables for both our own templates and external templates
     @app.context_processor

--- a/flexmeasures/data/__init__.py
+++ b/flexmeasures/data/__init__.py
@@ -39,11 +39,18 @@ def register_at(app: Flask):
             not app.database_schema_is_migrated_to_head
             and not _is_running_db_upgrade_command()
         ):
-            app.logger.warning(
-                "Database schema is not at the Alembic head revision "
-                f"({format_database_schema_revision_status(revision_status)}). "
-                "Run `flexmeasures db upgrade` before starting the app."
-            )
+            if revision_status.inspection_error is not None:
+                app.logger.error(
+                    "Could not determine the database schema revision. "
+                    "Check database connectivity and configuration before starting the app. "
+                    f"Details: {revision_status.inspection_error}"
+                )
+            else:
+                app.logger.error(
+                    "Database schema is not at the Alembic head revision "
+                    f"({format_database_schema_revision_status(revision_status)}). "
+                    "Run `flexmeasures db upgrade` before starting the app."
+                )
 
     global ma
     ma.init_app(app)

--- a/flexmeasures/data/__init__.py
+++ b/flexmeasures/data/__init__.py
@@ -20,6 +20,18 @@ def register_at(app: Flask):
     configure_db_for(app)
     Migrate(app, db, directory=os.path.join(app.root_path, "data", "migrations"))
 
+    app.database_schema_is_migrated_to_head = True
+    if not app.testing and app.config.get("FLEXMEASURES_ENV") != "documentation":
+        from flexmeasures.data.utils import database_schema_is_migrated_to_head
+
+        app.database_schema_is_migrated_to_head = database_schema_is_migrated_to_head(
+            app
+        )
+        if not app.database_schema_is_migrated_to_head:
+            app.logger.warning(
+                "Database schema is not at the Alembic head revision. Run `flexmeasures db upgrade` before starting the app."
+            )
+
     global ma
     ma.init_app(app)
 

--- a/flexmeasures/data/__init__.py
+++ b/flexmeasures/data/__init__.py
@@ -18,7 +18,8 @@ ma: Marshmallow = Marshmallow()
 
 def _is_running_db_upgrade_command() -> bool:
     """Return whether this process is already running the Alembic upgrade command."""
-    return len(sys.argv) >= 3 and sys.argv[1:3] == ["db", "upgrade"]
+    args = sys.argv[1:]
+    return any(args[i : i + 2] == ["db", "upgrade"] for i in range(len(args) - 1))
 
 
 def register_at(app: Flask):

--- a/flexmeasures/data/__init__.py
+++ b/flexmeasures/data/__init__.py
@@ -3,6 +3,7 @@ Models & schemata, as well as business logic (queries & services).
 """
 
 import os
+import sys
 
 from flask import Flask
 from flask_migrate import Migrate
@@ -15,6 +16,11 @@ from flexmeasures.data.transactional import after_request_exception_rollback_ses
 ma: Marshmallow = Marshmallow()
 
 
+def _is_running_db_upgrade_command() -> bool:
+    """Return whether this process is already running the Alembic upgrade command."""
+    return len(sys.argv) >= 3 and sys.argv[1:3] == ["db", "upgrade"]
+
+
 def register_at(app: Flask):
     # First configure the central db object and Alembic's migration tool
     configure_db_for(app)
@@ -22,14 +28,21 @@ def register_at(app: Flask):
 
     app.database_schema_is_migrated_to_head = True
     if not app.testing and app.config.get("FLEXMEASURES_ENV") != "documentation":
-        from flexmeasures.data.utils import database_schema_is_migrated_to_head
-
-        app.database_schema_is_migrated_to_head = database_schema_is_migrated_to_head(
-            app
+        from flexmeasures.data.utils import (
+            format_database_schema_revision_status,
+            get_database_schema_revision_status,
         )
-        if not app.database_schema_is_migrated_to_head:
+
+        revision_status = get_database_schema_revision_status(app)
+        app.database_schema_is_migrated_to_head = revision_status.is_migrated_to_head
+        if (
+            not app.database_schema_is_migrated_to_head
+            and not _is_running_db_upgrade_command()
+        ):
             app.logger.warning(
-                "Database schema is not at the Alembic head revision. Run `flexmeasures db upgrade` before starting the app."
+                "Database schema is not at the Alembic head revision "
+                f"({format_database_schema_revision_status(revision_status)}). "
+                "Run `flexmeasures db upgrade` before starting the app."
             )
 
     global ma

--- a/flexmeasures/data/tests/test_utils.py
+++ b/flexmeasures/data/tests/test_utils.py
@@ -4,7 +4,6 @@ from sqlalchemy.exc import OperationalError, ProgrammingError
 
 from flexmeasures.data import db
 from flexmeasures.data.utils import (
-    database_schema_is_migrated_to_head,
     format_database_schema_revision_status,
     get_database_schema_revision_status,
 )
@@ -45,7 +44,7 @@ def test_database_schema_is_migrated_to_head_when_revisions_match(app, monkeypat
         lambda config: _DummyScriptDirectory(("head-a",)),
     )
 
-    assert database_schema_is_migrated_to_head(app) is True
+    assert get_database_schema_revision_status(app).is_migrated_to_head is True
 
 
 def test_database_schema_revision_status_includes_current_and_expected_heads(
@@ -85,7 +84,7 @@ def test_database_schema_is_not_migrated_to_head_when_revisions_differ(
         lambda config: _DummyScriptDirectory(("head-a",)),
     )
 
-    assert database_schema_is_migrated_to_head(app) is False
+    assert get_database_schema_revision_status(app).is_migrated_to_head is False
 
 
 def test_database_schema_is_not_migrated_to_head_when_revision_lookup_fails(
@@ -104,7 +103,7 @@ def test_database_schema_is_not_migrated_to_head_when_revision_lookup_fails(
         lambda config: _DummyScriptDirectory(("head-a",)),
     )
 
-    assert database_schema_is_migrated_to_head(app) is False
+    assert get_database_schema_revision_status(app).is_migrated_to_head is False
 
 
 def test_database_schema_revision_status_records_connectivity_failure(app, monkeypatch):

--- a/flexmeasures/data/tests/test_utils.py
+++ b/flexmeasures/data/tests/test_utils.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from sqlalchemy.exc import OperationalError, ProgrammingError
+
+from flexmeasures.data import db
+from flexmeasures.data.utils import (
+    database_schema_is_migrated_to_head,
+    format_database_schema_revision_status,
+    get_database_schema_revision_status,
+)
+
+
+class _DummyConnection:
+    def __enter__(self):
+        return object()
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _DummyMigrationContext:
+    def __init__(self, heads: tuple[str, ...]):
+        self._heads = heads
+
+    def get_current_heads(self) -> tuple[str, ...]:
+        return self._heads
+
+
+class _DummyScriptDirectory:
+    def __init__(self, heads: tuple[str, ...]):
+        self._heads = heads
+
+    def get_heads(self) -> tuple[str, ...]:
+        return self._heads
+
+
+def test_database_schema_is_migrated_to_head_when_revisions_match(app, monkeypatch):
+    monkeypatch.setattr(db.engine, "connect", lambda: _DummyConnection())
+    monkeypatch.setattr(
+        "flexmeasures.data.utils.MigrationContext.configure",
+        lambda connection: _DummyMigrationContext(("head-a",)),
+    )
+    monkeypatch.setattr(
+        "flexmeasures.data.utils.ScriptDirectory.from_config",
+        lambda config: _DummyScriptDirectory(("head-a",)),
+    )
+
+    assert database_schema_is_migrated_to_head(app) is True
+
+
+def test_database_schema_revision_status_includes_current_and_expected_heads(
+    app, monkeypatch
+):
+    monkeypatch.setattr(db.engine, "connect", lambda: _DummyConnection())
+    monkeypatch.setattr(
+        "flexmeasures.data.utils.MigrationContext.configure",
+        lambda connection: _DummyMigrationContext(("current-a",)),
+    )
+    monkeypatch.setattr(
+        "flexmeasures.data.utils.ScriptDirectory.from_config",
+        lambda config: _DummyScriptDirectory(("head-a",)),
+    )
+
+    status = get_database_schema_revision_status(app)
+
+    assert status.current_heads == ("current-a",)
+    assert status.expected_heads == ("head-a",)
+    assert status.is_migrated_to_head is False
+    assert (
+        format_database_schema_revision_status(status)
+        == "current revision(s): current-a; head revision(s): head-a"
+    )
+
+
+def test_database_schema_is_not_migrated_to_head_when_revisions_differ(
+    app, monkeypatch
+):
+    monkeypatch.setattr(db.engine, "connect", lambda: _DummyConnection())
+    monkeypatch.setattr(
+        "flexmeasures.data.utils.MigrationContext.configure",
+        lambda connection: _DummyMigrationContext(("current-a",)),
+    )
+    monkeypatch.setattr(
+        "flexmeasures.data.utils.ScriptDirectory.from_config",
+        lambda config: _DummyScriptDirectory(("head-a",)),
+    )
+
+    assert database_schema_is_migrated_to_head(app) is False
+
+
+def test_database_schema_is_not_migrated_to_head_when_revision_lookup_fails(
+    app, monkeypatch
+):
+    def raise_programming_error():
+        raise ProgrammingError(
+            "SELECT version_num FROM alembic_version",
+            None,
+            Exception("relation alembic_version does not exist"),
+        )
+
+    monkeypatch.setattr(db.engine, "connect", raise_programming_error)
+    monkeypatch.setattr(
+        "flexmeasures.data.utils.ScriptDirectory.from_config",
+        lambda config: _DummyScriptDirectory(("head-a",)),
+    )
+
+    assert database_schema_is_migrated_to_head(app) is False
+
+
+def test_database_schema_revision_status_records_connectivity_failure(app, monkeypatch):
+    def raise_operational_error():
+        raise OperationalError(
+            "SELECT version_num FROM alembic_version",
+            None,
+            Exception("could not connect to server"),
+        )
+
+    monkeypatch.setattr(db.engine, "connect", raise_operational_error)
+    monkeypatch.setattr(
+        "flexmeasures.data.utils.ScriptDirectory.from_config",
+        lambda config: _DummyScriptDirectory(("head-a",)),
+    )
+
+    status = get_database_schema_revision_status(app)
+
+    assert status.current_heads == ()
+    assert status.expected_heads == ("head-a",)
+    assert status.inspection_error is not None
+    assert status.is_migrated_to_head is False

--- a/flexmeasures/data/utils.py
+++ b/flexmeasures/data/utils.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from alembic.config import Config as AlembicConfig
 from alembic.runtime.migration import MigrationContext
 from alembic.script import ScriptDirectory
+from dataclasses import dataclass
 from flask import current_app
 from timely_beliefs import BeliefsDataFrame, BeliefsSeries
 from sqlalchemy import select
@@ -34,30 +35,64 @@ SAVE_TO_DB_SUCCESS_WITH_CHANGES_STATUSES = (
 TEMPLATE_COPY_GUIDANCE_PREFIX = "Copy this"
 
 
+@dataclass(frozen=True)
+class DatabaseSchemaRevisionStatus:
+    """Alembic revision status for the connected database."""
+
+    current_heads: tuple[str, ...]
+    expected_heads: tuple[str, ...]
+
+    @property
+    def is_migrated_to_head(self) -> bool:
+        return bool(self.current_heads) and self.current_heads == self.expected_heads
+
+
 def database_schema_is_migrated_to_head(app) -> bool:
     """Return whether the connected database is already at the Alembic head(s)."""
+    return get_database_schema_revision_status(app).is_migrated_to_head
+
+
+def get_database_schema_revision_status(app) -> DatabaseSchemaRevisionStatus:
+    """Return current and expected Alembic head revisions for the connected database."""
     from sqlalchemy.exc import OperationalError, ProgrammingError
 
     migrate_extension = app.extensions.get("migrate")
     if migrate_extension is None:
-        return False
+        return DatabaseSchemaRevisionStatus(current_heads=(), expected_heads=())
 
     alembic_config = AlembicConfig()
     alembic_config.set_main_option("script_location", migrate_extension.directory)
     script = ScriptDirectory.from_config(alembic_config)
-    expected_heads = set(script.get_heads())
+    expected_heads = tuple(sorted(script.get_heads()))
     if not expected_heads:
-        return False
+        return DatabaseSchemaRevisionStatus(current_heads=(), expected_heads=())
 
     try:
         with app.app_context(), db.engine.connect() as connection:
-            current_heads = set(
-                MigrationContext.configure(connection).get_current_heads()
+            current_heads = tuple(
+                sorted(MigrationContext.configure(connection).get_current_heads())
             )
     except (OperationalError, ProgrammingError):
-        return False
+        current_heads = ()
 
-    return bool(current_heads) and current_heads == expected_heads
+    return DatabaseSchemaRevisionStatus(
+        current_heads=current_heads,
+        expected_heads=expected_heads,
+    )
+
+
+def format_database_schema_revision_status(
+    status: DatabaseSchemaRevisionStatus,
+) -> str:
+    """Format Alembic revisions for host-facing log messages."""
+
+    def format_heads(heads: tuple[str, ...]) -> str:
+        return ", ".join(heads) if heads else "unknown"
+
+    return (
+        f"current revision(s): {format_heads(status.current_heads)}; "
+        f"head revision(s): {format_heads(status.expected_heads)}"
+    )
 
 
 def save_to_session(objects: list[db.Model], overwrite: bool = False):

--- a/flexmeasures/data/utils.py
+++ b/flexmeasures/data/utils.py
@@ -52,11 +52,6 @@ class DatabaseSchemaRevisionStatus:
         )
 
 
-def database_schema_is_migrated_to_head(app) -> bool:
-    """Return whether the connected database is already at the Alembic head(s)."""
-    return get_database_schema_revision_status(app).is_migrated_to_head
-
-
 def get_database_schema_revision_status(app) -> DatabaseSchemaRevisionStatus:
     """Return current and expected Alembic head revisions for the connected database."""
     from sqlalchemy.exc import OperationalError, ProgrammingError

--- a/flexmeasures/data/utils.py
+++ b/flexmeasures/data/utils.py
@@ -4,6 +4,9 @@ Utils around the data models and db sessions
 
 from __future__ import annotations
 
+from alembic.config import Config as AlembicConfig
+from alembic.runtime.migration import MigrationContext
+from alembic.script import ScriptDirectory
 from flask import current_app
 from timely_beliefs import BeliefsDataFrame, BeliefsSeries
 from sqlalchemy import select
@@ -29,6 +32,32 @@ SAVE_TO_DB_SUCCESS_WITH_CHANGES_STATUSES = (
     SAVE_TO_DB_SUCCESS_WITH_UNCHANGED_BELIEFS_SKIPPED,
 )
 TEMPLATE_COPY_GUIDANCE_PREFIX = "Copy this"
+
+
+def database_schema_is_migrated_to_head(app) -> bool:
+    """Return whether the connected database is already at the Alembic head(s)."""
+    from sqlalchemy.exc import OperationalError, ProgrammingError
+
+    migrate_extension = app.extensions.get("migrate")
+    if migrate_extension is None:
+        return False
+
+    alembic_config = AlembicConfig()
+    alembic_config.set_main_option("script_location", migrate_extension.directory)
+    script = ScriptDirectory.from_config(alembic_config)
+    expected_heads = set(script.get_heads())
+    if not expected_heads:
+        return False
+
+    try:
+        with db.engine.connect() as connection:
+            current_heads = set(
+                MigrationContext.configure(connection).get_current_heads()
+            )
+    except (OperationalError, ProgrammingError):
+        return False
+
+    return bool(current_heads) and current_heads == expected_heads
 
 
 def save_to_session(objects: list[db.Model], overwrite: bool = False):

--- a/flexmeasures/data/utils.py
+++ b/flexmeasures/data/utils.py
@@ -41,10 +41,15 @@ class DatabaseSchemaRevisionStatus:
 
     current_heads: tuple[str, ...]
     expected_heads: tuple[str, ...]
+    inspection_error: str | None = None
 
     @property
     def is_migrated_to_head(self) -> bool:
-        return bool(self.current_heads) and self.current_heads == self.expected_heads
+        return (
+            self.inspection_error is None
+            and bool(self.current_heads)
+            and self.current_heads == self.expected_heads
+        )
 
 
 def database_schema_is_migrated_to_head(app) -> bool:
@@ -72,7 +77,13 @@ def get_database_schema_revision_status(app) -> DatabaseSchemaRevisionStatus:
             current_heads = tuple(
                 sorted(MigrationContext.configure(connection).get_current_heads())
             )
-    except (OperationalError, ProgrammingError):
+    except OperationalError as exc:
+        return DatabaseSchemaRevisionStatus(
+            current_heads=(),
+            expected_heads=expected_heads,
+            inspection_error=str(exc),
+        )
+    except ProgrammingError:
         current_heads = ()
 
     return DatabaseSchemaRevisionStatus(

--- a/flexmeasures/data/utils.py
+++ b/flexmeasures/data/utils.py
@@ -50,7 +50,7 @@ def database_schema_is_migrated_to_head(app) -> bool:
         return False
 
     try:
-        with db.engine.connect() as connection:
+        with app.app_context(), db.engine.connect() as connection:
             current_heads = set(
                 MigrationContext.configure(connection).get_current_heads()
             )

--- a/flexmeasures/utils/app_utils.py
+++ b/flexmeasures/utils/app_utils.py
@@ -17,6 +17,35 @@ from flexmeasures import __version__ as fm_version
 from flexmeasures.app import create as create_app
 
 
+def provision_default_template_assets_on_startup(app: Flask) -> None:
+    """Provision starter template assets when startup settings and schema allow it."""
+    if (
+        not app.config.get("FLEXMEASURES_CREATE_TEMPLATE_ASSETS_ON_STARTUP", False)
+        or app.testing
+        or app.config.get("FLEXMEASURES_ENV") == "documentation"
+    ):
+        return
+
+    if not getattr(app, "database_schema_is_migrated_to_head", True):
+        app.logger.info(
+            "Skipping startup template provisioning because the database schema is not at the Alembic head revision yet."
+        )
+        return
+
+    from sqlalchemy.exc import OperationalError, ProgrammingError
+
+    from flexmeasures.data import db
+    from flexmeasures.data.scripts.data_gen import provision_default_template_assets
+
+    try:
+        with app.app_context():
+            provision_default_template_assets(db)
+    except (OperationalError, ProgrammingError) as exc:
+        app.logger.warning(
+            f"Skipping startup template provisioning due to an error: {exc}"
+        )
+
+
 @click.group(cls=FlaskGroup, create_app=create_app)
 @with_appcontext
 def flexmeasures_cli():

--- a/flexmeasures/utils/tests/test_app_utils.py
+++ b/flexmeasures/utils/tests/test_app_utils.py
@@ -6,6 +6,7 @@ from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.transport import Transport
 from werkzeug.exceptions import InternalServerError, NotFound, SecurityError
 
+from flexmeasures.data import _is_running_db_upgrade_command
 from flexmeasures.utils.app_utils import (
     _sentry_filter_notfound,
     provision_default_template_assets_on_startup,
@@ -157,3 +158,15 @@ def test_provision_default_template_assets_on_startup_skips_old_schema(
         provision_default_template_assets_on_startup(app)
 
     assert "Skipping startup template provisioning" in caplog.text
+
+
+def test_is_running_db_upgrade_command(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["/path/to/flexmeasures", "db", "upgrade", "--sql"])
+
+    assert _is_running_db_upgrade_command() is True
+
+
+def test_is_running_db_upgrade_command_false_for_other_db_commands(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["/path/to/flexmeasures", "db", "current"])
+
+    assert _is_running_db_upgrade_command() is False

--- a/flexmeasures/utils/tests/test_app_utils.py
+++ b/flexmeasures/utils/tests/test_app_utils.py
@@ -6,7 +6,10 @@ from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.transport import Transport
 from werkzeug.exceptions import InternalServerError, NotFound, SecurityError
 
-from flexmeasures.utils.app_utils import _sentry_filter_notfound
+from flexmeasures.utils.app_utils import (
+    _sentry_filter_notfound,
+    provision_default_template_assets_on_startup,
+)
 from flexmeasures.utils.error_utils import add_basic_error_handlers
 
 
@@ -131,3 +134,26 @@ def app_logger_record(message):
         args=(),
         exc_info=None,
     )
+
+
+def test_provision_default_template_assets_on_startup_skips_old_schema(
+    app, monkeypatch, caplog
+):
+    def fail_if_called(db):
+        raise AssertionError("Template provisioning should not run.")
+
+    monkeypatch.setattr(app, "testing", False)
+    monkeypatch.setitem(app.config, "FLEXMEASURES_ENV", "production")
+    monkeypatch.setitem(
+        app.config, "FLEXMEASURES_CREATE_TEMPLATE_ASSETS_ON_STARTUP", True
+    )
+    monkeypatch.setattr(app, "database_schema_is_migrated_to_head", False)
+    monkeypatch.setattr(
+        "flexmeasures.data.scripts.data_gen.provision_default_template_assets",
+        fail_if_called,
+    )
+
+    with caplog.at_level(logging.INFO):
+        provision_default_template_assets_on_startup(app)
+
+    assert "Skipping startup template provisioning" in caplog.text


### PR DESCRIPTION
If the db schema has yet to be upgraded, we should hosts know, and it can be a useful flag *not* to do any data provisionin during app creation.

- [x] print a warning otherwise - useful for hosts. 
- [x] Concrete use case: do not create templates in this case, so db CLI commands are still free to run.
- [x] changelog entry

