### PR TITLE
feat: hint at comma-separated format when a FLEXMEASURES_PLUGINS entr…

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -36,6 +36,7 @@ Bugfixes
 * KPIs on the asset page now total the values the chart beside them draws, counting each event under the day it starts in: a sensor reported by several sources counted only one of them, and a revised value was counted on top of the value it revised [see `PR #2434 <https://www.github.com/FlexMeasures/flexmeasures/pull/2434>`_]
 * The time range sent when loading an asset's KPIs was off by the viewer's UTC offset, so KPIs could cover the wrong days [see `PR #2435 <https://www.github.com/FlexMeasures/flexmeasures/pull/2435>`_]
 * Avoid crashing on startup when the database is stamped with an Alembic revision unknown to this FlexMeasures checkout [see `PR #2465 <https://www.github.com/FlexMeasures/flexmeasures/pull/2465>`_]
+* The "module not installed" error for an unresolved ``FLEXMEASURES_PLUGINS`` entry now hints at the expected comma-separated format, which helps people who accidentally use an incorrect format like a JSON-array [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
 
 
 

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -36,7 +36,7 @@ Bugfixes
 * KPIs on the asset page now total the values the chart beside them draws, counting each event under the day it starts in: a sensor reported by several sources counted only one of them, and a revised value was counted on top of the value it revised [see `PR #2434 <https://www.github.com/FlexMeasures/flexmeasures/pull/2434>`_]
 * The time range sent when loading an asset's KPIs was off by the viewer's UTC offset, so KPIs could cover the wrong days [see `PR #2435 <https://www.github.com/FlexMeasures/flexmeasures/pull/2435>`_]
 * Avoid crashing on startup when the database is stamped with an Alembic revision unknown to this FlexMeasures checkout [see `PR #2465 <https://www.github.com/FlexMeasures/flexmeasures/pull/2465>`_]
-* The "module not installed" error for an unresolved ``FLEXMEASURES_PLUGINS`` entry now hints at the expected comma-separated format, which helps people who accidentally use an incorrect format like a JSON-array [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
+* The "module not installed" error for an unresolved ``FLEXMEASURES_PLUGINS`` entry now hints at the expected comma-separated format, which helps people who accidentally use an incorrect format like a JSON-array [see `PR #2473 <https://www.github.com/FlexMeasures/flexmeasures/pull/2473>`_]
 
 
 

--- a/flexmeasures/utils/plugin_utils.py
+++ b/flexmeasures/utils/plugin_utils.py
@@ -56,7 +56,7 @@ def register_plugins(app: Flask):  # noqa: C901
                 module = importlib.import_module(pkg_name)
             except ModuleNotFoundError:
                 app.logger.error(
-                    f"Attempted to import module {pkg_name} (as it is not a valid file path), but it is not installed."
+                    f'Attempted to import module {pkg_name} (as it is not a valid file path), but it is not installed. Make sure you use a comma-separated list of modules, e.g. "module1,module2".'
                 )
                 continue
         else:  # assume plugin is a file path

--- a/flexmeasures/utils/tests/test_plugin_utils.py
+++ b/flexmeasures/utils/tests/test_plugin_utils.py
@@ -1,0 +1,18 @@
+from flask import Flask
+
+from flexmeasures.utils.plugin_utils import register_plugins
+
+
+def test_register_plugins_error_hints_at_comma_separated_format(caplog):
+    """Failing to import an unrecognised plugin should hint at the expected
+    comma-separated format, so a malformed setting (e.g. a JSON array) doesn't
+    read as a packaging problem."""
+    app = Flask(__name__)
+    app.config["FLEXMEASURES_PLUGINS"] = '["flexmeasures_entsoe"]'
+    register_plugins(app)
+    errors = [
+        record.message
+        for record in caplog.records
+        if "comma-separated" in record.message
+    ]
+    assert errors


### PR DESCRIPTION
…y fails to import

## Description

Improves the error message for FLEXMEASURES_PLUGINS if the user uses the incorrect format

- [ ] ...
- [x] Added changelog item in `documentation/changelog.rst`

<!--
For changelog entries, please take into account the intended audience.

In our main changelog:
- The 'New features' section targets API / CLI / UI users.
- The 'Infrastructure / Support' section targets plugin developers and hosts.

Finally, please note that the API and CLI keep additional changelogs:
- `documentation/api/changelog.rst`
- `documentation/cli/changelog.rst`
-->

## Look & Feel

<!--
This section can contain example pictures for the UI, Input/Output for the CLI, Request / Response for an API endpoint, etc.
-->

...

## How to test

<!--
Steps to test it or name of the tests functions.

The library [flexmeasures-client](https://github.com/FlexMeasures/flexmeasures-client/) can be useful to showcase new features.
For example, it can be used to set some example data to be used in a new UI feature.
-->

...

## Further Improvements

<!--
Potential improvements to be done in the same PR or follow-up Issues/Discussions/PRs.
-->

...

## Related Items

<!--
Mention if this PR closes an Issue or Project.
-->

...

---

#### Sign-off

<!--
We ask contributors outside the FlexMeasures organisation to sign off on their contribution.
Please mark the below fields with an [x].
-->

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures
