### PR TITLE
Fix flexmeasures add user --roles comma-separated list parsing

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -57,7 +57,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
-* ``flexmeasures add user --roles`` now correctly accepts a comma-separated list of roles (and repeated ``--roles`` options) instead of creating one role whose name contains commas [see `PR #2339 <https://www.github.com/FlexMeasures/flexmeasures/pull/2339>`_ and `issue #1237 <https://github.com/FlexMeasures/flexmeasures/issues/1237>`_]
+* ``flexmeasures add user --roles`` now correctly accepts a comma-separated list of roles (and repeated ``--roles`` options) instead of creating one role whose name contains commas [see `PR #2339 <https://www.github.com/FlexMeasures/flexmeasures/pull/2339>`_]
 * Fix column sorting on the assets page, including when combined with the search filter [see `PR #2314 <https://www.github.com/FlexMeasures/flexmeasures/pull/2314>`_]
 * Fix forecasting with past or future regressors, which raised a ``TypeError`` on pandas 2.2 and higher [see `PR #2303 <https://www.github.com/FlexMeasures/flexmeasures/pull/2303>`_]
 * Show why a CLI option was rejected (e.g. "No account found with id 9999") instead of only echoing the offending value [see `PR #2303 <https://www.github.com/FlexMeasures/flexmeasures/pull/2303>`_]

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -57,7 +57,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
-* ``flexmeasures add user --roles`` now correctly accepts a comma-separated list of roles (and repeated ``--roles`` options) instead of creating one role whose name contains commas [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_ and `issue #1237 <https://github.com/FlexMeasures/flexmeasures/issues/1237>`_]
+* ``flexmeasures add user --roles`` now correctly accepts a comma-separated list of roles (and repeated ``--roles`` options) instead of creating one role whose name contains commas [see `PR #2339 <https://www.github.com/FlexMeasures/flexmeasures/pull/2339>`_ and `issue #1237 <https://github.com/FlexMeasures/flexmeasures/issues/1237>`_]
 * Fix column sorting on the assets page, including when combined with the search filter [see `PR #2314 <https://www.github.com/FlexMeasures/flexmeasures/pull/2314>`_]
 * Fix forecasting with past or future regressors, which raised a ``TypeError`` on pandas 2.2 and higher [see `PR #2303 <https://www.github.com/FlexMeasures/flexmeasures/pull/2303>`_]
 * Show why a CLI option was rejected (e.g. "No account found with id 9999") instead of only echoing the offending value [see `PR #2303 <https://www.github.com/FlexMeasures/flexmeasures/pull/2303>`_]

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -57,6 +57,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
+* ``flexmeasures add user --roles`` now correctly accepts a comma-separated list of roles (and repeated ``--roles`` options) instead of creating one role whose name contains commas [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_ and `issue #1237 <https://github.com/FlexMeasures/flexmeasures/issues/1237>`_]
 * Fix column sorting on the assets page, including when combined with the search filter [see `PR #2314 <https://www.github.com/FlexMeasures/flexmeasures/pull/2314>`_]
 * Fix forecasting with past or future regressors, which raised a ``TypeError`` on pandas 2.2 and higher [see `PR #2303 <https://www.github.com/FlexMeasures/flexmeasures/pull/2303>`_]
 * Show why a CLI option was rejected (e.g. "No account found with id 9999") instead of only echoing the offending value [see `PR #2303 <https://www.github.com/FlexMeasures/flexmeasures/pull/2303>`_]

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -7,6 +7,7 @@ FlexMeasures CLI Changelog
 since v1.0.0 | July XX, 2026
 =================================
 
