### PR TITLE
test: multi-session same-sensor schedules accumulate (sum)

### DIFF
--- a/flexmeasures/data/models/planning/tests/conftest.py
+++ b/flexmeasures/data/models/planning/tests/conftest.py
@@ -119,6 +119,30 @@ def building(db, setup_accounts, setup_markets) -> GenericAsset:
 
 
 @pytest.fixture(scope="module")
+def charge_point(db, setup_accounts) -> GenericAsset:
+    """
+    Set up a charge point. A charge point can have one or more connectors,
+    modeled as separate power sensors on this asset.
+    """
+    charge_point_type = db.session.execute(
+        select(GenericAssetType).filter_by(name="charge point")
+    ).scalar_one_or_none()
+    if not charge_point_type:
+        charge_point_type = GenericAssetType(name="charge point")
+    db.session.add(charge_point_type)
+    charge_point = GenericAsset(
+        name="planning charge point",
+        generic_asset_type=charge_point_type,
+        owner=setup_accounts["Prosumer"],
+        flex_context={
+            "site-power-capacity": "1 MVA",
+        },
+    )
+    db.session.add(charge_point)
+    return charge_point
+
+
+@pytest.fixture(scope="module")
 def flexible_devices(db, building) -> dict[str, Sensor]:
     """
     Set up power sensors for flexible devices:

--- a/flexmeasures/data/models/planning/tests/test_storage.py
+++ b/flexmeasures/data/models/planning/tests/test_storage.py
@@ -2798,6 +2798,8 @@ def test_multiple_sessions_same_sensor_accumulate_overlapping_windows(db, buildi
     np.testing.assert_allclose(schedule.values, [1.0, 1.0, 1.0, 1.0], atol=1e-3)
     # Overwrite would keep only the last session (~2 kWh at 0.5 kW).
     np.testing.assert_allclose(schedule.sum(), 4.0, atol=1e-3)
-    assert (schedule.values > 0.75).all(), (
+    assert (
+        schedule.values > 0.75
+    ).all(), (
         "overlapping sessions must both contribute; overwrite would stay near 0.5 kW"
     )

--- a/flexmeasures/data/models/planning/tests/test_storage.py
+++ b/flexmeasures/data/models/planning/tests/test_storage.py
@@ -2660,11 +2660,10 @@ def _storage_schedule_for_sensor(results, power_sensor):
 def test_multiple_sessions_same_sensor_accumulate_schedules(db, charge_point):
     """Two flex-model sessions on one power sensor must sum schedules (not overwrite).
 
-    Regression for https://github.com/FlexMeasures/flexmeasures/issues/1947
-    (core fix in #1948). Multiple independent storage entries may share a power
-    sensor (e.g. two EV sessions plugged into the same charge point connector,
-    one after the other). Their device schedules must be accumulated into a
-    single sensor schedule.
+    Multiple independent storage entries may share a power sensor (e.g. two EV
+    sessions plugged into the same charge point connector, one after the
+    other). Their device schedules must be accumulated into a single sensor
+    schedule.
 
     Setup: two non-overlapping sessions, each needing 2 kWh at 1 kW over a 2-hour
     window. Overwrite behaviour would keep only the second session (~2 kWh total,
@@ -2741,10 +2740,10 @@ def test_multiple_sessions_different_connectors_preallocate_overlap_capacity(
 
     Companion to ``test_multiple_sessions_same_sensor_accumulate_schedules``.
     Two EV sessions cannot overlap on the same connector, so overlap is only
-    meaningful across two connectors of one charge point (#2344 review). Each
-    connector has its own power sensor. During the shared hours the available
-    power is pre-allocated in each flex-model (each connector's power-capacity
-    is decreased), which is the modeling Flix6x described on #1947.
+    meaningful across two connectors of one charge point. Each connector has
+    its own power sensor. During the shared hours the available power is
+    pre-allocated in each flex-model (each connector's power-capacity is
+    decreased).
 
     Setup: session A on hours 0-3, session B on hours 1-4. Both run at 1 kW
     when alone and at 0.5 kW in the two overlapping hours. Each still needs

--- a/flexmeasures/data/models/planning/tests/test_storage.py
+++ b/flexmeasures/data/models/planning/tests/test_storage.py
@@ -2631,3 +2631,89 @@ def test_multi_device_validation_survives_stockless_device(add_battery_assets, d
 
     with pytest.raises(ValueError, match="Constraint validation"):
         scheduler.compute()
+
+def test_multiple_sessions_same_sensor_accumulate_schedules(db, building):
+    """Two flex-model sessions on one power sensor must sum schedules (not overwrite).
+
+    Regression for https://github.com/FlexMeasures/flexmeasures/issues/1947
+    (core fix in #1948). Multiple independent storage entries may share a power
+    sensor (e.g. EV sessions on one charge point). Their device schedules must be
+    accumulated into a single sensor schedule.
+
+    Setup: two non-overlapping sessions, each needing 2 kWh at 1 kW over a 2-hour
+    window. Overwrite behaviour would keep only the second session (~2 kWh total);
+    correct accumulation yields ~4 kWh with power in both halves of the horizon.
+    """
+    resolution = timedelta(hours=1)
+    start = pd.Timestamp("2020-01-01T00:00:00", tz="Europe/Amsterdam")
+    end = start + 4 * resolution
+    mid = start + 2 * resolution
+
+    power_sensor = Sensor(
+        name="shared EVSE power",
+        generic_asset=building,
+        event_resolution=resolution,
+        unit="kW",
+    )
+    db.session.add(power_sensor)
+    db.session.commit()
+
+    index = initialize_index(start=start, end=end, resolution=resolution)
+    # Pre-allocate capacity per session (required when sessions would otherwise
+    # compete for the same charger capacity; here they are non-overlapping).
+    session1_capacity = pd.Series([1.0, 1.0, 0.0, 0.0], index=index)
+    session2_capacity = pd.Series([0.0, 0.0, 1.0, 1.0], index=index)
+
+    flex_model = [
+        {
+            "sensor": power_sensor.id,
+            "soc-at-start": "0 kWh",
+            "soc-min": "0 kWh",
+            "soc-max": "100 kWh",
+            "soc-minima": [{"datetime": mid.isoformat(), "value": "2 kWh"}],
+            "power-capacity": "1 kW",
+            "consumption-capacity": series_to_ts_specs(session1_capacity, unit="kW"),
+            "production-capacity": "0 kW",
+        },
+        {
+            "sensor": power_sensor.id,
+            "soc-at-start": "0 kWh",
+            "soc-min": "0 kWh",
+            "soc-max": "100 kWh",
+            "soc-minima": [{"datetime": end.isoformat(), "value": "2 kWh"}],
+            "power-capacity": "1 kW",
+            "consumption-capacity": series_to_ts_specs(session2_capacity, unit="kW"),
+            "production-capacity": "0 kW",
+        },
+    ]
+
+    scheduler: Scheduler = StorageScheduler(
+        asset_or_sensor=building,
+        start=start,
+        end=end,
+        resolution=resolution,
+        flex_model=flex_model,
+        flex_context={
+            "consumption-price": "100 EUR/MWh",
+            "production-price": "0 EUR/MWh",
+            "site-power-capacity": "10 kW",
+            "soc-minima-breach-price": "6000 EUR/kWh",
+        },
+        return_multiple=True,
+    )
+    results = scheduler.compute()
+
+    storage_for_sensor = [
+        r
+        for r in results
+        if r.get("name") == "storage_schedule" and r.get("sensor") is power_sensor
+    ]
+    assert (
+        len(storage_for_sensor) == 1
+    ), "expected exactly one combined storage_schedule for the shared sensor"
+    schedule = storage_for_sensor[0]["data"]
+
+    # Each session charges 2 kWh at 1 kW over its half window → [1, 1, 1, 1] kW.
+    np.testing.assert_allclose(schedule.values, [1.0, 1.0, 1.0, 1.0], atol=1e-3)
+    # Overwrite would leave only the second session (~2 kWh total energy).
+    np.testing.assert_allclose(schedule.sum(), 4.0, atol=1e-3)

--- a/flexmeasures/data/models/planning/tests/test_storage.py
+++ b/flexmeasures/data/models/planning/tests/test_storage.py
@@ -2632,6 +2632,30 @@ def test_multi_device_validation_survives_stockless_device(add_battery_assets, d
     with pytest.raises(ValueError, match="Constraint validation"):
         scheduler.compute()
 
+def _shared_evse_power_sensor(db, building, resolution, name="shared EVSE power"):
+    power_sensor = Sensor(
+        name=name,
+        generic_asset=building,
+        event_resolution=resolution,
+        unit="kW",
+    )
+    db.session.add(power_sensor)
+    db.session.commit()
+    return power_sensor
+
+
+def _storage_schedule_for_sensor(results, power_sensor):
+    storage_for_sensor = [
+        r
+        for r in results
+        if r.get("name") == "storage_schedule" and r.get("sensor") is power_sensor
+    ]
+    assert (
+        len(storage_for_sensor) == 1
+    ), "expected exactly one combined storage_schedule for the shared sensor"
+    return storage_for_sensor[0]["data"]
+
+
 def test_multiple_sessions_same_sensor_accumulate_schedules(db, building):
     """Two flex-model sessions on one power sensor must sum schedules (not overwrite).
 
@@ -2641,22 +2665,18 @@ def test_multiple_sessions_same_sensor_accumulate_schedules(db, building):
     accumulated into a single sensor schedule.
 
     Setup: two non-overlapping sessions, each needing 2 kWh at 1 kW over a 2-hour
-    window. Overwrite behaviour would keep only the second session (~2 kWh total);
-    correct accumulation yields ~4 kWh with power in both halves of the horizon.
+    window. Overwrite behaviour would keep only the second session (~2 kWh total,
+    zeros in the first half); correct accumulation yields ~4 kWh with power in
+    both halves of the horizon.
     """
     resolution = timedelta(hours=1)
     start = pd.Timestamp("2020-01-01T00:00:00", tz="Europe/Amsterdam")
     end = start + 4 * resolution
     mid = start + 2 * resolution
 
-    power_sensor = Sensor(
-        name="shared EVSE power",
-        generic_asset=building,
-        event_resolution=resolution,
-        unit="kW",
+    power_sensor = _shared_evse_power_sensor(
+        db, building, resolution, name="shared EVSE power non-overlap"
     )
-    db.session.add(power_sensor)
-    db.session.commit()
 
     index = initialize_index(start=start, end=end, resolution=resolution)
     # Pre-allocate capacity per session (required when sessions would otherwise
@@ -2702,18 +2722,82 @@ def test_multiple_sessions_same_sensor_accumulate_schedules(db, building):
         return_multiple=True,
     )
     results = scheduler.compute()
-
-    storage_for_sensor = [
-        r
-        for r in results
-        if r.get("name") == "storage_schedule" and r.get("sensor") is power_sensor
-    ]
-    assert (
-        len(storage_for_sensor) == 1
-    ), "expected exactly one combined storage_schedule for the shared sensor"
-    schedule = storage_for_sensor[0]["data"]
+    schedule = _storage_schedule_for_sensor(results, power_sensor)
 
     # Each session charges 2 kWh at 1 kW over its half window → [1, 1, 1, 1] kW.
     np.testing.assert_allclose(schedule.values, [1.0, 1.0, 1.0, 1.0], atol=1e-3)
-    # Overwrite would leave only the second session (~2 kWh total energy).
+    # Overwrite would leave only the second session (zeros first half, ~2 kWh total).
+    np.testing.assert_allclose(schedule.iloc[:2].values, [1.0, 1.0], atol=1e-3)
+    np.testing.assert_allclose(schedule.iloc[2:].values, [1.0, 1.0], atol=1e-3)
     np.testing.assert_allclose(schedule.sum(), 4.0, atol=1e-3)
+
+
+def test_multiple_sessions_same_sensor_accumulate_overlapping_windows(db, building):
+    """Overlapping same-sensor sessions still sum after pre-allocating capacity.
+
+    Companion to ``test_multiple_sessions_same_sensor_accumulate_schedules``: when
+    two sessions share hours, power capacity must be pre-split in the flex-models
+    (Flix6x on #1947). The returned sensor schedule must still be the sum of both
+    device schedules, not the last session alone.
+
+    Setup: both sessions active all 4 hours at 0.5 kW each, each needing 2 kWh.
+    Sum → [1, 1, 1, 1] kW (~4 kWh). Overwrite would keep only one session at
+    0.5 kW (~2 kWh).
+    """
+    resolution = timedelta(hours=1)
+    start = pd.Timestamp("2020-01-01T00:00:00", tz="Europe/Amsterdam")
+    end = start + 4 * resolution
+
+    power_sensor = _shared_evse_power_sensor(
+        db, building, resolution, name="shared EVSE power overlap"
+    )
+
+    # Equal pre-allocation while both sessions are connected (Flix6x #1947).
+    shared_half_capacity = "0.5 kW"
+    flex_model = [
+        {
+            "sensor": power_sensor.id,
+            "soc-at-start": "0 kWh",
+            "soc-min": "0 kWh",
+            "soc-max": "100 kWh",
+            "soc-minima": [{"datetime": end.isoformat(), "value": "2 kWh"}],
+            "power-capacity": shared_half_capacity,
+            "consumption-capacity": shared_half_capacity,
+            "production-capacity": "0 kW",
+        },
+        {
+            "sensor": power_sensor.id,
+            "soc-at-start": "0 kWh",
+            "soc-min": "0 kWh",
+            "soc-max": "100 kWh",
+            "soc-minima": [{"datetime": end.isoformat(), "value": "2 kWh"}],
+            "power-capacity": shared_half_capacity,
+            "consumption-capacity": shared_half_capacity,
+            "production-capacity": "0 kW",
+        },
+    ]
+
+    scheduler: Scheduler = StorageScheduler(
+        asset_or_sensor=building,
+        start=start,
+        end=end,
+        resolution=resolution,
+        flex_model=flex_model,
+        flex_context={
+            "consumption-price": "100 EUR/MWh",
+            "production-price": "0 EUR/MWh",
+            "site-power-capacity": "10 kW",
+            "soc-minima-breach-price": "6000 EUR/kWh",
+        },
+        return_multiple=True,
+    )
+    results = scheduler.compute()
+    schedule = _storage_schedule_for_sensor(results, power_sensor)
+
+    # Two sessions at 0.5 kW each, full horizon → [1, 1, 1, 1] kW.
+    np.testing.assert_allclose(schedule.values, [1.0, 1.0, 1.0, 1.0], atol=1e-3)
+    # Overwrite would keep only the last session (~2 kWh at 0.5 kW).
+    np.testing.assert_allclose(schedule.sum(), 4.0, atol=1e-3)
+    assert (schedule.values > 0.75).all(), (
+        "overlapping sessions must both contribute; overwrite would stay near 0.5 kW"
+    )

--- a/flexmeasures/data/models/planning/tests/test_storage.py
+++ b/flexmeasures/data/models/planning/tests/test_storage.py
@@ -2632,10 +2632,11 @@ def test_multi_device_validation_survives_stockless_device(add_battery_assets, d
     with pytest.raises(ValueError, match="Constraint validation"):
         scheduler.compute()
 
-def _shared_evse_power_sensor(db, building, resolution, name="shared EVSE power"):
+
+def _evse_power_sensor(db, asset, resolution, name):
     power_sensor = Sensor(
         name=name,
-        generic_asset=building,
+        generic_asset=asset,
         event_resolution=resolution,
         unit="kW",
     )
@@ -2652,17 +2653,18 @@ def _storage_schedule_for_sensor(results, power_sensor):
     ]
     assert (
         len(storage_for_sensor) == 1
-    ), "expected exactly one combined storage_schedule for the shared sensor"
+    ), "expected exactly one combined storage_schedule for this sensor"
     return storage_for_sensor[0]["data"]
 
 
-def test_multiple_sessions_same_sensor_accumulate_schedules(db, building):
+def test_multiple_sessions_same_sensor_accumulate_schedules(db, charge_point):
     """Two flex-model sessions on one power sensor must sum schedules (not overwrite).
 
     Regression for https://github.com/FlexMeasures/flexmeasures/issues/1947
     (core fix in #1948). Multiple independent storage entries may share a power
-    sensor (e.g. EV sessions on one charge point). Their device schedules must be
-    accumulated into a single sensor schedule.
+    sensor (e.g. two EV sessions plugged into the same charge point connector,
+    one after the other). Their device schedules must be accumulated into a
+    single sensor schedule.
 
     Setup: two non-overlapping sessions, each needing 2 kWh at 1 kW over a 2-hour
     window. Overwrite behaviour would keep only the second session (~2 kWh total,
@@ -2674,8 +2676,8 @@ def test_multiple_sessions_same_sensor_accumulate_schedules(db, building):
     end = start + 4 * resolution
     mid = start + 2 * resolution
 
-    power_sensor = _shared_evse_power_sensor(
-        db, building, resolution, name="shared EVSE power non-overlap"
+    power_sensor = _evse_power_sensor(
+        db, charge_point, resolution, name="connector power non-overlap"
     )
 
     index = initialize_index(start=start, end=end, resolution=resolution)
@@ -2708,7 +2710,7 @@ def test_multiple_sessions_same_sensor_accumulate_schedules(db, building):
     ]
 
     scheduler: Scheduler = StorageScheduler(
-        asset_or_sensor=building,
+        asset_or_sensor=charge_point,
         start=start,
         end=end,
         resolution=resolution,
@@ -2732,74 +2734,85 @@ def test_multiple_sessions_same_sensor_accumulate_schedules(db, building):
     np.testing.assert_allclose(schedule.sum(), 4.0, atol=1e-3)
 
 
-def test_multiple_sessions_same_sensor_accumulate_overlapping_windows(db, building):
-    """Overlapping same-sensor sessions still sum after pre-allocating capacity.
+def test_multiple_sessions_different_connectors_share_charge_point_capacity(
+    db, charge_point
+):
+    """Overlapping sessions on different connectors still share the site cap.
 
-    Companion to ``test_multiple_sessions_same_sensor_accumulate_schedules``: when
-    two sessions share hours, power capacity must be pre-split in the flex-models
-    (Flix6x on #1947). The returned sensor schedule must still be the sum of both
-    device schedules, not the last session alone.
+    Companion to ``test_multiple_sessions_same_sensor_accumulate_schedules``. Two
+    EV sessions cannot overlap on the *same* connector - a connector serves one
+    car at a time - so overlap is only physically meaningful across two
+    *different* connectors of the same charge point (#2344 review). Each
+    connector gets its own power sensor; the charge point's site-power-capacity
+    is the shared constraint the two connectors compete for while both sessions
+    are active.
 
-    Setup: both sessions active all 4 hours at 0.5 kW each, each needing 2 kWh.
-    Sum → [1, 1, 1, 1] kW (~4 kWh). Overwrite would keep only one session at
-    0.5 kW (~2 kWh).
+    Setup: two sessions, one per connector, each with its own 1 kW nominal
+    connector capacity, each needing 2 kWh over a 4-hour window. An hourly
+    soc-minima ramp (0.5 kWh/hour for both) forces them to draw power in the
+    same hours. The charge point's site-power-capacity is capped at 1 kW total
+    - exactly the combined minimum required each hour - so the shared cap pins
+    each connector to 0.5 kW per hour, half of its own nominal capacity.
     """
     resolution = timedelta(hours=1)
     start = pd.Timestamp("2020-01-01T00:00:00", tz="Europe/Amsterdam")
     end = start + 4 * resolution
 
-    power_sensor = _shared_evse_power_sensor(
-        db, building, resolution, name="shared EVSE power overlap"
+    connector_a = _evse_power_sensor(
+        db, charge_point, resolution, name="connector A power"
+    )
+    connector_b = _evse_power_sensor(
+        db, charge_point, resolution, name="connector B power"
     )
 
-    # Equal pre-allocation while both sessions are connected (Flix6x #1947).
-    shared_half_capacity = "0.5 kW"
-    flex_model = [
-        {
-            "sensor": power_sensor.id,
-            "soc-at-start": "0 kWh",
-            "soc-min": "0 kWh",
-            "soc-max": "100 kWh",
-            "soc-minima": [{"datetime": end.isoformat(), "value": "2 kWh"}],
-            "power-capacity": shared_half_capacity,
-            "consumption-capacity": shared_half_capacity,
-            "production-capacity": "0 kW",
-        },
-        {
-            "sensor": power_sensor.id,
-            "soc-at-start": "0 kWh",
-            "soc-min": "0 kWh",
-            "soc-max": "100 kWh",
-            "soc-minima": [{"datetime": end.isoformat(), "value": "2 kWh"}],
-            "power-capacity": shared_half_capacity,
-            "consumption-capacity": shared_half_capacity,
-            "production-capacity": "0 kW",
-        },
+    # Both sessions must show 0.5 kWh of cumulative progress every hour, which
+    # (combined with the 1 kW site cap) pins both to exactly 0.5 kW per hour.
+    ramp = [
+        {"datetime": (start + n * resolution).isoformat(), "value": f"{0.5 * n} kWh"}
+        for n in range(1, 5)
     ]
 
+    def session_flex_model(sensor):
+        return {
+            "sensor": sensor.id,
+            "soc-at-start": "0 kWh",
+            "soc-min": "0 kWh",
+            "soc-max": "100 kWh",
+            "soc-minima": ramp,
+            "power-capacity": "1 kW",
+            "consumption-capacity": "1 kW",
+            "production-capacity": "0 kW",
+        }
+
     scheduler: Scheduler = StorageScheduler(
-        asset_or_sensor=building,
+        asset_or_sensor=charge_point,
         start=start,
         end=end,
         resolution=resolution,
-        flex_model=flex_model,
+        flex_model=[
+            session_flex_model(connector_a),
+            session_flex_model(connector_b),
+        ],
         flex_context={
             "consumption-price": "100 EUR/MWh",
             "production-price": "0 EUR/MWh",
-            "site-power-capacity": "10 kW",
+            "site-power-capacity": "1 kW",
             "soc-minima-breach-price": "6000 EUR/kWh",
         },
         return_multiple=True,
     )
     results = scheduler.compute()
-    schedule = _storage_schedule_for_sensor(results, power_sensor)
+    schedule_a = _storage_schedule_for_sensor(results, connector_a)
+    schedule_b = _storage_schedule_for_sensor(results, connector_b)
 
-    # Two sessions at 0.5 kW each, full horizon → [1, 1, 1, 1] kW.
-    np.testing.assert_allclose(schedule.values, [1.0, 1.0, 1.0, 1.0], atol=1e-3)
-    # Overwrite would keep only the last session (~2 kWh at 0.5 kW).
-    np.testing.assert_allclose(schedule.sum(), 4.0, atol=1e-3)
-    assert (
-        schedule.values > 0.75
-    ).all(), (
-        "overlapping sessions must both contribute; overwrite would stay near 0.5 kW"
+    # Each connector is pinned to 0.5 kW/hour - half its own 1 kW nominal
+    # capacity - because the two connectors share the charge point's 1 kW cap.
+    np.testing.assert_allclose(schedule_a.values, [0.5, 0.5, 0.5, 0.5], atol=1e-3)
+    np.testing.assert_allclose(schedule_b.values, [0.5, 0.5, 0.5, 0.5], atol=1e-3)
+    # The combined draw never exceeds the charge point's site-power-capacity.
+    np.testing.assert_allclose(
+        schedule_a.values + schedule_b.values, [1.0, 1.0, 1.0, 1.0], atol=1e-3
     )
+    # Each session still gets its full 2 kWh despite the shared cap.
+    np.testing.assert_allclose(schedule_a.sum(), 2.0, atol=1e-3)
+    np.testing.assert_allclose(schedule_b.sum(), 2.0, atol=1e-3)

--- a/flexmeasures/data/models/planning/tests/test_storage.py
+++ b/flexmeasures/data/models/planning/tests/test_storage.py
@@ -2734,25 +2734,22 @@ def test_multiple_sessions_same_sensor_accumulate_schedules(db, charge_point):
     np.testing.assert_allclose(schedule.sum(), 4.0, atol=1e-3)
 
 
-def test_multiple_sessions_different_connectors_share_charge_point_capacity(
+def test_multiple_sessions_different_connectors_preallocate_overlap_capacity(
     db, charge_point
 ):
-    """Overlapping sessions on different connectors still share the site cap.
+    """Overlapping sessions live on different connectors and pre-split capacity.
 
-    Companion to ``test_multiple_sessions_same_sensor_accumulate_schedules``. Two
-    EV sessions cannot overlap on the *same* connector - a connector serves one
-    car at a time - so overlap is only physically meaningful across two
-    *different* connectors of the same charge point (#2344 review). Each
-    connector gets its own power sensor; the charge point's site-power-capacity
-    is the shared constraint the two connectors compete for while both sessions
-    are active.
+    Companion to ``test_multiple_sessions_same_sensor_accumulate_schedules``.
+    Two EV sessions cannot overlap on the same connector, so overlap is only
+    meaningful across two connectors of one charge point (#2344 review). Each
+    connector has its own power sensor. During the shared hours the available
+    power is pre-allocated in each flex-model (each connector's power-capacity
+    is decreased), which is the modeling Flix6x described on #1947.
 
-    Setup: two sessions, one per connector, each with its own 1 kW nominal
-    connector capacity, each needing 2 kWh over a 4-hour window. An hourly
-    soc-minima ramp (0.5 kWh/hour for both) forces them to draw power in the
-    same hours. The charge point's site-power-capacity is capped at 1 kW total
-    - exactly the combined minimum required each hour - so the shared cap pins
-    each connector to 0.5 kW per hour, half of its own nominal capacity.
+    Setup: session A on hours 0-3, session B on hours 1-4. Both run at 1 kW
+    when alone and at 0.5 kW in the two overlapping hours. Each still needs
+    2 kWh. Site capacity is left slack so the binding limits are the
+    per-connector pre-split windows.
     """
     resolution = timedelta(hours=1)
     start = pd.Timestamp("2020-01-01T00:00:00", tz="Europe/Amsterdam")
@@ -2765,22 +2762,21 @@ def test_multiple_sessions_different_connectors_share_charge_point_capacity(
         db, charge_point, resolution, name="connector B power"
     )
 
-    # Both sessions must show 0.5 kWh of cumulative progress every hour, which
-    # (combined with the 1 kW site cap) pins both to exactly 0.5 kW per hour.
-    ramp = [
-        {"datetime": (start + n * resolution).isoformat(), "value": f"{0.5 * n} kWh"}
-        for n in range(1, 5)
-    ]
+    index = initialize_index(start=start, end=end, resolution=resolution)
+    # A: 1 kW, then 0.5 + 0.5 kW in the overlap, then unplugged.
+    # B: unplugged, then 0.5 + 0.5 kW in the overlap, then 1 kW.
+    cap_a = pd.Series([1.0, 0.5, 0.5, 0.0], index=index)
+    cap_b = pd.Series([0.0, 0.5, 0.5, 1.0], index=index)
 
-    def session_flex_model(sensor):
+    def session_flex_model(sensor, capacity, soc_deadline):
         return {
             "sensor": sensor.id,
             "soc-at-start": "0 kWh",
             "soc-min": "0 kWh",
             "soc-max": "100 kWh",
-            "soc-minima": ramp,
-            "power-capacity": "1 kW",
-            "consumption-capacity": "1 kW",
+            "soc-minima": [{"datetime": soc_deadline.isoformat(), "value": "2 kWh"}],
+            "power-capacity": series_to_ts_specs(capacity, unit="kW"),
+            "consumption-capacity": series_to_ts_specs(capacity, unit="kW"),
             "production-capacity": "0 kW",
         }
 
@@ -2790,13 +2786,13 @@ def test_multiple_sessions_different_connectors_share_charge_point_capacity(
         end=end,
         resolution=resolution,
         flex_model=[
-            session_flex_model(connector_a),
-            session_flex_model(connector_b),
+            session_flex_model(connector_a, cap_a, start + 3 * resolution),
+            session_flex_model(connector_b, cap_b, end),
         ],
         flex_context={
             "consumption-price": "100 EUR/MWh",
             "production-price": "0 EUR/MWh",
-            "site-power-capacity": "1 kW",
+            "site-power-capacity": "10 kW",
             "soc-minima-breach-price": "6000 EUR/kWh",
         },
         return_multiple=True,
@@ -2805,14 +2801,12 @@ def test_multiple_sessions_different_connectors_share_charge_point_capacity(
     schedule_a = _storage_schedule_for_sensor(results, connector_a)
     schedule_b = _storage_schedule_for_sensor(results, connector_b)
 
-    # Each connector is pinned to 0.5 kW/hour - half its own 1 kW nominal
-    # capacity - because the two connectors share the charge point's 1 kW cap.
-    np.testing.assert_allclose(schedule_a.values, [0.5, 0.5, 0.5, 0.5], atol=1e-3)
-    np.testing.assert_allclose(schedule_b.values, [0.5, 0.5, 0.5, 0.5], atol=1e-3)
-    # The combined draw never exceeds the charge point's site-power-capacity.
+    # Each connector follows its pre-split window, not the other's.
+    np.testing.assert_allclose(schedule_a.values, [1.0, 0.5, 0.5, 0.0], atol=1e-3)
+    np.testing.assert_allclose(schedule_b.values, [0.0, 0.5, 0.5, 1.0], atol=1e-3)
+    # Combined draw in the overlap hours is the sum of the decreased capacities.
     np.testing.assert_allclose(
         schedule_a.values + schedule_b.values, [1.0, 1.0, 1.0, 1.0], atol=1e-3
     )
-    # Each session still gets its full 2 kWh despite the shared cap.
     np.testing.assert_allclose(schedule_a.sum(), 2.0, atol=1e-3)
     np.testing.assert_allclose(schedule_b.sum(), 2.0, atol=1e-3)


### PR DESCRIPTION
## Description

Regression tests for multi flex-model sessions after #1948:

- Non-overlapping windows on one power sensor: schedules sum
- Overlapping sessions use two connectors on one charge point, with each connector's power-capacity pre-split during the shared hours
- EVSE generic asset is a charge point, not a building

Test-only. DCO signed.

## Validation
- `uv run pytest flexmeasures/data/models/planning/tests/test_storage.py -k multiple_sessions` (2 passed)

### AI/LLM disclosure

- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.