### PR TITLE
Run a job once, on its own queue, in flexmeasures jobs run-job

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -39,6 +39,7 @@ Bugfixes
 * The time range sent when loading an asset's KPIs was off by the viewer's UTC offset, so KPIs could cover the wrong days [see `PR #2435 <https://www.github.com/FlexMeasures/flexmeasures/pull/2435>`_]
 * Avoid crashing on startup when the database is stamped with an Alembic revision unknown to this FlexMeasures checkout [see `PR #2465 <https://www.github.com/FlexMeasures/flexmeasures/pull/2465>`_]
 * The "module not installed" error for an unresolved ``FLEXMEASURES_PLUGINS`` entry now hints at the expected comma-separated format, which helps people who accidentally use an incorrect format like a JSON-array [see `PR #2473 <https://www.github.com/FlexMeasures/flexmeasures/pull/2473>`_]
+* ``flexmeasures jobs run-job`` ran each job twice, and always as if it were a scheduling job, which lost the queue-specific reporting of why a job failed [see `PR #2480 <https://www.github.com/FlexMeasures/flexmeasures/pull/2480>`_]
 
 
 

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -8,6 +8,7 @@ since v1.1.0 | September XX, 2026
 =================================
 
 * Add ``flexmeasures add report --as-job`` and the ``reporting`` worker queue for asynchronous one-off reports.
+* ``flexmeasures jobs run-job`` now performs the job exactly once (it used to perform it a second time, outside the job timeout, repeating any side effects), on the queue the job belongs to, so that the queue's own exception handler records why a job failed and the job's registries are updated on that queue.
 
 since v1.0.0 | August 11, 2026
 =================================

--- a/flexmeasures/cli/jobs.py
+++ b/flexmeasures/cli/jobs.py
@@ -10,7 +10,7 @@ import string
 import sys
 from datetime import datetime, timedelta
 from types import TracebackType
-from typing import Type
+from typing import Callable, Type
 
 import click
 from flask import current_app as app
@@ -57,6 +57,12 @@ REGISTRY_MAP = dict(
     finished=FinishedJobRegistry,
     started=StartedJobRegistry,
     scheduled=ScheduledJobRegistry,
+)
+
+# Queues with an exception handler of their own; jobs on other queues use handle_worker_exception.
+QUEUE_EXCEPTION_HANDLERS = dict(
+    scheduling=handle_scheduling_exception,
+    forecasting=handle_forecasting_exception,
 )
 
 
@@ -404,15 +410,30 @@ def _estimate_service_time(
 )
 def run_job(job_id: str):
     """
-    Run a single job.
+    Run a single job, on the queue it was enqueued to.
 
     We use the app context to find out which redis queues to use.
+    The job is performed once, by a worker on the job's own queue,
+    so that the queue's exception handler applies and the job's registries are updated on that same queue.
     """
-    connection = app.queues["scheduling"].connection
-    job = Job.fetch(job_id, connection=connection)
-    work_on_rq(app.queues["scheduling"], exc_handler=handle_worker_exception, job=job)
-    result = job.perform()
-    click.echo(f"Job {job_id} finished with: {result}")
+    try:
+        job = Job.fetch(job_id, connection=app.redis_connection)
+    except NoSuchJobError:
+        click.secho(f"Job {job_id} not found.", **MsgStyle.ERROR)
+        raise click.Abort()
+
+    try:
+        queue = parse_queue_list(job.origin)[0]
+    except ValueError as e:
+        click.secho(
+            f"{e} Job {job_id} belongs to a queue that FlexMeasures is not configured with. Available queues: {join_words_into_a_list(list(app.queues.keys()))}",
+            **MsgStyle.ERROR,
+        )
+        raise click.Abort()
+
+    # The worker performs the job, records its outcome and hands failures to the queue's exception handler.
+    work_on_rq(queue, exc_handler=get_exception_handler(job.origin), job=job)
+    click.echo(f"Job {job_id} finished with: {job.return_value(refresh=True)}")
 
 
 @fm_jobs.command("inspect-job")
@@ -527,11 +548,7 @@ def run_worker(queue: str, name: str | None, with_scheduler: bool):
     while used_name in worker_names:
         used_name = f"{name}-{next(name_suffixes)}"
 
