### PR TITLE
Run the pre-commit hook against the tree being committed, and only for commits

### DIFF
--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -56,11 +56,17 @@ project_dir="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 # names the git directory rather than the working tree, and for a linked
 # worktree it points inside the primary checkout's `.git`, which is not a tree
 # to run hooks in.
+# A path may be quoted, and a quoted path may contain spaces, so the value of a
+# flag is either a quoted run or an unquoted word.
+value_after() {
+  echo "$command" | sed -nE "s/.*$1(\"[^\"]*\"|'[^']*'|[^[:space:];&|]+).*/\1/p" | head -n1
+}
+
 target=""
 if echo "$command" | grep -qE '[[:space:]]-C[[:space:]]'; then
-  target="$(echo "$command" | grep -oE '[[:space:]]-C[[:space:]]+[^[:space:];&|]+' | head -n1 | sed -E 's/^[[:space:]]*-C[[:space:]]+//')"
+  target="$(value_after '[[:space:]]-C[[:space:]]+')"
 elif echo "$command" | grep -qE '\-\-work-tree[=[:space:]]'; then
-  target="$(echo "$command" | grep -oE '\-\-work-tree[=[:space:]][^[:space:];&|]+' | head -n1 | sed -E 's/^--work-tree[=[:space:]]//')"
+  target="$(value_after '\-\-work-tree[=[:space:]]+')"
 elif echo "$command" | grep -qE '(^|[;&|])[[:space:]]*cd[[:space:]]+'; then
   target="$(echo "$command" | grep -oE '(^|[;&|])[[:space:]]*cd[[:space:]]+[^;&|]+' | tail -n1 | sed -E 's/^[;&|]?[[:space:]]*cd[[:space:]]+//')"
 fi

--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -2,12 +2,85 @@
 # Blocking PreToolUse hook: runs pre-commit before any `git commit` and blocks
 # the commit if hooks fail or modify files. Exit 2 = blocking error (Claude
 # sees stderr and can fix before retrying). Exit 0 = allow.
+#
+# Two things this hook has to work out for itself, because a PreToolUse hook
+# runs in the project dir and does not share the Bash tool's shell state.
+#
+# 1. Whether the command is a commit at all. The settings-level "if" matcher
+#    is not honoured by all Claude Code versions, so the filter is repeated
+#    here, as worktree-guard.sh does. Without it, an unrelated command such as
+#    `gh issue create` pays for a full `pre-commit run --all-files`.
+# 2. Which working tree the commit targets. The primary checkout is shared by
+#    several agents, so running the hooks there when the commit is really for a
+#    worktree checks the wrong tree, and any hook that rewrites a file (such as
+#    the OpenAPI spec) dirties another agent's work. The command text is the
+#    most reliable signal, since `cd <worktree> && git commit` leaves no trace
+#    in the payload's `cwd` once the shell's directory has been reset.
+#
+# Fails open (exit 0) on any parsing problem — never block a commit because the
+# hook could not read its own payload.
 
 set -euo pipefail
 
