### PR TITLE
Fix device misalignment when flex-model entries are filtered from multi-device schedules

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -53,6 +53,7 @@ Bugfixes
 * Let storage scheduling treat missing constant SoC bounds as unconstrained lower or upper bounds [see `PR #2221 <https://www.github.com/FlexMeasures/flexmeasures/pull/2221>`_]
 * Allow root assets belonging to different accounts to share the same name, while keeping asset names unique among root assets within the same account and among children of the same parent [see `PR #2226 <https://www.github.com/FlexMeasures/flexmeasures/pull/2226>`_]
 * Fix queued train-predict forecasting jobs losing their resolved forecast window or failing on detached database objects in workers [see `PR #2035 <https://www.github.com/FlexMeasures/flexmeasures/pull/2035>`_]
+* Fix multi-device storage scheduling misaligning devices with their assets when any flex-model entry is filtered out, which let a device inherit another device's power capacity and could silently drop a device (referencing its power sensor only through a nested ``consumption``/``production`` output reference) from the schedule [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
 
 
 v0.33.1 | July 1, 2026

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -53,7 +53,7 @@ Bugfixes
 * Let storage scheduling treat missing constant SoC bounds as unconstrained lower or upper bounds [see `PR #2221 <https://www.github.com/FlexMeasures/flexmeasures/pull/2221>`_]
 * Allow root assets belonging to different accounts to share the same name, while keeping asset names unique among root assets within the same account and among children of the same parent [see `PR #2226 <https://www.github.com/FlexMeasures/flexmeasures/pull/2226>`_]
 * Fix queued train-predict forecasting jobs losing their resolved forecast window or failing on detached database objects in workers [see `PR #2035 <https://www.github.com/FlexMeasures/flexmeasures/pull/2035>`_]
-* Fix multi-device storage scheduling misaligning devices with their assets when any flex-model entry is filtered out, which let a device inherit another device's power capacity and could silently drop a device (referencing its power sensor only through a nested ``consumption``/``production`` output reference) from the schedule [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
+* Fix multi-device storage scheduling misaligning devices with their assets when any flex-model entry is filtered out, which let a device inherit another device's power capacity and could silently drop a device (referencing its power sensor only through a nested ``consumption``/``production`` output reference) from the schedule [see `PR #2319 <https://www.github.com/FlexMeasures/flexmeasures/pull/2319>`_]
 
 
 v0.33.1 | July 1, 2026

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -223,7 +223,7 @@ class MetaStorageScheduler(Scheduler):
             sensors: list[Sensor | None] = [fm.get("sensor") for fm in device_models]
             assets: list[Asset | None] = [  # noqa: F841
                 s.asset if s is not None else flex_model_d.get("asset")
-                for s, flex_model_d in zip(sensors, self.flex_model)
+                for s, flex_model_d in zip(sensors, device_models)
             ]
             if resolution is None:
                 # in case of no sensors with a non-instantaneous resolution, schedule with a 15-minute resolution
@@ -1471,6 +1471,24 @@ class MetaStorageScheduler(Scheduler):
                 ).load(sensor_flex_model["sensor_flex_model"])
                 self.flex_model[d]["sensor"] = sensor_flex_model.get("sensor")
                 self.flex_model[d]["asset"] = sensor_flex_model.get("asset")
+
+                # Devices that reference their power sensor only via a nested output
+                # reference (e.g. {"consumption": {"sensor": N}}) have no top-level
+                # "sensor". Without one they would be misclassified as stock-only in
+                # _prepare() and silently dropped from the schedule. Resolve the power
+                # sensor from the output reference so the device is scheduled and its
+                # schedule is saved to its declared output sensor.
+                if self.flex_model[d]["sensor"] is None:
+                    for output_field in ("consumption", "production"):
+                        output_ref = self.flex_model[d].get(output_field)
+                        if isinstance(output_ref, dict):
+                            output_sensor = output_ref.get("sensor")
+                            if isinstance(output_sensor, Sensor):
+                                self.flex_model[d]["sensor"] = output_sensor
+                                break
+                            elif isinstance(output_sensor, SensorReference):
+                                self.flex_model[d]["sensor"] = output_sensor.sensor
+                                break
 
                 # Extend schedule period in case a target exceeds its end
                 self.possibly_extend_end(

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -11,6 +11,7 @@ from pandas.tseries.frequencies import to_offset
 from sqlalchemy import select
 
 from flexmeasures.data.models.data_sources import DataSource
+from flexmeasures.data.models.generic_assets import GenericAsset
 from flexmeasures.data.models.time_series import TimedBelief
 from flexmeasures.data.models.time_series import Sensor
 from flexmeasures.data.models.planning import Scheduler
@@ -26,10 +27,12 @@ from flexmeasures.data.models.planning.tests.utils import (
     check_constraints,
     get_sensors_from_db,
 )
+from flexmeasures.data.models.planning.tests.utils import series_to_ts_specs
 from flexmeasures.data.models.planning.utils import (
     initialize_device_commitment,
     initialize_df,
     initialize_energy_commitment,
+    initialize_index,
     initialize_series,
 )
 from flexmeasures.data.schemas.sensors import TimedEventSchema
@@ -3242,6 +3245,152 @@ def test_prefer_full_storage_skips_non_storage_devices(db, building):
         result.get("name") == "storage_schedule" and result.get("sensor") == battery
         for result in schedule
     )
