### PR TITLE
Asset tree: compact grid layout, plus zoom via scroll/pinch/buttons with responsive labels

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -41,6 +41,7 @@ New features
 * Extended the scheduling job ``result`` field with a ``num-beliefs`` field reporting the total number of beliefs (scheduled values) saved to the database [see `PR #2280 <https://www.github.com/FlexMeasures/flexmeasures/pull/2280>`_]
 * Migrate the asset tree in the UI's Structure tab from Vega to ECharts, adding interactive pan/zoom navigation and refreshed node styling [see `PR #2025 <https://www.github.com/FlexMeasures/flexmeasures/pull/2025>`_]
 * The asset tree in the UI's Structure tab now also zooms on scroll while the cursor is inside the tree, driving the same zoom level as the +/− buttons
+* Redesign the asset tree layout: an asset's leaf children now sit in one row (or, for many children, two balanced rows) next to their parent instead of one long column, with connectors reaching top-row boxes from above and bottom-row boxes from below — larger, non-overlapping boxes for wide asset trees
 
 Infrastructure / Support
 ----------------------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -40,6 +40,7 @@ New features
 * The ``group`` field now also accepts a ``{"asset": <id>}`` reference (in addition to ``{"sensor": <id>}``), allowing intermediate power constraints to be defined entirely from flex-models stored on the asset tree, with results saved via the group's ``consumption``/``production`` output sensors, without needing any flex-model in the scheduling trigger [see `issue #2092 <https://github.com/FlexMeasures/flexmeasures/issues/2092>`_]
 * Extended the scheduling job ``result`` field with a ``num-beliefs`` field reporting the total number of beliefs (scheduled values) saved to the database [see `PR #2280 <https://www.github.com/FlexMeasures/flexmeasures/pull/2280>`_]
 * Migrate the asset tree in the UI's Structure tab from Vega to ECharts, adding interactive pan/zoom navigation and refreshed node styling [see `PR #2025 <https://www.github.com/FlexMeasures/flexmeasures/pull/2025>`_]
+* The asset tree in the UI's Structure tab now also zooms on scroll while the cursor is inside the tree, driving the same zoom level as the +/− buttons
 
 Infrastructure / Support
 ----------------------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -39,9 +39,7 @@ New features
 * Add support for intermediate power constraints on groups of devices, via a new ``group`` field in the storage flex-model [see `PR #2276 <https://www.github.com/FlexMeasures/flexmeasures/pull/2276>`_ and `issue #2092 <https://github.com/FlexMeasures/flexmeasures/issues/2092>`_]
 * The ``group`` field now also accepts a ``{"asset": <id>}`` reference (in addition to ``{"sensor": <id>}``), allowing intermediate power constraints to be defined entirely from flex-models stored on the asset tree, with results saved via the group's ``consumption``/``production`` output sensors, without needing any flex-model in the scheduling trigger [see `issue #2092 <https://github.com/FlexMeasures/flexmeasures/issues/2092>`_]
 * Extended the scheduling job ``result`` field with a ``num-beliefs`` field reporting the total number of beliefs (scheduled values) saved to the database [see `PR #2280 <https://www.github.com/FlexMeasures/flexmeasures/pull/2280>`_]
-* Migrate the asset tree in the UI's Structure tab from Vega to ECharts, adding interactive pan/zoom navigation and refreshed node styling [see `PR #2025 <https://www.github.com/FlexMeasures/flexmeasures/pull/2025>`_]
-* The asset tree in the UI's Structure tab now also zooms on scroll while the cursor is inside the tree, driving the same zoom level as the +/− buttons
-* Redesign the asset tree layout: an asset's leaf children now sit in one row (or, for many children, two balanced rows) next to their parent instead of one long column, with connectors reaching top-row boxes from above and bottom-row boxes from below — larger, non-overlapping boxes for wide asset trees
+* Migrate the asset tree in the UI's Structure tab from Vega to ECharts, adding interactive pan/zoom navigation and refreshed node styling [see `PR #2025 <https://www.github.com/FlexMeasures/flexmeasures/pull/2025>`_ and `PR #2365 <https://www.github.com/FlexMeasures/flexmeasures/pull/2365>`_]
 
 Infrastructure / Support
 ----------------------

--- a/flexmeasures/ui/templates/_macros.html
+++ b/flexmeasures/ui/templates/_macros.html
@@ -147,18 +147,27 @@
           Math.max(BOX_REF, Math.min(104, fitBox)),
           Math.max(20, hCap)
         ));
