### PR TITLE
Fix the soc-usage examples in the docs, which the schema rejects

### DIFF
--- a/documentation/api/notation.rst
+++ b/documentation/api/notation.rst
@@ -35,15 +35,15 @@ Unless stated otherwise, values of such fields can take one of the following for
          ]
      }
 
-- A variable quantity defined for specific time ranges, to describe dynamic constraints/preferences such as usage forecasts.
+- A variable quantity defined for specific time ranges, to describe dynamic constraints/preferences such as minimum state-of-charge requirements.
 
   .. code-block:: json
 
      {
-         "soc-usage": [
-             {"start": "2024-02-05T08:00:00+01:00", "duration": "PT2H", "value": "10.1 kW"},
+         "soc-minima": [
+             {"start": "2024-02-05T08:00:00+01:00", "duration": "PT2H", "value": "10.1 kWh"},
              ...
-             {"start": "2024-02-05T13:00:00+01:00", "end": "2024-02-05T13:15:00+01:00", "value": "10.3 kW"}
+             {"start": "2024-02-05T13:00:00+01:00", "end": "2024-02-05T13:15:00+01:00", "value": "10.3 kWh"}
          ]
      }
 
@@ -80,6 +80,23 @@ Unless stated otherwise, values of such fields can take one of the following for
   - ``source``: a single specific data source ID.
 
   This is the same source filtering mechanism described under :ref:`sources`, just scoped to sensor references inside flex-model/flex-context fields rather than GET data endpoints.
+
+A few fields don't hold a single variable quantity, but a *list* of them, whose values add up.
+The ``soc-gain`` and ``soc-usage`` fields of the flex-model work this way, so that separate components (say, two loads draining the same buffer) can be described independently.
+Each component takes any of the forms listed above, so a component defined for specific time ranges sits one level deeper than in those examples:
+
+.. code-block:: json
+
+   {
+       "soc-usage": [
+           "100 W",
+           {"sensor": 23},
+           [
+               {"start": "2024-02-05T08:00:00+01:00", "duration": "PT2H", "value": "10.1 kW"},
+               {"start": "2024-02-05T13:00:00+01:00", "duration": "PT2H", "value": "10.3 kW"}
+           ]
+       ]
+   }
 
 
 Timeseries

--- a/documentation/tut/multi-feed-storage.rst
+++ b/documentation/tut/multi-feed-storage.rst
@@ -65,9 +65,11 @@ The final entry (without a power ``sensor``) carries the constraints that apply 
                 "soc-min": 20.0,
                 "soc-max": 22.0,
                 "soc-usage": [
-                    {"start": "2024-01-01T00:00:00+01:00", "duration": "PT7H", "value": "4 kW"},
-                    {"start": "2024-01-01T07:00:00+01:00", "duration": "PT2H", "value": "18 kW"},
-                    {"start": "2024-01-01T09:00:00+01:00", "duration": "PT15H", "value": "4 kW"}
+                    [
+                        {"start": "2024-01-01T00:00:00+01:00", "duration": "PT7H", "value": "4 kW"},
+                        {"start": "2024-01-01T07:00:00+01:00", "duration": "PT2H", "value": "18 kW"},
+                        {"start": "2024-01-01T09:00:00+01:00", "duration": "PT15H", "value": "4 kW"}
+                    ]
                 ]
             }
         ]
@@ -81,6 +83,7 @@ A few things to note:
 - **The shared-storage entry has no power ``sensor``.** It only carries the storage-level fields (``soc-at-start``, ``soc-min``, ``soc-max``, ``soc-usage``), which describe the buffer as a whole and must therefore not be repeated per feeder.
 - **Per-device efficiencies live in the device entries.** The heat pump's ``charging-efficiency`` of ``300%`` reflects its COP of 3 (1 kWh in yields 3 kWh of heat), while the resistive heater converts electricity to heat one-to-one at ``100%``. ``production-capacity`` of ``0 kW`` on both feeders means neither can extract heat back out of the buffer — they only ever charge it.
 - **``soc-usage`` models the continuous heat demand.** Unlike a one-off ``soc-targets`` entry, it drains the buffer throughout the horizon, so the scheduler must keep feeding it rather than just reach a target once. Here it steps from a 4 kW baseline up to 18 kW for a two-hour morning peak.
+- **``soc-usage`` takes a list of usage components,** which add up to the total drain, so a single component that varies over time is itself a list — hence the two levels of nesting above. Each component can just as well be a fixed quantity (``"4 kW"``) or a sensor reference (``{"sensor": 4}``).
 - **The narrow gap between ``soc-min`` and ``soc-max``** leaves the buffer only 2 kWh of slack, so it cannot simply pre-heat well ahead of the morning peak. It also means that once the heat pump's power capacity is exhausted during the peak, the buffer has almost nowhere else to draw from — which is what forces the resistive heater into action.
 
 .. note:: The ``state-of-charge`` sensor should have an instantaneous resolution (``PT0M``), since it records a stock value at a point in time rather than a quantity accumulated over an interval. See the ``state-of-charge`` field in :ref:`flex_models_and_schedulers`.
