### PR TITLE
Fix scheduling job success log printed twice

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -58,7 +58,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
-* Scheduling jobs no longer print ``Job ... made schedule.`` before ``scheduler.compute()`` runs (only after a successful schedule) [see `PR #2342 <https://www.github.com/FlexMeasures/flexmeasures/pull/2342>`_ and `issue #2049 <https://github.com/FlexMeasures/flexmeasures/issues/2049>`_]
+* Scheduling jobs no longer print ``Job ... made schedule.`` before ``scheduler.compute()`` runs (only after a successful schedule) [see `PR #2342 <https://www.github.com/FlexMeasures/flexmeasures/pull/2342>`_]
 * Fix column sorting on the assets page, including when combined with the search filter [see `PR #2314 <https://www.github.com/FlexMeasures/flexmeasures/pull/2314>`_]
 * Fix forecasting with past or future regressors, which raised a ``TypeError`` on pandas 2.2 and higher [see `PR #2303 <https://www.github.com/FlexMeasures/flexmeasures/pull/2303>`_]
 * Show why a CLI option was rejected (e.g. "No account found with id 9999") instead of only echoing the offending value [see `PR #2303 <https://www.github.com/FlexMeasures/flexmeasures/pull/2303>`_]

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -58,6 +58,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
+* Scheduling jobs no longer print ``Job ... made schedule.`` before ``scheduler.compute()`` runs (only after a successful schedule) [see `issue #2049 <https://github.com/FlexMeasures/flexmeasures/issues/2049>`_]
 * Fix column sorting on the assets page, including when combined with the search filter [see `PR #2314 <https://www.github.com/FlexMeasures/flexmeasures/pull/2314>`_]
 * Fix forecasting with past or future regressors, which raised a ``TypeError`` on pandas 2.2 and higher [see `PR #2303 <https://www.github.com/FlexMeasures/flexmeasures/pull/2303>`_]
 * Show why a CLI option was rejected (e.g. "No account found with id 9999") instead of only echoing the offending value [see `PR #2303 <https://www.github.com/FlexMeasures/flexmeasures/pull/2303>`_]

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -58,7 +58,7 @@ Infrastructure / Support
 
 Bugfixes
 -----------
-* Scheduling jobs no longer print ``Job ... made schedule.`` before ``scheduler.compute()`` runs (only after a successful schedule) [see `issue #2049 <https://github.com/FlexMeasures/flexmeasures/issues/2049>`_]
+* Scheduling jobs no longer print ``Job ... made schedule.`` before ``scheduler.compute()`` runs (only after a successful schedule) [see `PR #2342 <https://www.github.com/FlexMeasures/flexmeasures/pull/2342>`_ and `issue #2049 <https://github.com/FlexMeasures/flexmeasures/issues/2049>`_]
 * Fix column sorting on the assets page, including when combined with the search filter [see `PR #2314 <https://www.github.com/FlexMeasures/flexmeasures/pull/2314>`_]
 * Fix forecasting with past or future regressors, which raised a ``TypeError`` on pandas 2.2 and higher [see `PR #2303 <https://www.github.com/FlexMeasures/flexmeasures/pull/2303>`_]
 * Show why a CLI option was rejected (e.g. "No account found with id 9999") instead of only echoing the offending value [see `PR #2303 <https://www.github.com/FlexMeasures/flexmeasures/pull/2303>`_]

--- a/flexmeasures/data/services/scheduling.py
+++ b/flexmeasures/data/services/scheduling.py
@@ -771,7 +771,6 @@ def make_schedule(  # noqa: C901
 
     # we get the default scheduler info in case it fails in the compute step
     if rq_job:
-        click.echo("Job %s made schedule." % rq_job.id)
         rq_job.meta["scheduler_info"] = scheduler.info
 
     consumption_schedule: SchedulerOutputType = scheduler.compute()

--- a/flexmeasures/data/tests/test_scheduling_jobs.py
+++ b/flexmeasures/data/tests/test_scheduling_jobs.py
@@ -32,10 +32,12 @@ def test_scheduling_a_battery(
     add_battery_assets_fresh_db,
     setup_fresh_test_data,
     add_market_prices_fresh_db,
+    capsys,
 ):
     """Test one clean run of one scheduling job:
     - data source was made,
     - schedule has been made
+    - success is logged once (not before compute) — regression for #2049
     """
 
     battery = add_battery_assets_fresh_db["Test battery"].sensors[0]
@@ -86,6 +88,10 @@ def test_scheduling_a_battery(
     assert (
         sum(v.event_value for v in power_values) < -0.5
     ), "some cycling should have occurred to make a profit, resulting in overall consumption due to losses"
+
+    # Regression #2049: success message only after compute, not the pre-compute copy-paste echo
+    out = capsys.readouterr().out
+    assert out.count("made schedule") == 1, out
 
 
 scheduler_specs = {

--- a/flexmeasures/data/tests/test_scheduling_jobs.py
+++ b/flexmeasures/data/tests/test_scheduling_jobs.py
@@ -40,7 +40,12 @@ def test_scheduling_a_battery(
     - success is logged once (not before compute) — regression for #2049
     """
 
-    battery = add_battery_assets_fresh_db["Test battery"].sensors[0]
+    # Pin by name: sensors relationship has no guaranteed order
+    battery = next(
+        s
+        for s in add_battery_assets_fresh_db["Test battery"].sensors
+        if s.name == "power"
+    )
     tz = pytz.timezone("Europe/Amsterdam")
     # the start time does *not* match soc_datetime attribute from conftest, soc at start will be 0
     # TODO: stop using attributes in conftest
@@ -89,9 +94,10 @@ def test_scheduling_a_battery(
         sum(v.event_value for v in power_values) < -0.5
     ), "some cycling should have occurred to make a profit, resulting in overall consumption due to losses"
 
-    # Regression #2049: success message only after compute, not the pre-compute copy-paste echo
+    # Regression #2049: success message only after compute, not the pre-compute copy-paste echo.
+    # Count only this job's message — the RQ worker may also process other queued jobs.
     out = capsys.readouterr().out
-    assert out.count("made schedule") == 1, out
+    assert out.count(f"Job {job.id} made schedule.") == 1, out
 
 
 scheduler_specs = {


### PR DESCRIPTION
## Description

- [x] Stop printing `Job ... made schedule.` before `scheduler.compute()` runs
- [x] Keep writing default `scheduler_info` onto the RQ job meta before compute (so failures still expose it)
- [x] Still print the success message once after a successful compute
- [x] Regression assertion in `test_scheduling_a_battery` that the success string appears exactly once
- [x] Added changelog item in `documentation/changelog.rst`

## Look & Feel

Before (log noise on a successful job):

```
Running Scheduling Job <id>: ...
Job <id> made schedule.   # premature — compute not done yet
Job <id> made schedule.   # real success
```

After:

```
Running Scheduling Job <id>: ...
Job <id> made schedule.   # only after successful compute
```

## How to test

```bash
pytest flexmeasures/data/tests/test_scheduling_jobs.py::test_scheduling_a_battery -v
```

## Further Improvements

None.

## Related Items

Fixes #2049

---

#### Sign-off

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures

---