-        var ICON_SIZE = Math.max(4, Math.floor(BOX_SIZE * 0.26));
-        var FONT_SIZE = Math.max(6, Math.round(BOX_SIZE * 0.13));
-        var LINE_H = FONT_SIZE + 2;
         var slotY = BOX_SIZE * (1 + GAP_RATIO);   // vertical row pitch
         var colGapX = BOX_SIZE * 1.35;            // horizontal grid column pitch
         var blockGap = slotY * 0.55;              // gap between family blocks
 
+        // Labels (text + icon) are drawn by ECharts at a fixed on-screen
+        // size, unaffected by the view's zoom transform - so derive all
+        // label metrics from the EFFECTIVE on-screen box size instead.
+        // Since every zoom step re-renders, zooming in re-wraps names at a
+        // larger, more legible size, and zooming out shrinks them with the
+        // box instead of letting them pour out of it.
+        var BOX_EFF = BOX_SIZE * zoomFactor;
+        var SHOW_LABELS = BOX_EFF >= 24;  // below this, text is just noise
+        var ICON_SIZE = Math.max(4, Math.floor(BOX_EFF * 0.26));
+        var FONT_SIZE = Math.max(6, Math.round(BOX_EFF * 0.13));
+        var LINE_H = FONT_SIZE + 2;
+
         // How many text lines fit under the icon, inside the box?
-        var textBudget = BOX_SIZE - ICON_SIZE - 10;
+        var textBudget = BOX_EFF - ICON_SIZE - 10;
         var MAX_LINES = Math.min(3, Math.max(1, Math.floor(textBudget / LINE_H)));
         // Approx chars per line at this font (~0.56em average glyph width).
-        var charsPerLine = Math.max(4, Math.floor((BOX_SIZE - 12) / (FONT_SIZE * 0.56)));
+        var charsPerLine = Math.max(4, Math.floor((BOX_EFF - 12) / (FONT_SIZE * 0.56)));
 
         // Deterministically wrap a name into at most MAX_LINES lines, breaking on
         // spaces where possible and ellipsising the overflow. We do this ourselves
@@ -204,7 +213,7 @@
           var displayName = wrapName(node.name);
           var rich = {
             text: {
-              width:      BOX_SIZE - 6,
+              width:      BOX_EFF - 6,
               overflow:   'truncate',
               align:      'center',
               fontSize:   FONT_SIZE,
@@ -227,7 +236,7 @@
               ? [BOX_SIZE * 1.08, BOX_SIZE * 1.08]
               : [BOX_SIZE, BOX_SIZE],
             label: {
-              show:       true,
+              show:       SHOW_LABELS,
               position:   'inside',
               color:      isCurrent ? '#000000' : (isAdd ? '#ffffff' : '#1e293b'),
               fontSize:   FONT_SIZE,
@@ -425,9 +434,21 @@
         zoomFactor = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, Math.round(z * 100) / 100));
         updateChart(animate);
       }
+      // Reset zoom AND any drag-pan offset (clear() drops the roam state).
+      function resetView() {
+        zoomFactor = 1;
+        myChart.clear();
+        updateChart();
+      }
       document.getElementById('treeZoomIn').addEventListener('click', function() { setZoom(zoomFactor + ZOOM_STEP); });
       document.getElementById('treeZoomOut').addEventListener('click', function() { setZoom(zoomFactor - ZOOM_STEP); });
-      document.getElementById('treeZoomReset').addEventListener('click', function() { setZoom(1); });
+      document.getElementById('treeZoomReset').addEventListener('click', resetView);
+
+      // Double-click on an empty spot resets the view as well. (Nodes are
+      // excluded: a single click on a node already navigates away.)
+      myChart.getZr().on('dblclick', function(e) {
+        if (!e.target) { resetView(); }
+      });
 
       // Zoom on scroll while the cursor is inside the tree. The wheel drives
       // the same zoomFactor as the +/- buttons; preventDefault() keeps the

--- a/flexmeasures/ui/templates/_macros.html
+++ b/flexmeasures/ui/templates/_macros.html
@@ -1,6 +1,9 @@
 {% macro show_tree(assets, current_asset_name) %}
   <div class="container pb-4" style="position: relative;">
