### PR TITLE
fix: StorageScheduler falls back to 0 correctly if no starting SoC can be found

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -17,8 +17,6 @@ Infrastructure / Support
 Bugfixes
 -----------
 
-* Restore the default empty starting state of charge for constrained storage when neither ``soc-at-start`` nor ``state-of-charge`` is provided [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
-
 
 v1.0.0 | August 14, 2026
 ============================
@@ -46,7 +44,7 @@ New features
 -------------
 
 * The flex-context can now define multiple commodities, each specifying their own prices and grid capacities [see `PR #1946 <https://www.github.com/FlexMeasures/flexmeasures/pull/1946>`_, `PR #2172 <https://www.github.com/FlexMeasures/flexmeasures/pull/2172>`_, `PR #2235 <https://www.github.com/FlexMeasures/flexmeasures/pull/2235>`_, `PR #2271 <https://www.github.com/FlexMeasures/flexmeasures/pull/2271>`_, `PR #2355 <https://www.github.com/FlexMeasures/flexmeasures/pull/2355>`_ and `PR #2380 <https://www.github.com/FlexMeasures/flexmeasures/pull/2380>`_]
-* Support multiple feeders to a shared storage [see `PR #2001 <https://www.github.com/FlexMeasures/flexmeasures/pull/2001>`_, `PR #2321 <https://www.github.com/FlexMeasures/flexmeasures/pull/2321>`_, `PR #2322 <https://www.github.com/FlexMeasures/flexmeasures/pull/2322>`_ and `PR #2325 <https://www.github.com/FlexMeasures/flexmeasures/pull/2325>`_]
+* Support multiple feeders to a shared storage [see `PR #2001 <https://www.github.com/FlexMeasures/flexmeasures/pull/2001>`_, `PR #2321 <https://www.github.com/FlexMeasures/flexmeasures/pull/2321>`_, `PR #2322 <https://www.github.com/FlexMeasures/flexmeasures/pull/2322>`_, `PR #2325 <https://www.github.com/FlexMeasures/flexmeasures/pull/2325>`_ and `PR #2431 <https://www.github.com/FlexMeasures/flexmeasures/pull/2431>`_]
 * Add support for intermediate power constraints on groups of devices, via a new ``group`` field in the storage flex-model [see `PR #2276 <https://www.github.com/FlexMeasures/flexmeasures/pull/2276>`_ and `issue #2092 <https://github.com/FlexMeasures/flexmeasures/issues/2092>`_]
 * In the UI, asset and sensor charts now render with Apache ECharts (canvas) by default, for much faster drawing and interaction on dense time series, while staying visually and functionally equivalent to the previous Vega-Lite charts, which remain available as a fallback via a toggle [see `PR #2234 <https://www.github.com/FlexMeasures/flexmeasures/pull/2234>`_ and `PR #2399 <https://www.github.com/FlexMeasures/flexmeasures/pull/2399>`_]
 * The API is now rate-limited, with a generous default limit on all endpoints and a stricter limit on triggering schedules and forecasts (which only counts triggers we accepted). Limits are configurable, and can be set per organisation by putting its account on a plan, which hosts create with ``flexmeasures add plan`` and platform admins assign from the organisation's page in the UI; play servers are exempt, as they run simulations. See :ref:`plans-and-rate-limiting` [see `PR #2306 <https://www.github.com/FlexMeasures/flexmeasures/pull/2306>`_ and `PR #2407 <https://www.github.com/FlexMeasures/flexmeasures/pull/2407>`_]

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -17,6 +17,8 @@ Infrastructure / Support
 Bugfixes
 -----------
 
+* Restore the default empty starting state of charge for constrained storage when neither ``soc-at-start`` nor ``state-of-charge`` is provided [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
+
 
 v1.0.0 | August 14, 2026
 ============================

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -2443,11 +2443,12 @@ class MetaStorageScheduler(Scheduler):
     def _resolve_stock_soc_at_start(
         self, stock_model: dict, sensor: Sensor | None = None, stock_key=None
     ) -> float | None:
-        """Resolve a stock's soc-at-start (in MWh) from its (deserialized) state-of-charge.
+        """Resolve or default a stock's soc-at-start (in MWh).
 
         Used in multi-device mode, where soc-at-start is not resolved during deserialization.
-        Operates on the deserialized stock-owning entry,
-        whose ``state_of_charge`` is a :class:`Sensor`, :class:`SensorReference` or time series.
+        This mirrors ``ensure_soc_at_start()`` for the deserialized stock-owning entry:
+        resolve a configured ``state_of_charge``, fall back to the legacy asset attribute,
+        and finally default constrained storage to an empty stock.
 
         In line with single-sensor mode's ``ensure_soc_at_start()``,
         a state of charge that is given but cannot be resolved fails the schedule:
@@ -2455,7 +2456,7 @@ class MetaStorageScheduler(Scheduler):
 
         :param stock_model: The deserialized flex-model entry owning the stock's SoC parameters.
         :param sensor:      The stock's (first) device power sensor, used for the SoC lookup radius.
-        :returns:           Starting stock in MWh, or None if the entry defines no state of charge.
+        :returns:           Starting stock in MWh, or None if the entry has no state-of-charge semantics.
         """
         state_of_charge = stock_model.get("state_of_charge")
         if isinstance(state_of_charge, (Sensor, SensorReference)):
@@ -2472,6 +2473,25 @@ class MetaStorageScheduler(Scheduler):
             return self._resolve_soc_at_start_from_time_series(
                 state_of_charge, sensor, stock_key=stock_key
             )
+
+        if sensor is not None:
+            if (
+                self.start == sensor.get_attribute("soc_datetime")
+                and sensor.get_attribute("soc_in_mwh") is not None
+            ):
+                return sensor.get_attribute("soc_in_mwh")
+
+        if any(
+            field in stock_model
+            for field in (
+                "soc_min",
+                "soc_max",
+                "soc_minima",
+                "soc_maxima",
+                "soc_targets",
+            )
+        ):
+            return 0
         return None
 
     def possibly_extend_end(self, soc_targets, sensor: Sensor = None):
@@ -2512,8 +2532,9 @@ class MetaStorageScheduler(Scheduler):
         Preferably, a starting soc is given.
         Otherwise, we try to retrieve the current state of charge from the configured ``state-of-charge`` field.
         If that doesn't work, we try the (old-style) asset attribute.
-        Finally, we default the starting soc to 0 (only if there are soc limits, though, as some assets don't use
-        the concept of a state of charge, and without soc targets and limits the starting soc doesn't matter).
+        Finally, we default the starting soc to 0 when there are soc constraints.
+        Some assets don't use the concept of a state of charge,
+        and without soc targets or bounds the starting soc doesn't matter.
         """
         if flex_model is None:
             flex_model = self.flex_model
@@ -2533,8 +2554,15 @@ class MetaStorageScheduler(Scheduler):
                 and sensor.get_attribute("soc_in_mwh") is not None
             ):
                 flex_model["soc-at-start"] = sensor.get_attribute("soc_in_mwh")
-        if not self.has_soc_at_start_in(flex_model) and (
-            "soc-min" in flex_model or "soc-max" in flex_model
+        if not self.has_soc_at_start_in(flex_model) and any(
+            field in flex_model
+            for field in (
+                "soc-min",
+                "soc-max",
+                "soc-minima",
+                "soc-maxima",
+                "soc-targets",
+            )
         ):
             flex_model["soc-at-start"] = 0
 

--- a/flexmeasures/data/models/planning/storage.py
+++ b/flexmeasures/data/models/planning/storage.py
@@ -65,6 +65,25 @@ from flexmeasures.utils.unit_utils import ur, convert_units, units_are_convertib
 storage_asset_types = ["one-way_evse", "two-way_evse", "battery", "heat-storage"]
 
 
+ABSOLUTE_SOC_CONSTRAINT_FIELDS = (
+    "soc_min",
+    "soc_max",
+    "soc_minima",
+    "soc_maxima",
+    "soc_targets",
+)
+
+
+def _has_absolute_soc_constraints(flex_model: dict) -> bool:
+    """Return whether a serialized or deserialized model constrains absolute SoC.
+
+    SoC gain and usage describe flows. Without a bound or target, they do not make
+    the stock's absolute starting level relevant to the optimization.
+    """
+    normalized_fields = {field.replace("-", "_") for field in flex_model}
+    return any(field in normalized_fields for field in ABSOLUTE_SOC_CONSTRAINT_FIELDS)
+
+
 #: Key used to store and retrieve the ``SchedulingJobResult`` in RQ job metadata
 #: and in the multi-result list returned by ``StorageScheduler.compute()``.
 SCHEDULING_RESULT_KEY = "scheduling_result"
@@ -2481,16 +2500,8 @@ class MetaStorageScheduler(Scheduler):
             ):
                 return sensor.get_attribute("soc_in_mwh")
 
-        if any(
-            field in stock_model
-            for field in (
-                "soc_min",
-                "soc_max",
-                "soc_minima",
-                "soc_maxima",
-                "soc_targets",
-            )
-        ):
+        # Keep the historical empty-stock fallback when absolute SoC matters.
+        if _has_absolute_soc_constraints(stock_model):
             return 0
         return None
 
@@ -2554,15 +2565,8 @@ class MetaStorageScheduler(Scheduler):
                 and sensor.get_attribute("soc_in_mwh") is not None
             ):
                 flex_model["soc-at-start"] = sensor.get_attribute("soc_in_mwh")