-if ! output=$(uv run pre-commit run --all-files 2>&1); then
-    echo "pre-commit failed — fix the issues below before committing:" >&2
-    echo "$output" >&2
-    exit 2
-  fi
-  exit 0
+payload="$(cat)"
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+command="$(echo "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
+[ -n "$command" ] || exit 0
+
+# Self-filter: only act on `git commit`. Global options such as `-C <path>` or
+# `-c foo=bar` may sit between `git` and the verb, so allow a run of option
+# words (each optionally followed by its value) first. The verb has to be
+# followed by whitespace or the end of the command, so that `git commit-graph`
+# is left alone, and `git` has to start the command or follow a `;`, `&` or `|`,
+# so that a command merely *mentioning* a commit — an issue or PR body quoting
+# `git commit -s`, say — does not pay for a full run. The cost of that anchoring
+# is that an oddly wrapped commit (`time git commit ...`) goes unchecked, which
+# is the safe direction for a hook that only checks.
+commit_re='(^|[;&|])[[:space:]]*git[[:space:]]+(-[^[:space:]]*([[:space:]]+[^-[:space:];&|][^[:space:]]*)?[[:space:]]+)*commit([[:space:]]|$)'
+echo "$command" | grep -qE "$commit_re" || exit 0
+
+project_dir="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# Which working tree does this commit target? In priority order: an explicit
+# `-C <path>` / `--git-dir=<path>` on the git invocation, else a `cd` earlier in
+# the same command, else the Bash tool's own working directory from the payload,
+# else the project dir. Same derivation as worktree-guard.sh, which guards the
+# same shared checkout.
+target=""
+if echo "$command" | grep -qE '[[:space:]]-C[[:space:]]'; then
+  target="$(echo "$command" | grep -oE '[[:space:]]-C[[:space:]]+[^[:space:];&|]+' | head -n1 | sed -E 's/^[[:space:]]*-C[[:space:]]+//')"
+elif echo "$command" | grep -qE '\-\-git-dir[=[:space:]]'; then
+  target="$(echo "$command" | grep -oE '\-\-git-dir[=[:space:]][^[:space:];&|]+' | head -n1 | sed -E 's/^--git-dir[=[:space:]]//')"
+elif echo "$command" | grep -qE '(^|[;&|])[[:space:]]*cd[[:space:]]+'; then
+  target="$(echo "$command" | grep -oE '(^|[;&|])[[:space:]]*cd[[:space:]]+[^;&|]+' | tail -n1 | sed -E 's/^[;&|]?[[:space:]]*cd[[:space:]]+//')"
+fi
+
+# Strip surrounding quotes and whitespace, and expand a leading `~`.
+target="$(echo "$target" | sed -E "s/^[[:space:]]*['\"]?//; s/['\"]?[[:space:]]*$//")"
+case "$target" in
+  "~"|"~/"*) target="${HOME}${target#\~}" ;;
+  *'$'*) target="" ;;  # set in an earlier Bash call, whose state this hook cannot see
+esac
+
+# Fall back to the working directory the Bash tool reports, then to the project.
+if [ -z "$target" ]; then
+  target="$(echo "$payload" | jq -r '.cwd // empty' 2>/dev/null || true)"
+fi
+[ -n "$target" ] || target="$project_dir"
+
+# Resolve to the root of whichever checkout that is, so the hooks see the whole
+# working tree. A linked worktree resolves to its own root, not the primary one.
+if root="$(git -C "$target" rev-parse --show-toplevel 2>/dev/null)"; then
+  target="$root"
+else
+  target="$project_dir"
+fi
+
+if ! output=$(cd "$target" && uv run pre-commit run --all-files 2>&1); then
+  echo "pre-commit failed in $target — fix the issues below before committing:" >&2
+  echo "$output" >&2
+  exit 2
+fi
+exit 0

--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -1,24 +1,28 @@
 #!/usr/bin/env bash
-# Blocking PreToolUse hook: runs pre-commit before any `git commit` and blocks
-# the commit if hooks fail or modify files. Exit 2 = blocking error (Claude
-# sees stderr and can fix before retrying). Exit 0 = allow.
+# Blocking PreToolUse hook: runs pre-commit before any `git commit`,
+# and blocks the commit if hooks fail or modify files.
+# Exit 2 = blocking error (Claude sees stderr and can fix before retrying).
+# Exit 0 = allow.
 #
-# Two things this hook has to work out for itself, because a PreToolUse hook
-# runs in the project dir and does not share the Bash tool's shell state.
+# A PreToolUse hook runs in the project dir and does not share the Bash tool's shell state,
+# so there are two things this hook has to work out for itself.
 #
-# 1. Whether the command is a commit at all. The settings-level "if" matcher
-#    is not honoured by all Claude Code versions, so the filter is repeated
-#    here, as worktree-guard.sh does. Without it, an unrelated command such as
-#    `gh issue create` pays for a full `pre-commit run --all-files`.
-# 2. Which working tree the commit targets. The primary checkout is shared by
-#    several agents, so running the hooks there when the commit is really for a
-#    worktree checks the wrong tree, and any hook that rewrites a file (such as
-#    the OpenAPI spec) dirties another agent's work. The command text is the
-#    most reliable signal, since `cd <worktree> && git commit` leaves no trace
-#    in the payload's `cwd` once the shell's directory has been reset.
+# 1. Whether the command is a commit at all.
+#    The settings-level "if" matcher is not honoured by all Claude Code versions,
+#    so the filter is repeated here, as worktree-guard.sh does.
+#    Without it, an unrelated command such as `gh issue create` pays for a full run of every hook.
+# 2. Which working tree the commit targets.
+#    The primary checkout is shared by several agents,
+#    so running the hooks there when the commit is really for a worktree checks the wrong tree,
+#    and any hook that rewrites a file, such as the one regenerating the OpenAPI spec,
+#    dirties another agent's work.
+#    The command text is the most reliable signal here,
+#    since `cd <worktree> && git commit` leaves no trace in the payload's `cwd`
+#    once the shell's directory has been reset.
 #
