### PR TITLE
feat: add custom job timeouts, also configurable per queue

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -40,7 +40,7 @@ Infrastructure / Support
 * Make toy tutorials robust against pre-existing IDs [see `PR #2269 <https://www.github.com/FlexMeasures/flexmeasures/pull/2269>`_]
 * Document multi-tenancy and consultancy tenant structures for hosts [see `PR #2176 <https://www.github.com/FlexMeasures/flexmeasures/pull/2176>`_]
 * Warn hosts when the database schema is not at the latest migration, and skip startup template provisioning until migrations are applied [see `PR #2309 <https://www.github.com/FlexMeasures/flexmeasures/pull/2309>`_]
-* Add ``FLEXMEASURES_DEFAULT_JOB_TIMEOUT`` and ``FLEXMEASURES_JOB_TIMEOUT`` settings for configuring RQ job timeouts globally and per queue, while preserving the existing one-hour default for forecasting jobs [see `PR #2318 <https://github.com/FlexMeasures/flexmeasures/pull/2318>`_]
+* Add ``FLEXMEASURES_DEFAULT_JOB_TIMEOUT`` and ``FLEXMEASURES_JOB_TIMEOUT`` settings for configuring RQ job timeouts globally and per queue, and log actionable guidance when a forecasting job times out [see `PR #2318 <https://github.com/FlexMeasures/flexmeasures/pull/2318>`_]
 
 Bugfixes
 -----------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -40,7 +40,7 @@ Infrastructure / Support
 * Make toy tutorials robust against pre-existing IDs [see `PR #2269 <https://www.github.com/FlexMeasures/flexmeasures/pull/2269>`_]
 * Document multi-tenancy and consultancy tenant structures for hosts [see `PR #2176 <https://www.github.com/FlexMeasures/flexmeasures/pull/2176>`_]
 * Warn hosts when the database schema is not at the latest migration, and skip startup template provisioning until migrations are applied [see `PR #2309 <https://www.github.com/FlexMeasures/flexmeasures/pull/2309>`_]
