### PR TITLE
Fix: None-save unit conversion

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -30,6 +30,7 @@ Infrastructure / Support
 Bugfixes
 -----------
 
+* Sensor data ingestion now preserves ``null`` gaps when converting posted values to the sensor's unit, instead of failing the request [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
 * KPIs on the asset page counted one day more than the selected time range [see `PR #2434 <https://www.github.com/FlexMeasures/flexmeasures/pull/2434>`_]
 * KPIs on the asset page now total the values the chart beside them draws, counting each event under the day it starts in: a sensor reported by several sources counted only one of them, and a revised value was counted on top of the value it revised [see `PR #2434 <https://www.github.com/FlexMeasures/flexmeasures/pull/2434>`_]
 * The time range sent when loading an asset's KPIs was off by the viewer's UTC offset, so KPIs could cover the wrong days [see `PR #2435 <https://www.github.com/FlexMeasures/flexmeasures/pull/2435>`_]

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -30,7 +30,7 @@ Infrastructure / Support
 Bugfixes
 -----------
 
-* Sensor data ingestion now preserves ``null`` gaps when converting posted values to the sensor's unit, instead of failing the request [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
+* Sensor data ingestion now preserves ``null`` gaps when converting posted values to the sensor's unit, instead of failing the request [see `PR #2461 <https://www.github.com/FlexMeasures/flexmeasures/pull/2461>`_]
 * KPIs on the asset page counted one day more than the selected time range [see `PR #2434 <https://www.github.com/FlexMeasures/flexmeasures/pull/2434>`_]
 * KPIs on the asset page now total the values the chart beside them draws, counting each event under the day it starts in: a sensor reported by several sources counted only one of them, and a revised value was counted on top of the value it revised [see `PR #2434 <https://www.github.com/FlexMeasures/flexmeasures/pull/2434>`_]
 * The time range sent when loading an asset's KPIs was off by the viewer's UTC offset, so KPIs could cover the wrong days [see `PR #2435 <https://www.github.com/FlexMeasures/flexmeasures/pull/2435>`_]

--- a/flexmeasures/api/v3_0/tests/test_sensor_data_fresh_db.py
+++ b/flexmeasures/api/v3_0/tests/test_sensor_data_fresh_db.py
@@ -18,6 +18,7 @@ from flexmeasures.data.models.time_series import TimedBelief
         (6, 6, "m³/h", False, -11.28, True, 200),
         (6, 5, "m³/h", True, -11.28, False, 200),  # NaN value does not enter database
         (6, 6, "m³", False, 6 * -11.28, False, 200),  # 6 * 10-min intervals per hour
+        (6, 5, "m³", True, 6 * -11.28, False, 200),
         (6, 6, "l/h", False, -11.28 / 1000, False, 200),  # 1 m³ = 1000 l
         (3, 6, "m³/h", False, -11.28, False, 200),  # upsample from 20-min intervals
         (

--- a/flexmeasures/utils/tests/test_unit_utils.py
+++ b/flexmeasures/utils/tests/test_unit_utils.py
@@ -66,6 +66,35 @@ def test_convert_unit(
 
 
 @pytest.mark.parametrize(
+    "from_unit, to_unit, event_resolution, expected_values",
+    [
+        ("MW", "kW", None, [1000.0, None, 3000.0]),
+        ("kWh", "kW", timedelta(minutes=15), [4.0, None, 12.0]),
+        ("°C", "K", None, [274.15, None, 276.15]),
+    ],
+)
+def test_convert_unit_preserves_missing_list_values(
+    from_unit,
+    to_unit,
+    event_resolution,
+    expected_values,
+):
+    """Unit conversion should preserve gaps represented by null list values."""
+    converted_data = convert_units(
+        data=[1, None, 3],
+        from_unit=from_unit,
+        to_unit=to_unit,
+        event_resolution=event_resolution,
+    )
+
+    assert isinstance(converted_data, list)
+    pd.testing.assert_series_equal(
+        pd.Series(converted_data, dtype=float),
+        pd.Series(expected_values, dtype=float),
+    )
+
+
+@pytest.mark.parametrize(
     "from_unit, to_unit, timezone, input_values, expected_values",
     [
         # datetimes are converted to seconds since UNIX epoch

--- a/flexmeasures/utils/unit_utils.py
+++ b/flexmeasures/utils/unit_utils.py
@@ -459,18 +459,20 @@ def _convert_time_units(
 
 
 def convert_units(
-    data: tb.BeliefsSeries | pd.Series | list[int | float] | int | float,
+    data: tb.BeliefsSeries | pd.Series | list[int | float | None] | int | float,
     from_unit: str,
     to_unit: str,
     event_resolution: timedelta | None = None,
     capacity: str | None = None,
-) -> pd.Series | list[int | float] | int | float:
+) -> pd.Series | list[int | float | None] | int | float:
     """Updates data values to reflect the given unit conversion.
 
     Handles units in short scientific notation (e.g. m³/h, kW, and ºC), as well as three special units to convert from:
     - from_unit="datetime"          (with data point such as "2023-05-02", "2023-05-02 05:14:49" or "2023-05-02 05:14:49 +02:00")
     - from_unit="dayfirst datetime" (with data point such as "02-05-2023")
     - from_unit="timedelta"         (with data point such as "0 days 01:18:25")
+
+    During numeric list conversions, ``None`` values become ``NaN`` so gaps are preserved.
     """
     if from_unit in ("datetime", "dayfirst datetime", "timedelta"):
         return _convert_time_units(data, from_unit, to_unit)
@@ -479,7 +481,11 @@ def convert_units(
         from_magnitudes = (
             data.to_numpy()
             if isinstance(data, pd.Series)
-            else np.asarray(data) if isinstance(data, list) else np.array([data])
+            else (
+                np.asarray(data, dtype=float)
+                if isinstance(data, list)
+                else np.array([data])
+            )
         )
         try:
             from_quantities = ur.Quantity(from_magnitudes, from_unit)


### PR DESCRIPTION
## Description

If the ingested data contains `None` values and goes through unit coversion, FlexMeasures tripped, with errors like:

```
                     ^^^^^^^^^^^^^^
  File "/app/flexmeasures/utils/unit_utils.py", line 516, in convert_units
    to_magnitudes = from_magnitudes * multiplier
                    ~~~~~~~~~~~~~~~~^~~~~~~~~~~~
TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'
```

It affects not only conversions like kWh→kW, but ordinary conversions such as MW→kW whenever a list contains `None`. No conversion is attempted when units match, explaining why existing null-value tests pass.

- [x] preserve nulls during unit conversion
- [x] Added changelog item in `documentation/changelog.rst`


## How to test

You can manually test with the POST sensor/data endpoint and data with `None` in them and needs a simple conversion (e.g. MW -> kW), but we also have new tests now.