-# Fails open (exit 0) on any parsing problem — never block a commit because the
-# hook could not read its own payload.
+# Fails open (exit 0) rather than blocking, on any parsing problem,
+# and also when the command names a tree this hook cannot resolve:
+# an unchecked commit is a smaller price than hooks run against the wrong checkout.
 
 set -euo pipefail
 
@@ -62,12 +66,17 @@ value_after() {
   echo "$command" | sed -nE "s/.*$1(\"[^\"]*\"|'[^']*'|[^[:space:];&|]+).*/\1/p" | head -n1
 }
 
+# `named` records that the command pointed somewhere, resolvable or not.
+named=""
 target=""
 if echo "$command" | grep -qE '[[:space:]]-C[[:space:]]'; then
+  named="yes"
   target="$(value_after '[[:space:]]-C[[:space:]]+')"
 elif echo "$command" | grep -qE '\-\-work-tree[=[:space:]]'; then
+  named="yes"
   target="$(value_after '\-\-work-tree[=[:space:]]+')"
 elif echo "$command" | grep -qE '(^|[;&|])[[:space:]]*cd[[:space:]]+'; then
+  named="yes"
   target="$(echo "$command" | grep -oE '(^|[;&|])[[:space:]]*cd[[:space:]]+[^;&|]+' | tail -n1 | sed -E 's/^[;&|]?[[:space:]]*cd[[:space:]]+//')"
 fi
 
@@ -82,18 +91,29 @@ case "$target" in
   *'$'*) target="" ;;  # set in an earlier Bash call, whose state this hook cannot see
 esac
 
-# Fall back to the working directory the Bash tool reports, then to the project.
-if [ -z "$target" ]; then
-  target="$(echo "$payload" | jq -r '.cwd // empty' 2>/dev/null || true)"
-fi
-[ -n "$target" ] || target="$project_dir"
-
-# Resolve to the root of whichever checkout that is, so the hooks see the whole
-# working tree. A linked worktree resolves to its own root, not the primary one.
-if root="$(git -C "$target" rev-parse --show-toplevel 2>/dev/null)"; then
+# Resolve to the root of whichever checkout the target names,
+# so the hooks see the whole working tree.
+# A linked worktree resolves to its own root, rather than to the primary checkout.
+if [ -n "$named" ]; then
+  # The command pointed somewhere. If that path cannot be resolved to a checkout,
+  # because it was built from a variable set in an earlier Bash call,
+  # or because it is not a checkout at all, then skip rather than guess:
+  # running the hooks in some other tree would check the wrong files,
+  # and any hook that rewrites one would rewrite it there.
+  if [ -z "$target" ] || ! root="$(git -C "$target" rev-parse --show-toplevel 2>/dev/null)"; then
+    exit 0
+  fi
   target="$root"
 else
-  target="$project_dir"
+  # Nothing was named, so the Bash tool's own working directory is the best guess,
+  # and the project dir after that.
+  cwd="$(echo "$payload" | jq -r '.cwd // empty' 2>/dev/null || true)"
+  target="${cwd:-$project_dir}"
+  if root="$(git -C "$target" rev-parse --show-toplevel 2>/dev/null)"; then
+    target="$root"
+  else
+    target="$project_dir"
+  fi
 fi
 
 if ! output=$(cd "$target" && uv run pre-commit run --all-files 2>&1); then

--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -10,12 +10,10 @@
 #    is not honoured by all Claude Code versions, so the filter is repeated
 #    here, as worktree-guard.sh does. Without it, an unrelated command such as
 #    `gh issue create` pays for a full `pre-commit run --all-files`.
-# 2. Which working tree the commit targets. The primary checkout is shared by
-#    several agents, so running the hooks there when the commit is really for a
-#    worktree checks the wrong tree, and any hook that rewrites a file (such as
-#    the OpenAPI spec) dirties another agent's work. The command text is the
-#    most reliable signal, since `cd <worktree> && git commit` leaves no trace
-#    in the payload's `cwd` once the shell's directory has been reset.
+# 2. Which working tree the commit targets. The primary checkout is shared by several agents.
+#    Running the hooks there when the commit is really for a worktree checks the wrong tree,
+#    and any hook that rewrites a file (such as the OpenAPI spec) dirties another agent's work.
+#    The command text is the most reliable signal, since `cd <worktree> && git commit` leaves no trace in the payload's `cwd` once the shell's directory has been reset.
 #
 # Fails open (exit 0) on any parsing problem — never block a commit because the
 # hook could not read its own payload.

