### PR TITLE
Add an advisory agent hook reviewing the files a push adds

### DIFF
--- a/.claude/hooks/push-file-review.sh
+++ b/.claude/hooks/push-file-review.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Advisory check, run before an agent pushes: list the files this push adds,
+# and flag any that look unintended.
+# Never blocks -- it can only ask about intent.
+set -uo pipefail
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+python3 .claude/hooks/push_file_review.py 2>/dev/null || true
+exit 0

--- a/.claude/hooks/push_file_review.py
+++ b/.claude/hooks/push_file_review.py
@@ -1,0 +1,93 @@
+"""List the files a push would add, and flag the ones that look unintended.
+
+A file can enter a branch without anyone deciding it should:
+swept in by ``git add -A``, left behind by a merge, or carried along from another branch.
+Modified files are almost always deliberate;
+a brand-new file nobody mentioned is the thing worth a second look.
+
+Advisory only.
+It prints and exits 0, because it cannot know intent -- it can only ask whether the addition was meant.
+
+Usage:
+    python push_file_review.py            # compare against the tracked upstream, else origin/main
+    python push_file_review.py <base>     # compare against an explicit base
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+#: Patterns whose additions are almost never deliberate.
+SUSPICIOUS = [
+    (re.compile(r"(^|/)\.[^/]+$"), "a dotfile"),
+    (re.compile(r"\.(orig|rej|bak|tmp|swp)$"), "merge or editor debris"),
+    (
+        re.compile(r"(^|/|_|-)(local|scratch|probe|debug|tmp)[._/-]"),
+        "a scratch-looking name",
+    ),
+    (re.compile(r"\.(log|pyc|pkl|sqlite3?|db)$"), "a build or runtime artifact"),
+]
+
+#: Directories a change is normally confined to.
+#: Anything else is worth naming, rather than assuming it belongs.
+EXPECTED_ROOTS = ("flexmeasures/", "documentation/", "tests/", ".github/", ".claude/")
+
+
+def run(*args: str) -> str:
+    return subprocess.run(args, capture_output=True, text=True).stdout.strip()
+
+
+def pick_base(argv: list[str]) -> str | None:
+    """The ref to compare against: an explicit argument, the tracked upstream, or origin/main."""
+    if len(argv) > 1:
+        return argv[1]
+    upstream = run("git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
+    for candidate in (upstream, "origin/main"):
+        if candidate and run("git", "rev-parse", "--verify", "--quiet", candidate):
+            return candidate
+    return None
+
+
+def main() -> int:
+    base = pick_base(sys.argv)
+    if base is None:
+        return 0
+    merge_base = run("git", "merge-base", "HEAD", base)
+    if not merge_base:
+        return 0
+
+    added = [
+        name
+        for name in run(
+            "git", "diff", "--name-only", "--diff-filter=A", merge_base, "HEAD"
+        ).split("\n")
+        if name
+    ]
+    if not added:
+        return 0
+
+    flagged = []
+    for name in added:
+        for pattern, why in SUSPICIOUS:
+            if pattern.search(name):
+                flagged.append((name, why))
+                break
+        else:
+            if not name.startswith(EXPECTED_ROOTS):
+                flagged.append((name, "outside the usual directories"))
+
+    print(f"This push adds {len(added)} file(s), compared against {base}:")
+    for name in added:
+        print(f"    {name}")
+    if flagged:
+        print("\nWorth confirming you meant to add these:")
+        for name, why in flagged:
+            print(f"    {name} — {why}")
+        print("\nIf any of them is not part of this change, remove it before pushing.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,6 +48,12 @@
           },
           {
             "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/push-file-review.sh\"",
+            "if": "Bash(git push:*)",
+            "timeout": 30
+          },
+          {
+            "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/test-reminder.sh\"",
             "if": "Bash(git push:*)",
             "timeout": 10


### PR DESCRIPTION
## Description

A file can enter a branch without anyone deciding it should. This has happened twice recently:

- `.git-exclude` (containing a lone `conftest.py`) reached #2289 through a merge and survived until review caught it.
- A `git add -A` swept `scheduling_problem.py` into a commit that imported nothing from it — noticed only by auditing the commit afterwards.

Both were **additions**. Modified files are nearly always deliberate; a brand-new file nobody mentioned is the one worth a second look.

- [x] `.claude/hooks/push_file_review.py` — lists what a push adds relative to the merge-base, and names the ones that look unintended
- [x] Wired in `.claude/settings.json` as a `PreToolUse` hook on `git push`, next to the existing `test-reminder.sh`

## What it flags

Dotfiles, `.orig`/`.rej`/`.bak`/`.swp` debris, scratch-looking names (`local`, `scratch`, `probe`, `debug`, `tmp`), build and runtime artifacts, and anything outside `flexmeasures/`, `documentation/`, `tests/`, `.github/`, `.claude/`.

Everything added is listed regardless; the flagged subset just gets called out.

## Two deliberate choices

**Advisory, exits 0.** It cannot know intent — it can only ask whether an addition was meant. That is a question an agent can answer by looking, and a blocking gate cannot. Same reasoning as #2386.

**It prints which base it used.** The base is the tracked upstream when there is one, else `origin/main`. Getting that wrong makes the added-file list either noisy or empty, and a stacked branch's base changes when its parent merges — #2289's went from `feat/chp` to `main` mid-flight. Printing it makes a wrong guess visible rather than silent.

## How to test

**Proven capable of failing** (per #2384). Against a synthetic commit adding `.git-exclude`, `scratch/local_probe.py` and a legitimate module:

```
This push adds 5 file(s), compared against origin/main:
    .claude/hooks/push-file-review.sh
    .claude/hooks/push_file_review.py
    .git-exclude
    flexmeasures/data/models/planning/legit_module.py
    scratch/local_probe.py

Worth confirming you meant to add these:
    .git-exclude — a dotfile
    scratch/local_probe.py — a scratch-looking name
```

It flags the two junk files, and leaves the legitimate module and its own files alone. With only a legitimate addition, it lists it and flags nothing.

## Limits

It can ask "did you mean to add this?" but not "does this belong in *this* commit" — it would have caught `.git-exclude` cleanly, and the `scheduling_problem.py` case only partially.

## Related items

- #2386 — the docstring hook this follows in shape.
- #2289 — where `.git-exclude` surfaced.