### PR TITLE
Strip symbol tables from the compiled extensions in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,9 +58,15 @@ RUN rm -rf "${VIRTUAL_ENV}"/lib/python*/site-packages/docs \
 
 # Most wheels ship their compiled extensions unstripped, carrying symbol tables and debug
 # info that nothing needs at runtime. Dropping them here (in the builder, so only the
-# stripped result reaches the runtime image) is worth ~130 MB, over a fifth of it openturns.
-# --strip-unneeded keeps everything dynamic linking uses, so the extensions stay loadable.
-RUN find "${VIRTUAL_ENV}" \( -name '*.so' -o -name '*.so.*' \) -type f \
+# stripped result reaches the runtime image) is worth ~130 MB, over a fifth of that from
+# openturns. --strip-unneeded keeps everything dynamic linking uses, so the extensions stay
+# loadable. strip comes from binutils, which the gcc install above pulls in; we check for it
+# rather than let the trailing `|| true` turn a missing binutils into a silent 130 MB
+# regression. That `|| true` is only there to tolerate individual files strip cannot handle.
+RUN command -v strip > /dev/null || { \
+        echo "strip not found: the builder stage needs binutils" >&2; exit 1; \
+    }; \
+    find "${VIRTUAL_ENV}" \( -name '*.so' -o -name '*.so.*' \) -type f \
     -exec strip --strip-unneeded {} + 2>/dev/null || true
 
 # Use a separate runtime image to run the code

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,13 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN rm -rf "${VIRTUAL_ENV}"/lib/python*/site-packages/docs \
            "${VIRTUAL_ENV}"/lib/python*/site-packages/examples
 
+# Most wheels ship their compiled extensions unstripped, carrying symbol tables and debug
+# info that nothing needs at runtime. Dropping them here (in the builder, so only the
+# stripped result reaches the runtime image) is worth ~130 MB, over a fifth of it openturns.
+# --strip-unneeded keeps everything dynamic linking uses, so the extensions stay loadable.
+RUN find "${VIRTUAL_ENV}" \( -name '*.so' -o -name '*.so.*' \) -type f \
+    -exec strip --strip-unneeded {} + 2>/dev/null || true
+
 # Use a separate runtime image to run the code
 FROM python:${PYTHON_VERSION}-slim-${DEBIAN_VERSION} AS runtime
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 # Sync dependencies without installing the project itself (creates .venv)
+# --no-dev excludes the dev dependency-group (mypy, black, flake8, ...).
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --locked --no-install-project
+    uv sync --locked --no-install-project --no-dev
 
 # Ensure subsequent commands use the virtual environment
 ENV VIRTUAL_ENV=/app/.venv \
@@ -45,11 +46,15 @@ COPY .flaskenv wsgi.py ./
 ARG FLEXMEASURES_VERSION=
 RUN --mount=type=cache,target=/root/.cache/uv \
     SETUPTOOLS_SCM_PRETEND_VERSION="${FLEXMEASURES_VERSION}" \
-    uv sync --frozen --reinstall-package flexmeasures
+    uv sync --frozen --reinstall-package flexmeasures --no-dev
 
 # Install gunicorn separately since it's not a dependency of the project
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install gunicorn==25.0.3
+
+# sktime (and its scikit-base dependency) ship docs/ and examples/ as stray top-level directories. See: https://github.com/sktime/sktime/issues/10891
+RUN rm -rf "${VIRTUAL_ENV}"/lib/python*/site-packages/docs \
+           "${VIRTUAL_ENV}"/lib/python*/site-packages/examples
 
 # Use a separate runtime image to run the code
 FROM python:${PYTHON_VERSION}-slim-${DEBIAN_VERSION} AS runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,13 +56,11 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN rm -rf "${VIRTUAL_ENV}"/lib/python*/site-packages/docs \
            "${VIRTUAL_ENV}"/lib/python*/site-packages/examples
 
-# Most wheels ship their compiled extensions unstripped, carrying symbol tables and debug
-# info that nothing needs at runtime. Dropping them here (in the builder, so only the
-# stripped result reaches the runtime image) is worth ~130 MB, over a fifth of that from
-# openturns. --strip-unneeded keeps everything dynamic linking uses, so the extensions stay
-# loadable. strip comes from binutils, which the gcc install above pulls in; we check for it
-# rather than let the trailing `|| true` turn a missing binutils into a silent 130 MB
-# regression. That `|| true` is only there to tolerate individual files strip cannot handle.
+# Most wheels ship their compiled extensions unstripped, carrying symbol tables and debug info that nothing needs at runtime.
+# Stripping them here keeps ~130 MB out of the runtime image, which copies only the result of this stage.
+# --strip-unneeded leaves everything that dynamic linking uses, so the extensions stay loadable.
+# binutils only reaches this stage as a transitive of the gcc install above, so check for strip explicitly:
+# the trailing `|| true` is there for individual files strip cannot handle, and would otherwise hide a missing binutils.
 RUN command -v strip > /dev/null || { \
         echo "strip not found: the builder stage needs binutils" >&2; exit 1; \
     }; \

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,7 +13,7 @@ New features
 
 Infrastructure / Support
 -------------------------
