### PR TITLE
Run VACUUM ANALYZE after `flexmeasures db upgrade` (with --no-vacuum opt-out)

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -33,6 +33,7 @@ New features
 
 Infrastructure / Support
 ----------------------
+* ``flexmeasures db upgrade`` now runs ``VACUUM ANALYZE`` after upgrading by default, so Postgres has fresh planner statistics right after a migration; opt out with ``--no-vacuum``
 * Upgraded dependencies [see `PR #1485 <https://www.github.com/FlexMeasures/flexmeasures/pull/1485>`_, `PR #2215 <https://www.github.com/FlexMeasures/flexmeasures/pull/2215>`_ and `PR #2243 <https://www.github.com/FlexMeasures/flexmeasures/pull/2243>`_]
 * Prepare the ``device_scheduler`` to deal with commitments per device group [see `PR #1934 <https://www.github.com/FlexMeasures/flexmeasures/pull/1934>`_]
 * Speed up scheduling on longer horizons using a recursive stock model, making the solve time linear with the horizon instead of quadratic (about 10x faster solves at the 2-day default horizon, 23x at 3 days) [see `PR #2282 <https://www.github.com/FlexMeasures/flexmeasures/pull/2282>`_]

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -33,7 +33,7 @@ New features
 
 Infrastructure / Support
 ----------------------
-* ``flexmeasures db upgrade`` now runs ``VACUUM ANALYZE`` after upgrading by default, so Postgres has fresh planner statistics right after a migration; opt out with ``--no-vacuum``
+* ``flexmeasures db upgrade`` now runs ``VACUUM ANALYZE`` after upgrading by default, so Postgres has fresh planner statistics right after a migration; opt out with ``--no-vacuum`` [see `PR #2333 <https://www.github.com/FlexMeasures/flexmeasures/pull/2333>`_]
 * Upgraded dependencies [see `PR #1485 <https://www.github.com/FlexMeasures/flexmeasures/pull/1485>`_, `PR #2215 <https://www.github.com/FlexMeasures/flexmeasures/pull/2215>`_ and `PR #2243 <https://www.github.com/FlexMeasures/flexmeasures/pull/2243>`_]
 * Prepare the ``device_scheduler`` to deal with commitments per device group [see `PR #1934 <https://www.github.com/FlexMeasures/flexmeasures/pull/1934>`_]
 * Speed up scheduling on longer horizons using a recursive stock model, making the solve time linear with the horizon instead of quadratic (about 10x faster solves at the 2-day default horizon, 23x at 3 days) [see `PR #2282 <https://www.github.com/FlexMeasures/flexmeasures/pull/2282>`_]

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -7,6 +7,7 @@ FlexMeasures CLI Changelog
 since v1.0.0 | July XX, 2026
 =================================
 
+* ``flexmeasures db upgrade`` now runs ``VACUUM ANALYZE`` after upgrading (refreshing the query planner's statistics); opt out with ``--no-vacuum``.
 * Add ``flexmeasures edit secret`` to store an encrypted secret on an account or asset.
 * Add ``flexmeasures delete secret`` to remove an encrypted secret from an account or asset.
 

--- a/flexmeasures/data/__init__.py
+++ b/flexmeasures/data/__init__.py
@@ -2,12 +2,16 @@
 Models & schemata, as well as business logic (queries & services).
 """
 
+import functools
 import os
 import sys
 
+import click
 from flask import Flask
 from flask_migrate import Migrate
+from flask_migrate.cli import db as db_cli_group
 from flask_marshmallow import Marshmallow
+from sqlalchemy import text
 
 from flexmeasures.data.config import configure_db_for, db
 from flexmeasures.data.transactional import after_request_exception_rollback_session
@@ -22,10 +26,45 @@ def _is_running_db_upgrade_command() -> bool:
     return any(args[i : i + 2] == ["db", "upgrade"] for i in range(len(args) - 1))
 
 
+def _add_vacuum_option_to_db_upgrade(app: Flask):
+    """Extend `flexmeasures db upgrade` to vacuum-analyze the database afterwards.
+
+    After schema migrations, Postgres' planner statistics can be stale, leading to
+    poor query plans. Running VACUUM ANALYZE right after upgrading avoids that.
+    """
+    upgrade_command = db_cli_group.commands["upgrade"]
+    if getattr(upgrade_command, "_fm_vacuum_option_added", False):
+        return
+    upgrade_command._fm_vacuum_option_added = True
+    upgrade_command.params.append(
+        click.Option(
+            ["--vacuum/--no-vacuum"],
+            default=True,
+            show_default=True,
+            help="Run VACUUM ANALYZE after upgrading, refreshing the query planner's statistics.",
+        )
+    )
+    original_callback = upgrade_command.callback
+
+    @functools.wraps(original_callback)
+    def upgrade_then_vacuum(*args, vacuum: bool = True, **kwargs):
+        result = original_callback(*args, **kwargs)
+        if vacuum and not kwargs.get("sql"):
+            click.echo("Running VACUUM ANALYZE ...")
+            with db.engine.connect().execution_options(
+                isolation_level="AUTOCOMMIT"
+            ) as connection:
+                connection.execute(text("VACUUM ANALYZE"))
+        return result
+
+    upgrade_command.callback = upgrade_then_vacuum
+
+
 def register_at(app: Flask):
     # First configure the central db object and Alembic's migration tool
     configure_db_for(app)
     Migrate(app, db, directory=os.path.join(app.root_path, "data", "migrations"))
+    _add_vacuum_option_to_db_upgrade(app)
 
     app.database_schema_is_migrated_to_head = True
     if not app.testing and app.config.get("FLEXMEASURES_ENV") != "documentation":


### PR DESCRIPTION
## Motivation

After running `flexmeasures db upgrade`, Postgres planner statistics can be stale, and we sometimes had to run `VACUUM ANALYZE;` manually to get decent query plans (and speed). It is fast and harmless enough to do by default.

## What this does

- Extends the Flask-Migrate `upgrade` command (at registration time, so it applies to `flexmeasures db upgrade`) with a `--vacuum/--no-vacuum` option, defaulting to `--vacuum`.
- After a successful upgrade, runs `VACUUM ANALYZE` on an autocommit connection (VACUUM cannot run inside a transaction block).
- Skipped in `--sql` (offline/dump) mode, or with `--no-vacuum`.

## Verified

Ran against a throwaway Postgres 15 container: `flexmeasures db upgrade` applies all migrations and then prints `Running VACUUM ANALYZE ...` and completes; `--no-vacuum` skips the step. `--help` shows the new option with its default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)