-    <div id="view-scroll" style="width: 100%; height: 75vh; min-height: 500px; overflow-y: auto; overflow-x: hidden; border-radius: 8px; border: 1px solid #e2e8f0; background-color: #f8fafc; box-shadow: inset 0 2px 4px 0 rgba(0,0,0,0.06);">
+    {# touch-action: none keeps the browser from scrolling/zooming the page
+       on touch gestures inside the tree, so one-finger drags pan the chart
+       and two-finger pinches zoom it. #}
+    <div id="view-scroll" style="width: 100%; height: 75vh; min-height: 500px; overflow-y: auto; overflow-x: hidden; touch-action: none; border-radius: 8px; border: 1px solid #e2e8f0; background-color: #f8fafc; box-shadow: inset 0 2px 4px 0 rgba(0,0,0,0.06);">
       <div id="view-zoom" style="width: 100%; height: 100%; transform-origin: center center; transition: transform 0.12s ease;">
         <div id="view" style="width: 100%; height: 100%;"></div>
       </div>
@@ -444,10 +447,20 @@
       document.getElementById('treeZoomOut').addEventListener('click', function() { setZoom(zoomFactor - ZOOM_STEP); });
       document.getElementById('treeZoomReset').addEventListener('click', resetView);
 
-      // Double-click on an empty spot resets the view as well. (Nodes are
-      // excluded: a single click on a node already navigates away.)
-      myChart.getZr().on('dblclick', function(e) {
-        if (!e.target) { resetView(); }
+      // Double-click / double-tap on an empty spot resets the view as well.
+      // Implemented on zrender's 'click' (which also fires for taps) rather
+      // than 'dblclick', so it works on touch devices too. Nodes are
+      // excluded: a single click on a node already navigates away.
+      var lastBlankTap = 0;
+      myChart.getZr().on('click', function(e) {
+        if (e.target) { return; }
+        var now = Date.now();
+        if (now - lastBlankTap < 350) {
+          lastBlankTap = 0;
+          resetView();
+        } else {
+          lastBlankTap = now;
+        }
       });
 
       // Zoom on scroll while the cursor is inside the tree. The wheel drives
@@ -468,6 +481,46 @@
           });
         }
       }, { passive: false });
+
+      // Pinch-to-zoom on touch devices, driving the same zoomFactor as the
+      // wheel and the +/- buttons. Two-finger gestures are consumed here
+      // (together with touch-action: none on the container), so the browser
+      // doesn't zoom the page; one-finger drags stay with ECharts' roam
+      // panning.
+      var pinchStartDist = null, pinchStartZoom = null;
+      var pinchPending = null, pinchRafScheduled = false;
+      function touchDist(touches) {
+        var dx = touches[0].clientX - touches[1].clientX;
+        var dy = touches[0].clientY - touches[1].clientY;
+        return Math.sqrt(dx * dx + dy * dy) || 1;
+      }
+      scrollDom.addEventListener('touchstart', function(e) {
+        if (e.touches.length === 2) {
+          e.preventDefault();
+          pinchStartDist = touchDist(e.touches);
+          pinchStartZoom = zoomFactor;
+        }
+      }, { passive: false });
+      scrollDom.addEventListener('touchmove', function(e) {
+        if (pinchStartDist === null || e.touches.length !== 2) { return; }
+        e.preventDefault();
+        pinchPending = pinchStartZoom * (touchDist(e.touches) / pinchStartDist);
+        if (!pinchRafScheduled) {
+          pinchRafScheduled = true;
+          requestAnimationFrame(function() {
+            pinchRafScheduled = false;
+            if (pinchPending !== null) { setZoom(pinchPending, false); }
+          });
+        }
+      }, { passive: false });
+      ['touchend', 'touchcancel'].forEach(function(type) {
+        scrollDom.addEventListener(type, function(e) {
+          if (e.touches.length < 2) {
+            pinchStartDist = null;
+            pinchPending = null;
+          }
+        });
+      });
     };
   </script>
 {% endmacro %}

--- a/flexmeasures/ui/templates/_macros.html
+++ b/flexmeasures/ui/templates/_macros.html
@@ -56,55 +56,107 @@
       // itself never changes size.
       var zoomFactor = 1;
 
