### PR TITLE
Block image files from being committed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,14 @@ repos:
         pass_filenames: false
         language: system
         entry: bash -c '[[ "$GITHUB_ACTIONS" == "true" ]] && exit 0 || (uv run poe generate-open-api-specs)'
+  - repo: local
+    hooks:
+      - id: no-image-files
+        name: Block image files from being committed
+        language: fail
+        entry: >-
+          Image files must not be committed to this repo (they bloat .git forever).
+          Put screenshots in the FlexMeasures/screenshots repo, or leave them
+          untracked and attach them to the PR/issue manually.
+        files: '\.(png|jpe?g|gif|bmp|tiff?|webp|ico|psd)$'
+        exclude: '^(flexmeasures/ui/static/|documentation/)'

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -41,6 +41,7 @@ Infrastructure / Support
 * Make toy tutorials robust against pre-existing IDs [see `PR #2269 <https://www.github.com/FlexMeasures/flexmeasures/pull/2269>`_]
 * Document multi-tenancy and consultancy tenant structures for hosts [see `PR #2176 <https://www.github.com/FlexMeasures/flexmeasures/pull/2176>`_]
 * Warn hosts when the database schema is not at the latest migration, and skip startup template provisioning until migrations are applied [see `PR #2309 <https://www.github.com/FlexMeasures/flexmeasures/pull/2309>`_]
+* Add a pre-commit hook that blocks image files (png, jpg, gif, bmp, tiff, webp, ico, psd) from being committed outside of ``flexmeasures/ui/static/`` and ``documentation/``, to protect the git history from binary bloat; screenshots belong in the ``FlexMeasures/screenshots`` repo instead [see `PR #TODO <https://www.github.com/FlexMeasures/flexmeasures/pull/TODO>`_]
 
 Bugfixes
 -----------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -41,7 +41,7 @@ Infrastructure / Support
 * Make toy tutorials robust against pre-existing IDs [see `PR #2269 <https://www.github.com/FlexMeasures/flexmeasures/pull/2269>`_]
 * Document multi-tenancy and consultancy tenant structures for hosts [see `PR #2176 <https://www.github.com/FlexMeasures/flexmeasures/pull/2176>`_]
 * Warn hosts when the database schema is not at the latest migration, and skip startup template provisioning until migrations are applied [see `PR #2309 <https://www.github.com/FlexMeasures/flexmeasures/pull/2309>`_]
-* Add a pre-commit hook that blocks image files (png, jpg, gif, bmp, tiff, webp, ico, psd) from being committed outside of ``flexmeasures/ui/static/`` and ``documentation/``, to protect the git history from binary bloat; screenshots belong in the ``FlexMeasures/screenshots`` repo instead [see `PR #TODO <https://www.github.com/FlexMeasures/flexmeasures/pull/TODO>`_]
+* Add a pre-commit hook that blocks image files (png, jpg, gif, bmp, tiff, webp, ico, psd) from being committed outside of ``flexmeasures/ui/static/`` and ``documentation/``, to protect the git history from binary bloat; screenshots belong in the ``FlexMeasures/screenshots`` repo instead [see `PR #2315 <https://www.github.com/FlexMeasures/flexmeasures/pull/2315>`_]
 
 Bugfixes
 -----------


### PR DESCRIPTION
## Summary
- Add a `repo: local` / `language: fail` pre-commit hook (`no-image-files`) that fails the commit when staged files match `\.(png|jpe?g|gif|bmp|tiff?|webp|ico|psd)$`. SVG is untouched (text-based, not bloaty).
- Every git blob ever committed stays in `.git` forever (even after deletion), so binary screenshots silently bloat the repo over time. Screenshots should live in the dedicated `FlexMeasures/screenshots` repo instead, or be attached to a PR/issue manually without being tracked.
- Allowlist decision: existing tracked images are all small logos/icons/favicons under `flexmeasures/ui/static/` (e.g. `favicon.ico`, `glyphicons-halflings*.png`, a couple of jpgs used as UI imagery). No images currently exist under `documentation/`, but that's also a legitimate home for small doc figures, so both directories are excluded from the hook via `exclude: '^(flexmeasures/ui/static/|documentation/)'`.
- Added a changelog entry under Infrastructure / Support for v1.0.0 (PR number to be filled in as a follow-up commit).

## Test plan
- [x] `git add` a dummy `.png` at the repo root and confirm `pre-commit run no-image-files --files dummy.png` fails with the required error message
- [x] Confirm a `.py` file passes (hook reports "no files to check")
- [x] Confirm a `.png` under `documentation/_static/` passes (excluded, "no files to check")
- [x] Confirm the full pre-commit suite (flake8/black/mypy/openapi-specs/no-image-files) runs clean on the actual commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQFkeGxDwErydUV5ZmHmki