--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -39,20 +39,28 @@ command="$(echo "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null ||
 # is that an oddly wrapped commit (`time git commit ...`) goes unchecked, which
 # is the safe direction for a hook that only checks.
 commit_re='(^|[;&|])[[:space:]]*git[[:space:]]+(-[^[:space:]]*([[:space:]]+[^-[:space:];&|][^[:space:]]*)?[[:space:]]+)*commit([[:space:]]|$)'
-echo "$command" | grep -qE "$commit_re" || exit 0
+# Quoted text is not a command: an issue or PR body can quote a whole command
+# line, separators and all. Blank quoted spans out before deciding, but keep the
+# original command for the path extraction below, where a quoted path is real.
+# A heredoc body is not quoted this way, so one containing a commit line still
+# costs a run; the failure mode is a slow hook, not a wrong one.
+unquoted="$(echo "$command" | sed -E "s/\"[^\"]*\"//g; s/'[^']*'//g")"
+echo "$unquoted" | grep -qE "$commit_re" || exit 0
 
 project_dir="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
 # Which working tree does this commit target? In priority order: an explicit
-# `-C <path>` / `--git-dir=<path>` on the git invocation, else a `cd` earlier in
-# the same command, else the Bash tool's own working directory from the payload,
-# else the project dir. Same derivation as worktree-guard.sh, which guards the
-# same shared checkout.
+# `-C <path>` / `--work-tree=<path>` on the git invocation, else a `cd` earlier
+# in the same command, else the Bash tool's own working directory from the
+# payload, else the project dir. `--git-dir` is deliberately not consulted: it
+# names the git directory rather than the working tree, and for a linked
+# worktree it points inside the primary checkout's `.git`, which is not a tree
+# to run hooks in.
 target=""
 if echo "$command" | grep -qE '[[:space:]]-C[[:space:]]'; then
   target="$(echo "$command" | grep -oE '[[:space:]]-C[[:space:]]+[^[:space:];&|]+' | head -n1 | sed -E 's/^[[:space:]]*-C[[:space:]]+//')"
-elif echo "$command" | grep -qE '\-\-git-dir[=[:space:]]'; then
-  target="$(echo "$command" | grep -oE '\-\-git-dir[=[:space:]][^[:space:];&|]+' | head -n1 | sed -E 's/^--git-dir[=[:space:]]//')"
+elif echo "$command" | grep -qE '\-\-work-tree[=[:space:]]'; then
+  target="$(echo "$command" | grep -oE '\-\-work-tree[=[:space:]][^[:space:];&|]+' | head -n1 | sed -E 's/^--work-tree[=[:space:]]//')"
 elif echo "$command" | grep -qE '(^|[;&|])[[:space:]]*cd[[:space:]]+'; then
   target="$(echo "$command" | grep -oE '(^|[;&|])[[:space:]]*cd[[:space:]]+[^;&|]+' | tail -n1 | sed -E 's/^[;&|]?[[:space:]]*cd[[:space:]]+//')"
 fi
@@ -60,7 +68,11 @@ fi
 # Strip surrounding quotes and whitespace, and expand a leading `~`.
 target="$(echo "$target" | sed -E "s/^[[:space:]]*['\"]?//; s/['\"]?[[:space:]]*$//")"
 case "$target" in
-  "~"|"~/"*) target="${HOME}${target#\~}" ;;
+  "~"|"~/"*)
+    # Guard HOME: `set -u` would abort on an unset one, and aborting is the one
+    # thing this hook must not do.
+    if [ -n "${HOME:-}" ]; then target="${HOME}${target#\~}"; else target=""; fi
+    ;;
   *'$'*) target="" ;;  # set in an earlier Bash call, whose state this hook cannot see
 esac
 

--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -15,99 +15,25 @@
 #    and any hook that rewrites a file (such as the OpenAPI spec) dirties another agent's work.
 #    The command text is the most reliable signal, since `cd <worktree> && git commit` leaves no trace in the payload's `cwd` once the shell's directory has been reset.
 #
-# Fails open (exit 0) rather than blocking, on any parsing problem,
-# and also when the command names a tree this hook cannot resolve:
+# Both answers come from pre_commit_target.py, which tokenises the command rather than matching it,
+# and prints the directory to run in, or nothing when there is nothing safe to run.
+# See that file for why the parsing lives in Python.
+#
+# Fails open (exit 0) rather than blocking, whenever the answer is not clear:
 # an unchecked commit is a smaller price than hooks run against the wrong checkout.
 
 set -euo pipefail
 
 payload="$(cat)"
 
-command -v jq >/dev/null 2>&1 || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
 
-command="$(echo "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
-[ -n "$command" ] || exit 0
-
-# Self-filter: only act on `git commit`.
-# Global options such as `-C <path>` or `-c foo=bar` may sit between `git` and the verb, so allow a run of option words (each optionally followed by its value) first.
-# The verb has to be followed by whitespace or the end of the command, so that `git commit-graph` is left alone.
-# And `git` has to start the command or follow a `;`, `&` or `|`, so that a command merely *mentioning* a commit does not pay for a full run.
-# The cost of that anchoring is that an oddly wrapped commit (`time git commit ...`) goes unchecked, which is the safe direction for a hook that only checks.
-commit_re='(^|[;&|])[[:space:]]*git[[:space:]]+(-[^[:space:]]*([[:space:]]+[^-[:space:];&|][^[:space:]]*)?[[:space:]]+)*commit([[:space:]]|$)'
-# Quoted text is not a command: an issue or PR body can quote a whole command line, separators and all.
-# Blank quoted spans out before deciding, but keep the original command for the path extraction below, where a quoted path is real.
-# A heredoc body is not quoted this way, so one containing a commit line still costs a run: a slow hook rather than a wrong one.
-unquoted="$(echo "$command" | sed -E "s/\"[^\"]*\"//g; s/'[^']*'//g")"
-echo "$unquoted" | grep -qE "$commit_re" || exit 0
-
-project_dir="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-
-# Which working tree does this commit target?
-# In priority order: an explicit `-C <path>` or `--work-tree=<path>` on the git invocation,
-# else a `cd` earlier in the same command,
-# else the Bash tool's own working directory from the payload,
-# else the project dir.
-# `--git-dir` is deliberately not consulted: it names the git directory rather than the working tree,
-# and for a linked worktree it points inside the primary checkout's `.git`, which is not a tree to run hooks in.
-# A path may be quoted, and a quoted path may contain spaces,
-# so the value of a flag is either a quoted run or an unquoted word.
-value_after() {
-  echo "$command" | sed -nE "s/.*$1(\"[^\"]*\"|'[^']*'|[^[:space:];&|]+).*/\1/p" | head -n1
-}
-
-# `named` records that the command pointed somewhere, resolvable or not.
-named=""
-target=""
-if echo "$command" | grep -qE '[[:space:]]-C[[:space:]]'; then
-  named="yes"
-  target="$(value_after '[[:space:]]-C[[:space:]]+')"
-elif echo "$command" | grep -qE '\-\-work-tree[=[:space:]]'; then
-  named="yes"
-  target="$(value_after '\-\-work-tree[=[:space:]]+')"
-elif echo "$command" | grep -qE '(^|[;&|])[[:space:]]*cd[[:space:]]+'; then
-  named="yes"
-  target="$(echo "$command" | grep -oE '(^|[;&|])[[:space:]]*cd[[:space:]]+[^;&|]+' | tail -n1 | sed -E 's/^[;&|]?[[:space:]]*cd[[:space:]]+//')"
-fi
-
-# Strip surrounding quotes and whitespace, and expand a leading `~`.
-target="$(echo "$target" | sed -E "s/^[[:space:]]*['\"]?//; s/['\"]?[[:space:]]*$//")"
-case "$target" in
-  "~"|"~/"*)
-    # Guard HOME: `set -u` would abort on an unset one,
-    # and aborting is the one thing this hook must not do.
-    if [ -n "${HOME:-}" ]; then target="${HOME}${target#\~}"; else target=""; fi
-    ;;
-  *'$'*) target="" ;;  # set in an earlier Bash call, whose state this hook cannot see
-esac
-
-# Resolve to the root of whichever checkout the target names,
-# so the hooks see the whole working tree.
-# A linked worktree resolves to its own root, rather than to the primary checkout.
-if [ -n "$named" ]; then
-  # The command pointed somewhere. If that path cannot be resolved to a checkout,
-  # because it was built from a variable set in an earlier Bash call,
-  # or because it is not a checkout at all, then skip rather than guess:
-  # running the hooks in some other tree would check the wrong files,
-  # and any hook that rewrites one would rewrite it there.
-  if [ -z "$target" ] || ! root="$(git -C "$target" rev-parse --show-toplevel 2>/dev/null)"; then
-    exit 0
-  fi
-  target="$root"
-else
-  # Nothing was named, so the Bash tool's own working directory is the best guess,
-  # and the project dir after that.
-  cwd="$(echo "$payload" | jq -r '.cwd // empty' 2>/dev/null || true)"
-  target="${cwd:-$project_dir}"
-  if root="$(git -C "$target" rev-parse --show-toplevel 2>/dev/null)"; then
-    target="$root"
-  else
-    target="$project_dir"
-  fi
-fi
+target="$(printf '%s' "$payload" | python3 "$(dirname "${BASH_SOURCE[0]}")/pre_commit_target.py" 2>/dev/null || true)"
+[ -n "$target" ] || exit 0
 
 if ! output=$(cd "$target" && uv run pre-commit run --all-files 2>&1); then
-  echo "pre-commit failed in $target — fix the issues below before committing:" >&2
-  echo "$output" >&2
-  exit 2
+    echo "pre-commit failed in $target — fix the issues below before committing:" >&2
+    echo "$output" >&2
+    exit 2
 fi
 exit 0

--- a/.claude/hooks/pre_commit_target.py
+++ b/.claude/hooks/pre_commit_target.py
@@ -2,15 +2,17 @@
 """Work out which working tree the `git commit` in a Bash command targets.
 
 Reads a Claude Code PreToolUse payload on stdin.
-Prints the root of the tree to run the hooks in, and prints nothing at all when the command is not a
-commit, or when it names a tree that cannot be resolved from here.
+Prints the root of the tree to run the hooks in,
+and prints nothing at all when the command is not a commit,
+or when it names a tree that cannot be resolved from here.
 
 The command is tokenised with `shlex`, so quoting and escaping are read the way a shell reads them.
-Earlier versions of this hook matched the command with regular expressions, and each round of review
-turned up another string that fooled them: a quoted body holding `&& git commit`, an escaped quote
-inside such a body, a path with a space in it, a second `-C` later in the line.
-Tokenising removes that whole class of mistake, because quoted text arrives as one token and cannot
-look like a command.
+Earlier versions of this hook matched the command with regular expressions,
+and each round of review turned up another string that fooled them:
+a quoted body holding `&& git commit`, an escaped quote inside such a body,
+a path with a space in it, a second `-C` later in the line.
+Tokenising removes that whole class of mistake,
+because quoted text arrives as one token and cannot look like a command.
 """
 
 from __future__ import annotations
@@ -75,10 +77,11 @@ def _verb_and_options(tokens: list[str]) -> tuple[str | None, dict[str, str]]:
 def target_directory(command: str, cwd: str) -> str | None:
     """The directory whose hooks should run for this command, or None to run none.
 
-    None means either that the command does not commit, or that it points at a tree this process
-    cannot resolve: a path built from a shell variable set in an earlier call, or one that is not a
-    checkout. Running the hooks somewhere else would check the wrong files, and any hook that
-    rewrites one would rewrite it there, so nothing is the right answer.
+    None means either that the command does not commit,
+    or that it points at a tree this process cannot resolve:
+    a path built from a shell variable set in an earlier call, or one that is not a checkout.
+    Running the hooks somewhere else would check the wrong files,
+    and any hook that rewrites one would rewrite it there, so nothing is the right answer.
     """
     try:
         tokens = shlex.split(command)
@@ -95,8 +98,8 @@ def target_directory(command: str, cwd: str) -> str | None:
         verb, options = _verb_and_options(segment)
         if verb == "commit":
             committing = True
-            # `--git-dir` is deliberately ignored: it names the git directory rather than the
-            # working tree, and for a linked worktree it points inside the primary checkout.
+            # `--git-dir` is deliberately ignored: it names the git directory rather than the working tree,
+            # and for a linked worktree it points inside the primary checkout.
             named = options.get("-C") or options.get("--work-tree")
             break
     if not committing:

--- a/.claude/hooks/pre_commit_target.py
+++ b/.claude/hooks/pre_commit_target.py
@@ -88,12 +88,16 @@ def target_directory(command: str, cwd: str) -> str | None:
     except ValueError:
         return None  # unbalanced quotes: not something to guess at
 
+    # Paths compose, so follow the shell: each `cd` moves a running base,
+    # and a relative path is measured from wherever the previous one landed.
+    base = cwd
+    moved = False
     named: str | None = None
-    latest_cd: str | None = None
     committing = False
     for segment in segments(tokens):
         if segment and segment[0] == "cd" and len(segment) > 1:
-            latest_cd = segment[1]
+            base = _resolve(base, segment[1])
+            moved = True
             continue
         verb, options = _verb_and_options(segment)
         if verb == "commit":
@@ -105,11 +109,23 @@ def target_directory(command: str, cwd: str) -> str | None:
     if not committing:
         return None
 
-    if named or latest_cd:
-        return _toplevel(os.path.join(cwd, named or latest_cd or ""))
+    if named:
+        return _toplevel(_resolve(base, named))
+    if moved:
+        return _toplevel(base)
     # Nothing was named, so the Bash tool's own working directory is the best guess,
     # and the project directory after that.
     return _toplevel(cwd) or os.environ.get("CLAUDE_PROJECT_DIR") or None
+
+
+def _resolve(base: str, path: str) -> str:
+    """`path` as seen from `base`, the way the shell would see it.
+
+    A `~` is expanded, since the shell would have expanded it before git ever saw it.
+    A `$VAR` is left alone, and will simply not be a checkout: this process cannot see the variables
+    of a shell that ran in an earlier call, and guessing is worse than skipping the check.
+    """
+    return os.path.normpath(os.path.join(base, os.path.expanduser(path)))
 
 
 def _toplevel(path: str) -> str | None:

--- a/.claude/hooks/pre_commit_target.py
+++ b/.claude/hooks/pre_commit_target.py
@@ -122,8 +122,9 @@ def _resolve(base: str, path: str) -> str:
     """`path` as seen from `base`, the way the shell would see it.
 
     A `~` is expanded, since the shell would have expanded it before git ever saw it.
-    A `$VAR` is left alone, and will simply not be a checkout: this process cannot see the variables
-    of a shell that ran in an earlier call, and guessing is worse than skipping the check.
+    A `$VAR` is left alone, and will simply not be a checkout:
+    this process cannot see the variables of a shell that ran in an earlier call,
+    and guessing is worse than skipping the check.
     """
     return os.path.normpath(os.path.join(base, os.path.expanduser(path)))
 