-    error_handler = handle_worker_exception
-    if queue == "scheduling":
-        error_handler = handle_scheduling_exception
-    elif queue == "forecasting":
-        error_handler = handle_forecasting_exception
+    error_handler = get_exception_handler(queue)
 
     # On macOS: RQ's fork-based Worker triggers a known OpenSSL/psycopg2
     # segmentation fault due to reinitialization of SSL state in forked children.
@@ -862,6 +879,17 @@ def handle_worker_exception(
     click.echo(f"HANDLING RQ {queue_name.upper()} EXCEPTION: {exc_type}: {exc_value}")
     job.meta["exception"] = str(exc_value)  # meta must contain JSON serializable data
     job.save_meta()
+
+
+def get_exception_handler(queue_name: str) -> Callable:
+    """Look up the exception handler to use for jobs on a given queue.
+
+    Queues without a handler of their own fall back to the generic handler.
+
+    :param queue_name: the name of a single queue, e.g. 'forecasting'
+    :returns:          an RQ exception handler.
+    """
+    return QUEUE_EXCEPTION_HANDLERS.get(queue_name, handle_worker_exception)
 
 
 def parse_queue_list(queue_names_str: str) -> list[Queue]:

--- a/flexmeasures/cli/jobs.py
+++ b/flexmeasures/cli/jobs.py
@@ -886,7 +886,7 @@ def get_exception_handler(queue_name: str) -> Callable:
 
     Queues without a handler of their own fall back to the generic handler.
 
-    :param queue_name: the name of a single queue, e.g. 'forecasting'
+    :param queue_name: the name of a single queue, e.g. 'forecasting'.
     :returns:          an RQ exception handler.
     """
     return QUEUE_EXCEPTION_HANDLERS.get(queue_name, handle_worker_exception)

--- a/flexmeasures/cli/tests/test_jobs.py
+++ b/flexmeasures/cli/tests/test_jobs.py
@@ -70,3 +70,93 @@ def test_inspect_job_error_when_job_not_found(app):
     )
     assert result.exit_code != 0
     assert "not found" in result.output.lower()
+
+
+CALLS: list[str] = []
+
+
+def record_call() -> int:
+    """Record that this function ran, and return how often it ran so far.
+
+    Used to count how often a job's function is performed.
+    """
+    CALLS.append("called")
+    return len(CALLS)
+
+
+@pytest.fixture
+def clean_call_record():
+    CALLS.clear()
+    yield
+    CALLS.clear()
+
+
+def test_run_job_performs_the_job_exactly_once(app, clean_job_redis, clean_call_record):
+    """The job's function should run once, and its result should be reported."""
+    from flexmeasures.cli.jobs import fm_jobs
+
+    runner = app.test_cli_runner()
+
+    with app.app_context():
+        job = app.queues["scheduling"].enqueue(record_call)
+
+    result = runner.invoke(fm_jobs, ["run-job", "--job", job.id])
+    assert result.exit_code == 0, result.output
+
+    assert CALLS == ["called"], f"Job function ran {len(CALLS)} time(s)."
+    assert f"Job {job.id} finished with: 1" in result.output
+
+
+def test_run_job_uses_the_queue_the_job_belongs_to(app, clean_job_redis):
+    """A failing forecasting job should be handled by the forecasting queue's exception handler.
+
+    That handler stores a dict in the job's meta, whereas the generic fallback handler stores a plain string.
+    """
+    from flexmeasures.cli.jobs import fm_jobs
+    from rq.job import Job
+
+    runner = app.test_cli_runner()
+
+    with app.app_context():
+        job = app.queues["forecasting"].enqueue("math.sqrt", -1)
+
+    result = runner.invoke(fm_jobs, ["run-job", "--job", job.id])
+    assert result.exit_code == 0, result.output
+
+    with app.app_context():
+        job = Job.fetch(job.id, connection=app.redis_connection)
+        assert job.is_failed
+        exception = job.meta["exception"]
+        assert isinstance(
+            exception, dict
+        ), f"Expected the forecasting queue's exception handler to store a dict, got: {exception!r}"
+        assert exception["type"] == "ValueError"
+        assert job.id in app.queues["forecasting"].failed_job_registry.get_job_ids()
+
+
+def test_run_job_errors_on_a_queue_flexmeasures_does_not_have(app, clean_job_redis):
+    """A job on an unknown queue should lead to a clear CLI error, rather than a traceback."""
+    from flexmeasures.cli.jobs import fm_jobs
+    from rq import Queue
+
+    runner = app.test_cli_runner()
+
+    with app.app_context():
+        job = Queue("some-other-queue", connection=app.redis_connection).enqueue(
+            sum, [1, 2]
+        )
+
+    result = runner.invoke(fm_jobs, ["run-job", "--job", job.id])
+    assert result.exit_code != 0
+    assert "Unknown queue 'some-other-queue'." in result.output
+
+
+def test_run_job_errors_on_a_missing_job(app, clean_job_redis):
+    from flexmeasures.cli.jobs import fm_jobs
+
+    runner = app.test_cli_runner()
+    result = runner.invoke(
+        fm_jobs, ["run-job", "--job", "00000000-0000-0000-0000-000000000000"]
+    )
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()


### PR DESCRIPTION
## Description

`flexmeasures jobs run-job` performed each job **twice**, and always on the `scheduling` queue.

- `work_on_rq(..., job=job)` already performs the job (it builds a `SimpleWorker` and calls `worker.perform_job(job, queue)`), and the command then called `job.perform()` again. For an expensive job (e.g. forecasting) that doubles the work, re-applies side effects (a forecasting job saves its forecasts to the database a second time), and the second run is not wrapped in RQ's death penalty, so it is not bounded by the job timeout.
- The worker was always taken from the hardcoded `scheduling` queue with the generic `handle_worker_exception` fallback. A forecasting job that failed therefore recorded `meta["exception"]` as a bare string instead of the dict (with an actionable `hint` on timeouts) that `handle_forecasting_exception` writes, and its started/finished/failed registries landed on the wrong queue.

Changes:

- [x] Resolve the job's own queue from `job.origin` (via the existing `parse_queue_list`), and let a worker on that queue perform the job exactly once.
- [x] Report the outcome with `job.return_value(refresh=True)` instead of performing the job a second time.
- [x] Extract the queue-to-exception-handler lookup that `jobs run-worker` had inline into `get_exception_handler`, and use it from both commands.
- [x] Abort with a clear CLI message when the job does not exist, or belongs to a queue this FlexMeasures instance is not configured with, instead of raising a traceback.
- [x] Added changelog item in `documentation/changelog.rst` (and `documentation/cli/change_log.rst`)

## Look & Feel

```
$ flexmeasures jobs run-job --job <id of a job on an unknown queue>
Unknown queue 'some-other-queue'. Job <id> belongs to a queue that FlexMeasures is not configured with. Available queues: forecasting, scheduling, ingestion and reporting
Aborted!
```

## How to test

`pytest flexmeasures/cli/tests/test_jobs.py`

New tests:

- `test_run_job_performs_the_job_exactly_once` — enqueues a job whose function appends to a module-level list, and asserts the list has exactly one entry, plus that the reported result is the job's return value.
- `test_run_job_uses_the_queue_the_job_belongs_to` — a failing job on the `forecasting` queue must get the forecasting handler's dict in `job.meta["exception"]` (the fallback handler writes a plain string), and must land in the forecasting queue's failed registry.
- `test_run_job_errors_on_a_queue_flexmeasures_does_not_have` and `test_run_job_errors_on_a_missing_job` — clear CLI errors.

**Proving the tests can fail:** all four new tests were run against the old implementation (production change stashed, tests kept). `test_run_job_performs_the_job_exactly_once` went red with `AssertionError: Job function ran 2 time(s). assert ['called', 'called'] == ['called']`, and the other three failed too (the old code re-raised `ValueError: math domain error` from the second `job.perform()`, and raised `NoSuchJobError` / `redis` errors instead of a clean abort). With the fix in place, all 170 tests in `flexmeasures/cli/tests/` pass.

## Further Improvements

...

## Related Items

...

---

#### Sign-off

- [x] I agree to contribute to the project under Apache 2 License. 
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeRZd2nDDShZTE8ZmbERzn