-        if not self.has_soc_at_start_in(flex_model) and any(
-            field in flex_model
-            for field in (
-                "soc-min",
-                "soc-max",
-                "soc-minima",
-                "soc-maxima",
-                "soc-targets",
-            )
+        if not self.has_soc_at_start_in(flex_model) and _has_absolute_soc_constraints(
+            flex_model
         ):
             flex_model["soc-at-start"] = 0
 

--- a/flexmeasures/data/models/planning/tests/test_solver.py
+++ b/flexmeasures/data/models/planning/tests/test_solver.py
@@ -4612,6 +4612,122 @@ def test_multi_device_battery_fails_on_unresolvable_soc_sensor(
         scheduler.compute()
 
 
+def test_asset_scheduler_charges_from_default_zero_soc(
+    db, building, setup_generic_asset_types
+):
+    """An asset-scheduled battery can meet a soft minimum without ``soc-at-start``.
+
+    Asset scheduling uses the list-based flex-model path even when only one power
+    sensor is scheduled. With no explicit or measured starting SoC, the battery
+    defaults to empty and charges 2 kWh to reach its soft minimum. This exercises
+    the commitment calculation that previously multiplied ``None`` by a float.
+    """
+    battery_type = setup_generic_asset_types["battery"]
+    site = _add_parent_site(db, building, "default starting soc charging test site")
+    power_sensor, _ = _add_battery_device(
+        db,
+        site,
+        battery_type,
+        "default starting soc charging battery",
+        with_soc_sensor=False,
+    )
+    db.session.commit()
+
+    resolution = timedelta(hours=1)
+    start = pd.Timestamp("2020-01-01T00:00:00", tz="Europe/Amsterdam")
+    end = start + 4 * resolution
+
+    scheduler: Scheduler = StorageScheduler(
+        asset_or_sensor=site,
+        start=start,
+        end=end,
+        resolution=resolution,
+        flex_model=[
+            {
+                "sensor": power_sensor.id,
+                "soc-minima": [{"datetime": end.isoformat(), "value": "2 kWh"}],
+                "power-capacity": "1 kW",
+                "consumption-capacity": "1 kW",
+                "production-capacity": "0 kW",
+            },
+        ],
+        flex_context={
+            "consumption-price": "100 EUR/MWh",
+            "production-price": "0 EUR/MWh",
+            "site-power-capacity": "100 kW",
+            "soc-minima-breach-price": "1 EUR/kWh",
+        },
+        return_multiple=True,
+    )
+
+    results = scheduler.compute()
+    schedule = next(
+        result["data"]
+        for result in results
+        if result.get("name") == "storage_schedule"
+        and result.get("sensor") is power_sensor
+    )
+    assert schedule.sum() == pytest.approx(2)
+
+
+def test_asset_scheduler_cannot_discharge_from_default_zero_soc(
+    db, building, setup_generic_asset_types
+):
+    """Hard SoC bounds remain active when an asset-scheduled battery defaults empty.
+
+    Discharging is financially attractive and charging is disabled. The resulting
+    idle schedule demonstrates that the default zero starting SoC is connected to
+    the hard lower bound; without stock constraints, the optimizer would discharge
+    energy that the battery does not hold.
+    """
+    battery_type = setup_generic_asset_types["battery"]
+    site = _add_parent_site(db, building, "default starting soc safety test site")
+    power_sensor, _ = _add_battery_device(
+        db,
+        site,
+        battery_type,
+        "default starting soc safety battery",
+        with_soc_sensor=False,
+    )
+    db.session.commit()
+
+    resolution = timedelta(hours=1)
+    start = pd.Timestamp("2020-01-01T00:00:00", tz="Europe/Amsterdam")
+    end = start + 4 * resolution
+
+    scheduler: Scheduler = StorageScheduler(
+        asset_or_sensor=site,
+        start=start,
+        end=end,
+        resolution=resolution,
+        flex_model=[
+            {
+                "sensor": power_sensor.id,
+                "soc-min": "0 kWh",
+                "soc-max": "1 kWh",
+                "power-capacity": "1 kW",
+                "consumption-capacity": "0 kW",
+                "production-capacity": "1 kW",
+            }
+        ],
+        flex_context={
+            "consumption-price": "1000 EUR/MWh",
+            "production-price": "1000 EUR/MWh",
+            "site-power-capacity": "100 kW",
+        },
+        return_multiple=True,
+    )
+
+    results = scheduler.compute()
+    schedule = next(
+        result["data"]
+        for result in results
+        if result.get("name") == "storage_schedule"
+        and result.get("sensor") is power_sensor
+    )
+    assert np.allclose(schedule, 0)
+
+
 def test_battery_solver_respects_operation_mode_bands(db, add_battery_assets):
     """StorageScheduler.compute() must actually wire "operation-modes" from the
     flex-model through to the LP's device power bands.


### PR DESCRIPTION
## Desription

Closes #2430: Errors when no starting SoC is given to StorageScheduler

- [x] Fix defaulting to 0 SoC at start for the asset-triggering route. 
- [x] Added changelog item in `documentation/changelog.rst`

Note: If a `state-of-charge` sensor is given, but it has no recent data, we still fail with the clear “No recent state-of-charge value” error. 

## Analysis

Single-sensor scheduling calls ensure_soc_at_start(), which resolves a configured SoC source, tries the legacy asset value, and then defaults to 0 when soc-min or soc-max makes the entry a storage model. Asset/multi-device scheduling skips that routine entirely. The right correction is therefore to restore the same resolution/default policy per stock group, not to special-case soft minima.

PR #1946 deleted that call while retaining it for the sensor/dict branch. This affects your one-sensor case because an asset schedule with an explicit sensor entry remains a list; “multi-device mode” is really “asset/list mode,” not “more than one sensor.”
PR #2322 on July 15 partially repaired the regression by resolving soc-at-start from a configured state-of-charge source in the per-stock loop. It did not restore the zero fallback (or initially the legacy attribute fallback), which is why your no-source case still reaches _prepare() with None. In release terms, v0.33.1 still had the old behavior; the removal first appears in v0.33.2.dev0 and the v1.0 release line.

## Look & Feel

Schedules with no SoC at start information should succeed.

## How to test

Two tests were added to this PR without such information, but they still schedule.
