### PR TITLE
Fix: guard against scheduler result dicts without a 'name' key

### DIFF
--- a/flexmeasures/data/services/scheduling.py
+++ b/flexmeasures/data/services/scheduling.py
@@ -812,7 +812,7 @@ def make_schedule(  # noqa: C901
         if result.get("name") == SCHEDULING_RESULT_KEY:
             scheduling_result_dict = result["data"].to_dict()
             continue
-        if rq_job and result["name"] == "commitment_costs":
+        if rq_job and result.get("name") == "commitment_costs":
             rq_job.meta["scheduler_info"]["commitment_costs"] = result["data"]
             continue
         if "sensor" not in result:


### PR DESCRIPTION
One-liner: `result["name"]` → `result.get("name")` in `trigger_and_get_next_schedule`'s commitment-costs scan. Custom schedulers (e.g. a plugin's CommunityScheduler) legitimately return result dicts shaped `{"sensor": ..., "data": ...}` without a `"name"` key; the unguarded access right after an already-guarded `result.get("name")` on the neighbouring line raised a bare `KeyError: 'name'` that surfaced as an opaque scheduling-job failure. Found during a live community-scheduling simulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQFkeGxDwErydUV5ZmHmki