-      // Count the leaf nodes. In a horizontal tree, every leaf occupies its own
-      // vertical slot, so the leaf count is what determines how tightly nodes
-      // are packed vertically - and therefore how large each box can be.
-      function countLeaves(roots) {
-        var n = 0;
-        (function walk(list) {
-          list.forEach(function(x) {
-            if (!x.children || x.children.length === 0) { n++; }
-            else { walk(x.children); }
-          });
-        })(roots);
-        return Math.max(n, 1);
+      // ------------------------------------------------------------------
+      // Layout policy, per parent whose children are leaves ("a family"):
+      // keep the leaf children in ONE row until the canvas width is
+      // exhausted (at the 50px reference box), then use TWO balanced rows
+      // (top row at most 1 wider than the bottom), never more; when even
+      // two rows don't fit the width, the box size shrinks below the
+      // reference, i.e. the whole tree zooms out (wheel-zoom recovers
+      // detail). Non-leaf children and the "Add asset" action node each
+      // get their own row, recursively.
+      //
+      // Family connectors are routed to invisible "port" nodes on the
+      // top/bottom edge of each leaf box, so top-row connectors arrive
+      // from above and bottom-row connectors from below, keeping the lane
+      // between the two rows clean. Parents connect from their side.
+      // ------------------------------------------------------------------
+      var BOX_REF = 50;      // reference (minimum comfortable) box size
+      var GAP_RATIO = 0.28;  // vertical gap as a fraction of box size
+
+      function isAddAsset(node) { return node.name === 'Add asset'; }
+
+      // Leaf children go into the family grid; internal children and the
+      // "Add asset" button each get their own row.
+      function splitKids(node) {
+        var kids = node.children || [];
+        return {
+          gridKids: kids.filter(function(k) { return !(k.children || []).length && !isAddAsset(k); }),
+          rowKids: kids.filter(function(k) { return (k.children || []).length || isAddAsset(k); })
+        };
+      }
+
+      function depthOf(node) {
+        var d = 0;
+        (node.children || []).forEach(function(k) { d = Math.max(d, 1 + depthOf(k)); });
+        return d;
       }
 
       function updateChart(animate) {
-        var leaves = countLeaves(rootNodes);
         var viewportH = scrollDom.clientHeight;
-
-        // Size each box to FIT the viewport: divide the usable height among the
-        // leaves, reserving a vertical gap per node. Clamp to a legible range so
-        // few assets get large boxes and many assets get small (but readable) ones.
-        var GAP_RATIO = 0.28;                 // vertical gap as a fraction of box
-        var fitBox    = (viewportH * 0.92 / leaves) / (1 + GAP_RATIO);
-        // Base (zoom = 1) auto-fit box size, then apply the current zoom factor so
-        // the whole tree - node sizes AND spacing - scales together.
-        var BOX_SIZE  = Math.round(Math.max(50, Math.min(104, fitBox)) * zoomFactor);
-        var ICON_SIZE = Math.max(4, Math.floor(BOX_SIZE * 0.26));
-        var FONT_SIZE = Math.max(6, Math.round(BOX_SIZE * 0.13));
-        var LINE_H    = FONT_SIZE + 2;
-
-        // Keep the drawing canvas the SAME size as the gray container at every
-        // zoom level. Zoom is applied via node sizes (above) and layout margins
-        // (below), never by resizing the canvas - so zooming out shrinks the tree
-        // within a fixed area and zooming in overflows it (pan with drag).
+        // Keep the drawing canvas the SAME size as the gray container at
+        // every zoom level; zooming happens inside the canvas.
         chartDom.style.height = viewportH + 'px';
         myChart.resize();
+        var W = chartDom.clientWidth || 1000;
 
-        // Scale the tree's layout box about the canvas centre by the zoom factor.
-        // At zoom = 1 these reproduce the base framing (top 6% / left 12% /
-        // bottom 6% / right 14%); zooming out grows the margins (tree shrinks
-        // toward the centre) and zooming in drives them negative (tree overflows).
-        var mTop    = 50 - 44 * zoomFactor;
-        var mBottom = 50 - 44 * zoomFactor;
-        var mLeft   = 49 - 37 * zoomFactor;
-        var mRight  = 51 - 37 * zoomFactor;
+        // One x position per tree level (ancestors -> current -> children
+        // -> grandchildren); the deepest level's grid columns extend to
+        // the right from there.
+        var levels = 1;
+        rootNodes.forEach(function(rt) { levels = Math.max(levels, 1 + depthOf(rt)); });
+        var colPitch = levels > 1 ? Math.min(0.60 * W / (levels - 1), 0.30 * W) : 0;
+        function colX(d) { return 0.08 * W + d * colPitch; }
+
+        // Horizontal room for a grid block whose leaf column sits at level d.
+        function gridBudget(d) { return W - colX(d) - 8; }
+        function colsFitAt(d) {
+          return Math.max(1, Math.floor((gridBudget(d) - BOX_REF * 0.5) / (BOX_REF * 1.35)) + 1);
+        }
+        // One row while it fits; else two balanced rows, top at most 1 wider.
+        function colsFor(n, d) {
+          if (!n) return 1;
+          var fit = colsFitAt(d);
+          return n <= fit ? n : Math.ceil(n / 2);
+        }
+
+        // Pre-pass: total rows (drives the vertical fit) and the widest
+        // grid block (drives the horizontal cap on the box size).
+        var hCap = Infinity;
+        function rowsOf(node, d) {
+          var s = splitKids(node);
+          if (!s.gridKids.length && !s.rowKids.length) return 1;
+          var r = 0;
+          if (s.gridKids.length) {
+            var cols = colsFor(s.gridKids.length, d + 1);
+            r += Math.ceil(s.gridKids.length / cols);
+            hCap = Math.min(hCap, gridBudget(d + 1) / ((cols - 1) * 1.35 + 0.5));
+          }
+          s.rowKids.forEach(function(k) { r += rowsOf(k, d + 1); });
+          return Math.max(r, 1);
+        }
+        var totalRows = 0;
+        rootNodes.forEach(function(rt) { totalRows += rowsOf(rt, 0); });
+
+        // Box size: fit the viewport vertically, clamped to a legible
+        // range, then capped so the widest grid block still fits the
+        // width. Two rows is the maximum, so very wide families lower the
+        // box size (the tree zooms out) instead of wrapping further.
+        var fitBox = (viewportH * 0.92 / Math.max(totalRows + 1, 5)) / (1 + GAP_RATIO);
+        var BOX_SIZE = Math.round(Math.min(
+          Math.max(BOX_REF, Math.min(104, fitBox)),
+          Math.max(20, hCap)
+        ));
+        var ICON_SIZE = Math.max(4, Math.floor(BOX_SIZE * 0.26));
+        var FONT_SIZE = Math.max(6, Math.round(BOX_SIZE * 0.13));
+        var LINE_H = FONT_SIZE + 2;
+        var slotY = BOX_SIZE * (1 + GAP_RATIO);   // vertical row pitch
+        var colGapX = BOX_SIZE * 1.35;            // horizontal grid column pitch
+        var blockGap = slotY * 0.55;              // gap between family blocks
 
         // How many text lines fit under the icon, inside the box?
         var textBudget = BOX_SIZE - ICON_SIZE - 10;
-        var MAX_LINES  = Math.min(3, Math.max(1, Math.floor(textBudget / LINE_H)));
+        var MAX_LINES = Math.min(3, Math.max(1, Math.floor(textBudget / LINE_H)));
         // Approx chars per line at this font (~0.56em average glyph width).
         var charsPerLine = Math.max(4, Math.floor((BOX_SIZE - 12) / (FONT_SIZE * 0.56)));
 
@@ -143,17 +195,12 @@
           return lines.join('\n');
         }
 
-        // Enhance nodes with styles
-        function enrichNodeData(node) {
+        // Per-node style (same look as before: white round rects, gold
+        // current asset, green "Add asset" button).
+        function nodeStyles(node) {
           var isCurrent = node.name === currentAssetName;
-          var isAdd     = node.name === 'Add asset';
+          var isAdd = isAddAsset(node);
 
-          node.symbol     = 'roundRect';
-          node.symbolSize = isCurrent
-            ? [BOX_SIZE * 1.08, BOX_SIZE * 1.08]
-            : [BOX_SIZE, BOX_SIZE];
-
-          // Build rich-text dict so icon + text fit inside the symbol.
           var displayName = wrapName(node.name);
           var rich = {
             text: {
@@ -174,42 +221,135 @@
             };
           }
 
-          node.label = {
-            show:       true,
-            position:   'inside',
-            color:      isCurrent ? '#000000' : (isAdd ? '#ffffff' : '#1e293b'),
-            fontSize:   FONT_SIZE,
-            fontWeight: isCurrent ? 'bold' : '600',
-            fontFamily: 'system-ui, -apple-system, sans-serif',
-            // Capture the node and its pre-wrapped name in a closure so the
-            // formatter emits the correct rich-text key and text per node.
-            formatter: (function(n, dn) {
-              return function() {
-                return n.icon
-                  ? ('{icon_' + n.id + '|}\n{text|' + dn + '}')
-                  : ('{text|' + dn + '}');
-              };
-            })(node, displayName),
-            rich: rich
+          return {
+            symbol: 'roundRect',
+            symbolSize: isCurrent
+              ? [BOX_SIZE * 1.08, BOX_SIZE * 1.08]
+              : [BOX_SIZE, BOX_SIZE],
+            label: {
+              show:       true,
+              position:   'inside',
+              color:      isCurrent ? '#000000' : (isAdd ? '#ffffff' : '#1e293b'),
+              fontSize:   FONT_SIZE,
+              fontWeight: isCurrent ? 'bold' : '600',
+              fontFamily: 'system-ui, -apple-system, sans-serif',
+              formatter: (function(n, dn) {
+                return function() {
+                  return n.icon
+                    ? ('{icon_' + n.id + '|}\n{text|' + dn + '}')
+                    : ('{text|' + dn + '}');
+                };
+              })(node, displayName),
+              rich: rich
+            },
+            itemStyle: {
+              color:       isCurrent ? '#fcd34d' : (isAdd ? '#10b981' : '#ffffff'),
+              borderColor: isCurrent ? '#f59e0b' : (isAdd ? '#047857' : '#cbd5e1'),
+              borderWidth: isCurrent ? 3 : 1,
+              borderRadius: 8,
+              shadowColor:   'rgba(0, 0, 0, 0.2)',
+              shadowBlur:    10,
+              shadowOffsetX: 2,
+              shadowOffsetY: 6
+            }
           };
+        }
 
-          node.itemStyle = {
-            color:       isCurrent ? '#fcd34d' : (isAdd ? '#10b981' : '#ffffff'),
-            borderColor: isCurrent ? '#f59e0b' : (isAdd ? '#047857' : '#cbd5e1'),
-            borderWidth: isCurrent ? 3 : 1,
-            borderRadius: 8,
-            shadowColor:   'rgba(0, 0, 0, 0.2)',
-            shadowBlur:    10,
-            shadowOffsetX: 2,
-            shadowOffsetY: 6
-          };
+        var nodes = [];
+        var links = [];
 
-          if (node.children && node.children.length > 0) {
-            node.children.forEach(enrichNodeData);
+        var INVISIBLE = {
+          color: 'rgba(0,0,0,0)', borderWidth: 0, shadowBlur: 0,
+          shadowColor: 'transparent', shadowOffsetX: 0, shadowOffsetY: 0
+        };
+
+        // Place a node; if `port` is given, route the connector from the
+        // parent to an invisible port node on the box's top/bottom edge
+        // instead of to the box itself.
+        function pushNode(node, x, y, port) {
+          nodes.push(Object.assign({
+            id: String(node.id), name: node.name, x: x, y: y,
+            link: node.link, tooltip: node.tooltip
+          }, nodeStyles(node)));
+          if (node.parent === undefined || node.parent === null || !assetMap[node.parent]) {
+            return;
+          }
+          if (port) {
+            var pid = 'port-' + node.id;
+            nodes.push({
+              id: pid, name: '', x: port.x, y: port.y,
+              symbol: 'circle', symbolSize: 0.1, silent: true,
+              label: { show: false },
+              itemStyle: INVISIBLE
+            });
+            links.push({
+              source: String(node.parent), target: pid,
+              lineStyle: { curveness: port.curveness }
+            });
+          } else {
+            links.push({ source: String(node.parent), target: String(node.id) });
           }
         }
 
-        rootNodes.forEach(enrichNodeData);
+        // Recursively lay out `node` (at tree level `d`) and its subtree,
+        // starting at vertical offset topY. Returns the block height and
+        // the node's own center y.
+        function layoutSubtree(node, d, topY) {
+          var s = splitKids(node);
+          if (!s.gridKids.length && !s.rowKids.length) {
+            var cy = topY + slotY / 2;
+            pushNode(node, colX(d), cy);
+            return { height: slotY, centerY: cy };
+          }
+          var y = topY;
+          var centers = [];
+          if (s.gridKids.length) {
+            var cols = colsFor(s.gridKids.length, d + 1);
+            var rows = Math.ceil(s.gridKids.length / cols);
+            s.gridKids.forEach(function(k, i) {
+              var col = i % cols, row = Math.floor(i / cols);
+              var x = colX(d + 1) + col * colGapX;
+              var ky = y + slotY / 2 + row * slotY;
+              var topRow = row === 0;
+              pushNode(k, x, ky, {
+                x: x,
+                y: topRow ? ky - BOX_SIZE / 2 : ky + BOX_SIZE / 2,
+                curveness: topRow ? 0.18 : -0.18
+              });
+            });
+            var blockH = rows * slotY;
+            centers.push(y + blockH / 2);
+            y += blockH + blockGap;
+          }
+          s.rowKids.forEach(function(k) {
+            var sub = layoutSubtree(k, d + 1, y);
+            centers.push(sub.centerY);
+            y += sub.height + blockGap;
+          });
+          y -= blockGap; // drop the trailing gap
+          var centerY = centers.reduce(function(a, b) { return a + b; }, 0) / centers.length;
+          pushNode(node, colX(d), centerY);
+          return { height: y - topY, centerY: centerY };
+        }
+
+        var cursorY = slotY * 0.5;
+        rootNodes.forEach(function(rt) {
+          cursorY += layoutSubtree(rt, 0, cursorY).height + blockGap;
+        });
+        var contentH = cursorY - blockGap + slotY * 0.5;
+
+        // Invisible pin nodes make the layout's bounding box deterministic:
+        // exactly the canvas width by at least the viewport height. The
+        // graph view fits that box into the canvas, so the transform is
+        // identity while the content fits, and a uniform zoom-out once the
+        // content is taller than the viewport.
+        [[0, 0], [W, Math.max(contentH, viewportH)]].forEach(function(p, i) {
+          nodes.push({
+            id: '__pin' + i, name: '', x: p[0], y: p[1],
+            symbol: 'circle', symbolSize: 0.1, silent: true,
+            label: { show: false }, itemStyle: INVISIBLE
+          });
+        });
 
         var option = {
           tooltip: {
@@ -225,26 +365,24 @@
           },
           series: [
             {
-              type: 'tree',
-              data: rootNodes,
-              top: mTop + '%',
-              left: mLeft + '%',
-              bottom: mBottom + '%',
-              right: mRight + '%',
-              symbol: 'roundRect',
-              expandAndCollapse: true,
+              type: 'graph',
+              layout: 'none',
+              data: nodes,
+              links: links,
+              // Drag to pan; wheel and +/- buttons drive series.zoom below.
+              roam: 'move',
+              zoom: zoomFactor,
+              // Scale node symbols 1:1 with the view zoom.
+              nodeScaleRatio: 1,
+              edgeSymbol: ['none', 'none'],
               animationDuration: 550,
               // No update animation during continuous wheel-zoom, so the tree
               // follows the wheel without lagging behind.
               animationDurationUpdate: animate === false ? 0 : 400,
-              // Drag to pan. Zoom is driven by the +/- buttons (re-render), which
-              // keeps the canvas fixed while the tree scales inside it.
-              roam: 'move',
-              initialTreeDepth: -1,
               lineStyle: {
                 color: '#94a3b8',
                 width: 2,
-                curveness: 0.5
+                curveness: 0.15
               }
             }
           ]

--- a/flexmeasures/ui/templates/_macros.html
+++ b/flexmeasures/ui/templates/_macros.html
@@ -70,7 +70,7 @@
         return Math.max(n, 1);
       }
 
-      function updateChart() {
+      function updateChart(animate) {
         var leaves = countLeaves(rootNodes);
         var viewportH = scrollDom.clientHeight;
 
@@ -234,7 +234,9 @@
               symbol: 'roundRect',
               expandAndCollapse: true,
               animationDuration: 550,
-              animationDurationUpdate: 400,
+              // No update animation during continuous wheel-zoom, so the tree
+              // follows the wheel without lagging behind.
+              animationDurationUpdate: animate === false ? 0 : 400,
               // Drag to pan. Zoom is driven by the +/- buttons (re-render), which
               // keeps the canvas fixed while the tree scales inside it.
               roam: 'move',
@@ -281,13 +283,32 @@
       // while the canvas stays a fixed size - so the tree shrinks/grows WITHIN
       // the gray area (like a map), rather than the area itself changing size.
       var ZOOM_MIN = 0.3, ZOOM_MAX = 2.5, ZOOM_STEP = 0.2;
-      function setZoom(z) {
+      function setZoom(z, animate) {
         zoomFactor = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, Math.round(z * 100) / 100));
-        updateChart();
+        updateChart(animate);
       }
       document.getElementById('treeZoomIn').addEventListener('click', function() { setZoom(zoomFactor + ZOOM_STEP); });
       document.getElementById('treeZoomOut').addEventListener('click', function() { setZoom(zoomFactor - ZOOM_STEP); });
       document.getElementById('treeZoomReset').addEventListener('click', function() { setZoom(1); });
+
+      // Zoom on scroll while the cursor is inside the tree. The wheel drives
+      // the same zoomFactor as the +/- buttons; preventDefault() keeps the
+      // page itself from scrolling. Wheel deltas are coalesced per animation
+      // frame, since every zoom step re-renders the tree.
+      var pendingWheelDelta = 0, wheelRafScheduled = false;
+      scrollDom.addEventListener('wheel', function(e) {
+        e.preventDefault();
+        pendingWheelDelta += e.deltaY * (e.deltaMode === 1 ? 16 : 1);
+        if (!wheelRafScheduled) {
+          wheelRafScheduled = true;
+          requestAnimationFrame(function() {
+            var factor = Math.pow(1.0015, -pendingWheelDelta);
+            pendingWheelDelta = 0;
+            wheelRafScheduled = false;
+            setZoom(zoomFactor * factor, false);
+          });
+        }
+      }, { passive: false });
     };
   </script>
 {% endmacro %}


### PR DESCRIPTION
Improvements to the interactive asset tree on the Context page's Structure tab (follow-up to #2025):

## 1. Compact grid layout for leaf children
Previously every leaf occupied its own vertical slot, so a tree with e.g. 4 children × 4 grandchildren squeezed 17 leaf boxes into one overlapping column. Now each parent's leaf children are laid out as a grid next to it:

- **one row** while it fits the canvas width (at the 50px reference box size),
- then **two balanced rows** (top row at most one cell wider than the bottom),
- **never a third row** — beyond that the box size drops below the reference, i.e. the whole tree zooms out, and zooming in recovers detail.

Family connectors are routed via invisible edge-midpoint port nodes so top-row boxes are approached from above and bottom-row boxes from below, keeping the lane between the rows clean; parents still connect from their side. Non-leaf children and the "Add asset" button keep their own rows (recursively), and ancestor chains above the current asset render one column per level as before.

## 2. Zoom on scroll and pinch, with labels that respond to zoom
- The scroll wheel zooms the tree while the cursor is inside it, and two-finger **pinch-to-zoom** does the same on touch devices — both drive the same zoom level as the +/− buttons (deltas coalesced per animation frame, update animation disabled during gestures). The page itself doesn't scroll or zoom during gestures inside the tree (`preventDefault` + `touch-action: none`); one-finger drags keep panning the chart.
- **Labels and icons respond to zoom**: all label metrics (font size, icon size, wrap width, line count) derive from the effective on-screen box size, so zooming in re-wraps names at a larger, more legible size, and zooming out shrinks them with the box — hiding them entirely below 24px, where text is just noise.
- **Double-click / double-tap** on an empty spot resets the view, like the Reset button; both also clear any drag-pan offset.

## Technical notes
Rendering moves from the ECharts `tree` series (no per-node position control) to a `graph` series with precomputed positions; invisible corner pins make the view's auto-fit deterministic, and zooming goes through `series.zoom` with `nodeScaleRatio: 1` so boxes and connectors scale as one, while labels re-render per zoom step. Tooltips, click-to-navigate and drag-to-pan behave as before.

Verified headlessly (Jinja-rendered macro + synthetic wheel/touch events) across: root view with 4×4, 4×7 (4+3 grids), 4×10 (5+5 grids), families of 1–16 leaves, a mid-tree view with an ancestor chain, and wheel-zoom in/out plus a synthetic pinch gesture.

Before:

<img width="1225" height="719" alt="localhost_5000_assets_4585_context" src="https://github.com/user-attachments/assets/8feef842-3e63-4009-83de-7b5e6c238463" />

After:

<img width="1223" height="720" alt="localhost_5000_assets_4585_context (1)" src="https://github.com/user-attachments/assets/942be7be-e205-4f6a-a485-2f469fc89f95" />


🤖 Generated together with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvHmmnoweHoYjPCvfGAFX8