### PR TITLE
fix: shrink docker image by excluding dev deps and pruning sktime's s…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 # Sync dependencies without installing the project itself (creates .venv)
+# --no-dev excludes the dev dependency-group (mypy, black, flake8, ...).
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --locked --no-install-project
+    uv sync --locked --no-install-project --no-dev
 
 # Ensure subsequent commands use the virtual environment
 ENV VIRTUAL_ENV=/app/.venv \
@@ -45,11 +46,15 @@ COPY .flaskenv wsgi.py ./
 ARG FLEXMEASURES_VERSION=
 RUN --mount=type=cache,target=/root/.cache/uv \
     SETUPTOOLS_SCM_PRETEND_VERSION="${FLEXMEASURES_VERSION}" \
-    uv sync --frozen --reinstall-package flexmeasures
+    uv sync --frozen --reinstall-package flexmeasures --no-dev
 
 # Install gunicorn separately since it's not a dependency of the project
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install gunicorn==25.0.3
+
+# sktime (and its scikit-base dependency) ship docs/ and examples/ as stray top-level directories. See: https://github.com/sktime/sktime/issues/10891
+RUN rm -rf "${VIRTUAL_ENV}"/lib/python*/site-packages/docs \
+           "${VIRTUAL_ENV}"/lib/python*/site-packages/examples
 
 # Use a separate runtime image to run the code
 FROM python:${PYTHON_VERSION}-slim-${DEBIAN_VERSION} AS runtime

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,7 +13,7 @@ New features
 
 Infrastructure / Support
 -------------------------
-* Shrink the Docker image by excluding dev-only dependencies and pruning stray ``docs``/``examples`` payloads bundled by ``sktime``/``scikit-base`` (issue: https://github.com/sktime/sktime/issues/10891) [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
+* Shrink the Docker image by excluding dev-only dependencies and pruning stray ``docs``/``examples`` payloads bundled by ``sktime``/``scikit-base`` (issue: https://github.com/sktime/sktime/issues/10891) [see `PR #2438 <https://www.github.com/FlexMeasures/flexmeasures/pull/2438>`_]
 
 Bugfixes
 -----------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,6 +13,7 @@ New features
 
 Infrastructure / Support
 -------------------------
+* Shrink the Docker image by excluding dev-only dependencies and pruning stray ``docs``/``examples`` payloads bundled by ``sktime``/``scikit-base`` (issue: https://github.com/sktime/sktime/issues/10891) [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
 
 Bugfixes
 -----------
@@ -1425,7 +1426,7 @@ Infrastructure / Support
 .. warning:: The API endpoint (`[POST] /sensors/(id)/schedules/trigger <api/v3_0.html#post--api-v3_0-sensors-id-schedules-trigger>`_) to make new schedules will (in v0.13) sunset the storage flexibility parameters (they move to the ``flex-model`` parameter group), as well as the parameters describing other sensors (they move to ``flex-context``).
 
 .. warning:: The CLI command ``flexmeasures monitor tasks`` has been deprecated (it's being renamed to ``flexmeasures monitor last-run``). The old name will be sunset in version 0.13.
-    
+
 .. warning:: The CLI command ``flexmeasures add schedule`` has been renamed to ``flexmeasures add schedule for-storage``. The old name will be sunset in version 0.13.
 
 


### PR DESCRIPTION
…tray docs/examples

## Description

This PR will shrink the Docker image by a few tens of MBs by excluding dev dependencies and pruning sktime examples (see https://github.com/sktime/sktime/issues/10891)

- [x] Added changelog item in `documentation/changelog.rst`

<!--
For changelog entries, please take into account the intended audience.

In our main changelog:
- The 'New features' section targets API / CLI / UI users.
- The 'Infrastructure / Support' section targets plugin developers and hosts.

Finally, please note that the API and CLI keep additional changelogs:
- `documentation/api/changelog.rst`
- `documentation/cli/changelog.rst`
-->

## Look & Feel

<!--
This section can contain example pictures for the UI, Input/Output for the CLI, Request / Response for an API endpoint, etc.
-->

...

## How to test

<!--
Steps to test it or name of the tests functions.

The library [flexmeasures-client](https://github.com/FlexMeasures/flexmeasures-client/) can be useful to showcase new features.
For example, it can be used to set some example data to be used in a new UI feature.
-->

...

## Further Improvements

<!--
Potential improvements to be done in the same PR or follow-up Issues/Discussions/PRs.
-->

...

## Related Items

<!--
Mention if this PR closes an Issue or Project.
-->

...

---

#### Sign-off

<!--
We ask contributors outside the FlexMeasures organisation to sign off on their contribution.
Please mark the below fields with an [x].
-->

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
