### PR TITLE
Speed up post-processing of sensor data searches

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -32,6 +32,7 @@ New features
 Infrastructure / Support
 ----------------------
 * Upgraded dependencies [see `PR #1485 <https://www.github.com/FlexMeasures/flexmeasures/pull/1485>`_, `PR #2215 <https://www.github.com/FlexMeasures/flexmeasures/pull/2215>`_ and `PR #2243 <https://www.github.com/FlexMeasures/flexmeasures/pull/2243>`_]
+* Speed up post-processing of sensor data searches: latest-version filtering, deterministic-belief selection per event and chart-data serialization are now vectorized (up to three orders of magnitude faster on large search results) [see `PR #2322 <https://www.github.com/FlexMeasures/flexmeasures/pull/2322>`_]
 * Prepare the ``device_scheduler`` to deal with commitments per device group [see `PR #1934 <https://www.github.com/FlexMeasures/flexmeasures/pull/1934>`_]
 * Speed up scheduling on longer horizons using a recursive stock model, making the solve time linear with the horizon instead of quadratic (about 10x faster solves at the 2-day default horizon, 23x at 3 days) [see `PR #2282 <https://www.github.com/FlexMeasures/flexmeasures/pull/2282>`_]
 * Support storing encrypted connection secrets on organisations and assets, including utility functions, encryption key configuration, CLI commands to set and delete secrets, and UI tables that show stored secret names and optional expiration times without exposing their values [see `PR #2236 <https://www.github.com/FlexMeasures/flexmeasures/pull/2236>`_]

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -32,7 +32,7 @@ New features
 Infrastructure / Support
 ----------------------
 * Upgraded dependencies [see `PR #1485 <https://www.github.com/FlexMeasures/flexmeasures/pull/1485>`_, `PR #2215 <https://www.github.com/FlexMeasures/flexmeasures/pull/2215>`_ and `PR #2243 <https://www.github.com/FlexMeasures/flexmeasures/pull/2243>`_]
-* Speed up post-processing of sensor data searches: latest-version filtering, deterministic-belief selection per event and chart-data serialization are now vectorized (up to three orders of magnitude faster on large search results) [see `PR #2322 <https://www.github.com/FlexMeasures/flexmeasures/pull/2322>`_]
+* Speed up post-processing of sensor data searches: latest-version filtering, deterministic-belief selection per event and chart-data serialization are now vectorized (up to three orders of magnitude faster on large search results) [see `PR #2328 <https://www.github.com/FlexMeasures/flexmeasures/pull/2328>`_]
 * Prepare the ``device_scheduler`` to deal with commitments per device group [see `PR #1934 <https://www.github.com/FlexMeasures/flexmeasures/pull/1934>`_]
 * Speed up scheduling on longer horizons using a recursive stock model, making the solve time linear with the horizon instead of quadratic (about 10x faster solves at the 2-day default horizon, 23x at 3 days) [see `PR #2282 <https://www.github.com/FlexMeasures/flexmeasures/pull/2282>`_]
 * Support storing encrypted connection secrets on organisations and assets, including utility functions, encryption key configuration, CLI commands to set and delete secrets, and UI tables that show stored secret names and optional expiration times without exposing their values [see `PR #2236 <https://www.github.com/FlexMeasures/flexmeasures/pull/2236>`_]

--- a/flexmeasures/data/models/data_sources.py
+++ b/flexmeasures/data/models/data_sources.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.dialects.postgresql import JSONB
 
+import numpy as np
 import pandas as pd
 import timely_beliefs as tb
 
@@ -514,19 +515,30 @@ class DataSource(db.Model, tb.BeliefSourceDBMixin):
         self.attributes[attribute] = value
 
 
+def source_priorities(sources) -> dict:
+    """Rank sources by version (then by id), with a higher rank meaning a more recent version.
+
+    Sources without a version are assumed to have version 0.0.0.
+    """
+    priority_order = sorted(
+        sources,
+        key=lambda s: (
+            Version(s.version or "0.0.0"),
+            s.id if s.id is not None else -1,
+        ),
+    )
+    return {source: rank for rank, source in enumerate(priority_order)}
+
+
 def keep_latest_version(
     bdf: tb.BeliefsDataFrame,
     one_deterministic_belief_per_event: bool = False,
 ) -> tb.BeliefsDataFrame:
     """Filters the BeliefsDataFrame to keep the latest version of each source per event or per belief.
 
-    The function performs the following steps:
-
-    1. Adds columns for the source's name, type, model, version and id.
-    2. Sorts the rows by `source.version` and `source.id`, both in descending order.
-    3. Removes duplicates based on `source.name`, `source.type`, and `source.model`,
-       keeping the latest version for each `event_start` (and `belief_time`).
-    4. Drops the temporary columns added for source attributes.
+    Sources are grouped by (name, type, model); within each group, only data from
+    the latest version (breaking ties by highest id) is kept, per event or per belief.
+    Probabilistic beliefs are kept intact.
 
     :param bdf: The input `BeliefsDataFrame` containing `event_start` and source information.
     :param one_deterministic_belief_per_event:
@@ -541,70 +553,38 @@ def keep_latest_version(
     # Sanitize BeliefsDataFrame by removing duplicate indices
     bdf = bdf.loc[~bdf.index.duplicated(keep="first"), :]
 
-    # Get the event column and belief column names
+    # Group unique sources by (name, type, model)
+    source_codes, unique_sources = pd.factorize(bdf.index.get_level_values("source"))
+    group_keys: dict = {}
+    group_per_source = np.empty(len(unique_sources), dtype=np.int64)
+    for i, source in enumerate(unique_sources):
+        key = (source.name, source.type, source.model)
+        group_per_source[i] = group_keys.setdefault(key, len(group_keys))
+    if len(group_keys) == len(unique_sources):
+        # Every source is the sole member of its group, so nothing can be dropped
+        return bdf
+
+    # Prioritize each unique source within its group by version, then by id
+    priorities = source_priorities(unique_sources)
+    priority_per_source = np.array(
+        [priorities[source] for source in unique_sources], dtype=np.int64
+    )
+
+    # Keep, per event (and belief) and source group, only the rows of the
+    # highest-priority source, retaining probabilistic rows and row order
     index_levels = bdf.index.names
-    belief_column = "belief_time"
-    if belief_column not in index_levels:
-        belief_column = "belief_horizon"
-    event_column = "event_start"
-    if event_column not in index_levels:
-        event_column = "event_end"
-
-    # Add source-related columns using vectorized operations for clarity
-    source_values = set(bdf.index.get_level_values("source").values)
-    source_to_fields = {
-        s: {
-            "source.name": s.name,
-            "source.type": s.type,
-            "source.model": s.model,
-            "source.version": Version(s.version or "0.0.0"),
-            "source.id": s.id,
-        }
-        for s in source_values
-    }
-    source_expanded = bdf.index.get_level_values("source").map(source_to_fields)
-
-    bdf[
-        ["source.name", "source.type", "source.model", "source.version", "source.id"]
-    ] = pd.DataFrame(source_expanded.tolist(), index=bdf.index)
-    bdf["_" + event_column] = bdf.index.get_level_values(event_column)
-    if not one_deterministic_belief_per_event:
-        bdf["_" + belief_column] = bdf.index.get_level_values(belief_column)
-    # Sort by event_start (belief_time), version and ID, keeping only the latest version and highest ID
-    if one_deterministic_belief_per_event:
-        sort_by = ["_" + event_column, "source.version", "source.id"]
-        ascending = [True, False, False]
-    else:
-        sort_by = [
-            "_" + event_column,
-            "_" + belief_column,
-            "source.version",
-            "source.id",
-        ]
-        ascending = [
-            True,
-            True if belief_column == "belief_time" else False,
-            False,
-            False,
-        ]
-    bdf_sorted = bdf.sort_values(by=sort_by, ascending=ascending)
-
-    # Drop duplicates based on event_start and source identifiers, keeping the latest version
-    unique_columns = [
-        "_" + event_column,
-        "source.name",
-        "source.type",
-        "source.model",
+    event_column = "event_start" if "event_start" in index_levels else "event_end"
+    group_keys_per_row = [
+        bdf.index.get_level_values(event_column).asi8,
+        group_per_source[source_codes],
     ]
     if not one_deterministic_belief_per_event:
-        unique_columns += ["_" + belief_column]
-    # Keep probabilistic beliefs intact
-    unique_keys = (
-        bdf_sorted[unique_columns].drop_duplicates().droplevel("cumulative_probability")
+        belief_column = (
+            "belief_time" if "belief_time" in index_levels else "belief_horizon"
+        )
+        group_keys_per_row.append(bdf.index.get_level_values(belief_column).asi8)
+    priority_per_row = pd.Series(priority_per_source[source_codes])
+    winning_priority = (
+        priority_per_row.groupby(group_keys_per_row).transform("max").to_numpy()
     )
-    bdf = bdf.loc[bdf.index.droplevel("cumulative_probability").isin(unique_keys.index)]
-
-    # Remove temporary columns
-    bdf = bdf.drop(columns=unique_columns + ["source.version", "source.id"])
-
-    return bdf
+    return bdf[priority_per_row.to_numpy() == winning_priority]

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -1163,7 +1163,8 @@ class GenericAsset(db.Model, AuthModelMixin):
         :param resolution: optionally set the resolution of data being displayed
         :returns: dictionary of BeliefsDataFrames or JSON string (if as_json is True)
         """