+* ``flexmeasures add user --roles`` now parses comma-separated role lists and accepts repeated ``--roles`` options.
 * ``flexmeasures db upgrade`` now runs ``VACUUM ANALYZE`` after upgrading (refreshing the query planner's statistics); opt out with ``--no-vacuum``.
 * Add ``flexmeasures edit secret`` to store an encrypted secret on an account or asset.
 * Add ``flexmeasures delete secret`` to remove an encrypted secret from an account or asset.

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -40,6 +40,7 @@ from flexmeasures.cli.utils import (
     DeprecatedOption,
     DeprecatedOptionsCommand,
     add_cli_options_from_schema,
+    split_commas,
 )
 from flexmeasures.data import db
 from flexmeasures.data.scripts.data_gen import (
@@ -277,7 +278,12 @@ def new_account(
     preferred="--account",
     help="Add user to this account. Follow up with the account's ID.",
 )
-@click.option("--roles", help="e.g. anonymous,Prosumer,CPO")
+@click.option(
+    "--roles",
+    multiple=True,
+    callback=split_commas,
+    help="User roles, e.g. anonymous, account-admin. Pass a comma-separated list and/or use this option multiple times.",
+)
 @click.option(
     "--timezone",
     "timezone_optional",

--- a/flexmeasures/cli/tests/test_data_add_fresh_db.py
+++ b/flexmeasures/cli/tests/test_data_add_fresh_db.py
@@ -9,7 +9,7 @@ from sqlalchemy import select
 
 from flexmeasures import Asset
 from flexmeasures.cli.tests.utils import to_flags
-from flexmeasures.data.models.user import Account
+from flexmeasures.data.models.user import Account, User
 from flexmeasures.data.models.time_series import Sensor, TimedBelief
 
 from flexmeasures.cli.tests.utils import check_command_ran_without_error
@@ -431,6 +431,62 @@ def test_add_account(
     else:
         # fail because "Test ConsultancyClient Account" already exists
         assert result.exit_code == 1
+
+
+@pytest.mark.parametrize(
+    "roles_args, expected_roles",
+    [
+        (["--roles", "consultant,account-admin"], {"consultant", "account-admin"}),
+        (
+            ["--roles", "consultant", "--roles", "account-admin"],
+            {"consultant", "account-admin"},
+        ),
+        (
+            ["--roles", "consultant,account-admin", "--roles", "admin"],
+            {"consultant", "account-admin", "admin"},
+        ),
+        ([], set()),
+    ],
+)
+def test_add_user_roles(
+    app,
+    fresh_db,
+    setup_accounts_fresh_db,
+    monkeypatch,
+    roles_args,
+    expected_roles,
+):
+    """``--roles`` accepts a comma-separated list and/or repeated options (see issue #1237)."""
+    from flexmeasures.cli.data_add import new_user
+
+    monkeypatch.setattr("getpass.getpass", lambda prompt="": "testtest")
+
+    account = setup_accounts_fresh_db["Prosumer"]
+    username = f"cli-user-{'-'.join(sorted(expected_roles)) or 'noroles'}"
+    email = f"{username}@example.com"
+
+    runner = app.test_cli_runner()
+    result = runner.invoke(
+        new_user,
+        [
+            "--username",
+            username,
+            "--email",
+            email,
+            "--account",
+            str(account.id),
+            "--timezone",
+            "UTC",
+            *roles_args,
+        ],
+    )
+    check_command_ran_without_error(result)
+    assert "Successfully created user" in result.output
+
+    user = fresh_db.session.execute(
+        select(User).filter_by(username=username)
+    ).scalar_one()
+    assert {role.name for role in user.roles} == expected_roles
 
 
 def test_add_process_toy_account_reuses_existing_root_assets(app, fresh_db):


### PR DESCRIPTION
## Description

- [x] Fix `flexmeasures add user --roles` so a comma-separated list (and repeated `--roles`) assigns multiple roles instead of creating one role whose name contains commas
- [x] Add regression tests covering comma-separated, repeated, mixed, and empty `--roles`
- [x] Added changelog item in `documentation/changelog.rst` and `documentation/cli/change_log.rst`

## Look & Feel

```bash
# before: created one role named "consultant,account-admin"
flexmeasures add user --username alice --email alice@example.com --account 1 --roles consultant,account-admin

# after: assigns both roles (also works with repeated options)
flexmeasures add user --username alice --email alice@example.com --account 1 --roles consultant,account-admin
flexmeasures add user --username bob --email bob@example.com --account 1 --roles consultant --roles account-admin
```

## How to test

```bash
pytest flexmeasures/cli/tests/test_data_add_fresh_db.py::test_add_user_roles -v
```

Also covered by:

```bash
pytest flexmeasures/cli/tests/test_data_add_fresh_db.py -k "add_user or add_account" -v
```

## Further Improvements

- `flexmeasures add account --roles` already splits on commas manually; it could be aligned with `multiple=True` + `split_commas` later (related: #736).

## Related Items

Fixes #1237

---

#### Sign-off

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures

---
