### PR TITLE
Raise clear error when flex-model sensor is missing

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -60,6 +60,7 @@ Infrastructure / Support
 Bugfixes
 -----------
 * ``flexmeasures add user --roles`` now correctly accepts a comma-separated list of roles (and repeated ``--roles`` options) instead of creating one role whose name contains commas [see `PR #2339 <https://www.github.com/FlexMeasures/flexmeasures/pull/2339>`_]
+* Raise a clear ``ValueError`` when a flex-model references a missing sensor ID instead of ``AttributeError: 'NoneType' object has no attribute 'asset_id'`` [see `PR #2343 <https://www.github.com/FlexMeasures/flexmeasures/pull/2343>`_]
 * Fix column sorting on the assets page, including when combined with the search filter [see `PR #2314 <https://www.github.com/FlexMeasures/flexmeasures/pull/2314>`_]
 * Fix forecasting with past or future regressors, which raised a ``TypeError`` on pandas 2.2 and higher [see `PR #2303 <https://www.github.com/FlexMeasures/flexmeasures/pull/2303>`_]
 * Show why a CLI option was rejected (e.g. "No account found with id 9999") instead of only echoing the offending value [see `PR #2303 <https://www.github.com/FlexMeasures/flexmeasures/pull/2303>`_]

--- a/flexmeasures/data/models/planning/__init__.py
+++ b/flexmeasures/data/models/planning/__init__.py
@@ -265,11 +265,18 @@ class Scheduler:
                 sensor_id = flex_model_d.get("sensor")
                 if sensor_id is not None:
                     sensor = db.session.get(Sensor, sensor_id)
+                    if sensor is None:
+                        raise ValueError(f"No sensor found with ID {sensor_id}.")
                     asset_id = sensor.asset_id
                 else:
                     soc_sensor_ref = flex_model_d.get("state-of-charge")
                     if soc_sensor_ref is not None:
-                        soc_sensor = db.session.get(Sensor, soc_sensor_ref["sensor"])
+                        soc_sensor_id = soc_sensor_ref["sensor"]
+                        soc_sensor = db.session.get(Sensor, soc_sensor_id)
+                        if soc_sensor is None:
+                            raise ValueError(
+                                f"No sensor found with ID {soc_sensor_id}."
+                            )
                         asset_id = soc_sensor.asset_id
             if asset_id in db_flex_model:
                 flex_model_d = {**db_flex_model[asset_id], **flex_model_d}

--- a/flexmeasures/data/models/planning/__init__.py
+++ b/flexmeasures/data/models/planning/__init__.py
@@ -220,6 +220,14 @@ class Scheduler:
         """
         pass
 
+    @staticmethod
+    def _get_sensor_or_raise(sensor_id: int) -> Sensor:
+        """Look up a sensor by ID; raise ValueError if missing (SensorIdField style)."""
+        sensor = db.session.get(Sensor, sensor_id)
+        if sensor is None:
+            raise ValueError(f"No sensor found with ID {sensor_id}.")
+        return sensor
+
     def collect_flex_config(self):
         """Merge the flex-config from the db (from the asset and its ancestors) with the initialization flex-config.
 
@@ -264,20 +272,13 @@ class Scheduler:
             if asset_id is None:
                 sensor_id = flex_model_d.get("sensor")
                 if sensor_id is not None:
-                    sensor = db.session.get(Sensor, sensor_id)
-                    if sensor is None:
-                        raise ValueError(f"No sensor found with ID {sensor_id}.")
-                    asset_id = sensor.asset_id
+                    asset_id = self._get_sensor_or_raise(sensor_id).asset_id
                 else:
                     soc_sensor_ref = flex_model_d.get("state-of-charge")
                     if soc_sensor_ref is not None:
-                        soc_sensor_id = soc_sensor_ref["sensor"]
-                        soc_sensor = db.session.get(Sensor, soc_sensor_id)
-                        if soc_sensor is None:
-                            raise ValueError(
-                                f"No sensor found with ID {soc_sensor_id}."
-                            )
-                        asset_id = soc_sensor.asset_id
+                        asset_id = self._get_sensor_or_raise(
+                            soc_sensor_ref["sensor"]
+                        ).asset_id
             if asset_id in db_flex_model:
                 flex_model_d = {**db_flex_model[asset_id], **flex_model_d}
             amended_flex_model.append(flex_model_d)

--- a/flexmeasures/data/models/planning/tests/test_utils_fresh_db.py
+++ b/flexmeasures/data/models/planning/tests/test_utils_fresh_db.py
@@ -1,5 +1,6 @@
 import pandas as pd
