### PR TITLE
Drop the timely-beliefs forecast extra (sktime) from the dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,13 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN rm -rf "${VIRTUAL_ENV}"/lib/python*/site-packages/docs \
            "${VIRTUAL_ENV}"/lib/python*/site-packages/examples
 
+# Most wheels ship their compiled extensions unstripped, carrying symbol tables and debug
+# info that nothing needs at runtime. Dropping them here (in the builder, so only the
+# stripped result reaches the runtime image) is worth ~130 MB, over a fifth of it openturns.
+# --strip-unneeded keeps everything dynamic linking uses, so the extensions stay loadable.
+RUN find "${VIRTUAL_ENV}" \( -name '*.so' -o -name '*.so.*' \) -type f \
+    -exec strip --strip-unneeded {} + 2>/dev/null || true
+
 # Use a separate runtime image to run the code
 FROM python:${PYTHON_VERSION}-slim-${DEBIAN_VERSION} AS runtime
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 # Sync dependencies without installing the project itself (creates .venv)
+# --no-dev excludes the dev dependency-group (mypy, black, flake8, ...).
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --locked --no-install-project
+    uv sync --locked --no-install-project --no-dev
 
 # Ensure subsequent commands use the virtual environment
 ENV VIRTUAL_ENV=/app/.venv \
@@ -45,11 +46,15 @@ COPY .flaskenv wsgi.py ./
 ARG FLEXMEASURES_VERSION=
 RUN --mount=type=cache,target=/root/.cache/uv \
     SETUPTOOLS_SCM_PRETEND_VERSION="${FLEXMEASURES_VERSION}" \
-    uv sync --frozen --reinstall-package flexmeasures
+    uv sync --frozen --reinstall-package flexmeasures --no-dev
 
 # Install gunicorn separately since it's not a dependency of the project
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install gunicorn==25.0.3
+
+# sktime (and its scikit-base dependency) ship docs/ and examples/ as stray top-level directories. See: https://github.com/sktime/sktime/issues/10891
+RUN rm -rf "${VIRTUAL_ENV}"/lib/python*/site-packages/docs \
+           "${VIRTUAL_ENV}"/lib/python*/site-packages/examples
 
 # Use a separate runtime image to run the code
 FROM python:${PYTHON_VERSION}-slim-${DEBIAN_VERSION} AS runtime

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,7 +13,7 @@ New features
 
 Infrastructure / Support
 -------------------------
