### PR TITLE
Ci/qa hems play mode

### DIFF
--- a/.github/workflows/docker-qa.yml
+++ b/.github/workflows/docker-qa.yml
@@ -47,8 +47,13 @@ jobs:
           ref: ${{ inputs.flexmeasures-client-ref }}
           path: flexmeasures-client
 
-      - name: Add compose override to mount the HEMS configs directory
+      - name: Prepare HEMS Compose override and server config
         run: |
+          # Create the bind-mounted instance directory before Compose does, so
+          # the runner can update this config later without ownership issues.
+          mkdir -p flexmeasures-instance
+          printf '%s\n' 'FLEXMEASURES_MODE = "development"' > flexmeasures-instance/flexmeasures.cfg
+
           cat > qa-hems-override.yml <<EOF
           services:
             server:
@@ -96,6 +101,11 @@ jobs:
           ACCOUNT_ID=$(echo "$OUTPUT" | grep -oP '(?<=ID: )\d+')
           docker compose exec -T server bash -c \
             "printf 'admin\nadmin\n' | flexmeasures add user --username admin --email admin@admin.com --account $ACCOUNT_ID --roles admin"
+
+      - name: Switch the server to play mode for HEMS
+        run: |
+          printf '%s\n' 'FLEXMEASURES_MODE = "play"' > flexmeasures-instance/flexmeasures.cfg
+          docker compose up --detach --no-deps --force-recreate --wait --wait-timeout 300 server
 
       - name: Run the HEMS example against the running stack
         working-directory: flexmeasures-client

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -73,6 +73,7 @@ New features
 Infrastructure / Support
 ----------------------
 
+* Run the HEMS release QA example in play mode so simulation loops are not blocked by API rate limits [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
 * Add a ``FLEXMEASURES_SENTRY_DAILY_RATE_LIMIT`` setting for spreading a host's Sentry error allowance across the month with a fail-open daily Redis counter, and send the startup error about the database schema not being at the Alembic head revision to Sentry at most once per UTC calendar day per pair of current and expected revisions (it is still logged in full on every start) [see `PR #2366 <https://www.github.com/FlexMeasures/flexmeasures/pull/2366>`_]
 * Shrink the scheduler's mixed-integer program for one-way devices: where a device can only consume or only produce, its power-sign binaries and their big-M constraints are dropped, as simultaneous consumption and production is already ruled out by the power bounds [see `PR #2412 <https://www.github.com/FlexMeasures/flexmeasures/pull/2412>`_]
 * ``uv run poe clean-db`` now works on macOS as well, takes its arguments as ``--db-name my-db --db-user my-user``, reads your answers to its prompts, and handles names containing a dash [see `PR #2408 <https://www.github.com/FlexMeasures/flexmeasures/pull/2408>`_]

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -73,7 +73,6 @@ New features
 Infrastructure / Support
 ----------------------
 
-* Run the HEMS release QA example in play mode so simulation loops are not blocked by API rate limits [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
 * Add a ``FLEXMEASURES_SENTRY_DAILY_RATE_LIMIT`` setting for spreading a host's Sentry error allowance across the month with a fail-open daily Redis counter, and send the startup error about the database schema not being at the Alembic head revision to Sentry at most once per UTC calendar day per pair of current and expected revisions (it is still logged in full on every start) [see `PR #2366 <https://www.github.com/FlexMeasures/flexmeasures/pull/2366>`_]
 * Shrink the scheduler's mixed-integer program for one-way devices: where a device can only consume or only produce, its power-sign binaries and their big-M constraints are dropped, as simultaneous consumption and production is already ruled out by the power bounds [see `PR #2412 <https://www.github.com/FlexMeasures/flexmeasures/pull/2412>`_]
 * ``uv run poe clean-db`` now works on macOS as well, takes its arguments as ``--db-name my-db --db-user my-user``, reads your answers to its prompts, and handles names containing a dash [see `PR #2408 <https://www.github.com/FlexMeasures/flexmeasures/pull/2408>`_]
@@ -106,6 +105,7 @@ Infrastructure / Support
 * Stop manual runs of the Docker publishing workflow from overwriting the ``latest`` image tag, and let them opt in to it explicitly [see `PR #2316 <https://www.github.com/FlexMeasures/flexmeasures/pull/2316>`_]
 * Add a pre-commit hook that blocks image files (png, jpg, gif, bmp, tiff, webp, ico, psd) from being committed outside of ``flexmeasures/ui/static/`` and ``documentation/``, to protect the git history from binary bloat; screenshots belong in the ``FlexMeasures/screenshots`` repo instead [see `PR #2315 <https://www.github.com/FlexMeasures/flexmeasures/pull/2315>`_]
 * Schedulers track devices via a typed device inventory, which classifies every flex-model entry once and serves as the single source of truth for device roles and canonical device indices [see `PR #2321 <https://www.github.com/FlexMeasures/flexmeasures/pull/2321>`_ and `PR #2360 <https://www.github.com/FlexMeasures/flexmeasures/pull/2360>`_]
+* Run the HEMS release QA example in play mode so simulation loops are not blocked by API rate limits [see `PR #2422 <https://www.github.com/FlexMeasures/flexmeasures/pull/2422>`_]
 
 Bugfixes
 -----------


### PR DESCRIPTION
## Description

The HEMS script needs to be run in play mode, since we are rate-limiting expensive API operations by default.
This PR sets this mode in the QA GH Action, but only for the HEMS part.

- [x] Run HEMS script with play mode
- [x] Added changelog item in `documentation/changelog.rst`

## How to test

Run the QA action for this branch (I did that, see [here](https://github.com/FlexMeasures/flexmeasures/actions/runs/31583219292))