+
+
+def test_multi_device_flex_model_alignment(db, building, setup_generic_asset_types):
+    """Regression test for two bugs in multi-device storage scheduling.
+
+    The flex-model lists two devices under a common parent asset:
+
+    - Device A: a normal storage device with a top-level ``sensor`` and no explicit
+      ``power-capacity`` (so its capacity is looked up from its own asset's flex-model,
+      a small 1 kW).
+    - Device B: a storage device whose power sensor is referenced only via a nested
+      ``consumption`` output reference (no top-level ``sensor``), with its own
+      state-of-charge sensor and a much larger 9 kW ``power-capacity``.
+
+    Device B is listed first so that, on unfixed code, filtering it out shifts the
+    device/asset alignment for device A.
+
+    Two bugs manifest without the fixes:
+
+    1. Device B is silently dropped (misclassified as a stock-only entry because it has
+       no top-level ``sensor``), so its consumption output sensor never receives a
+       schedule.
+    2. Because B is dropped, the remaining device A picks up B's (larger) power capacity
+       through the misaligned zip in ``_prepare`` / ``_get_device_power_capacity``,
+       letting A charge above its own 1 kW capacity.
+    """
+    parent = building
+    battery_type = setup_generic_asset_types["battery"]
+    owner = parent.owner
+
+    resolution = timedelta(hours=1)
+    tz = pytz.timezone("Europe/Amsterdam")
+    start = tz.localize(datetime(2020, 1, 1))
+    end = start + 4 * resolution
+    end_iso = end.isoformat()
+
+    def make_device(name: str, power_capacity: str) -> tuple[Sensor, Sensor]:
+        asset = GenericAsset(
+            name=name,
+            generic_asset_type=battery_type,
+            owner=owner,
+            parent_asset_id=parent.id,
+            flex_model={"power-capacity": power_capacity},
+        )
+        db.session.add(asset)
+        db.session.flush()
+        power_sensor = Sensor(
+            name=f"{name} power",
+            generic_asset=asset,
+            event_resolution=resolution,
+            unit="kW",
+        )
+        soc_sensor = Sensor(
+            name=f"{name} soc",
+            generic_asset=asset,
+            event_resolution=timedelta(0),
+            unit="kWh",
+        )
+        db.session.add_all([power_sensor, soc_sensor])
+        db.session.flush()
+        return power_sensor, soc_sensor
+
+    # Device A: small (1 kW) capacity, provided only via its asset's flex-model.
+    a_power, a_soc = make_device("device A", "1 kW")
+    # Device B: larger (9 kW) capacity, power sensor referenced only via "consumption".
+    b_power, b_soc = make_device("device B", "9 kW")
+    b_output = Sensor(
+        name="device B consumption output",
+        generic_asset=b_power.generic_asset,
+        event_resolution=resolution,
+        unit="kW",
+    )
+    db.session.add(b_output)
+    db.session.commit()
+
+    # Make the first slot the cheapest so that a device allowed to exceed 1 kW would
+    # front-load its charging into slot 0 (revealing the wrong, larger capacity).
+    index = initialize_index(start=start, end=end, resolution=resolution)
+    consumption_prices = pd.Series([1, 100, 100, 100], index=index)
+
+    # Device B is listed first, so dropping it (bug 2) shifts the alignment for device A.
+    flex_model = [
+        {
+            "state-of-charge": {"sensor": b_soc.id},
+            "consumption": {"sensor": b_output.id},
+            "power-capacity": "9 kW",
+            "soc-at-start": "0 kWh",
+            "soc-min": "0 kWh",
+            "soc-max": "100 kWh",
+            "soc-minima": [{"datetime": end_iso, "value": "2 kWh"}],
+        },
+        {
+            "sensor": a_power.id,
+            "state-of-charge": {"sensor": a_soc.id},
+            "soc-at-start": "0 kWh",
+            "soc-min": "0 kWh",
+            "soc-max": "100 kWh",
+            "soc-minima": [{"datetime": end_iso, "value": "4 kWh"}],
+        },
+    ]
+
+    scheduler: Scheduler = StorageScheduler(
+        asset_or_sensor=parent,
+        start=start,
+        end=end,
+        resolution=resolution,
+        flex_model=flex_model,
+        flex_context={
+            "consumption-price": series_to_ts_specs(consumption_prices, unit="EUR/MWh"),
+            "production-price": "0 EUR/MWh",
+            "site-power-capacity": "100 kW",
+            "soc-minima-breach-price": "6000 EUR/kWh",
+        },
+        return_multiple=True,
+    )
+    results = scheduler.compute()
+
+    # Bug 1: device A must respect its own 1 kW capacity, not device B's 9 kW.
+    a_schedule = next(
+        r["data"]
+        for r in results
+        if r.get("name") == "storage_schedule" and r.get("sensor") is a_power
+    )
+    # Charge is in kW (sensor unit); allow a small numerical tolerance.
+    assert (a_schedule <= 1 + 1e-3).all(), (
+        "Device A charged above its own 1 kW power capacity, "
+        "indicating it inherited device B's larger capacity through a misaligned zip."
+    )
+    # Sanity: device A still meets its 4 kWh soc-minimum (1 kW across all four hours).
+    np.testing.assert_allclose(a_schedule.values, 1.0, atol=1e-3)
+
+    # Bug 2: device B must be scheduled and its consumption output sensor must receive data.
+    consumption_result = next(
+        (
+            r
+            for r in results
+            if r.get("name") == "consumption_schedule" and r.get("sensor") is b_output
+        ),
+        None,
+    )
+    assert (
+        consumption_result is not None
+    ), "Device B was dropped: its consumption output sensor received no schedule."
+    # Device B charges 2 kWh in total (consumption is positive).
+    b_consumption = consumption_result["data"]
+    np.testing.assert_allclose(b_consumption.sum(), 2.0, atol=1e-3)
 
 
 def test_multiple_devices_sequential_scheduler():