-* Shrink the Docker image by excluding dev-only dependencies and pruning stray ``docs``/``examples`` payloads bundled by ``sktime``/``scikit-base`` (issue: https://github.com/sktime/sktime/issues/10891) [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
+* Shrink the Docker image by excluding dev-only dependencies and pruning stray ``docs``/``examples`` payloads bundled by ``sktime``/``scikit-base`` (issue: https://github.com/sktime/sktime/issues/10891) [see `PR #2438 <https://www.github.com/FlexMeasures/flexmeasures/pull/2438>`_]
 
 Bugfixes
 -----------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,6 +13,7 @@ New features
 
 Infrastructure / Support
 -------------------------
+* Shrink the Docker image by excluding dev-only dependencies and pruning stray ``docs``/``examples`` payloads bundled by ``sktime``/``scikit-base`` (issue: https://github.com/sktime/sktime/issues/10891) [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
 
 Bugfixes
 -----------
@@ -1425,7 +1426,7 @@ Infrastructure / Support
 .. warning:: The API endpoint (`[POST] /sensors/(id)/schedules/trigger <api/v3_0.html#post--api-v3_0-sensors-id-schedules-trigger>`_) to make new schedules will (in v0.13) sunset the storage flexibility parameters (they move to the ``flex-model`` parameter group), as well as the parameters describing other sensors (they move to ``flex-context``).
 
 .. warning:: The CLI command ``flexmeasures monitor tasks`` has been deprecated (it's being renamed to ``flexmeasures monitor last-run``). The old name will be sunset in version 0.13.
-    
+
 .. warning:: The CLI command ``flexmeasures add schedule`` has been renamed to ``flexmeasures add schedule for-storage``. The old name will be sunset in version 0.13.
 
 

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,7 +13,7 @@ New features
 
 Infrastructure / Support
 -------------------------
-* Shrink the Docker image by excluding dev-only dependencies and pruning stray ``docs``/``examples`` payloads bundled by ``sktime``/``scikit-base`` (issue: https://github.com/sktime/sktime/issues/10891) [see `PR #2438 <https://www.github.com/FlexMeasures/flexmeasures/pull/2438>`_]
+* Shrink the Docker image by excluding dev-only dependencies, pruning stray ``docs``/``examples`` payloads bundled by ``sktime``/``scikit-base`` (issue: https://github.com/sktime/sktime/issues/10891), and stripping the symbol tables that the compiled extensions ship with [see `PR #2438 <https://www.github.com/FlexMeasures/flexmeasures/pull/2438>`_ and `PR #2439 <https://www.github.com/FlexMeasures/flexmeasures/pull/2439>`_]
 
 Bugfixes
 -----------


### PR DESCRIPTION
## Description

Strips the symbol tables from the compiled extensions in the image. Most wheels ship them unstripped; nothing uses them at runtime.

Shares the changelog entry introduced by #2438 rather than adding one of its own, since both shrink the image through the builder stage. #2440 is stacked on this and widens the same entry again.

## What changed

One `RUN` in the builder stage, after the existing `rm -rf` of sktime's stray payloads:

```dockerfile
RUN command -v strip > /dev/null || { \
        echo "strip not found: the builder stage needs binutils" >&2; exit 1; \
    }; \
    find "${VIRTUAL_ENV}" \( -name '*.so' -o -name '*.so.*' \) -type f \
    -exec strip --strip-unneeded {} + 2>/dev/null || true
```

Placement matters. Because the runtime stage only does `COPY --from=builder ${VIRTUAL_ENV}`, the unstripped copies never reach a layer that ships &mdash; stripping in the runtime stage instead would *grow* the image, since the fat layer would still sit underneath. `strip --strip-unneeded` keeps everything dynamic linking needs, which is why the extensions stay loadable.

The explicit `strip` check came out of review: `binutils` only reaches this stage incidentally, as a transitive of the `gcc` install above. Without the check, the trailing `|| true` would swallow `strip: not found` and turn the whole step into a no-op, growing the image back by ~130 MB with nothing failing and CI staying green. The `|| true` stays on the `find`, where it is wanted &mdash; tolerating individual files strip cannot handle.

## Measured

| image | size |
|---|---|
| `main` (with #2438) | 1.52 GB |
| plus this PR | **1.39 GB** |
| | **&minus;130 MB** |

Against `main` *before* #2438 the same step was worth 132.8 MB. The 2.8 MB difference is symbol tables in dev-only packages that `--no-dev` already removes, mostly mypy's mypyc extensions &mdash; the two changes overlap slightly, so the numbers should not be added.

Where it comes from, measured across all 726 shared objects belonging to locked distributions:

| distribution | saved | % of its `.so` bytes |
|---|---|---|
| openturns | 53.2 MB | 22.6% |
| llvmlite | 18.8 MB | 11.2% |
| fonttools | 10.0 MB | 88.9% |
| scipy | 9.3 MB | 11.4% |
| kiwisolver, sqlalchemy, pillow, numba, numpy, cryptography, pyyaml, scikit-learn, greenlet | ~28 MB | 7&ndash;96% |

## How to test

```bash
docker build -t fm-strip .
docker run --rm fm-strip flexmeasures --version
```

Smoke-tested on the built image: the CLI starts (and stops at the missing `SQLALCHEMY_DATABASE_URI`, as expected without a database), and `flexmeasures`, `timely_beliefs`, `openturns`, `scipy`, `numpy`, `pandas`, `sklearn`, `lightgbm`, `darts` and `statsmodels` all import. openturns got the closest look, being both the biggest saver and a C++/SWIG library with a large ABI surface: `Normal`, `UserDefined`, `NormalCopula`, `IndependentCopula`, `JointDistribution` and `Mixture` all behave identically stripped.

The guard was checked on `/bin/sh`, the builder's shell, in both directions: with `strip` present it exits 0 and strips; with `strip` off the PATH it prints the message and exits 1.

## Further Improvements

The bigger remaining items are about what is in the image rather than how it is packed: `darts` and its chain (`shap`/`pyod` &rarr; `numba` &rarr; `llvmlite`) is ~310 MB, `openturns` ~250 MB, `vl-convert-python` 88 MB. Ranked with their user-facing costs in #2437.

## Related Items

Part of #2437. #2440 stacks on this.

---

#### Sign-off

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another incompatible license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
