### PR TITLE
Persist commitment costs on scheduling job meta

### DIFF
--- a/flexmeasures/data/services/scheduling.py
+++ b/flexmeasures/data/services/scheduling.py
@@ -845,6 +845,10 @@ def make_schedule(  # noqa: C901
             continue
         if rq_job and result.get("name") == "commitment_costs":
             rq_job.meta["scheduler_info"]["commitment_costs"] = result["data"]
+            # Persist right away: this runs after the job's last save_meta() call,
+            # and RQ saves a finishing job with include_meta=False,
+            # so without an explicit save here the costs never reach Redis.
+            rq_job.save_meta()
             continue
         if "sensor" not in result:
             continue

--- a/flexmeasures/data/tests/test_scheduling_jobs.py
+++ b/flexmeasures/data/tests/test_scheduling_jobs.py
@@ -109,11 +109,11 @@ def test_commitment_costs_are_persisted_on_job_meta(
 ):
     """The commitment cost breakdown must survive into the job meta stored in Redis.
 
-    Regression test: the costs used to be written to ``rq_job.meta`` after the job's last
-    ``save_meta()`` call, and RQ persists a finishing job with ``include_meta=False``,
+    Regression test: the costs used to be written to ``rq_job.meta`` after the job's last ``save_meta()`` call,
+    and RQ persists a finishing job with ``include_meta=False``,
     so they were computed and then silently lost — for every scheduling job.
-    Fetching a fresh Job instance (rather than inspecting the worker's in-memory object)
-    is what makes this test see only what actually reached Redis.
+    Fetching a fresh Job instance is what makes this test see only what actually reached Redis,
+    rather than the worker's in-memory job object.
     """
     battery = next(
         s

--- a/flexmeasures/data/tests/test_scheduling_jobs.py
+++ b/flexmeasures/data/tests/test_scheduling_jobs.py
@@ -100,6 +100,56 @@ def test_scheduling_a_battery(
     assert out.count(f"Job {job.id} made schedule.") == 1, out
 
 
+def test_commitment_costs_are_persisted_on_job_meta(
+    fresh_db,
+    app,
+    add_battery_assets_fresh_db,
+    setup_fresh_test_data,
+    add_market_prices_fresh_db,
+):
+    """The commitment cost breakdown must survive into the job meta stored in Redis.
+
+    Regression test: the costs used to be written to ``rq_job.meta`` after the job's last
+    ``save_meta()`` call, and RQ persists a finishing job with ``include_meta=False``,
+    so they were computed and then silently lost — for every scheduling job.
+    Fetching a fresh Job instance (rather than inspecting the worker's in-memory object)
+    is what makes this test see only what actually reached Redis.
+    """
+    battery = next(
+        s
+        for s in add_battery_assets_fresh_db["Test battery"].sensors
+        if s.name == "power"
+    )
+    tz = pytz.timezone("Europe/Amsterdam")
+    start = tz.localize(datetime(2015, 1, 2))
+    end = tz.localize(datetime(2015, 1, 3))
+
+    job = create_scheduling_job(
+        asset_or_sensor=battery,
+        start=start,
+        end=end,
+        belief_time=start,
+        resolution=timedelta(minutes=15),
+        flex_model={
+            "roundtrip-efficiency": "98%",
+            "storage-efficiency": 0.999,
+        },
+    )
+    work_on_rq(app.queues["scheduling"], exc_handler=exception_reporter)
+
+    # Fetch fresh from Redis: in-memory meta mutations on the worker's job object don't count.
+    finished_job = Job.fetch(job.id, connection=app.queues["scheduling"].connection)
+    assert finished_job.is_finished
+    commitment_costs = finished_job.meta["scheduler_info"]["commitment_costs"]
+    assert (
+        commitment_costs
+    ), "the scheduler reported commitment costs, so the persisted job meta must carry them"
+    assert all(
+        isinstance(cost, float) and np.isfinite(cost)
+        for cost in commitment_costs.values()
+    )
+
+
 scheduler_specs = {
     "module": None,  # use make_module_descr, see below
     "class": "DummyScheduler",

--- a/flexmeasures/data/tests/test_scheduling_jobs.py
+++ b/flexmeasures/data/tests/test_scheduling_jobs.py
@@ -37,6 +37,7 @@ def test_scheduling_a_battery(
     """Test one clean run of one scheduling job:
     - data source was made,
     - schedule has been made
+    - the commitment costs reached the job meta stored in Redis — regression for #2418
     - success is logged once (not before compute) — regression for #2049
     """
 
@@ -94,50 +95,10 @@ def test_scheduling_a_battery(
         sum(v.event_value for v in power_values) < -0.5
     ), "some cycling should have occurred to make a profit, resulting in overall consumption due to losses"
 
-    # Regression #2049: success message only after compute, not the pre-compute copy-paste echo.
-    # Count only this job's message — the RQ worker may also process other queued jobs.
-    out = capsys.readouterr().out
-    assert out.count(f"Job {job.id} made schedule.") == 1, out
-
-
-def test_commitment_costs_are_persisted_on_job_meta(
-    fresh_db,
-    app,
-    add_battery_assets_fresh_db,
-    setup_fresh_test_data,
-    add_market_prices_fresh_db,
-):
-    """The commitment cost breakdown must survive into the job meta stored in Redis.
-
-    Regression test: the costs used to be written to ``rq_job.meta`` after the job's last ``save_meta()`` call,
-    and RQ persists a finishing job with ``include_meta=False``,
-    so they were computed and then silently lost — for every scheduling job.
-    Fetching a fresh Job instance is what makes this test see only what actually reached Redis,
-    rather than the worker's in-memory job object.
-    """
-    battery = next(
-        s
-        for s in add_battery_assets_fresh_db["Test battery"].sensors
-        if s.name == "power"
-    )
-    tz = pytz.timezone("Europe/Amsterdam")
-    start = tz.localize(datetime(2015, 1, 2))
-    end = tz.localize(datetime(2015, 1, 3))
-
-    job = create_scheduling_job(
-        asset_or_sensor=battery,
-        start=start,
-        end=end,
-        belief_time=start,
-        resolution=timedelta(minutes=15),
-        flex_model={
-            "roundtrip-efficiency": "98%",
-            "storage-efficiency": 0.999,
-        },
-    )
-    work_on_rq(app.queues["scheduling"], exc_handler=exception_reporter)
-
-    # Fetch fresh from Redis: in-memory meta mutations on the worker's job object don't count.
+    # Regression #2418: the commitment costs used to be written to the job meta after the
+    # job's last save_meta() call, and RQ persists a finishing job with include_meta=False,
+    # so they were computed and then silently lost. Fetch a fresh Job to see only what
+    # actually reached Redis, rather than the worker's in-memory job object.
     finished_job = Job.fetch(job.id, connection=app.queues["scheduling"].connection)
     assert finished_job.is_finished
     commitment_costs = finished_job.meta["scheduler_info"]["commitment_costs"]
@@ -148,6 +109,11 @@ def test_commitment_costs_are_persisted_on_job_meta(
         isinstance(cost, float) and np.isfinite(cost)
         for cost in commitment_costs.values()
     )
+
+    # Regression #2049: success message only after compute, not the pre-compute copy-paste echo.
+    # Count only this job's message — the RQ worker may also process other queued jobs.
+    out = capsys.readouterr().out
+    assert out.count(f"Job {job.id} made schedule.") == 1, out
 
 
 scheduler_specs = {


### PR DESCRIPTION
## The bug

`make_schedule` records the scheduler's commitment cost breakdown on the job:

```python
if rq_job and result.get("name") == "commitment_costs":
    rq_job.meta["scheduler_info"]["commitment_costs"] = result["data"]
```

…but this runs **after** the function's last `rq_job.save_meta()` call, and RQ persists a finishing job with `include_meta=False`. So the costs were computed and then silently dropped: no scheduling job has ever carried `commitment_costs` in the meta actually stored in Redis. The ordering has been wrong since the feature was introduced in #1946, so this never worked. Any consumer reading job meta (e.g. the jobs API) saw a `scheduler_info` without them.

Observed live: after a successful `StorageScheduler` job, `Job.fetch(...)` returns `scheduler_info` containing only `{"scheduler": ...}`, while the in-memory job object in the worker (e.g. seen from an RQ success callback) still holds the full cost dict.

## The fix

Call `rq_job.save_meta()` right where the costs are recorded, with a comment explaining why the explicit save is load-bearing.

## The test

The assertions live in `test_scheduling_a_battery`, which already runs a real battery scheduling job with these fixtures. After the job finishes it **fetches a fresh `Job` instance from Redis** and asserts the persisted meta carries a non-empty, finite cost breakdown — deliberately not inspecting the worker's in-memory object, which held the data even when the bug was live.

Mutation-tested (each mutant applied to `scheduling.py`, test rerun):

| Mutant | Outcome |
|---|---|
| Fix reverted (no `save_meta`) | killed |
| `save_meta()` before the assignment | killed |
| Costs stored under a wrong key | killed |
| Costs replaced by `{}` | killed |
| Branch condition inverted | killed |

Pristine fix: passes. Full `test_scheduling_jobs.py` module: 14 passed.

No changelog entry: the feature this repairs is itself part of unreleased v1.0.0 (#1946).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKx19DmqHiTBS7iEeFTijs
