### PR TITLE
Require new tests to be proven capable of failing

### DIFF
--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -75,6 +75,42 @@ Before changing a test that fails, investigate whether the test is intentionally
 
 A failing test often reveals a production bug, not a test bug.
 
+## Prove a new test can fail
+
+A test that never fails asserts nothing, and it is indistinguishable from a test that works.
+Before considering a new test done, break the thing it covers and watch it go red:
+comment out the constraint, invert the condition, delete the line — then restore.
+If the test still passes, it is not testing what its name says.
+
+This matters most where the assertion depends on the *problem* having a unique answer.
+An optimisation test is the classic trap:
+constrain devices that have no incentive to move, and the optimum is "do nothing" with or without the constraint,
+so the test passes whether or not the feature works.
+
+```python
+# ❌ Vacuous: with no cost incentive, both devices sit at zero either way,
+#    so the balance constraint is satisfied trivially and the test proves nothing.
+device_constraints = [make_flow_device(0, 1), make_flow_device(-1, 0)]
+
+# ✅ Binding: the consumer's draw is pinned, so the balance is the only reason
+#    the producer runs. Remove the constraint and the schedules diverge.
+consumer["derivative equals"] = -0.4
+```
+
+This was not hypothetical: a balance-group scenario in
+`flexmeasures/data/models/planning/tests/test_highspy_equivalence.py`
+passed with the constraint it was named after entirely disabled, and only this check caught it.
+
+Say in the PR description that you did it, and what you broke to prove it.
+Reviewers cannot tell a binding test from a vacuous one by reading it.
+
+## Equivalence tests need both sides exercised
+
+When two implementations are compared (see `test_highspy_equivalence.py`),
+a scenario only has value if each side actually reaches the code under comparison.
+Disable the new code path on one side and confirm the scenario fails;
+a scenario that passes with the feature removed is comparing two no-ops.
+
 ## Module-scoped fixture state
 
 Module-scoped fixtures are shared across tests. When modifying shared objects (e.g. `asset.sensors_to_show`), reset them to the column default — not to `None` — in teardown:

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -77,39 +77,15 @@ A failing test often reveals a production bug, not a test bug.
 
 ## Prove a new test can fail
 
-A test that never fails asserts nothing, and it is indistinguishable from a test that works.
-Before considering a new test done, break the thing it covers and watch it go red:
-comment out the constraint, invert the condition, delete the line — then restore.
-If the test still passes, it is not testing what its name says.
+A test that never fails asserts nothing, and reads exactly like one that works.
+Before calling a new test done, break what it covers — comment out the constraint, invert the condition — and confirm it goes red, then restore.
 
-This matters most where the assertion depends on the *problem* having a unique answer.
-An optimisation test is the classic trap:
-constrain devices that have no incentive to move, and the optimum is "do nothing" with or without the constraint,
-so the test passes whether or not the feature works.
+Watch for assertions that depend on the problem having a unique answer.
+An optimisation test over devices with no incentive to move has the same optimum with or without the constraint, so it passes either way.
+In `test_highspy_equivalence.py`, where two backends are compared, also disable the new code path on one side: a scenario that survives that is comparing two no-ops.
+Both traps have been hit — a balance-group scenario there passed with the constraint it was named after entirely disabled.
 
-```python
-# ❌ Vacuous: with no cost incentive, both devices sit at zero either way,
-#    so the balance constraint is satisfied trivially and the test proves nothing.
-device_constraints = [make_flow_device(0, 1), make_flow_device(-1, 0)]
-
-# ✅ Binding: the consumer's draw is pinned, so the balance is the only reason
-#    the producer runs. Remove the constraint and the schedules diverge.
-consumer["derivative equals"] = -0.4
-```
-
-This was not hypothetical: a balance-group scenario in
-`flexmeasures/data/models/planning/tests/test_highspy_equivalence.py`
-passed with the constraint it was named after entirely disabled, and only this check caught it.
-
-Say in the PR description that you did it, and what you broke to prove it.
-Reviewers cannot tell a binding test from a vacuous one by reading it.
-
-## Equivalence tests need both sides exercised
-
-When two implementations are compared (see `test_highspy_equivalence.py`),
-a scenario only has value if each side actually reaches the code under comparison.
-Disable the new code path on one side and confirm the scenario fails;
-a scenario that passes with the feature removed is comparing two no-ops.
+Say in the PR description what you broke to prove it — a reviewer cannot tell a binding test from a vacuous one by reading it.
 
 ## Module-scoped fixture state
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,10 @@ Most-missed rules, called out so they are not forgotten:
   commit again. See [`pre-commit-hooks.instructions.md`](.github/instructions/pre-commit-hooks.instructions.md).
 - **Add a changelog entry** for user-facing changes, in the right section, with a PR link. See
   [`changelog.instructions.md`](.github/instructions/changelog.instructions.md).