--- a/.claude/hooks/pre_commit_target.py
+++ b/.claude/hooks/pre_commit_target.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Work out which working tree the `git commit` in a Bash command targets.
+
+Reads a Claude Code PreToolUse payload on stdin.
+Prints the root of the tree to run the hooks in, and prints nothing at all when the command is not a
+commit, or when it names a tree that cannot be resolved from here.
+
+The command is tokenised with `shlex`, so quoting and escaping are read the way a shell reads them.
+Earlier versions of this hook matched the command with regular expressions, and each round of review
+turned up another string that fooled them: a quoted body holding `&& git commit`, an escaped quote
+inside such a body, a path with a space in it, a second `-C` later in the line.
+Tokenising removes that whole class of mistake, because quoted text arrives as one token and cannot
+look like a command.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+
+#: Tokens that end one command and start the next.
+SEPARATORS = {"&&", "||", ";", "|", "&"}
+
+#: Git's own options which take their value as the following token.
+#: A `--flag=value` spelling carries its value with it, so it needs no entry here.
+VALUE_OPTIONS = {
+    "-C",
+    "-c",
+    "--git-dir",
+    "--work-tree",
+    "--namespace",
+    "--super-prefix",
+    "--config-env",
+    "--exec-path",
+}
+
+
+def segments(tokens: list[str]) -> list[list[str]]:
+    """Split a token list into the separate commands it holds."""
+    found: list[list[str]] = [[]]
+    for token in tokens:
+        if token in SEPARATORS:
+            found.append([])
+        else:
+            found[-1].append(token)
+    return found
+
+
+def _verb_and_options(tokens: list[str]) -> tuple[str | None, dict[str, str]]:
+    """The git subcommand a segment invokes, and the values of git's own options before it.
+
+    Returns `(None, {})` for anything that is not a git invocation.
+    """
+    if not tokens or os.path.basename(tokens[0]) != "git":
+        return None, {}
+    options: dict[str, str] = {}
+    index = 1
+    while index < len(tokens):
+        token = tokens[index]
+        if not token.startswith("-"):
+            return token, options
+        name, _, inline_value = token.partition("=")
+        if inline_value:
+            options[name] = inline_value
+        elif name in VALUE_OPTIONS and index + 1 < len(tokens):
+            index += 1
+            options[name] = tokens[index]
+        index += 1
+    return None, options
+
+
+def target_directory(command: str, cwd: str) -> str | None:
+    """The directory whose hooks should run for this command, or None to run none.
+
+    None means either that the command does not commit, or that it points at a tree this process
+    cannot resolve: a path built from a shell variable set in an earlier call, or one that is not a
+    checkout. Running the hooks somewhere else would check the wrong files, and any hook that
+    rewrites one would rewrite it there, so nothing is the right answer.
+    """
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return None  # unbalanced quotes: not something to guess at
+
+    named: str | None = None
+    latest_cd: str | None = None
+    committing = False
+    for segment in segments(tokens):
+        if segment and segment[0] == "cd" and len(segment) > 1:
+            latest_cd = segment[1]
+            continue
+        verb, options = _verb_and_options(segment)
+        if verb == "commit":
+            committing = True
+            # `--git-dir` is deliberately ignored: it names the git directory rather than the
+            # working tree, and for a linked worktree it points inside the primary checkout.
+            named = options.get("-C") or options.get("--work-tree")
+            break
+    if not committing:
+        return None
+
+    if named or latest_cd:
+        return _toplevel(os.path.join(cwd, named or latest_cd or ""))
+    # Nothing was named, so the Bash tool's own working directory is the best guess,
+    # and the project directory after that.
+    return _toplevel(cwd) or os.environ.get("CLAUDE_PROJECT_DIR") or None
+
+
+def _toplevel(path: str) -> str | None:
+    """The root of the checkout containing `path`, or None if it is not in one."""
+    try:
+        finished = subprocess.run(
+            ["git", "-C", path, "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if finished.returncode != 0:
+        return None
+    return finished.stdout.strip() or None
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (ValueError, OSError):
+        return 0  # never block a commit over a payload this hook cannot read
+    command = (payload.get("tool_input") or {}).get("command") or ""
+    cwd = payload.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+    target = target_directory(command, cwd)
+    if target:
+        print(target)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

`.claude/hooks/pre-commit-check.sh` runs `pre-commit` before a `git commit` and blocks the commit if
it fails. It got two things wrong, both because a PreToolUse hook runs in the project directory and
does not share the Bash tool's shell state.

**It ran in the wrong working tree.** The script never read its payload; it ran wherever the hook
process happened to start, which is always the primary checkout. Committing from a `git worktree`
therefore checked the wrong tree — and worse, a hook that rewrites files rewrote them over there. In
the case that prompted this, regenerating the OpenAPI spec left a stray `version` change in the
primary checkout while another agent had unrelated uncommitted work in it.

It now works out which tree the command targets, in the same priority order `worktree-guard.sh`
already uses for the same shared checkout: an explicit `-C <path>` (or `--git-dir=`), else a `cd`
earlier in the same command, else the working directory from the payload, else the project directory.
Whatever it lands on is resolved with `git rev-parse --show-toplevel`, so a linked worktree resolves
to its own root.

Reading the path out of the command text is the part that matters in practice. The shell's working
directory is reset between Bash calls, so `cd <worktree> && git commit ...` reports the *primary*
checkout in the payload's `cwd`; only the command text says where the commit is really going.

**It ran on commands that were not commits.** It is registered with `"if": "Bash(git commit:*)"`, but
that settings-level matcher is not honoured by every Claude Code version — `worktree-guard.sh` says
as much in a comment and repeats its filter in the script. This one did not, so an unrelated command
paid for a full `pre-commit run --all-files`: it fired on a `gh issue create`, which is how the stray
spec change happened in the first place.

The filter now lives in the script too, anchored so that `git commit-graph` and a command that merely
quotes `git commit` in an issue or PR body are left alone. The cost of anchoring is that an oddly
wrapped commit (`time git commit ...`) goes unchecked, which is the safe direction for a hook that
only checks.

## How to test

The hook is not covered by the test suite, so it was exercised by feeding it payloads directly. With
a deliberate lint error planted in the target worktree, the failure message names the directory the
hooks ran in:

| Payload | Expected | Result |
| --- | --- | --- |
| `cd <worktree> && git commit`, `cwd` = primary checkout | runs in the worktree | ✅ `pre-commit failed in .../fm-wt-hooks` |
| `git -C <worktree> commit` | runs in the worktree | ✅ same |
| `git commit`, `cwd` = worktree | runs in the worktree | ✅ same |
| `git commit`, `cwd` = `/tmp` (not a repo) | falls back to the project dir | ✅ ran in `$CLAUDE_PROJECT_DIR` |
| `git -c user.name=x commit` | still recognised as a commit | ✅ ran |
| `git commit-graph write` | skipped | ✅ exit 0 |
| `gh issue create --body "run git commit -s to sign off"` | skipped | ✅ exit 0, 8 ms instead of ~40 s |
| `git commit` on a clean worktree | allowed | ✅ exit 0 |

Afterwards the primary checkout was confirmed to hold only the other agent's own uncommitted work,
with no spec change left behind.

## Related items

Fallout from the review of #2472, where the hook fired on a `gh issue create` and regenerated
`flexmeasures/ui/static/openapi-specs.json` in the shared primary checkout.

---

#### Sign-off

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another incompatible license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtMZ49GH6LaiY5MdgtfNe2
