### PR TITLE
Fix OpenAPI docs: GET /sensors/<id>/stats accepts `sort`, not `sort_keys`

### DIFF
--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -1733,7 +1733,7 @@ class SensorAPI(FlaskView):
                 type: string
                 format: date-time
             - in: query
-              name: sort_keys
+              name: sort
               description: Whether to sort the stats by keys (defaults to true).
               schema:
                 type: boolean

--- a/flexmeasures/ui/static/openapi-specs.json
+++ b/flexmeasures/ui/static/openapi-specs.json
@@ -880,7 +880,7 @@
           },
           {
             "in": "query",
-            "name": "sort_keys",
+            "name": "sort",
             "description": "Whether to sort the stats by keys (defaults to true).",
             "schema": {
               "type": "boolean"


### PR DESCRIPTION
## Description

`GET /sensors/<id>/stats` accepts a `sort` query parameter (`sort_keys = fields.Boolean(data_key="sort", ...)` in `flexmeasures/api/v3_0/sensors.py`), but the OpenAPI docstring for this endpoint documented the parameter as `sort_keys` — the internal Python variable name, not the actual `data_key`. That means the published Swagger docs / OpenAPI spec told clients to send a query parameter the server doesn't actually read.

Found while verifying an unrelated AI-generated API audit against current `main` for a separate discussion.

## Changes

- Fixed the OpenAPI parameter name in the docstring for `get_stats` from `sort_keys` to `sort`, matching the actual accepted query key.
- Regenerated `flexmeasures/ui/static/openapi-specs.json`.

## How to test

Docs-only change, no behavior change. `flexmeasures/ui/static/openapi-specs.json` diff shows only the corrected parameter name for this one endpoint.