-* Add ``FLEXMEASURES_DEFAULT_JOB_TIMEOUT`` and ``FLEXMEASURES_JOB_TIMEOUT`` settings for configuring RQ job timeouts globally and per queue [see `PR #XXXX <https://github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
+* Add ``FLEXMEASURES_DEFAULT_JOB_TIMEOUT`` and ``FLEXMEASURES_JOB_TIMEOUT`` settings for configuring RQ job timeouts globally and per queue [see `PR #2318 <https://github.com/FlexMeasures/flexmeasures/pull/2318>`_]
 
 Bugfixes
 -----------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -40,7 +40,7 @@ Infrastructure / Support
 * Make toy tutorials robust against pre-existing IDs [see `PR #2269 <https://www.github.com/FlexMeasures/flexmeasures/pull/2269>`_]
 * Document multi-tenancy and consultancy tenant structures for hosts [see `PR #2176 <https://www.github.com/FlexMeasures/flexmeasures/pull/2176>`_]
 * Warn hosts when the database schema is not at the latest migration, and skip startup template provisioning until migrations are applied [see `PR #2309 <https://www.github.com/FlexMeasures/flexmeasures/pull/2309>`_]
-* Add ``FLEXMEASURES_DEFAULT_JOB_TIMEOUT`` and ``FLEXMEASURES_JOB_TIMEOUT`` settings for configuring RQ job timeouts globally and per queue [see `PR #2318 <https://github.com/FlexMeasures/flexmeasures/pull/2318>`_]
+* Add ``FLEXMEASURES_DEFAULT_JOB_TIMEOUT`` and ``FLEXMEASURES_JOB_TIMEOUT`` settings for configuring RQ job timeouts globally and per queue, while preserving the existing one-hour default for forecasting jobs [see `PR #2318 <https://github.com/FlexMeasures/flexmeasures/pull/2318>`_]
 
 Bugfixes
 -----------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -40,6 +40,7 @@ Infrastructure / Support
 * Make toy tutorials robust against pre-existing IDs [see `PR #2269 <https://www.github.com/FlexMeasures/flexmeasures/pull/2269>`_]
 * Document multi-tenancy and consultancy tenant structures for hosts [see `PR #2176 <https://www.github.com/FlexMeasures/flexmeasures/pull/2176>`_]
 * Warn hosts when the database schema is not at the latest migration, and skip startup template provisioning until migrations are applied [see `PR #2309 <https://www.github.com/FlexMeasures/flexmeasures/pull/2309>`_]
+* Add ``FLEXMEASURES_DEFAULT_JOB_TIMEOUT`` and ``FLEXMEASURES_JOB_TIMEOUT`` settings for configuring RQ job timeouts globally and per queue [see `PR #XXXX <https://github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
 
 Bugfixes
 -----------

--- a/documentation/configuration.rst
+++ b/documentation/configuration.rst
@@ -340,7 +340,7 @@ Supported queue names are ``forecasting``, ``scheduling`` and ``ingestion``.
 
 Example: ``{"forecasting": "PT2M", "scheduling": "PT5M", "ingestion": "PT30S"}``
 
-Default: ``{"forecasting": timedelta(hours=1)}``
+Default: ``{}``
 
 FLEXMEASURES_PLANNING_TTL
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/documentation/configuration.rst
+++ b/documentation/configuration.rst
@@ -336,10 +336,11 @@ FLEXMEASURES_JOB_TIMEOUT
 
 Timeouts per queue, expressed as fixed ISO 8601 durations.
 Queue-specific values override ``FLEXMEASURES_DEFAULT_JOB_TIMEOUT``.
+Supported queue names are ``forecasting``, ``scheduling`` and ``ingestion``.
 
 Example: ``{"forecasting": "PT2M", "scheduling": "PT5M", "ingestion": "PT30S"}``
 
-Default: ``{}``
+Default: ``{"forecasting": timedelta(hours=1)}``
 
 FLEXMEASURES_PLANNING_TTL
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/documentation/configuration.rst
+++ b/documentation/configuration.rst
@@ -323,6 +323,24 @@ A job that is passed this time to live might get cleaned out by Redis' memory ma
 
 Default: ``timedelta(days=1)``
 
+FLEXMEASURES_DEFAULT_JOB_TIMEOUT
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Default timeout for jobs (e.g. forecasting, scheduling and ingestion), expressed as a fixed ISO 8601 duration.
+Jobs that exceed this timeout are moved to RQ's failed queue.
+
+Default: ``timedelta(seconds=180)`` (``"PT180S"``)
+
+FLEXMEASURES_JOB_TIMEOUT
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Timeouts per queue, expressed as fixed ISO 8601 durations.
+Queue-specific values override ``FLEXMEASURES_DEFAULT_JOB_TIMEOUT``.
+
+Example: ``{"forecasting": "PT2M", "scheduling": "PT5M", "ingestion": "PT30S"}``
+
+Default: ``{}``
+
 FLEXMEASURES_PLANNING_TTL
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/flexmeasures/app.py
+++ b/flexmeasures/app.py
@@ -20,6 +20,7 @@ from redis import Redis
 from rq import Queue
 
 from flexmeasures.data.services.job_cache import JobCache
+from flexmeasures.utils.job_utils import get_job_timeout
 
 
 def create(  # noqa C901
@@ -108,9 +109,21 @@ def create(  # noqa C901
         """
     app.redis_connection = redis_conn
     app.queues = dict(
-        forecasting=Queue(connection=redis_conn, name="forecasting"),
-        scheduling=Queue(connection=redis_conn, name="scheduling"),
-        ingestion=Queue(connection=redis_conn, name="ingestion"),
+        forecasting=Queue(
+            connection=redis_conn,
+            name="forecasting",
+            default_timeout=get_job_timeout("forecasting", app.config, app.logger),
+        ),
+        scheduling=Queue(
+            connection=redis_conn,
+            name="scheduling",
+            default_timeout=get_job_timeout("scheduling", app.config, app.logger),
+        ),
+        ingestion=Queue(
+            connection=redis_conn,
+            name="ingestion",
+            default_timeout=get_job_timeout("ingestion", app.config, app.logger),
+        ),
         # reporting=Queue(connection=redis_conn, name="reporting"),
         # labelling=Queue(connection=redis_conn, name="labelling"),
         # alerting=Queue(connection=redis_conn, name="alerting"),

--- a/flexmeasures/data/models/forecasting/pipelines/train_predict.py
+++ b/flexmeasures/data/models/forecasting/pipelines/train_predict.py
@@ -439,7 +439,6 @@ class TrainPredictPipeline(Forecaster):
                         ).total_seconds()
                     ),  # NB job.cleanup docs says a negative number of seconds means persisting forever
                     meta=job_metadata,
-                    timeout=60 * 60,  # 1 hour
                 )
 
                 # Store the job ID for this cycle

--- a/flexmeasures/data/services/forecasting.py
+++ b/flexmeasures/data/services/forecasting.py
@@ -2,7 +2,18 @@
 
 from __future__ import annotations
 
+import logging
+
 import click
+from rq.timeouts import JobTimeoutException
+
+
+FORECASTING_JOB_TIMEOUT_HINT = (
+    "Forecasting job timed out. Try splitting the forecast request into smaller "
+    "periods, reducing the prediction window by lowering `max-forecast-horizon`, "
+    "using fewer forecast cycles via `forecast-frequency`, or increasing "
+    "FLEXMEASURES_JOB_TIMEOUT for the `forecasting` queue."
+)
 
 
 # TODO: we could also monitor the failed queue and re-enqueue jobs who had missing data
@@ -25,8 +36,16 @@ def handle_forecasting_exception(job, exc_type, exc_value, traceback):
         job.meta["failures"] = job.meta["failures"] + 1
     job.save_meta()
 
-    job.meta["exception"] = {
+    exception = {
         "type": exc_type.__name__ if exc_type is not None else None,
         "message": str(exc_value),
     }
+
+    if isinstance(exc_type, type) and issubclass(exc_type, JobTimeoutException):
+        logger = logging.getLogger(__name__)
+        logger.warning(FORECASTING_JOB_TIMEOUT_HINT)
+        click.echo(FORECASTING_JOB_TIMEOUT_HINT)
+        exception["hint"] = FORECASTING_JOB_TIMEOUT_HINT
+
+    job.meta["exception"] = exception
     job.save_meta()

--- a/flexmeasures/data/services/forecasting.py
+++ b/flexmeasures/data/services/forecasting.py
@@ -8,11 +8,12 @@ import click
 from rq.timeouts import JobTimeoutException
 
 
-FORECASTING_JOB_TIMEOUT_HINT = (
-    "Forecasting job timed out. Try splitting the forecast request into smaller "
-    "periods, reducing the prediction window by lowering `max-forecast-horizon`, "
-    "using fewer forecast cycles via `forecast-frequency`, or increasing "
-    "FLEXMEASURES_JOB_TIMEOUT for the `forecasting` queue."
+FORECASTING_JOB_TIMEOUT_LOG_MESSAGE = (
+    "Forecasting job timed out. To reduce runtime per job, decrease "
+    "max-forecast-horizon or create more forecast cycles by setting "
+    "forecast-frequency to a smaller timedelta (and retrain-frequency too, if it "
+    "is larger). This splits the request into more, shorter jobs. Alternatively, "
+    "increase FLEXMEASURES_JOB_TIMEOUT for the forecasting queue."
 )
 
 
@@ -43,9 +44,7 @@ def handle_forecasting_exception(job, exc_type, exc_value, traceback):
 
     if isinstance(exc_type, type) and issubclass(exc_type, JobTimeoutException):
         logger = logging.getLogger(__name__)
-        logger.warning(FORECASTING_JOB_TIMEOUT_HINT)
-        click.echo(FORECASTING_JOB_TIMEOUT_HINT)
-        exception["hint"] = FORECASTING_JOB_TIMEOUT_HINT
+        logger.warning(FORECASTING_JOB_TIMEOUT_LOG_MESSAGE)
 
     job.meta["exception"] = exception
     job.save_meta()

--- a/flexmeasures/data/services/forecasting.py
+++ b/flexmeasures/data/services/forecasting.py
@@ -8,13 +8,14 @@ import click
 from rq.timeouts import JobTimeoutException
 
 
-FORECASTING_JOB_TIMEOUT_LOG_MESSAGE = (
-    "Forecasting job timed out. To reduce runtime per job, decrease "
-    "max-forecast-horizon or create more forecast cycles by setting "
-    "forecast-frequency to a smaller timedelta (and retrain-frequency too, if it "
-    "is larger). This splits the request into more, shorter jobs. Alternatively, "
-    "increase FLEXMEASURES_JOB_TIMEOUT for the forecasting queue."
+FORECASTING_JOB_TIMEOUT_HINT = (
+    "Forecasting job timed out. "
+    "Decrease max-forecast-horizon to reduce runtime per job. "
+    "To create more forecast cycles, set forecast-frequency to a smaller timedelta. "
+    "If retrain-frequency is larger, decrease it too. "
+    "More cycles split the request into more, shorter jobs."
 )
+FORECASTING_JOB_TIMEOUT_HOST_HINT = "Alternatively, hosts can increase FLEXMEASURES_JOB_TIMEOUT for the forecasting queue."
 
 
 # TODO: we could also monitor the failed queue and re-enqueue jobs who had missing data
@@ -44,7 +45,12 @@ def handle_forecasting_exception(job, exc_type, exc_value, traceback):
 
     if isinstance(exc_type, type) and issubclass(exc_type, JobTimeoutException):
         logger = logging.getLogger(__name__)
-        logger.warning(FORECASTING_JOB_TIMEOUT_LOG_MESSAGE)
+        logger.warning(
+            "%s %s",
+            FORECASTING_JOB_TIMEOUT_HINT,
+            FORECASTING_JOB_TIMEOUT_HOST_HINT,
+        )
+        exception["hint"] = FORECASTING_JOB_TIMEOUT_HINT
 
     job.meta["exception"] = exception
     job.save_meta()

--- a/flexmeasures/data/tests/test_forecasting_jobs.py
+++ b/flexmeasures/data/tests/test_forecasting_jobs.py
@@ -10,7 +10,7 @@ from rq.timeouts import JobTimeoutException
 
 from flexmeasures.data.models.forecasting.pipelines import TrainPredictPipeline
 from flexmeasures.data.services.forecasting import (
-    FORECASTING_JOB_TIMEOUT_HINT,
+    FORECASTING_JOB_TIMEOUT_LOG_MESSAGE,
     handle_forecasting_exception,
 )
 from flexmeasures.utils.job_utils import work_on_rq
@@ -107,9 +107,7 @@ def test_failed_forecasting_job_does_not_enqueue_fallback(
     assert app.queues["forecasting"].count == 0
 
 
-def test_forecasting_job_timeout_exception_has_actionable_hint(
-    app, clean_redis, caplog, capsys
-):
+def test_forecasting_job_timeout_exception_logs_host_hint(app, clean_redis, caplog):
     job = app.queues["forecasting"].enqueue(sum, [1, 2])
 
     with caplog.at_level(logging.WARNING):
@@ -120,14 +118,12 @@ def test_forecasting_job_timeout_exception_has_actionable_hint(
             None,
         )
 
-    captured = capsys.readouterr()
     failed_job = Job.fetch(job.id, connection=app.queues["forecasting"].connection)
 
-    assert FORECASTING_JOB_TIMEOUT_HINT in captured.out
-    assert FORECASTING_JOB_TIMEOUT_HINT in caplog.text
+    assert FORECASTING_JOB_TIMEOUT_LOG_MESSAGE in caplog.text
     assert failed_job.meta["failures"] == 1
     assert failed_job.meta["exception"]["type"] == "JobTimeoutException"
-    assert failed_job.meta["exception"]["hint"] == FORECASTING_JOB_TIMEOUT_HINT
+    assert "hint" not in failed_job.meta["exception"]
 
 
 def test_forecasting_job_meta_is_json_serializable(

--- a/flexmeasures/data/tests/test_forecasting_jobs.py
+++ b/flexmeasures/data/tests/test_forecasting_jobs.py
@@ -10,7 +10,8 @@ from rq.timeouts import JobTimeoutException
 
 from flexmeasures.data.models.forecasting.pipelines import TrainPredictPipeline
 from flexmeasures.data.services.forecasting import (
-    FORECASTING_JOB_TIMEOUT_LOG_MESSAGE,
+    FORECASTING_JOB_TIMEOUT_HINT,
+    FORECASTING_JOB_TIMEOUT_HOST_HINT,
     handle_forecasting_exception,
 )
 from flexmeasures.utils.job_utils import work_on_rq
@@ -107,7 +108,9 @@ def test_failed_forecasting_job_does_not_enqueue_fallback(
     assert app.queues["forecasting"].count == 0
 
 
-def test_forecasting_job_timeout_exception_logs_host_hint(app, clean_redis, caplog):
+def test_forecasting_job_timeout_exception_routes_hints_by_audience(
+    app, clean_redis, caplog
+):
     job = app.queues["forecasting"].enqueue(sum, [1, 2])
 
     with caplog.at_level(logging.WARNING):
@@ -120,10 +123,12 @@ def test_forecasting_job_timeout_exception_logs_host_hint(app, clean_redis, capl
 
     failed_job = Job.fetch(job.id, connection=app.queues["forecasting"].connection)
 
-    assert FORECASTING_JOB_TIMEOUT_LOG_MESSAGE in caplog.text
+    assert FORECASTING_JOB_TIMEOUT_HINT in caplog.text
+    assert FORECASTING_JOB_TIMEOUT_HOST_HINT in caplog.text
     assert failed_job.meta["failures"] == 1
     assert failed_job.meta["exception"]["type"] == "JobTimeoutException"
-    assert "hint" not in failed_job.meta["exception"]
+    assert failed_job.meta["exception"]["hint"] == FORECASTING_JOB_TIMEOUT_HINT
+    assert FORECASTING_JOB_TIMEOUT_HOST_HINT not in failed_job.meta["exception"]["hint"]
 
 
 def test_forecasting_job_meta_is_json_serializable(

--- a/flexmeasures/data/tests/test_forecasting_jobs.py
+++ b/flexmeasures/data/tests/test_forecasting_jobs.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 from datetime import datetime
 import json
+import logging
 import os
 
 from rq.job import Job
+from rq.timeouts import JobTimeoutException
 
 from flexmeasures.data.models.forecasting.pipelines import TrainPredictPipeline
-from flexmeasures.data.services.forecasting import handle_forecasting_exception
+from flexmeasures.data.services.forecasting import (
+    FORECASTING_JOB_TIMEOUT_HINT,
+    handle_forecasting_exception,
+)
 from flexmeasures.utils.job_utils import work_on_rq
 from flexmeasures.utils.time_utils import as_server_time
 
@@ -100,6 +105,29 @@ def test_failed_forecasting_job_does_not_enqueue_fallback(
         assert failed_job.meta["exception"]["message"] != ""
         assert failed_job.meta.get("fallback_job_id") is None
     assert app.queues["forecasting"].count == 0
+
+
+def test_forecasting_job_timeout_exception_has_actionable_hint(
+    app, clean_redis, caplog, capsys
+):
+    job = app.queues["forecasting"].enqueue(sum, [1, 2])
+
+    with caplog.at_level(logging.WARNING):
+        handle_forecasting_exception(
+            job,
+            JobTimeoutException,
+            JobTimeoutException("Task exceeded maximum timeout value"),
+            None,
+        )
+
+    captured = capsys.readouterr()
+    failed_job = Job.fetch(job.id, connection=app.queues["forecasting"].connection)
+
+    assert FORECASTING_JOB_TIMEOUT_HINT in captured.out
+    assert FORECASTING_JOB_TIMEOUT_HINT in caplog.text
+    assert failed_job.meta["failures"] == 1
+    assert failed_job.meta["exception"]["type"] == "JobTimeoutException"
+    assert failed_job.meta["exception"]["hint"] == FORECASTING_JOB_TIMEOUT_HINT
 
 
 def test_forecasting_job_meta_is_json_serializable(

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -156,9 +156,7 @@ class Config(object):
     }  # how to group assets by asset types
     FLEXMEASURES_LP_SOLVER: str = "appsi_highs"
     FLEXMEASURES_DEFAULT_JOB_TIMEOUT: timedelta = timedelta(seconds=180)
-    FLEXMEASURES_JOB_TIMEOUT: dict[str, timedelta | str] = {
-        "forecasting": timedelta(hours=1),
-    }
+    FLEXMEASURES_JOB_TIMEOUT: dict[str, timedelta | str] = {}
     FLEXMEASURES_JOB_TTL: timedelta = timedelta(days=1)
     FLEXMEASURES_PLANNING_HORIZON: timedelta = timedelta(days=2)
     FLEXMEASURES_MAX_PLANNING_HORIZON: timedelta | int | None = (

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -155,6 +155,8 @@ class Config(object):
         "EVSE": ["one-way_evse", "two-way_evse"],
     }  # how to group assets by asset types
     FLEXMEASURES_LP_SOLVER: str = "appsi_highs"
+    FLEXMEASURES_DEFAULT_JOB_TIMEOUT: timedelta = timedelta(seconds=180)
+    FLEXMEASURES_JOB_TIMEOUT: dict[str, timedelta | str] = {}
     FLEXMEASURES_JOB_TTL: timedelta = timedelta(days=1)
     FLEXMEASURES_PLANNING_HORIZON: timedelta = timedelta(days=2)
     FLEXMEASURES_MAX_PLANNING_HORIZON: timedelta | int | None = (

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -156,7 +156,9 @@ class Config(object):
     }  # how to group assets by asset types
     FLEXMEASURES_LP_SOLVER: str = "appsi_highs"
     FLEXMEASURES_DEFAULT_JOB_TIMEOUT: timedelta = timedelta(seconds=180)
-    FLEXMEASURES_JOB_TIMEOUT: dict[str, timedelta | str] = {}
+    FLEXMEASURES_JOB_TIMEOUT: dict[str, timedelta | str] = {
+        "forecasting": timedelta(hours=1),
+    }
     FLEXMEASURES_JOB_TTL: timedelta = timedelta(days=1)
     FLEXMEASURES_PLANNING_HORIZON: timedelta = timedelta(days=2)
     FLEXMEASURES_MAX_PLANNING_HORIZON: timedelta | int | None = (

--- a/flexmeasures/utils/job_utils.py
+++ b/flexmeasures/utils/job_utils.py
@@ -12,6 +12,7 @@ from rq import Queue
 from rq.job import Job
 
 RQ_DEFAULT_JOB_TIMEOUT = 180
+KNOWN_JOB_QUEUES = frozenset(("forecasting", "scheduling", "ingestion"))
 
 
 def _timeout_to_seconds(timeout: timedelta | str) -> int:
@@ -82,6 +83,18 @@ def get_job_timeout(
             queue_timeouts,
         )
         return _configured_default_job_timeout(config, logger)
+
+    unknown_queue_names = sorted(
+        str(configured_queue_name)
+        for configured_queue_name in queue_timeouts
+        if configured_queue_name not in KNOWN_JOB_QUEUES
+    )
+    if unknown_queue_names:
+        logger.error(
+            "Invalid FLEXMEASURES_JOB_TIMEOUT queue names %s. Expected queue names are %s.",
+            unknown_queue_names,
+            sorted(KNOWN_JOB_QUEUES),
+        )
 
     if queue_name not in queue_timeouts:
         return _configured_default_job_timeout(config, logger)

--- a/flexmeasures/utils/job_utils.py
+++ b/flexmeasures/utils/job_utils.py
@@ -1,9 +1,102 @@
 from __future__ import annotations
 
+from datetime import timedelta
 import os
+import logging
+from collections.abc import Mapping
+from typing import Any
 
+import isodate  # type: ignore[import-untyped]
+from flask import current_app, has_app_context
 from rq import Queue
 from rq.job import Job
+
+RQ_DEFAULT_JOB_TIMEOUT = 180
+
+
+def _timeout_to_seconds(timeout: timedelta | str) -> int:
+    """Convert a configured timeout value to whole seconds for RQ."""
+    if isinstance(timeout, str):
+        try:
+            timeout = isodate.parse_duration(timeout)
+        except isodate.ISO8601Error as exc:
+            raise ValueError(
+                f"Job timeout {timeout!r} is not a valid ISO 8601 duration."
+            ) from exc
+
+    if isinstance(timeout, isodate.Duration):
+        raise ValueError(
+            "Job timeouts must be fixed durations without years or months."
+        )
+
+    if isinstance(timeout, timedelta):
+        seconds = timeout.total_seconds()
+    else:
+        raise TypeError(
+            f"Job timeout values must be ISO 8601 strings or timedeltas, not {type(timeout).__name__}."
+        )
+
+    if seconds <= 0:
+        raise ValueError("Job timeouts must be positive.")
+    if not seconds.is_integer():
+        raise ValueError("Job timeouts must resolve to whole seconds.")
+    return int(seconds)
+
+
+def _configured_default_job_timeout(
+    config: Mapping[str, Any], logger: logging.Logger
+) -> int:
+    timeout = config.get(
+        "FLEXMEASURES_DEFAULT_JOB_TIMEOUT",
+        timedelta(seconds=RQ_DEFAULT_JOB_TIMEOUT),
+    )
+    try:
+        return _timeout_to_seconds(timeout)
+    except (TypeError, ValueError) as exc:
+        logger.error(
+            "Invalid FLEXMEASURES_DEFAULT_JOB_TIMEOUT %r: %s. Falling back to RQ's default of %s seconds.",
+            timeout,
+            exc,
+            RQ_DEFAULT_JOB_TIMEOUT,
+        )
+        return RQ_DEFAULT_JOB_TIMEOUT
+
+
+def get_job_timeout(
+    queue_name: str,
+    config: Mapping[str, Any] | None = None,
+    logger: logging.Logger | None = None,
+) -> int:
+    """Return the configured RQ timeout for jobs in ``queue_name``."""
+    if config is None:
+        config = current_app.config
+    if logger is None:
+        logger = (
+            current_app.logger if has_app_context() else logging.getLogger(__name__)
+        )
+
+    queue_timeouts = config.get("FLEXMEASURES_JOB_TIMEOUT", {})
+    if not isinstance(queue_timeouts, Mapping):
+        logger.error(
+            "Invalid FLEXMEASURES_JOB_TIMEOUT %r: expected a mapping of queue names to timeouts. Falling back to FLEXMEASURES_DEFAULT_JOB_TIMEOUT.",
+            queue_timeouts,
+        )
+        return _configured_default_job_timeout(config, logger)
+
+    if queue_name not in queue_timeouts:
+        return _configured_default_job_timeout(config, logger)
+
+    timeout = queue_timeouts[queue_name]
+    try:
+        return _timeout_to_seconds(timeout)
+    except (TypeError, ValueError) as exc:
+        logger.error(
+            "Invalid FLEXMEASURES_JOB_TIMEOUT for queue %r (%r): %s. Falling back to FLEXMEASURES_DEFAULT_JOB_TIMEOUT.",
+            queue_name,
+            timeout,
+            exc,
+        )
+        return _configured_default_job_timeout(config, logger)
 
 
 def work_on_rq(
@@ -15,7 +108,7 @@ def work_on_rq(
 
     #  we only want this import distinction to matter when we actually are testing
     if os.name == "nt":
-        from rq_win import WindowsWorker as SimpleWorker
+        from rq_win import WindowsWorker as SimpleWorker  # type: ignore[import-untyped]
     else:
         from rq import SimpleWorker
 

--- a/flexmeasures/utils/tests/test_job_utils.py
+++ b/flexmeasures/utils/tests/test_job_utils.py
@@ -134,7 +134,7 @@ def test_queue_default_timeout_is_used_when_enqueueing_created_jobs():
 
 
 def test_app_queues_use_default_job_timeout(app):
-    assert app.queues["forecasting"]._default_timeout == 3600
+    assert app.queues["forecasting"]._default_timeout == 180
     assert app.queues["scheduling"]._default_timeout == 180
     assert app.queues["ingestion"]._default_timeout == 180
 

--- a/flexmeasures/utils/tests/test_job_utils.py
+++ b/flexmeasures/utils/tests/test_job_utils.py
@@ -85,6 +85,20 @@ def test_get_job_timeout_falls_back_on_non_mapping_queue_timeouts(caplog):
     assert "Invalid FLEXMEASURES_JOB_TIMEOUT" in caplog.text
 
 
+def test_get_job_timeout_logs_unknown_queue_names(caplog):
+    with caplog.at_level(logging.ERROR):
+        timeout = get_job_timeout(
+            "forecasting",
+            {
+                "FLEXMEASURES_DEFAULT_JOB_TIMEOUT": "PT5M",
+                "FLEXMEASURES_JOB_TIMEOUT": {"forecast": "PT1H"},
+            },
+        )
+
+    assert timeout == 300
+    assert "Invalid FLEXMEASURES_JOB_TIMEOUT queue names ['forecast']" in caplog.text
+
+
 def test_queue_default_timeout_is_used_for_enqueued_jobs():
     queue = Queue(
         name="scheduling",
@@ -120,12 +134,12 @@ def test_queue_default_timeout_is_used_when_enqueueing_created_jobs():
 
 
 def test_app_queues_use_default_job_timeout(app):
-    assert app.queues["forecasting"]._default_timeout == 180
+    assert app.queues["forecasting"]._default_timeout == 3600
     assert app.queues["scheduling"]._default_timeout == 180
     assert app.queues["ingestion"]._default_timeout == 180
 
 
-def test_app_queues_use_custom_queue_job_timeout(tmp_path, monkeypatch):
+def test_app_queues_use_custom_global_and_queue_job_timeout(tmp_path, monkeypatch):
     import flexmeasures.ui
 
     monkeypatch.setattr(flexmeasures.ui, "register_at", lambda app: None)
@@ -136,6 +150,7 @@ def test_app_queues_use_custom_queue_job_timeout(tmp_path, monkeypatch):
                 'SECRET_KEY = "dummy-key-for-job-timeout-test"',
                 'SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"',
                 "SQLALCHEMY_ENGINE_OPTIONS = {}",
+                'FLEXMEASURES_DEFAULT_JOB_TIMEOUT = "PT5M"',
                 'FLEXMEASURES_JOB_TIMEOUT = {"forecasting": "PT1H"}',
                 "FLEXMEASURES_PROFILE_REQUESTS = False",
                 "FLEXMEASURES_CREATE_TEMPLATE_ASSETS_ON_STARTUP = False",
@@ -147,5 +162,5 @@ def test_app_queues_use_custom_queue_job_timeout(tmp_path, monkeypatch):
     custom_app = create_app(env="development", path_to_config=str(config_file))
 
     assert custom_app.queues["forecasting"]._default_timeout == 3600
-    assert custom_app.queues["scheduling"]._default_timeout == 180
-    assert custom_app.queues["ingestion"]._default_timeout == 180
+    assert custom_app.queues["scheduling"]._default_timeout == 300
+    assert custom_app.queues["ingestion"]._default_timeout == 300

--- a/flexmeasures/utils/tests/test_job_utils.py
+++ b/flexmeasures/utils/tests/test_job_utils.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+
+from rq import Queue
+from rq.job import Job
+
+from flexmeasures.app import create as create_app
+from flexmeasures.tests.utils import RQCompatibleFakeStrictRedis
+from flexmeasures.utils.job_utils import get_job_timeout
+
+
+def test_get_job_timeout_uses_default_timeout():
+    config = {
+        "FLEXMEASURES_DEFAULT_JOB_TIMEOUT": "PT5M",
+        "FLEXMEASURES_JOB_TIMEOUT": {},
+    }
+
+    assert get_job_timeout("scheduling", config) == 300
+
+
+def test_get_job_timeout_uses_queue_specific_timeout():
+    config = {
+        "FLEXMEASURES_DEFAULT_JOB_TIMEOUT": "PT5M",
+        "FLEXMEASURES_JOB_TIMEOUT": {"forecasting": "PT1H"},
+    }
+
+    assert get_job_timeout("forecasting", config) == 3600
+    assert get_job_timeout("scheduling", config) == 300
+
+
+def test_get_job_timeout_accepts_timedelta_values():
+    assert (
+        get_job_timeout(
+            "scheduling",
+            {
+                "FLEXMEASURES_DEFAULT_JOB_TIMEOUT": timedelta(minutes=5),
+                "FLEXMEASURES_JOB_TIMEOUT": {"scheduling": timedelta(minutes=10)},
+            },
+        )
+        == 600
+    )
+
+
+def test_get_job_timeout_falls_back_on_numeric_seconds(caplog):
+    with caplog.at_level(logging.ERROR):
+        timeout = get_job_timeout(
+            "scheduling",
+            {
+                "FLEXMEASURES_DEFAULT_JOB_TIMEOUT": "PT5M",
+                "FLEXMEASURES_JOB_TIMEOUT": {"scheduling": 45},
+            },
+        )
+
+    assert timeout == 300
+    assert "Invalid FLEXMEASURES_JOB_TIMEOUT for queue 'scheduling'" in caplog.text
+
+
+def test_get_job_timeout_falls_back_on_nominal_default_duration(caplog):
+    with caplog.at_level(logging.ERROR):
+        timeout = get_job_timeout(
+            "scheduling",
+            {
+                "FLEXMEASURES_DEFAULT_JOB_TIMEOUT": "P1M",
+                "FLEXMEASURES_JOB_TIMEOUT": {},
+            },
+        )
+
+    assert timeout == 180
+    assert "Invalid FLEXMEASURES_DEFAULT_JOB_TIMEOUT" in caplog.text
+
+
+def test_get_job_timeout_falls_back_on_non_mapping_queue_timeouts(caplog):
+    with caplog.at_level(logging.ERROR):
+        timeout = get_job_timeout(
+            "scheduling",
+            {
+                "FLEXMEASURES_DEFAULT_JOB_TIMEOUT": "PT5M",
+                "FLEXMEASURES_JOB_TIMEOUT": ["scheduling"],
+            },
+        )
+
+    assert timeout == 300
+    assert "Invalid FLEXMEASURES_JOB_TIMEOUT" in caplog.text
+
+
+def test_queue_default_timeout_is_used_for_enqueued_jobs():
+    queue = Queue(
+        name="scheduling",
+        connection=RQCompatibleFakeStrictRedis(),
+        default_timeout=get_job_timeout(
+            "scheduling",
+            {
+                "FLEXMEASURES_DEFAULT_JOB_TIMEOUT": "PT5M",
+                "FLEXMEASURES_JOB_TIMEOUT": {},
+            },
+        ),
+    )
+
+    job = queue.enqueue(sum, [1, 2])
+
+    assert queue._default_timeout == 300
+    assert job.timeout == 300
+
+
+def test_queue_default_timeout_is_used_when_enqueueing_created_jobs():
+    queue = Queue(
+        name="scheduling",
+        connection=RQCompatibleFakeStrictRedis(),
+        default_timeout=300,
+    )
+    job = Job.create(sum, args=([1, 2],), connection=queue.connection)
+
+    assert job.timeout is None
+
+    queue.enqueue_job(job)
+
+    assert job.timeout == 300
+
+
+def test_app_queues_use_default_job_timeout(app):
+    assert app.queues["forecasting"]._default_timeout == 180
+    assert app.queues["scheduling"]._default_timeout == 180
+    assert app.queues["ingestion"]._default_timeout == 180
+
+
+def test_app_queues_use_custom_queue_job_timeout(tmp_path, monkeypatch):
+    import flexmeasures.ui
+
+    monkeypatch.setattr(flexmeasures.ui, "register_at", lambda app: None)
+    config_file = tmp_path / "flexmeasures.cfg"
+    config_file.write_text(
+        "\n".join(
+            [
+                'SECRET_KEY = "dummy-key-for-job-timeout-test"',
+                'SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"',
+                "SQLALCHEMY_ENGINE_OPTIONS = {}",
+                'FLEXMEASURES_JOB_TIMEOUT = {"forecasting": "PT1H"}',
+                "FLEXMEASURES_PROFILE_REQUESTS = False",
+                "FLEXMEASURES_CREATE_TEMPLATE_ASSETS_ON_STARTUP = False",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    custom_app = create_app(env="development", path_to_config=str(config_file))
+
+    assert custom_app.queues["forecasting"]._default_timeout == 3600
+    assert custom_app.queues["scheduling"]._default_timeout == 180
+    assert custom_app.queues["ingestion"]._default_timeout == 180


### PR DESCRIPTION
## Description

Hosts might want to increase the default timeout altogether (for slower hardware), or even per queue. This PR adds 2 config settings to do that.

Closes #2227

- [x] add & apply two config settings
- [x] Added changelog item in `documentation/changelog.rst`

## How to test

Run flexmeasures/utils/job_utils.py

## Notes

I found that there was a timeout setting for forecasts, in a rather obscure manner inside the code, giving forecasts 1 hour instead of 3 minutes.
So in that sense this PR is not completely backwards-compatible. @BelhsanHmida maybe you can comment on that.