+- **Prove a new test can fail before calling it done** — break what it covers and watch it go red, then
+  restore. A test that passes with the feature disabled asserts nothing; optimisation tests are especially
+  prone to this, because a problem with no incentive to move has the same optimum either way. See
+  [`testing.instructions.md`](.github/instructions/testing.instructions.md).
 - **One logical change per commit** ([`atomic-commits.instructions.md`](.github/instructions/atomic-commits.instructions.md)),
   **timezone-aware datetimes always** ([`timezone-awareness.instructions.md`](.github/instructions/timezone-awareness.instructions.md)),
   **catch specific exceptions** ([`error-handling.instructions.md`](.github/instructions/error-handling.instructions.md)),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,8 @@ Most-missed rules, called out so they are not forgotten:
   commit again. See [`pre-commit-hooks.instructions.md`](.github/instructions/pre-commit-hooks.instructions.md).
 - **Add a changelog entry** for user-facing changes, in the right section, with a PR link. See
   [`changelog.instructions.md`](.github/instructions/changelog.instructions.md).
-- **Prove a new test can fail before calling it done** — break what it covers and watch it go red, then
-  restore. A test that passes with the feature disabled asserts nothing; optimisation tests are especially
-  prone to this, because a problem with no incentive to move has the same optimum either way. See
+- **Prove a new test can fail** — break what it covers, confirm it goes red, restore. A test that passes
+  with the feature disabled asserts nothing. See
   [`testing.instructions.md`](.github/instructions/testing.instructions.md).
 - **One logical change per commit** ([`atomic-commits.instructions.md`](.github/instructions/atomic-commits.instructions.md)),
   **timezone-aware datetimes always** ([`timezone-awareness.instructions.md`](.github/instructions/timezone-awareness.instructions.md)),


### PR DESCRIPTION
## Description

Adds a convention: before a new test is done, break the thing it covers, watch it go red, then restore. A test that never fails asserts nothing — and reads exactly like one that works.

- [x] Section in `.github/instructions/testing.instructions.md`
- [x] Surfaced in `CLAUDE.md`'s most-missed list

## Why now

This is a real miss, not a hypothetical.

While adding an `internal_commodity_balance` scenario to `test_highspy_equivalence.py` (#2289), the test passed with the balance constraint it was named after **entirely disabled**. Both devices in the heat node had a free flow band and no cost incentive, so the optimum was zero flow whether or not the balance was enforced. Nothing about reading the test revealed that.

The failure mode generalises, which is why it's worth writing down: an optimisation test over devices that have no reason to move is satisfied trivially. The same trap applies to any assertion that depends on the problem having a unique answer.

## What it asks for

1. **Prove the test can fail** — comment out the constraint, invert the condition, delete the line. If it still passes, it isn't testing what its name says.
2. **Equivalence tests need both sides exercised** — disable the new code path on one side and confirm the scenario fails, or the comparison is between two no-ops.
3. **Say so in the PR description**, including what you broke. A reviewer cannot distinguish a binding test from a vacuous one by reading it, so it has to be reported.

The instructions include the concrete vacuous-vs-binding contrast from that scenario.

## How to test

Docs only — no code paths touched.

## Related items

- #2289, where the vacuous scenario was caught and fixed.
- #2364, whose equivalence scenarios were mutation-tested the same way.