### PR TITLE
Speed up listing assets by eager-loading sensors

### DIFF
--- a/.github/instructions/docstrings.instructions.md
+++ b/.github/instructions/docstrings.instructions.md
@@ -35,7 +35,7 @@ def function_name(param1: str, param2: int) -> bool:
 - Use `Example::` (double colon) to introduce a doctest block.
 - Complement type hints — don't duplicate them in the docstring text.
 - Use exactly one space after punctuation (no double spaces after periods).
-- Use line breaks only after punctuation (this facilitates review commenting and text searching).
+- Use line breaks only after punctuation (this facilitates review commenting and text searching). This applies to in-line comments as well, not only docstrings; keep in-line comments short.
 
 ## Click CLI commands
 

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -44,6 +44,7 @@ New features
 Infrastructure / Support
 ----------------------
 
+* Speed up listing assets: eager-load each asset's sensors instead of lazy-loading them one query per asset during serialization, and skip loading sensors entirely for field-filtered responses that do not include them [see `PR #2364 <https://www.github.com/FlexMeasures/flexmeasures/pull/2364>`_]
 * Price fields in the flex-context (including nested commitment prices, which are now also held to the flex-context's shared currency) are selected for currency validation by field type (``PriceField``) instead of by name suffix [see `PR #2311 <https://www.github.com/FlexMeasures/flexmeasures/pull/2311>`_]
 * Document ``SECURITY_TWO_FACTOR`` and related 2FA configuration settings [see `PR #2340 <https://www.github.com/FlexMeasures/flexmeasures/pull/2340>`_]
 * ``flexmeasures db upgrade`` now runs ``VACUUM ANALYZE`` after upgrading by default, so Postgres has fresh planner statistics right after a migration; opt out with ``--no-vacuum`` [see `PR #2333 <https://www.github.com/FlexMeasures/flexmeasures/pull/2333>`_]

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -44,7 +44,7 @@ New features
 Infrastructure / Support
 ----------------------
 
-* Speed up listing assets: eager-load each asset's sensors instead of lazy-loading them one query per asset during serialization, and skip loading sensors entirely for field-filtered responses that do not include them [see `PR #2364 <https://www.github.com/FlexMeasures/flexmeasures/pull/2364>`_]
+* Speed up listing assets: eager-load each asset's sensors instead of lazy-loading them one query per asset during serialization, and skip loading sensors entirely for field-filtered responses that do not include them [see `PR #2363 <https://www.github.com/FlexMeasures/flexmeasures/pull/2363>`_]
 * Price fields in the flex-context (including nested commitment prices, which are now also held to the flex-context's shared currency) are selected for currency validation by field type (``PriceField``) instead of by name suffix [see `PR #2311 <https://www.github.com/FlexMeasures/flexmeasures/pull/2311>`_]
 * Document ``SECURITY_TWO_FACTOR`` and related 2FA configuration settings [see `PR #2340 <https://www.github.com/FlexMeasures/flexmeasures/pull/2340>`_]
 * ``flexmeasures db upgrade`` now runs ``VACUUM ANALYZE`` after upgrading by default, so Postgres has fresh planner statistics right after a migration; opt out with ``--no-vacuum`` [see `PR #2333 <https://www.github.com/FlexMeasures/flexmeasures/pull/2333>`_]

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -16,6 +16,7 @@ from marshmallow import fields, post_load, ValidationError, Schema, validate
 
 from webargs.flaskparser import use_kwargs, use_args
 from sqlalchemy import select, func, or_
+from sqlalchemy import exc as sa_exc
 from sqlalchemy.orm import selectinload
 
 from flexmeasures.data.services.generic_assets import (
@@ -428,9 +429,17 @@ class AssetAPI(FlaskView):
         # this endpoint take seconds (profiled: ~6.7 s for ~2k assets, ~3x
         # faster with eager loading). Only load sensors when the response
         # schema will actually dump them - derived from the schema itself, so
-        # this can never diverge from the response contents.
+        # this can never diverge from the response contents. The loader is
+        # anchored on the query's own root entity: search filters and owner
+        # sorting root the query on an aliased GenericAsset, for which the
+        # plain class attribute raises an ArgumentError. Failing to install
+        # the loader is never fatal - sensors then simply lazy-load as before.
         if "sensors" in response_schema.dump_fields:
-            query = query.options(selectinload(GenericAsset.sensors))
+            try:
+                root_entity = query.column_descriptions[0]["entity"]
+                query = query.options(selectinload(root_entity.sensors))
+            except (KeyError, IndexError, sa_exc.ArgumentError):
+                pass
 
         if page is None:
             response = response_schema.dump(db.session.scalars(query).all(), many=True)

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -16,6 +16,7 @@ from marshmallow import fields, post_load, ValidationError, Schema, validate
 
 from webargs.flaskparser import use_kwargs, use_args
 from sqlalchemy import select, func, or_
+from sqlalchemy.orm import selectinload
 
 from flexmeasures.data.services.generic_assets import (
     create_asset,
@@ -411,6 +412,19 @@ class AssetAPI(FlaskView):
         query = filter_assets_under_root(
             query=query, root_asset=root_asset, max_depth=max_depth
         )
+
+        # Serializing an asset's sensors lazy-loads them per asset: dumping a
+        # multi-thousand-asset catalog issued one query per asset and made
+        # this endpoint take seconds (profiled: ~6.7 s for ~2k assets, ~3x
+        # faster with eager loading). Only load sensors when the response
+        # will actually include them.
+        dump_includes_sensors = (
+            "sensors" in fields_in_response
+            if fields_in_response != default_response_fields
+            else not current_app.config["FLEXMEASURES_API_SUNSET_ACTIVE"]
+        )
+        if dump_includes_sensors:
+            query = query.options(selectinload(GenericAsset.sensors))
 
         if current_app.config["FLEXMEASURES_API_SUNSET_ACTIVE"]:
             # TODO: for v0.31, this is to be tested in sunset mode; in v0.32 we only do this

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -424,16 +424,9 @@ class AssetAPI(FlaskView):
         if fields_in_response != default_response_fields:
             response_schema = AssetSchema(many=True, only=fields_in_response)
 
-        # Serializing an asset's sensors lazy-loads them per asset: dumping a
-        # multi-thousand-asset catalog issued one query per asset and made
-        # this endpoint take seconds (profiled: ~6.7 s for ~2k assets, ~3x
-        # faster with eager loading). Only load sensors when the response
-        # schema will actually dump them - derived from the schema itself, so
-        # this can never diverge from the response contents. The loader is
-        # anchored on the query's own root entity: search filters and owner
-        # sorting root the query on an aliased GenericAsset, for which the
-        # plain class attribute raises an ArgumentError. Failing to install
-        # the loader is never fatal - sensors then simply lazy-load as before.
+        # Eager-load sensors only when the response schema will dump them, avoiding an N+1 lazy load per asset that made this endpoint take seconds on large catalogs.
+        # The loader is anchored on the query's own root entity, which is an aliased GenericAsset under search filters or owner sorting.
+        # Failing to install the loader is never fatal: sensors then simply lazy-load as before.
         if "sensors" in response_schema.dump_fields:
             try:
                 root_entity = query.column_descriptions[0]["entity"]

--- a/flexmeasures/api/v3_0/assets.py
+++ b/flexmeasures/api/v3_0/assets.py
@@ -413,19 +413,6 @@ class AssetAPI(FlaskView):
             query=query, root_asset=root_asset, max_depth=max_depth
         )
 
-        # Serializing an asset's sensors lazy-loads them per asset: dumping a
-        # multi-thousand-asset catalog issued one query per asset and made
-        # this endpoint take seconds (profiled: ~6.7 s for ~2k assets, ~3x
-        # faster with eager loading). Only load sensors when the response
-        # will actually include them.
-        dump_includes_sensors = (
-            "sensors" in fields_in_response
-            if fields_in_response != default_response_fields
-            else not current_app.config["FLEXMEASURES_API_SUNSET_ACTIVE"]
-        )
-        if dump_includes_sensors:
-            query = query.options(selectinload(GenericAsset.sensors))
-
         if current_app.config["FLEXMEASURES_API_SUNSET_ACTIVE"]:
             # TODO: for v0.31, this is to be tested in sunset mode; in v0.32 we only do this
             response_schema = default_list_assets_schema
@@ -435,6 +422,15 @@ class AssetAPI(FlaskView):
             )  # in non-sunset, we default like usual, but still respect fields_in_response
         if fields_in_response != default_response_fields:
             response_schema = AssetSchema(many=True, only=fields_in_response)
+
+        # Serializing an asset's sensors lazy-loads them per asset: dumping a
+        # multi-thousand-asset catalog issued one query per asset and made
+        # this endpoint take seconds (profiled: ~6.7 s for ~2k assets, ~3x
+        # faster with eager loading). Only load sensors when the response
+        # schema will actually dump them - derived from the schema itself, so
+        # this can never diverge from the response contents.
+        if "sensors" in response_schema.dump_fields:
+            query = query.options(selectinload(GenericAsset.sensors))
 
         if page is None:
             response = response_schema.dump(db.session.scalars(query).all(), many=True)


### PR DESCRIPTION
## Description

Listing assets was slow on servers with many assets: serializing each asset's `sensors` lazy-loaded them with one query per asset (a classic N+1). Profiled on a ~2,000-asset database, `GET /api/v3_0/assets` spent 0.22 s loading the assets and ~6.7 s serializing them.

This PR eager-loads sensors with `selectinload` on the index query — and only when the requested response fields actually include sensors, so lean `fields`-filtered listings (e.g. `fields=id|name`) skip loading sensors entirely.

Measured on the same database:
- full listing: ~6–7 s → **3.1 s**
- `fields=id|name` listing: **0.31 s**

## Look & feel

API-only; no visual changes (though UI pages listing assets benefit indirectly).

## How to test

Time `GET /api/v3_0/assets?all_accessible=true` on a database with a few thousand assets, with and without this change; existing asset API tests cover correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtuVTVfL4fQ9QSqbLXmAGD