-from datetime import timedelta
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -7,6 +8,7 @@ from flexmeasures.data.models.generic_assets import GenericAsset, GenericAssetTy
 from flexmeasures.data.models.time_series import Sensor, TimedBelief
 from flexmeasures.data.models.data_sources import DataSource
 from flexmeasures.data.schemas.sensors import SensorReference
+from flexmeasures.data.models.planning.storage import StorageScheduler
 from flexmeasures.data.models.planning.utils import get_series_from_quantity_or_sensor
 
 
@@ -224,13 +226,6 @@ def test_collect_flex_config_missing_sensor_raises(fresh_db):
     attribute 'asset_id'``. Flex-context already validates via marshmallow;
     flex-model path should match that clarity.
     """
-    from datetime import datetime, timedelta
-    from zoneinfo import ZoneInfo
-
-    import pytest
-
-    from flexmeasures.data.models.planning.storage import StorageScheduler
-
     asset_type = GenericAssetType(name="test-asset-type-missing-sensor")
     fresh_db.session.add(asset_type)
     asset = GenericAsset(

--- a/flexmeasures/data/models/planning/tests/test_utils_fresh_db.py
+++ b/flexmeasures/data/models/planning/tests/test_utils_fresh_db.py
@@ -214,3 +214,61 @@ def test_get_series_from_sensor_reference_source_account_filter_integration(fres
     )
     assert isinstance(result, pd.Series)
     assert result.iloc[0] == pytest.approx(33.0)
+
+
+def test_collect_flex_config_missing_sensor_raises(fresh_db):
+    """Missing flex-model sensor IDs should raise a clear ValueError (GH-2250).
+
+    Previously ``collect_flex_config`` did ``sensor.asset_id`` on a ``None``
+    lookup result and raised ``AttributeError: 'NoneType' object has no
+    attribute 'asset_id'``. Flex-context already validates via marshmallow;
+    flex-model path should match that clarity.
+    """
+    from datetime import datetime, timedelta
+    from zoneinfo import ZoneInfo
+
+    import pytest
+
+    from flexmeasures.data.models.planning.storage import StorageScheduler
+
+    asset_type = GenericAssetType(name="test-asset-type-missing-sensor")
+    fresh_db.session.add(asset_type)
+    asset = GenericAsset(
+        name="test-asset-missing-sensor", generic_asset_type=asset_type
+    )
+    fresh_db.session.add(asset)
+    fresh_db.session.commit()
+
+    start = datetime(2023, 1, 1, tzinfo=ZoneInfo("UTC"))
+    end = start + timedelta(hours=1)
+    missing_id = 44207999
+
+    scheduler = StorageScheduler(
+        asset_or_sensor=asset,
+        start=start,
+        end=end,
+        resolution=timedelta(hours=1),
+        flex_model=[
+            {
+                "sensor": missing_id,
+                "soc-at-start": "4 kWh",
+                "roundtrip-efficiency": 0.9,
+                "soc-min": "2 kWh",
+            }
+        ],
+        flex_context={},
+    )
+    with pytest.raises(ValueError, match=f"No sensor found with ID {missing_id}"):
+        scheduler.collect_flex_config()
+
+    # Same clarity when resolving asset via state-of-charge sensor reference
+    scheduler_soc = StorageScheduler(
+        asset_or_sensor=asset,
+        start=start,
+        end=end,
+        resolution=timedelta(hours=1),
+        flex_model=[{"state-of-charge": {"sensor": missing_id}}],
+        flex_context={},
+    )
+    with pytest.raises(ValueError, match=f"No sensor found with ID {missing_id}"):
+        scheduler_soc.collect_flex_config()


### PR DESCRIPTION
## Description

- [x] When `collect_flex_config` resolves a flex-model entry via `sensor` or `state-of-charge.sensor`, raise a clear `ValueError` if the sensor ID does not exist (instead of `AttributeError: 'NoneType' object has no attribute 'asset_id'`)
- [x] Match the message style used by flex-context validation: `No sensor found with ID {id}.`
- [x] Regression tests for both resolution paths
- [x] Changelog entry

## Look & Feel

Before (missing sensor in flex-model):

```
AttributeError: 'NoneType' object has no attribute 'asset_id'
```

After:

```
ValueError: No sensor found with ID 44207999.
```

Flex-context already validated this cleanly via marshmallow; flex-model now matches.

## How to test

```bash
pytest flexmeasures/data/models/planning/tests/test_utils_fresh_db.py::test_collect_flex_config_missing_sensor_raises -q
```

## Related Items

Fixes #2250

---

#### Sign-off

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures

---