-* Shrink the Docker image by excluding dev-only dependencies and pruning stray ``docs``/``examples`` payloads bundled by ``sktime``/``scikit-base`` (issue: https://github.com/sktime/sktime/issues/10891) [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
+* Shrink the Docker image by excluding dev-only dependencies and pruning stray ``docs``/``examples`` payloads bundled by ``sktime``/``scikit-base`` (issue: https://github.com/sktime/sktime/issues/10891) [see `PR #2438 <https://www.github.com/FlexMeasures/flexmeasures/pull/2438>`_]
 
 Bugfixes
 -----------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,7 +13,7 @@ New features
 
 Infrastructure / Support
 -------------------------
-* Shrink the Docker image by excluding dev-only dependencies, pruning stray ``docs``/``examples`` payloads bundled by ``sktime``/``scikit-base`` (issue: https://github.com/sktime/sktime/issues/10891), and stripping the symbol tables that the compiled extensions ship with [see `PR #2438 <https://www.github.com/FlexMeasures/flexmeasures/pull/2438>`_ and `PR #2439 <https://www.github.com/FlexMeasures/flexmeasures/pull/2439>`_]
+* Shrink the Docker image by excluding dev-only dependencies, pruning stray ``docs``/``examples`` payloads bundled by ``sktime``/``scikit-base`` (issue: https://github.com/sktime/sktime/issues/10891), stripping the symbol tables that the compiled extensions ship with, and dropping the ``sktime``-backed belief-formation extra of ``timely-beliefs``, which FlexMeasures does not use [see `PR #2438 <https://www.github.com/FlexMeasures/flexmeasures/pull/2438>`_, `PR #2439 <https://www.github.com/FlexMeasures/flexmeasures/pull/2439>`_ and `PR #2440 <https://www.github.com/FlexMeasures/flexmeasures/pull/2440>`_]
 
 Bugfixes
 -----------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,6 +13,7 @@ New features
 
 Infrastructure / Support
 -------------------------
+* Shrink the Docker image by excluding dev-only dependencies and pruning stray ``docs``/``examples`` payloads bundled by ``sktime``/``scikit-base`` (issue: https://github.com/sktime/sktime/issues/10891) [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
 
 Bugfixes
 -----------
@@ -1425,7 +1426,7 @@ Infrastructure / Support
 .. warning:: The API endpoint (`[POST] /sensors/(id)/schedules/trigger <api/v3_0.html#post--api-v3_0-sensors-id-schedules-trigger>`_) to make new schedules will (in v0.13) sunset the storage flexibility parameters (they move to the ``flex-model`` parameter group), as well as the parameters describing other sensors (they move to ``flex-context``).
 
 .. warning:: The CLI command ``flexmeasures monitor tasks`` has been deprecated (it's being renamed to ``flexmeasures monitor last-run``). The old name will be sunset in version 0.13.
-    
+
 .. warning:: The CLI command ``flexmeasures add schedule`` has been renamed to ``flexmeasures add schedule for-storage``. The old name will be sunset in version 0.13.
 
 

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -13,7 +13,7 @@ New features
 
 Infrastructure / Support
 -------------------------
-* Shrink the Docker image by excluding dev-only dependencies and pruning stray ``docs``/``examples`` payloads bundled by ``sktime``/``scikit-base`` (issue: https://github.com/sktime/sktime/issues/10891) [see `PR #2438 <https://www.github.com/FlexMeasures/flexmeasures/pull/2438>`_]
+* Shrink the Docker image by excluding dev-only dependencies, pruning stray ``docs``/``examples`` payloads bundled by ``sktime``/``scikit-base`` (issue: https://github.com/sktime/sktime/issues/10891), and stripping the symbol tables that the compiled extensions ship with [see `PR #2438 <https://www.github.com/FlexMeasures/flexmeasures/pull/2438>`_ and `PR #2439 <https://www.github.com/FlexMeasures/flexmeasures/pull/2439>`_]
 
 Bugfixes
 -----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
     "pyomo>=5.6,<6.9",
     "tabulate>=0.9.0",
     # 3.5.5: got rid of BlockManager deprecation warnings
-    "timely-beliefs[forecast]>=3.5.5",
+    "timely-beliefs>=3.5.5",
     "python-dotenv>=1.2.1",
     # see GH#607 for issue on this pin
     "sqlalchemy>=2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ dependencies = [
     { name = "setuptools", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "sqlalchemy", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "tabulate", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "timely-beliefs", extra = ["forecast"], marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "timely-beliefs", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "tldextract", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "uniplot", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "urllib3", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -1407,7 +1407,7 @@ requires-dist = [
     { name = "setuptools", specifier = ">=83.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "tabulate", specifier = ">=0.9.0" },
-    { name = "timely-beliefs", extras = ["forecast"], specifier = ">=3.5.5" },
+    { name = "timely-beliefs", specifier = ">=3.5.5" },
     { name = "tldextract", specifier = ">=5.3.1" },
     { name = "uniplot", specifier = ">=0.12.1" },
     { name = "urllib3", specifier = ">=2.7.0" },
@@ -3698,15 +3698,6 @@ wheels = [
 ]
 
 [[package]]
-name = "scikit-base"
-version = "1.0.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2d/d6/ebcf140944069dd35d12492564188a5f92f03c2ed87cadcc7850081165ee/scikit_base-1.0.2.tar.gz", hash = "sha256:2bddbc77c3fe9d83dc692d3d3b6a0c7bf5443c2d4f703a08fb8559d2781c4246", size = 139550, upload-time = "2026-06-22T19:33:25.401Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/7a/24d871929849e61a245ee36806900ae6655b1820efd0dc096e49e88f43f9/scikit_base-1.0.2-py3-none-any.whl", hash = "sha256:4a1ba87a65a92d58f29d30620832c1c4304375b6140cb463eabb61a7e00fe024", size = 165251, upload-time = "2026-06-22T19:33:23.267Z" },
-]
-
-[[package]]
 name = "scikit-learn"
 version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4031,27 +4022,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
-name = "sktime"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "joblib", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version != '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
-    { name = "packaging", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "pandas", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "scikit-base", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "scikit-learn", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')" },
-    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/39/9ecac07485950a6f428b1c2e69cb0f19434bd39115f0229fb509f3016d76/sktime-1.1.0.tar.gz", hash = "sha256:f5cf8b5d01a03af50e0d0fd915bd880e6528e6cd44027de1c5c4a4dac70cb07d", size = 36339689, upload-time = "2026-07-28T17:10:50.279Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/ef/46c8fe85a7d26c4a30bdb81d3b07f0fefb9640ff0d6ad6f054c9e2c15955/sktime-1.1.0-py3-none-any.whl", hash = "sha256:6af5430777aa56aa85b2a5c1c5363e7f4a468f666737aaf178ae3f941c3dd6c4", size = 37591916, upload-time = "2026-07-28T17:10:45.174Z" },
 ]
 
 [[package]]
@@ -4526,12 +4496,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2d/31/21909375dd54d9c883687c0f9ded62244abe6f992bcafdf2a188ff0b94b7/timely_beliefs-4.2.0-py2.py3-none-any.whl", hash = "sha256:d955b71a269aafe7380575a155850667d602649020235aedd4498b32cdacd85b", size = 817900, upload-time = "2026-08-03T10:28:34.991Z" },
 ]
 
-[package.optional-dependencies]
-forecast = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version != '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
-    { name = "sktime", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-]
 
 [[package]]
 name = "times"


### PR DESCRIPTION
## Description

Depends on plain `timely-beliefs` instead of `timely-beliefs[forecast]`, which removes `sktime` and `scikit-base` from the image (~28 MB).

**Stacked on #2439** &mdash; branched off its head. It shares the same changelog entry as #2438 and #2439 rather than adding one, since all three shrink the image.

## Why this is safe

The `forecast` extra exists for `timely-beliefs`' *own* belief-formation model, which accepts an sktime forecaster. FlexMeasures never calls it &mdash; our forecasting is the darts/lightgbm `TrainPredictPipeline`. There is no reference to `sktime`, `form_beliefs`, `BaseForecaster` or `NaiveForecaster` anywhere in `flexmeasures/` or `tests/`.

On the pinned version (3.5.5), `timely-beliefs` imports sktime only under `if TYPE_CHECKING:` and inside that one function, so it is never imported at runtime unless you call that API. Plain `timely-beliefs` therefore behaves identically for us.

## About the lock file

The lock edit is hand-applied: it removes the two package blocks, the `forecast` extra edge from our dependency, and the now-unselected `forecast` block on `timely-beliefs`.

Running `uv lock` produces the same resolution but rewrites **~5,200 lines** of environment-marker serialization with **zero version changes** &mdash; unreviewable noise for a two-package removal. The hand-applied version is 40 lines, and `uv lock --check` passes on it, resolving the same 251 packages. (Same approach as #2407.)

```
$ uv lock
Resolved 251 packages
Removed scikit-base v1.0.2
Removed sktime v1.1.0
$ # versions changed: none
```

## How to test

```bash
uv lock --check
uv sync --frozen
pytest flexmeasures/data/tests/test_forecasting_pipeline.py flexmeasures/data/tests/test_forecasting_jobs.py \
       flexmeasures/api/v3_0/tests/test_forecasting_api.py flexmeasures/cli/tests/test_data_add.py
```

Verified by blocking `sktime` at the import hook and running FlexMeasures against it: **72 forecasting tests pass** with the package entirely unimportable, and `flexmeasures`, `timely_beliefs` and `TrainPredictPipeline` all import cleanly.

## Related Items

Stacked on #2439, which is stacked on #2438. Part of #2437.

---

#### Sign-off

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another incompatible license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