-        bdf_dict = {}
+        from flexmeasures.data.models.time_series import TimedBelief
+
         if sensors is None:
             sensors = self.sensors
 
@@ -1171,8 +1172,10 @@ class GenericAsset(db.Model, AuthModelMixin):
             list(set([sensor.unit for sensor in sensors]))
         )
 
-        for sensor in sensors:
-            bdf_dict[sensor] = sensor.search_beliefs(
+        # One search call for all sensors, so source criteria are parsed only once
+        bdf_dict = (
+            TimedBelief.search(
+                sensors=list(sensors),
                 event_starts_after=event_starts_after,
                 event_ends_before=event_ends_before,
                 beliefs_after=beliefs_after,
@@ -1186,7 +1189,11 @@ class GenericAsset(db.Model, AuthModelMixin):
                 most_recent_events_only=most_recent_events_only,
                 one_deterministic_belief_per_event_per_source=True,
                 resolution=resolution,
+                sum_multiple=False,
             )
+            if sensors
+            else {}
+        )
         if as_json and not compress_json:
             from flexmeasures.data.services.time_series import simplify_index
 
@@ -1342,56 +1349,43 @@ class GenericAsset(db.Model, AuthModelMixin):
 
                     # Add source IDs if available
                     if "source" in df.columns:
-                        source_ids = (
-                            df["source"]
-                            .apply(lambda x: x.id if hasattr(x, "id") else None)
-                            .tolist()
-                        )
-                        base_records["src"] = source_ids
+                        source_codes, unique_sources = pd.factorize(df["source"])
+                        unique_source_ids = [
+                            source_obj.id if hasattr(source_obj, "id") else None
+                            for source_obj in unique_sources
+                        ]
+                        base_records["src"] = [
+                            unique_source_ids[code] if code >= 0 else None
+                            for code in source_codes
+                        ]
 
-                    # Add belief horizons if available
+                    # Add belief horizons if available (in milliseconds)
                     if "belief_horizon" in df.columns:
-                        belief_horizons_sec = (
-                            df["belief_horizon"]
-                            .apply(
-                                lambda x: (
-                                    int(x.total_seconds() * 1000)
-                                    if pd.notnull(x)
-                                    else None
-                                )
-                            )
-                            .tolist()
-                        )
-                        base_records["bh"] = belief_horizons_sec
+                        bh_values = df["belief_horizon"]
+                        bh_mask = bh_values.notna().to_numpy()
+                        bh_ms = bh_values.to_numpy().view("int64") // 1_000_000
+                        base_records["bh"] = [
+                            int(value) if keep else None
+                            for value, keep in zip(bh_ms, bh_mask)
+                        ]
 
-                    # Add belief times if needed
+                    # Add belief times if needed (in milliseconds)
                     if not most_recent_beliefs_only and "belief_time" in df.columns:
-                        belief_times_ms = (
-                            df["belief_time"]
-                            .apply(
-                                lambda x: (
-                                    int(x.timestamp() * 1000) if pd.notnull(x) else None
-                                )
-                            )
-                            .tolist()
+                        bt_values = df["belief_time"]
+                        bt_mask = bt_values.notna().to_numpy()
+                        bt_ms = (
+                            bt_values.to_numpy(dtype="datetime64[ns]").view("int64")
+                            // 1_000_000
                         )
-                        base_records["bt"] = belief_times_ms
-
-                    cleaned_records = {}
-                    for key, values in base_records.items():
-                        if isinstance(values, list):
-                            cleaned_records[key] = values
-                        else:
-                            cleaned_records[key] = (
-                                pd.Series(values).fillna(None).tolist()
-                            )
+                        base_records["bt"] = [
+                            int(value) if keep else None
+                            for value, keep in zip(bt_ms, bt_mask)
+                        ]
 
                     # Convert to list of dictionaries
-                    for i in range(len(df)):
-                        record = {
-                            key: values[i] for key, values in cleaned_records.items()
-                        }
-                        all_records.append(record)
+                    record_keys = list(base_records)
+                    for row_values in zip(*base_records.values()):
+                        all_records.append(dict(zip(record_keys, row_values)))
 
                 return json.dumps(
                     {

--- a/flexmeasures/data/models/generic_assets.py
+++ b/flexmeasures/data/models/generic_assets.py
@@ -30,7 +30,10 @@ from flexmeasures.auth.policy import (
     CONSULTANT_ROLE,
 )
 from flexmeasures.utils import geo_utils
-from flexmeasures.utils.time_utils import determine_minimum_resampling_resolution
+from flexmeasures.utils.time_utils import (
+    determine_minimum_resampling_resolution,
+    truncated_integer_epochs,
+)
 from flexmeasures.utils.unit_utils import find_smallest_common_unit
 
 
@@ -1363,7 +1366,9 @@ class GenericAsset(db.Model, AuthModelMixin):
                     if "belief_horizon" in df.columns:
                         bh_values = df["belief_horizon"]
                         bh_mask = bh_values.notna().to_numpy()
-                        bh_ms = bh_values.to_numpy().view("int64") // 1_000_000
+                        bh_ms = truncated_integer_epochs(
+                            bh_values.to_numpy().view("int64"), 1_000_000
+                        )
                         base_records["bh"] = [
                             int(value) if keep else None
                             for value, keep in zip(bh_ms, bh_mask)
@@ -1373,9 +1378,9 @@ class GenericAsset(db.Model, AuthModelMixin):
                     if not most_recent_beliefs_only and "belief_time" in df.columns:
                         bt_values = df["belief_time"]
                         bt_mask = bt_values.notna().to_numpy()
-                        bt_ms = (
-                            bt_values.to_numpy(dtype="datetime64[ns]").view("int64")
-                            // 1_000_000
+                        bt_ms = truncated_integer_epochs(
+                            bt_values.to_numpy(dtype="datetime64[ns]").view("int64"),
+                            1_000_000,
                         )
                         base_records["bt"] = [
                             int(value) if keep else None

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -32,6 +32,7 @@ from flexmeasures.utils.entity_address_utils import (
     EntityAddressException,
     build_entity_address,
 )
+from flexmeasures.utils.time_utils import truncated_integer_epochs
 from flexmeasures.utils.unit_utils import (
     is_energy_unit,
     is_power_unit,
@@ -831,13 +832,14 @@ def compress_belief_records(df: pd.DataFrame, sensor_id: int) -> tuple[list, dic
 
     # Convert the timing columns to epoch values (vectorized)
     def to_epoch_list(column: str, np_dtype: str | None, divisor: int) -> list:
-        """Integer epoch value (ns // divisor) per row, or None for missing values."""
+        """Integer epoch value (ns / divisor, truncated toward zero) per row,
+        or None for missing values."""
         if column not in df.columns:
             return [None] * len(df)
         values = df[column]
         mask = values.notna().to_numpy()
         raw = values.to_numpy(dtype=np_dtype) if np_dtype else values.to_numpy()
-        ints = raw.view("int64") // divisor
+        ints = truncated_integer_epochs(raw.view("int64"), divisor)
         return [int(value) if keep else None for value, keep in zip(ints, mask)]
 
     ts_per_row = to_epoch_list("event_start", "datetime64[ns]", 10**6)  # ms

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -7,6 +7,7 @@ import json
 from packaging.version import Version
 from flask import current_app
 
+import numpy as np
 import pandas as pd
 from sqlalchemy import exists, select
 from sqlalchemy.ext.declarative import declared_attr
@@ -858,6 +859,38 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin, OrderByIdMixin):
         return self.search_data_sources()
 
 
+def _select_latest_version_and_belief_per_event(
+    bdf: tb.BeliefsDataFrame,
+) -> tb.BeliefsDataFrame:
+    """Keep, per event, the single belief with the latest source version,
+    breaking version ties by most recent belief time.
+
+    Assumes deterministic beliefs (probabilistic depth 1) and a belief_time index level.
+    """
+    source_codes, unique_sources = pd.factorize(bdf.index.get_level_values("source"))
+    versions = [
+        Version(source.version if source.version else "0.0.0")
+        for source in unique_sources
+    ]
+    version_ranks = {
+        version: rank for rank, version in enumerate(sorted(set(versions)))
+    }
+    rank_per_row = np.array([version_ranks[version] for version in versions])[
+        source_codes
+    ]
+    event_values = bdf.index.get_level_values("event_start").asi8
+    belief_values = bdf.index.get_level_values("belief_time").asi8
+    # Sort by event (ascending), then version rank and belief time (both descending)
+    order = np.lexsort((-belief_values, -rank_per_row, event_values))
+    sorted_events = event_values[order]
+    is_first_of_event = np.empty(len(order), dtype=bool)
+    is_first_of_event[:1] = True
+    is_first_of_event[1:] = sorted_events[1:] != sorted_events[:-1]
+    mask = np.zeros(len(order), dtype=bool)
+    mask[order[is_first_of_event]] = True
+    return bdf[mask]
+
+
 class TimedBelief(db.Model, tb.TimedBeliefDBMixin):
     """A timed belief holds a precisely timed record of a belief about an event.
 
@@ -1030,25 +1063,34 @@ class TimedBelief(db.Model, tb.TimedBeliefDBMixin):
                 ):
                     # Fast track, no need to loop over beliefs
                     pass
+                elif (
+                    bdf.lineage.probabilistic_depth == 1
+                    and "belief_time" in bdf.index.names
+                ):
+                    # Deterministic beliefs: no need to take the median,
+                    # just pick the winning belief per event directly
+                    bdf = _select_latest_version_and_belief_per_event(bdf)
                 else:
                     # First make deterministic
                     bdf = bdf.for_each_belief(get_median_belief)
-                    # Then sort each event by most recent source version and most recent belief_time
+                    # Then sort each event by latest source version and most recent belief_time
+                    version_per_source = {
+                        source: Version(source.version if source.version else "0.0.0")
+                        for source in bdf.lineage.sources
+                    }
                     bdf = bdf.sort_values(
                         by=["event_start", "source", "belief_time"],
                         ascending=[True, False, False],
                         key=lambda col: (
-                            col.map(
-                                lambda s: Version(s.version if s.version else "0.0.0")
-                            )
-                            if col.name == "source"
-                            else col
+                            col.map(version_per_source) if col.name == "source" else col
                         ),
                     )
-                    # Finally, take the first belief for each event, thus preference most recent belief_time first, latest version second
-                    bdf = bdf.groupby(level=["event_start"], group_keys=False).apply(
-                        lambda x: x.head(1)
-                    )
+                    # Finally, take the first belief for each event, thus preference latest version first, most recent belief_time second
+                    bdf = bdf[
+                        ~bdf.index.get_level_values("event_start").duplicated(
+                            keep="first"
+                        )
+                    ]
             elif one_deterministic_belief_per_event_per_source:
                 if len(bdf) == 0 or bdf.lineage.probabilistic_depth == 1:
                     # Fast track, no need to loop over beliefs

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -467,8 +467,6 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin, OrderByIdMixin):
 
             # Build metadata dictionaries
             sensors_metadata = {}
-            sources_metadata = {}
-            all_records = []
 
             # Build sensor metadata
             sensor_dict = self.as_dict
@@ -485,69 +483,7 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin, OrderByIdMixin):
                 "asset_description": sensor_dict.get("asset_description", ""),
             }
 
-            # Process each row in the dataframe
-            for _, row in df.iterrows():
-                source_obj = row.get("source")
-
-                if (
-                    source_obj
-                    and hasattr(source_obj, "id")
-                    and source_obj.id not in sources_metadata
-                ):
-
-                    source_dict = source_obj.as_dict
-                    sources_metadata[source_obj.id] = {
-                        "name": source_dict.get("name", ""),
-                        "model": source_dict.get("model", ""),
-                        "version": source_dict.get("version", ""),
-                        "type": source_dict.get("type", "other"),
-                        "raw_type": source_dict.get("raw_type", ""),
-                        "display_type": source_dict.get(
-                            "display_type", source_dict.get("type", "other")
-                        ),
-                        "description": source_dict.get("description", ""),
-                    }
-
-                # Build the data record with reference IDs instead of full objects
-                record = {
-                    "ts": int(
-                        row["event_start"].timestamp() * 1000
-                    ),  # timestamp in milliseconds for JavaScript compatibility
-                    "sid": self.id,  # sensor ID reference
-                    "val": row["event_value"],
-                }
-
-                # Add optional fields
-                if source_obj and hasattr(source_obj, "id"):
-                    record["src"] = source_obj.id  # source ID reference
-
-                if "belief_time" in row and pd.notnull(row["belief_time"]):
-                    record["bt"] = int(
-                        row["belief_time"].timestamp() * 1000
-                    )  # timestamp in milliseconds for JavaScript compatibility
-
-                if "belief_horizon" in row and pd.notnull(row["belief_horizon"]):
-                    record["bh"] = int(row["belief_horizon"].total_seconds())
-
-                if "cumulative_probability" in row and pd.notnull(
-                    row["cumulative_probability"]
-                ):
-                    record["cp"] = row["cumulative_probability"]
-
-                # Clean up any problematic types
-                for key, value in record.items():
-                    if pd.isna(value):
-                        record[key] = None
-                    elif isinstance(value, pd.Timestamp):
-                        record[key] = int(
-                            value.timestamp() * 1000
-                        )  # timestamp in milliseconds for JavaScript compatibility
-                    elif isinstance(value, (pd.Timedelta, timedelta)):
-                        record[key] = int(value.total_seconds())
-                    elif hasattr(value, "item"):  # numpy types
-                        record[key] = value.item()
-
-                all_records.append(record)
+            all_records, sources_metadata = compress_belief_records(df, self.id)
 
             # Return in the new structured format
             result = {
@@ -857,6 +793,85 @@ class Sensor(db.Model, tb.SensorDBMixin, AuthModelMixin, OrderByIdMixin):
         Equivalent to ``search_data_sources()`` with no filters.
         """
         return self.search_data_sources()
+
+
+def compress_belief_records(df: pd.DataFrame, sensor_id: int) -> tuple[list, dict]:
+    """Build compact belief records and source metadata from a reset-index beliefs frame.
+
+    Records hold reference IDs instead of full objects, and timestamps in epoch
+    milliseconds for JavaScript compatibility (belief horizons in seconds).
+    Missing values (e.g. an unknown belief time) leave their key out of the record.
+    """
+    sources_metadata: dict = {}
+
+    # Build source metadata and the source id per row (in first-appearance order)
+    source_codes, unique_sources = pd.factorize(df["source"])
+    unique_source_ids: list[int | None] = []
+    for source_obj in unique_sources:
+        if source_obj and hasattr(source_obj, "id"):
+            unique_source_ids.append(source_obj.id)
+            if source_obj.id not in sources_metadata:
+                source_dict = source_obj.as_dict
+                sources_metadata[source_obj.id] = {
+                    "name": source_dict.get("name", ""),
+                    "model": source_dict.get("model", ""),
+                    "version": source_dict.get("version", ""),
+                    "type": source_dict.get("type", "other"),
+                    "raw_type": source_dict.get("raw_type", ""),
+                    "display_type": source_dict.get(
+                        "display_type", source_dict.get("type", "other")
+                    ),
+                    "description": source_dict.get("description", ""),
+                }
+        else:
+            unique_source_ids.append(None)
+    src_per_row = [
+        unique_source_ids[code] if code >= 0 else None for code in source_codes
+    ]
+
+    # Convert the timing columns to epoch values (vectorized)
+    def to_epoch_list(column: str, np_dtype: str | None, divisor: int) -> list:
+        """Integer epoch value (ns // divisor) per row, or None for missing values."""
+        if column not in df.columns:
+            return [None] * len(df)
+        values = df[column]
+        mask = values.notna().to_numpy()
+        raw = values.to_numpy(dtype=np_dtype) if np_dtype else values.to_numpy()
+        ints = raw.view("int64") // divisor
+        return [int(value) if keep else None for value, keep in zip(ints, mask)]
+
+    ts_per_row = to_epoch_list("event_start", "datetime64[ns]", 10**6)  # ms
+    bt_per_row = to_epoch_list("belief_time", "datetime64[ns]", 10**6)  # ms
+    bh_per_row = to_epoch_list("belief_horizon", None, 10**9)  # s
+    cp_per_row = (
+        [
+            None if value != value else value
+            for value in df["cumulative_probability"].tolist()
+        ]
+        if "cumulative_probability" in df.columns
+        else [None] * len(df)
+    )
+    val_per_row = df["event_value"].tolist()
+
+    all_records = []
+    for ts, val, src, bt, bh, cp in zip(
+        ts_per_row, val_per_row, src_per_row, bt_per_row, bh_per_row, cp_per_row
+    ):
+        record = {
+            "ts": ts,
+            "sid": sensor_id,  # sensor ID reference
+            "val": None if val != val else val,
+        }
+        if src is not None:
+            record["src"] = src  # source ID reference
+        if bt is not None:
+            record["bt"] = bt
+        if bh is not None:
+            record["bh"] = bh
+        if cp is not None:
+            record["cp"] = cp
+        all_records.append(record)
+    return all_records, sources_metadata
 
 
 def _select_latest_version_and_belief_per_event(

--- a/flexmeasures/data/queries/utils.py
+++ b/flexmeasures/data/queries/utils.py
@@ -141,14 +141,13 @@ def user_source_criterion(
     """
     if user_source_ids is not None and not isinstance(user_source_ids, list):
         user_source_ids = [user_source_ids]  # ensure user_source_ids is a list
-    ignorable_user_sources = db.session.scalars(
-        select(DataSource)
+    # Uncorrelated subquery, so building the criterion costs no extra round trip
+    ignorable_user_source_ids = (
+        select(DataSource.id)
         .filter(DataSource.type == "user")
         .filter(DataSource.id.not_in(user_source_ids))
-    ).all()
-    ignorable_user_source_ids = [
-        user_source.id for user_source in ignorable_user_sources
-    ]
+        .scalar_subquery()
+    )
 
     # todo: [legacy] deprecate this if-statement, which is used to support the TimedValue class
     if hasattr(cls, "data_source_id"):

--- a/flexmeasures/data/scripts/benchmark_search_postprocessing.py
+++ b/flexmeasures/data/scripts/benchmark_search_postprocessing.py
@@ -1,0 +1,198 @@
+"""Benchmark search_beliefs post-processing on synthetic data (no database needed).
+
+Usage:
+
+    python flexmeasures/data/scripts/benchmark_search_postprocessing.py
+
+Run it twice to compare implementations, e.g. once on main and once on a perf branch.
+On code that predates the vectorized implementations, the script falls back to
+timing verbatim copies of the previous per-row implementations, so the printed
+table is comparable across branches.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import timedelta
+from statistics import median
+
+import numpy as np
+import pandas as pd
+import timely_beliefs as tb
+from packaging.version import Version
+
+from flexmeasures.data.models.data_sources import DataSource, keep_latest_version
+
+SIZES = [10_000, 100_000]
+REPS = 3
+
+
+def make_bdf(
+    n_rows: int, sources: list[DataSource], cps: tuple = (0.5,)
+) -> tb.BeliefsDataFrame:
+    sensor = tb.Sensor("bench sensor", event_resolution=timedelta(minutes=15))
+    n_belief_times = 2
+    n_events = max(1, n_rows // (n_belief_times * len(cps)))
+    event_starts = pd.date_range("2025-01-01", periods=n_events, freq="15min", tz="UTC")
+    belief_times = pd.date_range(
+        "2024-12-01", periods=n_belief_times, freq="1h", tz="UTC"
+    )
+    rng = np.random.default_rng(0)
+    records = [
+        (event_start, belief_time, sources[int(rng.integers(len(sources)))], cp, value)
+        for event_start in event_starts
+        for belief_time in belief_times
+        for cp, value in [(cp, float(rng.random())) for cp in cps]
+    ]
+    df = pd.DataFrame(
+        records,
+        columns=[
+            "event_start",
+            "belief_time",
+            "source",
+            "cumulative_probability",
+            "event_value",
+        ],
+    )
+    return tb.BeliefsDataFrame(df, sensor=sensor)
+
+
+def timeit(label: str, fn) -> None:
+    times = []
+    for _ in range(REPS):
+        t0 = time.perf_counter()
+        fn()
+        times.append(time.perf_counter() - t0)
+    print("{:<60} {:>10.1f} ms".format(label, median(times) * 1000))
+
+
+def deterministic_selection(bdf: tb.BeliefsDataFrame) -> tb.BeliefsDataFrame:
+    """One deterministic belief per event (deterministic multi-source data)."""
+    try:
+        from flexmeasures.data.models.time_series import (
+            _select_latest_version_and_belief_per_event,
+        )
+
+        return _select_latest_version_and_belief_per_event(bdf)
+    except ImportError:
+        # Fallback: previous implementation (from TimedBelief.search)
+        bdf = bdf.sort_values(
+            by=["event_start", "source", "belief_time"],
+            ascending=[True, False, False],
+            key=lambda col: (
+                col.map(lambda s: Version(s.version if s.version else "0.0.0"))
+                if col.name == "source"
+                else col
+            ),
+        )
+        return bdf.groupby(level=["event_start"], group_keys=False).apply(
+            lambda x: x.head(1)
+        )
+
+
+def compress_records(df: pd.DataFrame, sensor_id: int):  # noqa: C901
+    try:
+        from flexmeasures.data.models.time_series import compress_belief_records
+
+        return compress_belief_records(df, sensor_id)
+    except ImportError:
+        # Fallback: previous implementation (from Sensor.search_beliefs)
+        sources_metadata: dict = {}
+        all_records = []
+        for _, row in df.iterrows():
+            source_obj = row.get("source")
+            if (
+                source_obj
+                and hasattr(source_obj, "id")
+                and source_obj.id not in sources_metadata
+            ):
+                source_dict = source_obj.as_dict
+                sources_metadata[source_obj.id] = {
+                    "name": source_dict.get("name", ""),
+                    "model": source_dict.get("model", ""),
+                    "version": source_dict.get("version", ""),
+                    "type": source_dict.get("type", "other"),
+                    "raw_type": source_dict.get("raw_type", ""),
+                    "display_type": source_dict.get(
+                        "display_type", source_dict.get("type", "other")
+                    ),
+                    "description": source_dict.get("description", ""),
+                }
+            record = {
+                "ts": int(row["event_start"].timestamp() * 1000),
+                "sid": sensor_id,
+                "val": row["event_value"],
+            }
+            if source_obj and hasattr(source_obj, "id"):
+                record["src"] = source_obj.id
+            if "belief_time" in row and pd.notnull(row["belief_time"]):
+                record["bt"] = int(row["belief_time"].timestamp() * 1000)
+            if "belief_horizon" in row and pd.notnull(row["belief_horizon"]):
+                record["bh"] = int(row["belief_horizon"].total_seconds())
+            if "cumulative_probability" in row and pd.notnull(
+                row["cumulative_probability"]
+            ):
+                record["cp"] = row["cumulative_probability"]
+            for key, value in record.items():
+                if pd.isna(value):
+                    record[key] = None
+                elif isinstance(value, pd.Timestamp):
+                    record[key] = int(value.timestamp() * 1000)
+                elif isinstance(value, (pd.Timedelta, timedelta)):
+                    record[key] = int(value.total_seconds())
+                elif hasattr(value, "item"):
+                    record[key] = value.item()
+            all_records.append(record)
+        return all_records, sources_metadata
+
+
+def main():
+    single_source = [
+        DataSource(id=1, name="s1", model="model 1", type="forecaster", version="1.0")
+    ]
+    distinct_sources = [
+        DataSource(id=1, name="s1", model="model 1", type="forecaster", version="1.0"),
+        DataSource(id=2, name="s2", model="model 2", type="scheduler"),
+        DataSource(id=3, name="s3", model="model 3", type="reporter", version="2.0"),
+    ]
+    versioned_sources = [
+        DataSource(
+            id=1, name="s1", model="model 1", type="forecaster", version="0.1.0"
+        ),
+        DataSource(
+            id=2, name="s1", model="model 1", type="forecaster", version="0.2.0"
+        ),
+        DataSource(id=3, name="s2", model="model 2", type="scheduler"),
+    ]
+
+    for n_rows in SIZES:
+        print("--- {} rows ---".format(n_rows))
+        for mix_label, sources in [
+            ("1 source", single_source),
+            ("3 sources, distinct groups", distinct_sources),
+            ("3 sources, 2 versions of one", versioned_sources),
+        ]:
+            bdf = make_bdf(n_rows, sources)
+            timeit(
+                "keep_latest_version           ({})".format(mix_label),
+                lambda bdf=bdf: keep_latest_version(bdf),
+            )
+        bdf = make_bdf(n_rows, versioned_sources)
+        timeit(
+            "deterministic belief per event (3 sources, 2 versions)",
+            lambda bdf=bdf: deterministic_selection(bdf),
+        )
+        bdf_prob = make_bdf(n_rows, versioned_sources, cps=(0.1587, 0.5, 0.8413))
+        timeit(
+            "keep_latest_version           (probabilistic, 3 sources)",
+            lambda bdf=bdf_prob: keep_latest_version(bdf),
+        )
+        df = make_bdf(n_rows, distinct_sources).reset_index()
+        timeit(
+            "compress_belief_records       (3 sources, distinct groups)",
+            lambda df=df: compress_records(df, sensor_id=42),
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/flexmeasures/data/tests/test_data_source.py
+++ b/flexmeasures/data/tests/test_data_source.py
@@ -432,3 +432,90 @@ def test_sensor_data_sources_and_data_source_sensors_load_fast(db, app):
         f"DataSource.sensors took {elapsed_data_source_sensors * 1000:.1f} ms "
         f"(limit {THRESHOLD_S * 1000:.0f} ms) — use the two-step subquery property"
     )
+
+
+def test_keep_latest_version_equivalence():
+    """Compare keep_latest_version against a naive per-row reference implementation."""
+    from packaging.version import Version
+
+    def naive_keep_latest_version(
+        bdf: tb.BeliefsDataFrame, one_deterministic_belief_per_event: bool
+    ) -> tb.BeliefsDataFrame:
+        bdf = bdf.loc[~bdf.index.duplicated(keep="first"), :]
+        names = list(bdf.index.names)
+        event_level = names.index("event_start")
+        belief_level = names.index("belief_time")
+        source_level = names.index("source")
+
+        def group_key(index_tuple):
+            source = index_tuple[source_level]
+            key = (index_tuple[event_level], source.name, source.type, source.model)
+            if not one_deterministic_belief_per_event:
+                key += (index_tuple[belief_level],)
+            return key
+
+        winners: dict = {}
+        for index_tuple in bdf.index:
+            source = index_tuple[source_level]
+            key = group_key(index_tuple)
+            incumbent = winners.get(key)
+            if incumbent is None or (
+                Version(source.version or "0.0.0"),
+                source.id if source.id is not None else -1,
+            ) > (
+                Version(incumbent.version or "0.0.0"),
+                incumbent.id if incumbent.id is not None else -1,
+            ):
+                winners[key] = source
+        mask = [
+            index_tuple[source_level] is winners[group_key(index_tuple)]
+            for index_tuple in bdf.index
+        ]
+        return bdf[mask]
+
+    rng = np.random.default_rng(42)
+    sensor = tb.Sensor("equivalence sensor", event_resolution=timedelta(hours=1))
+    sources = [
+        DataSource(
+            id=i + 1 if rng.random() > 0.2 else None,
+            name=rng.choice(["s1", "s2"]),
+            model=rng.choice(["model 1", "model 2"]),
+            type=rng.choice(["forecaster", "scheduler"]),
+            version=rng.choice([None, "0.1.0", "0.2.0", "1.0.0"]),
+        )
+        for i in range(6)
+    ]
+    event_starts = pd.date_range("2025-01-01", periods=5, freq="1h", tz="UTC")
+    belief_times = pd.date_range("2024-12-31", periods=3, freq="1h", tz="UTC")
+
+    for trial in range(10):
+        beliefs = []
+        for _ in range(rng.integers(2, 20)):
+            source = sources[rng.integers(len(sources))]
+            cps = [(0.5, float(rng.random()))]
+            if rng.random() > 0.7:
+                cps = [(0.3, float(rng.random())), (0.7, float(rng.random()))]
+            event_start = event_starts[rng.integers(len(event_starts))]
+            belief_time = belief_times[rng.integers(len(belief_times))]
+            beliefs.extend(
+                tb.TimedBelief(
+                    sensor=sensor,
+                    source=source,
+                    event_start=event_start,
+                    belief_time=belief_time,
+                    cumulative_probability=cp,
+                    event_value=value,
+                )
+                for cp, value in cps
+            )
+        bdf = tb.BeliefsDataFrame(beliefs)
+        for one_deterministic in (False, True):
+            result = keep_latest_version(
+                bdf, one_deterministic_belief_per_event=one_deterministic
+            )
+            expected = naive_keep_latest_version(
+                bdf, one_deterministic_belief_per_event=one_deterministic
+            )
+            pd.testing.assert_frame_equal(
+                pd.DataFrame(result), pd.DataFrame(expected), check_like=False
+            )

--- a/flexmeasures/data/tests/test_queries.py
+++ b/flexmeasures/data/tests/test_queries.py
@@ -417,3 +417,43 @@ def test_generic_asset_search_beliefs_account_id_filter(
     )
     bdf_all = bdf_dict_all[sensor]
     assert len(bdf_all) == 3
+
+
+def test_user_source_ids_criterion(db, setup_markets, setup_roles_users):
+    """Searching with user_source_ids should ignore other users' data,
+    while leaving non-user sources unaffected."""
+    from flexmeasures.data.models.user import User
+    from flexmeasures.data.services.data_sources import get_or_create_source
+
+    sensor = db.session.execute(
+        select(Sensor).filter(Sensor.name == "epex_da")
+    ).scalar_one_or_none()
+    user_1 = get_or_create_source(
+        db.session.get(User, setup_roles_users["Test Prosumer User"])
+    )
+    user_2 = get_or_create_source(
+        db.session.get(User, setup_roles_users["Test Prosumer User 2"])
+    )
+    script = DataSource(name="test script", type="scheduling script")
+    db.session.add(script)
+    db.session.flush()
+    db.session.add_all(
+        TimedBelief(
+            sensor=sensor,
+            source=source,
+            event_value=value,
+            event_start="2021-04-01 00:00+02",
+            belief_horizon=timedelta(0),
+        )
+        for value, source in [(1, user_1), (2, user_2), (3, script)]
+    )
+
+    bdf = TimedBelief.search(
+        sensor,
+        user_source_ids=[user_1.id],
+        most_recent_beliefs_only=False,
+    )
+    returned_sources = set(bdf.index.get_level_values("source"))
+    assert user_1 in returned_sources
+    assert script in returned_sources, "non-user sources should be unaffected"
+    assert user_2 not in returned_sources, "other users' data should be ignored"

--- a/flexmeasures/data/tests/test_search_postprocessing.py
+++ b/flexmeasures/data/tests/test_search_postprocessing.py
@@ -1,0 +1,72 @@
+"""DB-free equivalence tests for vectorized search_beliefs post-processing."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import numpy as np
+import pandas as pd
+import timely_beliefs as tb
+from packaging.version import Version
+
+from flexmeasures.data.models.data_sources import DataSource
+from flexmeasures.data.models.time_series import (
+    _select_latest_version_and_belief_per_event,
+)
+
+
+def make_random_deterministic_bdf(
+    rng: np.random.Generator, sources: list[DataSource], n_beliefs: int
+) -> tb.BeliefsDataFrame:
+    sensor = tb.Sensor("postprocessing sensor", event_resolution=timedelta(hours=1))
+    event_starts = pd.date_range("2025-01-01", periods=5, freq="1h", tz="UTC")
+    belief_times = pd.date_range("2024-12-31", periods=3, freq="1h", tz="UTC")
+    beliefs = [
+        tb.TimedBelief(
+            sensor=sensor,
+            source=sources[rng.integers(len(sources))],
+            event_start=event_starts[rng.integers(len(event_starts))],
+            belief_time=belief_times[rng.integers(len(belief_times))],
+            event_value=float(rng.random()),
+        )
+        for _ in range(n_beliefs)
+    ]
+    return tb.BeliefsDataFrame(beliefs)
+
+
+def naive_select_latest_version_and_belief_per_event(
+    bdf: tb.BeliefsDataFrame,
+) -> tb.BeliefsDataFrame:
+    """Reference implementation: per event, pick the belief with the latest
+    source version, breaking version ties by most recent belief time."""
+    winners: dict = {}
+    for i, (event_start, belief_time, source, _cp) in enumerate(bdf.index):
+        candidate = (Version(source.version or "0.0.0"), belief_time)
+        incumbent = winners.get(event_start)
+        if incumbent is None or candidate > incumbent[0]:
+            winners[event_start] = (candidate, i)
+    winning_rows = {i for _, i in winners.values()}
+    return bdf[[i in winning_rows for i in range(len(bdf))]]
+
+
+def test_select_latest_version_and_belief_per_event_equivalence():
+    rng = np.random.default_rng(7)
+    sources = [
+        DataSource(
+            id=i + 1,
+            name="s1",
+            model="model 1",
+            type="forecaster",
+            version=version,
+        )
+        for i, version in enumerate([None, "0.1.0", "0.2.0", "0.2.0", "1.0.0"])
+    ]
+    for trial in range(10):
+        bdf = make_random_deterministic_bdf(
+            rng, sources, n_beliefs=int(rng.integers(2, 30))
+        )
+        result = _select_latest_version_and_belief_per_event(bdf)
+        expected = naive_select_latest_version_and_belief_per_event(bdf)
+        pd.testing.assert_frame_equal(pd.DataFrame(result), pd.DataFrame(expected))
+        # Exactly one belief per event
+        assert not result.index.get_level_values("event_start").duplicated().any()

--- a/flexmeasures/data/tests/test_search_postprocessing.py
+++ b/flexmeasures/data/tests/test_search_postprocessing.py
@@ -135,19 +135,24 @@ def test_compress_belief_records_equivalence():
     ]
     sensor = tb.Sensor("compress sensor", event_resolution=timedelta(hours=1))
     event_starts = pd.date_range("2025-01-01", periods=6, freq="1h", tz="UTC")
-    belief_times = pd.date_range("2024-12-31", periods=3, freq="1h", tz="UTC")
+    # Belief times both before and after the events (i.e. positive and negative
+    # belief horizons), with sub-second components (like real recording times)
+    belief_times = pd.date_range("2024-12-31", periods=60, freq="1h", tz="UTC")
     beliefs = []
     for i in range(30):
         cps = [(0.5, float(rng.random()))]
         if rng.random() > 0.7:
             cps = [(0.3, float(rng.random())), (0.7, float(rng.random()))]
+        belief_time = belief_times[rng.integers(len(belief_times))] + pd.Timedelta(
+            microseconds=int(rng.integers(0, 1_000_000))
+        )
         for cp, value in cps:
             beliefs.append(
                 tb.TimedBelief(
                     sensor=sensor,
                     source=sources[rng.integers(len(sources))],
                     event_start=event_starts[rng.integers(len(event_starts))],
-                    belief_time=belief_times[rng.integers(len(belief_times))],
+                    belief_time=belief_time,
                     cumulative_probability=cp,
                     event_value=np.nan if rng.random() > 0.8 else value,
                 )

--- a/flexmeasures/data/tests/test_search_postprocessing.py
+++ b/flexmeasures/data/tests/test_search_postprocessing.py
@@ -70,3 +70,100 @@ def test_select_latest_version_and_belief_per_event_equivalence():
         pd.testing.assert_frame_equal(pd.DataFrame(result), pd.DataFrame(expected))
         # Exactly one belief per event
         assert not result.index.get_level_values("event_start").duplicated().any()
+
+
+def naive_compress_belief_records(df: pd.DataFrame, sensor_id: int):
+    """Reference implementation: the previous per-row loop."""
+    sources_metadata: dict = {}
+    all_records = []
+    for _, row in df.iterrows():
+        source_obj = row.get("source")
+        if (
+            source_obj
+            and hasattr(source_obj, "id")
+            and source_obj.id not in sources_metadata
+        ):
+            source_dict = source_obj.as_dict
+            sources_metadata[source_obj.id] = {
+                "name": source_dict.get("name", ""),
+                "model": source_dict.get("model", ""),
+                "version": source_dict.get("version", ""),
+                "type": source_dict.get("type", "other"),
+                "raw_type": source_dict.get("raw_type", ""),
+                "display_type": source_dict.get(
+                    "display_type", source_dict.get("type", "other")
+                ),
+                "description": source_dict.get("description", ""),
+            }
+        record = {
+            "ts": int(row["event_start"].timestamp() * 1000),
+            "sid": sensor_id,
+            "val": row["event_value"],
+        }
+        if source_obj and hasattr(source_obj, "id"):
+            record["src"] = source_obj.id
+        if "belief_time" in row and pd.notnull(row["belief_time"]):
+            record["bt"] = int(row["belief_time"].timestamp() * 1000)
+        if "belief_horizon" in row and pd.notnull(row["belief_horizon"]):
+            record["bh"] = int(row["belief_horizon"].total_seconds())
+        if "cumulative_probability" in row and pd.notnull(
+            row["cumulative_probability"]
+        ):
+            record["cp"] = row["cumulative_probability"]
+        for key, value in record.items():
+            if pd.isna(value):
+                record[key] = None
+            elif isinstance(value, pd.Timestamp):
+                record[key] = int(value.timestamp() * 1000)
+            elif isinstance(value, (pd.Timedelta, timedelta)):
+                record[key] = int(value.total_seconds())
+            elif hasattr(value, "item"):  # numpy types
+                record[key] = value.item()
+        all_records.append(record)
+    return all_records, sources_metadata
+
+
+def test_compress_belief_records_equivalence():
+    import json
+
+    from flexmeasures.data.models.time_series import compress_belief_records
+
+    rng = np.random.default_rng(11)
+    sources = [
+        DataSource(id=1, name="s1", model="model 1", type="forecaster", version="2.0"),
+        DataSource(id=2, name="s2", model="model 2", type="scheduler"),
+    ]
+    sensor = tb.Sensor("compress sensor", event_resolution=timedelta(hours=1))
+    event_starts = pd.date_range("2025-01-01", periods=6, freq="1h", tz="UTC")
+    belief_times = pd.date_range("2024-12-31", periods=3, freq="1h", tz="UTC")
+    beliefs = []
+    for i in range(30):
+        cps = [(0.5, float(rng.random()))]
+        if rng.random() > 0.7:
+            cps = [(0.3, float(rng.random())), (0.7, float(rng.random()))]
+        for cp, value in cps:
+            beliefs.append(
+                tb.TimedBelief(
+                    sensor=sensor,
+                    source=sources[rng.integers(len(sources))],
+                    event_start=event_starts[rng.integers(len(event_starts))],
+                    belief_time=belief_times[rng.integers(len(belief_times))],
+                    cumulative_probability=cp,
+                    event_value=np.nan if rng.random() > 0.8 else value,
+                )
+            )
+    bdf = tb.BeliefsDataFrame(beliefs)
+
+    # belief_time-indexed frame
+    df = bdf.reset_index()
+    result = compress_belief_records(df, sensor_id=42)
+    expected = naive_compress_belief_records(df, sensor_id=42)
+    assert json.dumps(result[0]) == json.dumps(expected[0])
+    assert json.dumps(result[1]) == json.dumps(expected[1])
+
+    # belief_horizon-indexed frame (and a NaT belief time column for good measure)
+    df_horizon = bdf.convert_index_from_belief_time_to_horizon().reset_index()
+    result = compress_belief_records(df_horizon, sensor_id=42)
+    expected = naive_compress_belief_records(df_horizon, sensor_id=42)
+    assert json.dumps(result[0]) == json.dumps(expected[0])
+    assert json.dumps(result[1]) == json.dumps(expected[1])

--- a/flexmeasures/utils/time_utils.py
+++ b/flexmeasures/utils/time_utils.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta, timezone
 from flask import current_app
 from flask_security.core import current_user
 from humanize import naturaldate, naturaltime
+import numpy as np
 import pandas as pd
 from pandas.tseries.frequencies import to_offset
 import pytz
@@ -430,3 +431,16 @@ def to_utc_timestamp(value):
 
     # Return Unix timestamp (seconds since epoch)
     return value.timestamp()
+
+
+def truncated_integer_epochs(ns: np.ndarray, divisor: int) -> np.ndarray:
+    """Convert int64 nanosecond values to integer epoch units (ns / divisor),
+    truncating toward zero.
+
+    Note that floor division would round negative values with a remainder
+    (e.g. a belief horizon of -0.5s) away from zero instead, unlike
+    int(td.total_seconds()).
+    """
+    quotients, remainders = np.divmod(ns, divisor)
+    quotients[(remainders != 0) & (ns < 0)] += 1
+    return quotients


### PR DESCRIPTION
## What

Vectorize the pandas post-processing that runs after (or while) searching sensor data, one commit per win. This complements the materialized-views work (which targets the SQL side); everything here is pure post-processing and does not touch the most-recent-beliefs SQL logic.

Micro-benchmark (committed as `flexmeasures/data/scripts/benchmark_search_postprocessing.py`, DB-free, synthetic BeliefsDataFrames; median of 3 reps at 100k rows):

| function | before | after | speedup |
|---|---|---|---|
| `keep_latest_version` (1 source) | 609 ms | 26 ms | 23x |
| `keep_latest_version` (3 sources, distinct groups) | 623 ms | 24 ms | 26x |
| `keep_latest_version` (3 sources, 2 versions of one) | 647 ms | 48 ms | 13x |
| `keep_latest_version` (probabilistic, 3 sources) | 609 ms | 42 ms | 15x |
| deterministic belief per event (3 sources, 2 versions) | 32,942 ms | 21 ms | ~1600x |
| compressed chart-data records (3 sources) | 15,705 ms | 209 ms | 75x |

At 10k rows the same wins are roughly: 67→3 ms, 2,885→2.5 ms and 1,581→19 ms respectively.

`keep_latest_version` runs on **every** `TimedBelief.search` by default, so the first row benefits all search calls. The deterministic-selection and serialization wins mainly speed up GET /sensors/data, chart data endpoints, schedulers and reporters.

## How

- **`keep_latest_version`** (data_sources.py): replaced the temp-column + sort + drop_duplicates + index-isin implementation with vectorized groupby transforms over integer arrays. Versions are parsed once per unique source instead of once per row, and a fast path returns immediately when every source is the sole member of its (name, type, model) group (the common case, decided without touching the data). Two documented behavioral deltas: with `one_deterministic_belief_per_event=True` and multiple beliefs per event from the winning source, all its beliefs are now kept (downstream code picks one; previously an arbitrary one survived due to an unstable sort), and pre-existing `source.*` columns in the input frame are no longer dropped.
- **`one_deterministic_belief_per_event`** (time_series.py): new vectorized track for deterministic multi-source data (taking the median per belief is a no-op at probabilistic depth 1), picking the winning belief per event with a single lexsort — latest source version first, most recent belief time second, matching the existing sort (the code comment claiming belief time takes precedence was stale). The probabilistic slow path parses each unique source version once and uses a duplicated-mask instead of a per-event groupby-apply.
- **Compressed chart-data serialization** (time_series.py): the per-row `iterrows` loop is now column-wise epoch conversions + one tight loop over Python scalars, factored into `compress_belief_records`. JSON output is unchanged (same key order and key-omission semantics).
- **`GenericAsset.search_beliefs`** (generic_assets.py): the per-sensor `Sensor.search_beliefs` loop is one `TimedBelief.search(sensors=..., sum_multiple=False)` call (source criteria parsed once); the compressed path's per-row apply lambdas are vectorized; a dead `pd.Series(values).fillna(None)` branch (which would raise if ever reached) is removed.
- **`user_source_criterion`** (queries/utils.py): the eager SELECT of all ignorable user-type source ids is now an uncorrelated scalar subquery — zero extra round trips.

## Verification

- New randomized equivalence tests compare each rewrite against a naive (or the previous) reference implementation: `test_keep_latest_version_equivalence`, `test_select_latest_version_and_belief_per_event_equivalence`, `test_compress_belief_records_equivalence` (covering NaN event values, NaT belief times, probabilistic rows, belief_horizon-indexed frames), plus new coverage for `user_source_ids` filtering (previously untested).
- Existing suites pass: test_queries, test_belief_charts, test_data_source, test_sensor_data (API), reporting tests, test_time_series_services (159 tests total across runs).
- Also ran the search-path suites against the timely-beliefs perf branch (SeitaBV/timely-beliefs#237): all pass.

## Related

- SeitaBV/timely-beliefs#237 speeds up the timely-beliefs side of the same hot path (row ingest, index building, most-recent-belief fallback); FlexMeasures gains those wins after a timely-beliefs release + pin bump.
- The materialized-views PR covers the SQL-side most-recent read path and is untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjAZFQmASY65gPmVtQAahG
