### PR TITLE
Fix: render a sensor in every fast-chart subplot that configures it

### DIFF
--- a/flexmeasures/ui/static/js/fast-chart.js
+++ b/flexmeasures/ui/static/js/fast-chart.js
@@ -241,7 +241,9 @@ function numericRows(data) {
  */
 function groupData(data, groupSpec) {
   const groups = [];
-  const groupBySensorId = new Map();
+  // A sensor may be configured in several subplots (sensors_to_show rows), and
+  // then its data must show in each of them, as in the Vega-Lite charts.
+  const groupsBySensorId = new Map(); // sensor id -> [group, ...]
   const groupByUnit = new Map(); // fallback for rows not covered by the spec
 
   function newGroup(title, sensorType, yAxis) {
@@ -261,7 +263,10 @@ function groupData(data, groupSpec) {
     for (const entry of groupSpec) {
       const group = newGroup(entry.title || "", entry.sensorType || "", entry.yAxis);
       for (const sensorId of entry.sensorIds || []) {
-        groupBySensorId.set(sensorId, group);
+        if (!groupsBySensorId.has(sensorId)) {
+          groupsBySensorId.set(sensorId, []);
+        }
+        groupsBySensorId.get(sensorId).push(group);
       }
     }
   }
@@ -270,34 +275,36 @@ function groupData(data, groupSpec) {
     const sensor = row.sensor || {};
     const source = row.source || {};
     const unit = sensor.unit || row.sensor_unit || "";
-    let group = groupBySensorId.get(sensor.id);
-    if (!group) {
-      group = groupByUnit.get(unit) || groupByUnit.set(unit, newGroup("", "")).get(unit);
+    let rowGroups = groupsBySensorId.get(sensor.id);
+    if (!rowGroups) {
+      rowGroups = [groupByUnit.get(unit) || groupByUnit.set(unit, newGroup("", "")).get(unit)];
     }
-    group.units.add(unit);
-    group.sensorNames.add(sensor.name || "sensor " + sensor.id);
-    const seriesKey = sensor.id + "|" + source.id;
-    if (!group.series.has(seriesKey)) {
-      group.series.set(seriesKey, {
-        sensorName: sensor.name || "sensor " + sensor.id,
-        sensorDescription: sensor.description || sensor.name || "",
-        sourceLabel: sourceLabel(source),
-        source: source,
-        unit: unit,
-        // The sensor's real event resolution in seconds (0 = instantaneous),
-        // as sent by Sensor.as_dict; undefined for legacy data, in which case we
-        // fall back to inferring it from the event spacing.
-        eventResolutionSec:
-          typeof sensor.event_resolution === "number" ? sensor.event_resolution : null,
-        points: [],
-        eventStarts: [], // kept for resolution inference (not sent to ECharts)
-      });
+    for (const group of rowGroups) {
+      group.units.add(unit);
+      group.sensorNames.add(sensor.name || "sensor " + sensor.id);
+      const seriesKey = sensor.id + "|" + source.id;
+      if (!group.series.has(seriesKey)) {
+        group.series.set(seriesKey, {
+          sensorName: sensor.name || "sensor " + sensor.id,
+          sensorDescription: sensor.description || sensor.name || "",
+          sourceLabel: sourceLabel(source),
+          source: source,
+          unit: unit,
+          // The sensor's real event resolution in seconds (0 = instantaneous),
+          // as sent by Sensor.as_dict; undefined for legacy data, in which case we
+          // fall back to inferring it from the event spacing.
+          eventResolutionSec:
+            typeof sensor.event_resolution === "number" ? sensor.event_resolution : null,
+          points: [],
+          eventStarts: [], // kept for resolution inference (not sent to ECharts)
+        });
+      }
+      const ser = group.series.get(seriesKey);
+      // Third dimension carries the belief horizon (ms) for the tooltip;
+      // LTTB sampling selects original points, so it survives downsampling.
+      ser.points.push([row.event_start, row.event_value, row.belief_horizon]);
+      ser.eventStarts.push(row.event_start);
     }
-    const ser = group.series.get(seriesKey);
-    // Third dimension carries the belief horizon (ms) for the tooltip;
-    // LTTB sampling selects original points, so it survives downsampling.
-    ser.points.push([row.event_start, row.event_value, row.belief_horizon]);
-    ser.eventStarts.push(row.event_start);
   }
 
   // Mirror the Vega-Lite legend encoding:


### PR DESCRIPTION
## Description

A sensor configured in more than one asset graph row (`sensors_to_show`) only rendered in the **last** row that listed it in the ECharts fast charts, while the Vega-Lite charts render it in each configured row. Found by @BelhsanHmida while testing #2312 (unrelated to that PR's annotation work — this dates from the ECharts port in #2234).

Cause: `groupData` mapped each sensor id to a single group, so later `sensors_to_show` entries overwrote earlier ones and every data row was routed to just that one subplot.

Fix: map each sensor id to the list of groups that configure it and route every data row to all of them. Each group keeps its own series objects (own points arrays), and series colors are keyed by sensor name, so the duplicated sensor keeps the same color in every subplot. Legend behavior is unchanged (entries toggle by name, so the duplicated sensor toggles in all its subplots together, as in Vega-Lite).

No changelog entry, as this fixes behavior of the not-yet-released #2234.

## Look & Feel

The shared sensor (blue) now renders in both configured rows:

<img src="https://raw.githubusercontent.com/FlexMeasures/screenshots/main/pr2338/echarts-duplicate-sensor-fixed.png" width="420">

## How to test

1. On an asset, configure `sensors_to_show` with the same sensor in two rows, e.g. `[{"title": "Overview", "sensors": [8, 9, 7]}, {"title": "Prices", "sensors": [7]}]`, with data present.
2. Open the asset's Graphs page in fast-chart mode: the shared sensor shows in both rows (same color), not just the last one; the Vega-Lite toggle shows the same picture.

Verified with a headless-Chrome harness driving `renderFastChart` with a two-row spec sharing a sensor: before the fix the first row missed the shared sensor's series (reproducing the report); after it, both rows render it with identical data and color, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBYFTyXL1dLcqX6M76Av6e
