### PR TITLE
fix: handle unknown alembic revisions during startup

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -33,7 +33,7 @@ Bugfixes
 * KPIs on the asset page counted one day more than the selected time range [see `PR #2434 <https://www.github.com/FlexMeasures/flexmeasures/pull/2434>`_]
 * KPIs on the asset page now total the values the chart beside them draws, counting each event under the day it starts in: a sensor reported by several sources counted only one of them, and a revised value was counted on top of the value it revised [see `PR #2434 <https://www.github.com/FlexMeasures/flexmeasures/pull/2434>`_]
 * The time range sent when loading an asset's KPIs was off by the viewer's UTC offset, so KPIs could cover the wrong days [see `PR #2435 <https://www.github.com/FlexMeasures/flexmeasures/pull/2435>`_]
-* Avoid crashing on startup when the database is stamped with an Alembic revision unknown to this FlexMeasures checkout [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
+* Avoid crashing on startup when the database is stamped with an Alembic revision unknown to this FlexMeasures checkout [see `PR #2465 <https://www.github.com/FlexMeasures/flexmeasures/pull/2465>`_]
 
 
 

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -33,6 +33,7 @@ Bugfixes
 * KPIs on the asset page counted one day more than the selected time range [see `PR #2434 <https://www.github.com/FlexMeasures/flexmeasures/pull/2434>`_]
 * KPIs on the asset page now total the values the chart beside them draws, counting each event under the day it starts in: a sensor reported by several sources counted only one of them, and a revised value was counted on top of the value it revised [see `PR #2434 <https://www.github.com/FlexMeasures/flexmeasures/pull/2434>`_]
 * The time range sent when loading an asset's KPIs was off by the viewer's UTC offset, so KPIs could cover the wrong days [see `PR #2435 <https://www.github.com/FlexMeasures/flexmeasures/pull/2435>`_]
+* Avoid crashing on startup when the database is stamped with an Alembic revision unknown to this FlexMeasures checkout [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
 
 
 

--- a/flexmeasures/data/tests/test_utils.py
+++ b/flexmeasures/data/tests/test_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+from alembic.script.revision import ResolutionError
 from sqlalchemy.exc import OperationalError, ProgrammingError
 
 from flexmeasures.data import db, register_at
@@ -54,10 +55,23 @@ class _DummyRevisionMap:
         return (_DummyRevision(revision) for revision in self._revisions)
 
 
+class _DummyRevisionMapWithUnknownRevision:
+    def iterate_revisions(self, *args, **kwargs):
+        def revisions():
+            raise ResolutionError("No such revision or branch 'unknown-a'", "unknown-a")
+            yield
+
+        return revisions()
+
+
 class _DummyScriptDirectoryWithRevisionMap(_DummyScriptDirectory):
     def __init__(self, heads: tuple[str, ...], revisions: tuple[str, ...]):
         super().__init__(heads)
         self.revision_map = _DummyRevisionMap(revisions)
+
+
+class _DummyScriptDirectoryWithUnknownRevisionMap(_DummyScriptDirectory):
+    revision_map = _DummyRevisionMapWithUnknownRevision()
 
 
 def test_schema_mismatch_log_record_is_deduplicated(
@@ -234,6 +248,22 @@ def test_database_schema_has_revision_false_when_revision_is_not_in_current_hist
         lambda config: _DummyScriptDirectoryWithRevisionMap(
             heads=("head-a",), revisions=("old-a",)
         ),
+    )
+
+    assert database_schema_has_revision(app, "required-a") is False
+
+
+def test_database_schema_has_revision_false_when_current_revision_is_unknown(
+    app, monkeypatch
+):
+    monkeypatch.setattr(db.engine, "connect", lambda: _DummyConnection())
+    monkeypatch.setattr(
+        "flexmeasures.data.utils.MigrationContext.configure",
+        lambda connection: _DummyMigrationContext(("unknown-a",)),
+    )
+    monkeypatch.setattr(
+        "flexmeasures.data.utils.ScriptDirectory.from_config",
+        lambda config: _DummyScriptDirectoryWithUnknownRevisionMap(("head-a",)),
     )
 
     assert database_schema_has_revision(app, "required-a") is False

--- a/flexmeasures/data/utils.py
+++ b/flexmeasures/data/utils.py
@@ -112,10 +112,10 @@ def database_schema_has_revision(app, required_revision: str) -> bool:
                 inclusive=True,
                 assert_relative_length=False,
             )
+            if any(revision.revision == required_revision for revision in revisions):
+                return True
         except RevisionError:
             continue
-        if any(revision.revision == required_revision for revision in revisions):
-            return True
     return False
 
 


### PR DESCRIPTION
## Description

Changing the branch, where a specific recent db migration from another unmerged branch is unknown, leads to this startup error:

```
  File "/home/nicolas/workspace/seita/flexmeasures/.venv/lib/python3.12/site-packages/alembic/script/revision.py", line 1481, in _collect_upgrade_revisions
    raise RangeNotAncestorError(lower, upper)
alembic.script.revision.RangeNotAncestorError: Revision 4b0f2e9c1a6d is not an ancestor of revision b2c3d4e5f6a7
```

This affects developers, mostly. This PR solves this problem

- [x] Do not trip over unknown revision when checking if we are on HEAD at startup
- [x] Added changelog item in `documentation/changelog.rst`