### PR DESCRIPTION
## Summary

Fixes two confirmed bugs in `StorageScheduler` multi-device scheduling that surface whenever a flex-model entry is filtered from the device list. Both were reproduced in a community simulation with a heat pump and a child battery: the heat pump inherited the battery's ±2.5 kW power capacity, and the battery was never scheduled.

### Bug 1 — misaligned zip in `_prepare()` (zip truncation since #1946 × #1429)

`device_models` is a filtered subset of `self.flex_model` (stock-only entries are dropped). When building the per-device asset list, the code zipped `sensors` (built from `device_models`) against the **unfiltered** `self.flex_model`. Whenever anything was filtered out, this misassigned assets. Combined with `_get_device_power_capacity`'s `asset.flex_model.get("power-capacity")` fallback, a device could inherit another device's power capacity. The latent assumption dates to #1429; #1946 broke it by adding the stock-only filtering.

**Fix:** zip against `device_models` (the same list `sensors` is built from).

### Bug 2 — devices with only a nested output reference silently dropped

A flex-model entry that references its power sensor only via a nested `"consumption": {"sensor": N}` (or `"production"`) and has a `"state-of-charge"` sensor ends up with `sensor = None` after deserialization. It is then classified as stock-only and removed from `device_models` — the device is never scheduled and its consumption/production output sensor receives zero beliefs.

**Fix:** in `_deserialize_flex_model` (list branch), when a device entry has no top-level `"sensor"`, resolve it from the `consumption`/`production` output reference. Genuine stock-only entries (no sensor and no output reference) are still filtered.

## Test

Adds `test_multi_device_flex_model_alignment`, which schedules two devices under a common parent:
- Device A: normal storage with a top-level sensor and a small (1 kW) capacity taken from its asset flex-model.
- Device B (listed first): no top-level sensor, power sensor referenced only via `consumption`, its own state-of-charge, and a larger (9 kW) capacity.

Asserts (i) device A respects its own 1 kW capacity (fails before Bug 1 fix — A charged 4 kW) and (ii) device B's consumption output sensor receives a schedule (fails before Bug 2 fix). Verified to fail on unfixed code and pass with the fixes. Existing `test_storage.py` output-sensor tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQFkeGxDwErydUV5ZmHmki