### PR TITLE
Freeze the clock in test_run_automations

### DIFF
--- a/flexmeasures/cli/tests/test_automations.py
+++ b/flexmeasures/cli/tests/test_automations.py
@@ -736,7 +736,9 @@ def test_add_automation_rejects_non_object_yaml_file(
     assert "Traceback" not in result.output
 
 
-def test_run_automations(app, fresh_db, setup_dummy_data, clean_redis):
+def test_run_automations(
+    app, fresh_db, setup_dummy_data, clean_redis, freeze_server_now
+):
     """Active automations due this minute queue forecasting jobs (with trigger meta data); inactive ones do not.
 
     We use two automations with the same forecaster config (thus sharing a generator data source),
@@ -745,6 +747,10 @@ def test_run_automations(app, fresh_db, setup_dummy_data, clean_redis):
     from flexmeasures.cli.data_add import add_automation
     from flexmeasures.cli.jobs import run_automations
 
+    # Freeze the clock, as this test runs the runner twice and asserts that the second
+    # run finds nothing due. Without freezing, a slow first run can cross a minute
+    # boundary, after which an every-minute automation is legitimately due again.
+    freeze_server_now(datetime(2026, 1, 15, 8, 58, 30, tzinfo=timezone.utc))
     sensor1_id, sensor2_id = setup_dummy_data[0], setup_dummy_data[1]
     runner = app.test_cli_runner()
     for name, sensor_id in [


### PR DESCRIPTION
## Description

`test_run_automations` invokes `flexmeasures jobs run-automations` twice and asserts that the second invocation reports nothing due, under the comment *"running again within the same minute does not queue jobs twice"*. That only holds while both invocations land in the same clock minute.

The two automations it sets up recur every minute (`* * * * *`). The first invocation queues real forecasting jobs, so on a slow runner it can cross a minute boundary — after which both automations are legitimately due again, and the assertion fails:

```
AssertionError: Automation 1 ('Every minute') queued 1 forecasting job(s) for asset 1.
assert 'No automations due' in "Automation 1 ('Every minute') queued 1 forecasting job(s) ...
```

Nothing is wrong with the behaviour under test: queueing again in a new minute is exactly what an every-minute automation should do. The test is simply time-dependent, and fails at random.

Observed on Python 3.11 in CI on #2299, but it is not specific to that PR — the assertion is on `main`, so any PR can hit it.

## Change

Froze the clock with the existing `freeze_server_now` fixture, which the neighbouring `test_run_automations_catches_up_once_after_downtime` already uses for the same reason. No production code is touched.

## How to test

```bash
pytest flexmeasures/cli/tests/test_automations.py
```

No changelog entry, as this changes a test only.

---

#### Sign-off

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another incompatible license.