@@ -147,9 +150,11 @@ We schedule on the **heat buffer asset**, so that FlexMeasures considers both fe
                         "soc-min": 20.0,
                         "soc-max": 22.0,
                         "soc-usage": [
-                            {"start": "2024-01-01T00:00:00+01:00", "duration": "PT7H", "value": "4 kW"},
-                            {"start": "2024-01-01T07:00:00+01:00", "duration": "PT2H", "value": "18 kW"},
-                            {"start": "2024-01-01T09:00:00+01:00", "duration": "PT15H", "value": "4 kW"}
+                            [
+                                {"start": "2024-01-01T00:00:00+01:00", "duration": "PT7H", "value": "4 kW"},
+                                {"start": "2024-01-01T07:00:00+01:00", "duration": "PT2H", "value": "18 kW"},
+                                {"start": "2024-01-01T09:00:00+01:00", "duration": "PT15H", "value": "4 kW"}
+                            ]
                         ]
                     }
                 ],
@@ -190,9 +195,11 @@ We schedule on the **heat buffer asset**, so that FlexMeasures considers both fe
                         "soc-min": 20.0,
                         "soc-max": 22.0,
                         "soc-usage": [
-                            {"start": "2024-01-01T00:00:00+01:00", "duration": "PT7H", "value": "4 kW"},
-                            {"start": "2024-01-01T07:00:00+01:00", "duration": "PT2H", "value": "18 kW"},
-                            {"start": "2024-01-01T09:00:00+01:00", "duration": "PT15H", "value": "4 kW"},
+                            [
+                                {"start": "2024-01-01T00:00:00+01:00", "duration": "PT7H", "value": "4 kW"},
+                                {"start": "2024-01-01T07:00:00+01:00", "duration": "PT2H", "value": "18 kW"},
+                                {"start": "2024-01-01T09:00:00+01:00", "duration": "PT15H", "value": "4 kW"},
+                            ]
                         ],
                     },
                 ],


### PR DESCRIPTION
## Problem

The `soc-usage` examples in two docs pages are rejected by the schema, so copy-pasting them fails:

```
{'soc-usage': {0: ['Dictionary provided but `sensor` key not found.'],
               1: ['Dictionary provided but `sensor` key not found.'],
               2: ['Dictionary provided but `sensor` key not found.']}}
```

`soc-usage` (and `soc-gain`) is a `fields.List(VariableQuantityField("MW"))` — a list of usage *components* that add up, as `SOC_USAGE`'s own metadata says ("This field allows setting multiple components, either fixed or dynamic, which add up to an aggregated usage", example `["100 Wh/h", {"sensor": 23}]`). Each element must therefore itself be a variable quantity. A component that varies over time is a list of time ranges, so it needs one more level of nesting.

Both pages instead showed a flat list of time-range segments, which the schema reads as a list of *sensor references*.

Unlike `soc-minima` / `soc-maxima` / `soc-targets`, which are plain `VariableQuantityField`s and do take a flat list — which is probably where the confusion came from.

## Changes

**`documentation/tut/multi-feed-storage.rst`** — nests the heat-demand series one level deeper in all three tabs (JSON, API, FlexMeasures Client), and adds a bullet explaining why.

**`documentation/api/notation.rst`** — the bullet "A variable quantity defined for specific time ranges" used `soc-usage` as its example, which is exactly the field that *isn't* a plain variable quantity. Switched it to `soc-minima` (in kWh), and added a short paragraph covering the list-of-components fields with a mixed example.

## Verification

Loaded each form through `StorageFlexModelSchema` on this branch:

| example | result |
|---|---|
| old flat `soc-usage` | ✗ rejected (error above) |
| new nested `soc-usage` (tutorial) | ✓ loads as 4 kW / 18 kW / 4 kW segments |
| mixed components `["100 W", {"sensor": 23}, [...]]` (notation) | ✓ loads as quantity + sensor + series |
| `soc-minima` with `duration` and with `end` (notation) | ✓ loads |

The tutorial's scenario also runs end to end through `StorageScheduler` with the corrected payload, and produces exactly the schedule its "What to expect" section describes — that run is what generated FlexMeasures/screenshots#16, which supplies the tutorial's missing chart.

No changelog entry: documentation-only, per `.github/instructions/changelog.instructions.md`.
