### PR TITLE
fix(ci): never claim :latest on a manual docker-publish run

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,6 +16,11 @@ on:
       tag:
         description: "Git tag to build/push (e.g. v1.0.0). Required when run manually."
         required: false
+      latest:
+        description: "Also push as `latest`. Only tick this when re-running a stable release; never for a pre-release."
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -42,8 +47,24 @@ jobs:
           # on the `release` webhook payload, reflecting whether the "Set as
           # a pre-release" checkbox was ticked when the GitHub Release was
           # created. We only want stable releases to also claim `:latest`.
+          #
+          # On `workflow_dispatch` there is no release payload at all, so that
+          # field renders as an empty string -- which would sail past a bare
+          # `!= "true"` check and clobber `:latest` with a manually built image.
+          # Hence the explicit event check, with an opt-in input to keep the
+          # documented "re-run a stable release" path working.
+          if [ "${{ github.event_name }}" = "release" ]; then
+            if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+              PUSH_LATEST=false
+            else
+              PUSH_LATEST=true
+            fi
+          else
+            PUSH_LATEST="${{ inputs.latest }}"
+          fi
+
           IMAGE_TAGS="lfenergy/flexmeasures:${TAG}"
-          if [ "${{ github.event.release.prerelease }}" != "true" ]; then
+          if [ "$PUSH_LATEST" = "true" ]; then
             IMAGE_TAGS="${IMAGE_TAGS}
           lfenergy/flexmeasures:latest"
           fi

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -41,6 +41,7 @@ Infrastructure / Support
 * Make toy tutorials robust against pre-existing IDs [see `PR #2269 <https://www.github.com/FlexMeasures/flexmeasures/pull/2269>`_]
 * Document multi-tenancy and consultancy tenant structures for hosts [see `PR #2176 <https://www.github.com/FlexMeasures/flexmeasures/pull/2176>`_]
 * Warn hosts when the database schema is not at the latest migration, and skip startup template provisioning until migrations are applied [see `PR #2309 <https://www.github.com/FlexMeasures/flexmeasures/pull/2309>`_]
+* Stop manual runs of the Docker publishing workflow from overwriting the ``latest`` image tag, and let them opt in to it explicitly [see `PR #2316 <https://www.github.com/FlexMeasures/flexmeasures/pull/2316>`_]
 
 Bugfixes
 -----------

--- a/documentation/dev/release_process.rst
+++ b/documentation/dev/release_process.rst
@@ -53,7 +53,9 @@ Publishing the GitHub Release (step 3) triggers two workflows:
 Check the Actions tab for both workflow runs to confirm they succeeded; also spot-check that the new version shows up on `PyPI <https://pypi.org/project/flexmeasures>`_, `Docker Hub <https://hub.docker.com/r/lfenergy/flexmeasures>`_, and that the ReadTheDocs build for the new tag completed.
 
 .. note::
-   The ``docker-publish.yml`` workflow can also be re-run manually (``workflow_dispatch``, with a ``tag`` input) if a run needs to be retried.
+   The ``docker-publish.yml`` workflow can also be run manually (``workflow_dispatch``, with a ``tag`` input) if a run needs to be retried, or to build an image from a tag that has no GitHub Release (e.g. a pre-release image for a downstream plugin).
+   A manual run only pushes ``lfenergy/flexmeasures:<tag>``; it claims ``latest`` solely when you tick the ``latest`` input, which you should do only when re-running a *stable* release.
+   Note that ``workflow_dispatch`` reads the workflow file from the ref you pick in the "Use workflow from" dropdown, whereas the ``tag`` input determines which ref is checked out and built.
 
 5. Announce (manual)
 ----------------------


### PR DESCRIPTION
## Problem

`docker-publish.yml` decides whether to also push `lfenergy/flexmeasures:latest` with:

```bash
if [ "${{ github.event.release.prerelease }}" != "true" ]; then
```

`github.event.release.prerelease` only exists on the **`release`** webhook payload. On **`workflow_dispatch`** there is no release payload, so the expression renders as an **empty string**, `[ "" != "true" ]` is true, and the run pushes `:latest` alongside the requested tag — silently overwriting the stable image with whatever was manually built.

That makes the manual-dispatch path documented in `release_process.rst` unsafe for anything but a stable release.

## Fix

- Gate the `latest` tag on `github.event_name == 'release'`, so a dispatch never claims it implicitly.
- Add an opt-in `latest` boolean input (default `false`) so the documented "re-run a stable release" path still works.
- Document both in `release_process.rst`, including the easy-to-miss detail that `workflow_dispatch` reads the *workflow file* from the ref picked in the "Use workflow from" dropdown, while the `tag` input decides which ref is *checked out and built*.

## Behaviour

| event | prerelease | `latest` input | pushed tags |
|---|---|---|---|
| `release` | false | — | `:v0.33.1` **+ `:latest`** |
| `release` | true | — | `:v0.34.0rc1` |
| `workflow_dispatch` | n/a | unticked | `:v0.34.0rc1` |
| `workflow_dispatch` | n/a | ticked | `:v0.33.1` **+ `:latest`** |

Before this change, row 3 also pushed `:latest`.

## Context

Found while preparing a pre-release image for a downstream plugin, which needs exactly the dispatch path in row 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)