### PR TITLE
Add a --dry-run flag to `flexmeasures add forecasts`, and stop `add schedule --dry-run` from saving

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -35,6 +35,7 @@ Infrastructure / Support
 Bugfixes
 -----------
 
+* ``flexmeasures add schedule --dry-run`` no longer saves a schedule when it is combined with ``--as-job``, where the flag used to be dropped without a word and the queued job stored its schedule anyway; that combination is now rejected, and a dry run says how many beliefs it would have saved and which events they cover [see `PR #2483 <https://www.github.com/FlexMeasures/flexmeasures/pull/2483>`_]
 * Upgrading a database old enough to still carry the pre-``GenericAsset``/``Sensor`` tables now works, where the v0.18.0 migration that removes them crashed twice over: once while checking whether those tables hold data, as soon as one of them held more than a single row, and once while dropping them, because it dropped each table before the ones referencing it [see `PR #2475 <https://www.github.com/FlexMeasures/flexmeasures/pull/2475>`_]
 * Sensor data ingestion now preserves ``null`` gaps when converting posted values to the sensor's unit, instead of failing the request [see `PR #2461 <https://www.github.com/FlexMeasures/flexmeasures/pull/2461>`_]
 * KPIs on the asset page counted one day more than the selected time range [see `PR #2434 <https://www.github.com/FlexMeasures/flexmeasures/pull/2434>`_]

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -17,6 +17,7 @@ v1.1.0 | September XX, 2026
 New features
 -------------
 
+* Try out a forecast without recording it, using ``flexmeasures add forecasts --dry-run``, which computes the forecast in full and reports the sensor, data source, number of beliefs and event range it would have saved [see `PR #2483 <https://www.github.com/FlexMeasures/flexmeasures/pull/2483>`_]
 * Run one-off reports as background jobs from the CLI or the asset API, with sensor-level authorization and a dedicated reporting worker queue [see `PR #2298 <https://github.com/FlexMeasures/flexmeasures/pull/2298>`_]
 * A single automation can now be run on demand, from the CLI (``flexmeasures jobs run-automation``), the API (``POST /assets/<id>/automations/<automation_id>/trigger``) and the asset's *Automations* page (a *Run now* button), which is useful to try out a new automation, to re-run one after fixing what made it fail, or to refresh its results after late input data arrived [see `PR #2460 <https://www.github.com/FlexMeasures/flexmeasures/pull/2460>`_]
 * Changing the selected time range on an asset or sensor chart now only loads the data that is actually new, instead of reloading the whole range, which makes stepping through or extending a long period much faster; reloading the page, or leaving it open for five minutes, still fetches everything afresh [see `PR #2433 <https://www.github.com/FlexMeasures/flexmeasures/pull/2433>`_]

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -7,7 +7,7 @@ FlexMeasures CLI Changelog
 since v1.1.0 | September XX, 2026
 =================================
 
-* Add ``flexmeasures add forecasts --dry-run``, to compute a forecast and see what it would record, without saving anything to the database. It cannot be combined with ``--as-job``.
+* Add ``flexmeasures add forecasts --dry-run`` to compute a forecast and see what it would record, without saving anything to the database. It cannot be combined with ``--as-job``.
 * Add ``flexmeasures add report --as-job`` and the ``reporting`` worker queue for asynchronous one-off reports.
 * ``flexmeasures jobs run-job`` now performs the job exactly once (it used to perform it a second time, outside the job timeout, repeating any side effects), on the queue the job belongs to, so that the queue's own exception handler records why a job failed and the job's registries are updated on that queue.
 

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -7,6 +7,7 @@ FlexMeasures CLI Changelog
 since v1.1.0 | September XX, 2026
 =================================
 
+* Fix ``flexmeasures add schedule --dry-run`` saving a schedule when combined with ``--as-job``: the combination is now rejected, and a dry run reports the beliefs and events it would have saved.
 * Add ``flexmeasures add forecasts --dry-run`` to compute a forecast and see what it would record, without saving anything to the database. It cannot be combined with ``--as-job``.
 * Add ``flexmeasures add report --as-job`` and the ``reporting`` worker queue for asynchronous one-off reports.
 * ``flexmeasures jobs run-job`` now performs the job exactly once (it used to perform it a second time, outside the job timeout, repeating any side effects), on the queue the job belongs to, so that the queue's own exception handler records why a job failed and the job's registries are updated on that queue.

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -7,6 +7,7 @@ FlexMeasures CLI Changelog
 since v1.1.0 | September XX, 2026
 =================================
 
+* Add ``flexmeasures add forecasts --dry-run``, to compute a forecast and see what it would record, without saving anything to the database. It cannot be combined with ``--as-job``.
 * Add ``flexmeasures add report --as-job`` and the ``reporting`` worker queue for asynchronous one-off reports.
 * ``flexmeasures jobs run-job`` now performs the job exactly once (it used to perform it a second time, outside the job timeout, repeating any side effects), on the queue the job belongs to, so that the queue's own exception handler records why a job failed and the job's registries are updated on that queue.
 

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -1942,7 +1942,11 @@ class SensorAPI(FlaskView):
     @use_args(
         ForecastingTriggerSchema(
             # partial=True,
-            exclude=EXCLUDED_FORECASTING_FIELDS,
+            # The API always queues a job, whose results only make sense when they are recorded,
+            # so dry runs are supported on the CLI only.
+            # Note that dry-run is already left out of the OpenAPI schema, being a CLI-exclusive field.
+            exclude=EXCLUDED_FORECASTING_FIELDS
+            + ["dry_run"],
         ),
         location="combined_sensor_data_description",
         as_kwargs=True,

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -105,6 +105,7 @@ from flexmeasures.data.services.data_sources import (
 )
 from flexmeasures.data.services.utils import get_or_create_model
 from flexmeasures.utils import flexmeasures_inflection
+from flexmeasures.utils.flexmeasures_inflection import pluralize
 from flexmeasures.utils.time_utils import server_now, apply_offset_chain
 from flexmeasures.utils.unit_utils import convert_units, ur
 from flexmeasures.cli.utils import (
@@ -1685,7 +1686,8 @@ def add_forecast(  # noqa: C901
             )
             click.secho(
                 f"Not saving forecasts to the database (because of --dry-run), but this is what I computed:"
-                f"\n{total_beliefs} forecast beliefs across {len(unique_belief_times)} unique belief times,"
+                f"\n{pluralize('forecast belief', total_beliefs, include_count=True)}"
+                f" across {pluralize('unique belief time', len(unique_belief_times), include_count=True)},"
                 f"{event_range}"
                 f" for sensor `{sensor_to_save}` (ID {sensor_to_save.id}),"
                 f" to be recorded under data source `{forecaster.data_source}` (ID {forecaster.data_source.id}).",
@@ -1696,7 +1698,8 @@ def add_forecast(  # noqa: C901
             return
 
         click.secho(
-            f"Successfully created {total_beliefs} forecast beliefs across {len(unique_belief_times)} unique belief times.",
+            f"Successfully created {pluralize('forecast belief', total_beliefs, include_count=True)}"
+            f" across {pluralize('unique belief time', len(unique_belief_times), include_count=True)}.",
             **MsgStyle.SUCCESS,
         )
 

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -1602,16 +1602,6 @@ def add_forecast(  # noqa: C901
         does not grow.
     """
 
-    dry_run = kwargs.get("dry_run", False)
-    if as_job and dry_run:
-        click.secho(
-            "The --as-job flag cannot be combined with --dry-run:"
-            " a queued job runs on a worker, where the forecast that a dry run computes would be discarded unseen."
-            " Drop --as-job to compute the forecast here.",
-            **MsgStyle.ERROR,
-        )
-        raise click.Abort()
-
     # Deprecation warnings for CLI options specific to rolling viewpoint predictions
     if kwargs.get("horizon") is not None:
         click.secho(
@@ -1634,6 +1624,18 @@ def add_forecast(  # noqa: C901
         edit_config,
         edit_parameters,
     )
+
+    # Read the flag from the assembled parameters, so that it counts however it was supplied:
+    # as the --dry-run option, or through the --parameters file or the --edit-parameters editor.
+    dry_run = parameters.get("dry-run", False)
+    if as_job and dry_run:
+        click.secho(
+            "The --as-job flag cannot be combined with --dry-run:"
+            " a queued job runs on a worker, where the forecast that a dry run computes would be discarded unseen."
+            " Drop --as-job to compute the forecast here.",
+            **MsgStyle.ERROR,
+        )
+        raise click.Abort()
 
     try:
         forecaster = get_data_generator(

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -1673,18 +1673,22 @@ def add_forecast(  # noqa: C901
         }
         if dry_run:
             sensor_to_save = forecaster.output_sensors[0]
-            first_event_start = min(
-                item["data"].event_starts.min() for item in pipeline_returns
-            )
-            last_event_end = max(
-                item["data"].event_ends.max() for item in pipeline_returns
+            # Only frames with beliefs have an event range; without any, we still report the rest.
+            frames_with_beliefs = [
+                item["data"] for item in pipeline_returns if not item["data"].empty
+            ]
+            event_range = (
+                f" covering events from {min(data.event_starts.min() for data in frames_with_beliefs)}"
+                f" until {max(data.event_ends.max() for data in frames_with_beliefs)},"
+                if frames_with_beliefs
+                else ""
             )
             click.secho(
                 f"Not saving forecasts to the database (because of --dry-run), but this is what I computed:"
                 f"\n{total_beliefs} forecast beliefs across {len(unique_belief_times)} unique belief times,"
+                f"{event_range}"
                 f" for sensor `{sensor_to_save}` (ID {sensor_to_save.id}),"
-                f" to be recorded under data source `{forecaster.data_source}` (ID {forecaster.data_source.id}),"
-                f" covering events from {first_event_start} until {last_event_end}.",
+                f" to be recorded under data source `{forecaster.data_source}` (ID {forecaster.data_source.id}).",
                 **MsgStyle.SUCCESS,
             )
             for item in pipeline_returns:

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -1589,6 +1589,7 @@ def add_forecast(  # noqa: C901
       - Prediction window: defaults from CLI execution time until --to-date.
       - max-forecast-horizon: defaults to the length of the prediction window.
       - Forecasts are computed immediately; use --as-job to enqueue them.
+      - Forecasts are saved to the database; use --dry-run to compute them without saving.
       - Sensor 2093 is used as a regressor in this example.
 
     \b
@@ -1600,6 +1601,16 @@ def add_forecast(  # noqa: C901
         forecast period each cycle, similar to the training window, but its size
         does not grow.
     """
+
+    dry_run = kwargs.get("dry_run", False)
+    if as_job and dry_run:
+        click.secho(
+            "The --as-job flag cannot be combined with --dry-run:"
+            " a queued job runs on a worker, where the forecast that a dry run computes would be discarded unseen."
+            " Drop --as-job to compute the forecast here.",
+            **MsgStyle.ERROR,
+        )
+        raise click.Abort()
 
     # Deprecation warnings for CLI options specific to rolling viewpoint predictions
     if kwargs.get("horizon") is not None:
@@ -1658,6 +1669,26 @@ def add_forecast(  # noqa: C901
         unique_belief_times = {
             ts for item in pipeline_returns for ts in item["data"].belief_times.unique()
         }
+        if dry_run:
+            sensor_to_save = forecaster.output_sensors[0]
+            first_event_start = min(
+                item["data"].event_starts.min() for item in pipeline_returns
+            )
+            last_event_end = max(
+                item["data"].event_ends.max() for item in pipeline_returns
+            )
+            click.secho(
+                f"Not saving forecasts to the database (because of --dry-run), but this is what I computed:"
+                f"\n{total_beliefs} forecast beliefs across {len(unique_belief_times)} unique belief times,"
+                f" for sensor `{sensor_to_save}` (ID {sensor_to_save.id}),"
+                f" to be recorded under data source `{forecaster.data_source}` (ID {forecaster.data_source.id}),"
+                f" covering events from {first_event_start} until {last_event_end}.",
+                **MsgStyle.SUCCESS,
+            )
+            for item in pipeline_returns:
+                click.echo(item["data"])
+            return
+
         click.secho(
             f"Successfully created {total_beliefs} forecast beliefs across {len(unique_belief_times)} unique belief times.",
             **MsgStyle.SUCCESS,
@@ -1795,6 +1826,15 @@ def add_automation(
     config, parameters = _assemble_forecaster_config_and_parameters(
         kwargs, source, config_file, parameters_file
     )
+
+    # An automation exists to record forecasts, so a dry run would render it pointless.
+    # Popping the parameter also keeps it out of the parameters stored on the automation.
+    if parameters.pop("dry-run", False):
+        click.secho(
+            "The dry-run option is not supported for automations, which exist to record the forecasts they compute.",
+            **MsgStyle.ERROR,
+        )
+        raise click.Abort()
 
     # Validate the parameters using the forecast parameters schema (we store them serialized)
     try:

--- a/flexmeasures/cli/data_add.py
+++ b/flexmeasures/cli/data_add.py
@@ -1996,6 +1996,16 @@ def add_schedule(  # noqa C901
     - Limited to power sensors (probably possible to generalize to non-electric assets)
     - Only supports datetimes on the hour or a multiple of the sensor resolution thereafter
     """
+    if as_job and dry_run:
+        click.secho(
+            "The --as-job flag cannot be combined with --dry-run:"
+            " a queued job runs on a worker, where the schedule that a dry run computes would be discarded unseen,"
+            " and where it would be saved to the database, which is exactly what --dry-run asks it not to do."
+            " Drop --as-job to compute the schedule here.",
+            **MsgStyle.ERROR,
+        )
+        raise click.Abort()
+
     asset_or_sensor = None
     if not power_sensor and not asset:
         click.secho(
@@ -2068,6 +2078,11 @@ def add_schedule(  # noqa C901
         )
         if not dry_run:
             click.secho("New schedule is stored.", **MsgStyle.SUCCESS)
+        else:
+            click.secho(
+                "The schedule above was computed but not stored (because of --dry-run).",
+                **MsgStyle.SUCCESS,
+            )
 
 
 @fm_add_data.command("report")

--- a/flexmeasures/cli/tests/test_data_add_fresh_db.py
+++ b/flexmeasures/cli/tests/test_data_add_fresh_db.py
@@ -5,7 +5,7 @@ import logging
 import os
 from datetime import datetime
 import pytz
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from flexmeasures import Asset
 from flexmeasures.cli.tests.utils import to_flags
@@ -27,6 +27,52 @@ def test_add_forecast(app, setup_dummy_data):
     runner = app.test_cli_runner()
     result = runner.invoke(add_forecast, to_flags(cli_input))
     assert result.exit_code == 0, result.output
+
+
+def _count_beliefs(db, sensor_id: int) -> int:
+    """Count the beliefs recorded on the given sensor."""
+    return db.session.scalar(
+        select(func.count()).select_from(TimedBelief).filter_by(sensor_id=sensor_id)
+    )
+
+
+def test_add_forecast_dry_run_saves_no_beliefs(app, fresh_db, setup_dummy_data):
+    """A dry run reports the forecast it computed, without recording any belief."""
+    from flexmeasures.cli.data_add import add_forecast
+
+    sensor_id, *_ = setup_dummy_data
+    runner = app.test_cli_runner()
+
+    beliefs_before_dry_run = _count_beliefs(fresh_db, sensor_id)
+    result = runner.invoke(
+        add_forecast, to_flags({"sensor": sensor_id}) + ["--dry-run"]
+    )
+    assert result.exit_code == 0, result.output
+    assert (
+        "Not saving forecasts to the database (because of --dry-run)" in result.output
+    )
+    assert f"for sensor `sensor 1` (ID {sensor_id})" in result.output
+    assert _count_beliefs(fresh_db, sensor_id) == beliefs_before_dry_run
+
+    # A normal run does record beliefs, so the dry run really skipped that step
+    result = runner.invoke(add_forecast, to_flags({"sensor": sensor_id}))
+    assert result.exit_code == 0, result.output
+    assert "Successfully created" in result.output
+    assert _count_beliefs(fresh_db, sensor_id) > beliefs_before_dry_run
+
+
+def test_add_forecast_rejects_dry_run_as_job(app, setup_dummy_data):
+    """A dry run cannot be queued, because its results would never reach the user."""
+    from flexmeasures.cli.data_add import add_forecast
+
+    sensor_id, *_ = setup_dummy_data
+    runner = app.test_cli_runner()
+    result = runner.invoke(
+        add_forecast, to_flags({"sensor": sensor_id}) + ["--dry-run", "--as-job"]
+    )
+
+    assert result.exit_code == 1
+    assert "The --as-job flag cannot be combined with --dry-run" in result.output
 
 
 def test_add_forecast_reports_invalid_annotation_regressor(app, setup_dummy_data):

--- a/flexmeasures/cli/tests/test_data_add_fresh_db.py
+++ b/flexmeasures/cli/tests/test_data_add_fresh_db.py
@@ -461,13 +461,13 @@ def _process_schedule_cli_input(db, process_power_sensor_id: int) -> dict:
 
 
 def test_add_schedule_dry_run_saves_no_beliefs(
-    app, process_power_sensor, add_market_prices_fresh_db, db
+    app, fresh_db, process_power_sensor, add_market_prices_fresh_db
 ):
     """A dry run shows the schedule it computed, without recording any belief."""
     from flexmeasures.cli.data_add import add_schedule
 
     runner = app.test_cli_runner()
-    cli_input = to_flags(_process_schedule_cli_input(db, process_power_sensor))
+    cli_input = to_flags(_process_schedule_cli_input(fresh_db, process_power_sensor))
 
     result = runner.invoke(add_schedule, cli_input + ["--dry-run"])
     check_command_ran_without_error(result)
@@ -475,7 +475,7 @@ def test_add_schedule_dry_run_saves_no_beliefs(
     assert "covering events from" in result.output
     assert "computed but not stored (because of --dry-run)" in result.output
     assert "New schedule is stored." not in result.output
-    sensor = db.session.get(Sensor, process_power_sensor)
+    sensor = fresh_db.session.get(Sensor, process_power_sensor)
     assert len(sensor.search_beliefs()) == 0
 
     # A normal run does record the schedule, so the dry run really skipped that step

--- a/flexmeasures/cli/tests/test_data_add_fresh_db.py
+++ b/flexmeasures/cli/tests/test_data_add_fresh_db.py
@@ -36,6 +36,11 @@ def _count_beliefs(db, sensor_id: int) -> int:
     )
 
 
+def _count_sources(db) -> int:
+    """Count the data sources on record."""
+    return db.session.scalar(select(func.count()).select_from(DataSource))
+
+
 def test_add_forecast_dry_run_saves_no_beliefs(app, fresh_db, setup_dummy_data):
     """A dry run reports the forecast it computed, without recording any belief."""
     from flexmeasures.cli.data_add import add_forecast
@@ -44,6 +49,7 @@ def test_add_forecast_dry_run_saves_no_beliefs(app, fresh_db, setup_dummy_data):
     runner = app.test_cli_runner()
 
     beliefs_before_dry_run = _count_beliefs(fresh_db, sensor_id)
+    sources_before_dry_run = _count_sources(fresh_db)
     result = runner.invoke(
         add_forecast, to_flags({"sensor": sensor_id}) + ["--dry-run"]
     )
@@ -52,7 +58,12 @@ def test_add_forecast_dry_run_saves_no_beliefs(app, fresh_db, setup_dummy_data):
         "Not saving forecasts to the database (because of --dry-run)" in result.output
     )
     assert f"for sensor `sensor 1` (ID {sensor_id})" in result.output
+
+    # The forecaster's data source is flushed, because the dry run reports which source it would have recorded under,
+    # but it is never committed, so no more of it survives the session than of the beliefs.
+    fresh_db.session.rollback()
     assert _count_beliefs(fresh_db, sensor_id) == beliefs_before_dry_run
+    assert _count_sources(fresh_db) == sources_before_dry_run
 
     # A normal run does record beliefs, so the dry run really skipped that step
     result = runner.invoke(add_forecast, to_flags({"sensor": sensor_id}))

--- a/flexmeasures/cli/tests/test_data_add_fresh_db.py
+++ b/flexmeasures/cli/tests/test_data_add_fresh_db.py
@@ -86,6 +86,26 @@ def test_add_forecast_rejects_dry_run_as_job(app, setup_dummy_data):
     assert "The --as-job flag cannot be combined with --dry-run" in result.output
 
 
+def test_add_forecast_rejects_dry_run_as_job_from_parameters_file(
+    app, setup_dummy_data, tmp_path
+):
+    """A dry run set in a parameters file is rejected in combination with --as-job, too."""
+    from flexmeasures.cli.data_add import add_forecast
+
+    sensor_id, *_ = setup_dummy_data
+    parameters_file = tmp_path / "parameters.yml"
+    parameters_file.write_text(yaml.safe_dump({"dry-run": True}))
+    runner = app.test_cli_runner()
+    result = runner.invoke(
+        add_forecast,
+        to_flags({"sensor": sensor_id, "parameters": str(parameters_file)})
+        + ["--as-job"],
+    )
+
+    assert result.exit_code == 1
+    assert "The --as-job flag cannot be combined with --dry-run" in result.output
+
+
 def test_add_forecast_reports_invalid_annotation_regressor(app, setup_dummy_data):
     from flexmeasures.cli.data_add import add_forecast
 

--- a/flexmeasures/cli/tests/test_data_add_fresh_db.py
+++ b/flexmeasures/cli/tests/test_data_add_fresh_db.py
@@ -445,6 +445,81 @@ def test_add_process(
     assert (schedule == -0.4).event_value.sum() == 4
 
 
+def _process_schedule_cli_input(db, process_power_sensor_id: int) -> dict:
+    """Build the CLI input for scheduling a shiftable process, as used by the dry-run tests."""
+    epex_da = get_test_sensor(db)
+    return {
+        "sensor": process_power_sensor_id,
+        "start": "2015-01-02T00:00:00+01:00",
+        "duration": "PT24H",
+        "scheduler": "ProcessScheduler",
+        "flex-context": json.dumps({"consumption-price": {"sensor": epex_da.id}}),
+        "flex-model": json.dumps(
+            {"duration": "PT4H", "power": "0.4", "process-type": "SHIFTABLE"}
+        ),
+    }
+
+
+def test_add_schedule_dry_run_saves_no_beliefs(
+    app, process_power_sensor, add_market_prices_fresh_db, db
+):
+    """A dry run shows the schedule it computed, without recording any belief."""
+    from flexmeasures.cli.data_add import add_schedule
+
+    runner = app.test_cli_runner()
+    cli_input = to_flags(_process_schedule_cli_input(db, process_power_sensor))
+
+    result = runner.invoke(add_schedule, cli_input + ["--dry-run"])
+    check_command_ran_without_error(result)
+    assert "Not saving schedule for sensor `power`" in result.output
+    assert "covering events from" in result.output
+    assert "computed but not stored (because of --dry-run)" in result.output
+    assert "New schedule is stored." not in result.output
+    sensor = db.session.get(Sensor, process_power_sensor)
+    assert len(sensor.search_beliefs()) == 0
+
+    # A normal run does record the schedule, so the dry run really skipped that step
+    result = runner.invoke(add_schedule, cli_input)
+    check_command_ran_without_error(result)
+    assert "New schedule is stored." in result.output
+    assert len(sensor.search_beliefs()) > 0
+
+
+def test_add_schedule_rejects_dry_run_as_job(app, fresh_db, add_market_prices_fresh_db):
+    """A dry run cannot be queued: the worker would save the schedule that the flag rules out."""
+    from flexmeasures.cli.data_add import add_schedule, add_toy_account
+
+    runner = app.test_cli_runner()
+    runner.invoke(add_toy_account)
+    toy_account = fresh_db.session.execute(
+        select(Account).filter_by(name="Toy Account")
+    ).scalar_one_or_none()
+    battery = fresh_db.session.execute(
+        select(Asset).filter_by(name="toy-battery", owner=toy_account)
+    ).scalar_one_or_none()
+    power_sensor = battery.sensors[0]
+    prices = add_market_prices_fresh_db["epex_da"]
+
+    cli_input = to_flags(
+        {
+            "start": "2014-12-31T23:00:00+00",
+            "duration": "PT12H",
+            "sensor": power_sensor.id,
+            "scheduler": "StorageScheduler",
+            "soc-at-start": "50%",
+            "flex-context": json.dumps({"consumption-price": {"sensor": prices.id}}),
+            "flex-model": json.dumps({"roundtrip-efficiency": "90%"}),
+        }
+    )
+    result = runner.invoke(add_schedule, cli_input + ["--dry-run", "--as-job"])
+
+    assert result.exit_code == 1
+    assert "The --as-job flag cannot be combined with --dry-run" in result.output
+    # Without the guard, the flag would be dropped and the queued job would store a schedule.
+    assert app.queues["scheduling"].count == 0
+    assert len(power_sensor.search_beliefs()) == 0
+
+
 @pytest.mark.parametrize(
     "event_resolution, name, success",
     [("PT20M", "ONE", True), (15, "TWO", True), ("some_string", "THREE", False)],

--- a/flexmeasures/cli/tests/test_data_add_fresh_db.py
+++ b/flexmeasures/cli/tests/test_data_add_fresh_db.py
@@ -72,6 +72,34 @@ def test_add_forecast_dry_run_saves_no_beliefs(app, fresh_db, setup_dummy_data):
     assert _count_beliefs(fresh_db, sensor_id) > beliefs_before_dry_run
 
 
+def test_add_forecast_dry_run_reports_an_empty_forecast(
+    app, fresh_db, setup_dummy_data, monkeypatch
+):
+    """A dry run that computes no beliefs at all still reports, rather than crashing on an empty frame."""
+    import timely_beliefs as tb
+
+    from flexmeasures.cli.data_add import add_forecast
+    from flexmeasures.data.models.forecasting.pipelines import TrainPredictPipeline
+
+    sensor_id, *_ = setup_dummy_data
+    sensor = fresh_db.session.get(Sensor, sensor_id)
+
+    def compute_nothing(self, *args, **kwargs):
+        self._parameters = {"sensor": sensor, "sensor_to_save": sensor}
+        return [{"data": tb.BeliefsDataFrame(sensor=sensor), "sensor": sensor}]
+
+    monkeypatch.setattr(TrainPredictPipeline, "compute", compute_nothing)
+
+    runner = app.test_cli_runner()
+    result = runner.invoke(
+        add_forecast, to_flags({"sensor": sensor_id}) + ["--dry-run"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "0 forecast beliefs across 0 unique belief times" in result.output
+    assert "covering events from" not in result.output
+
+
 def test_add_forecast_rejects_dry_run_as_job(app, setup_dummy_data):
     """A dry run cannot be queued, because its results would never reach the user."""
     from flexmeasures.cli.data_add import add_forecast

--- a/flexmeasures/data/models/forecasting/__init__.py
+++ b/flexmeasures/data/models/forecasting/__init__.py
@@ -103,6 +103,7 @@ class Forecaster(DataGenerator):
         - model-save-dir:       used internally for the train and predict pipelines to save and load the model
         - output-path:          for exporting forecasts to file, more of a developer feature
         - as-job:               only indicates whether the computation was offloaded to a worker
+        - dry-run:              only indicates whether the computation was allowed to save its results
         """
         _parameters = deepcopy(parameters)
         # Note: Parameter keys are in kebab-case due to Marshmallow schema data_key settings
@@ -116,6 +117,7 @@ class Forecaster(DataGenerator):
             "output-path",
             "sensor-to-save",
             "as-job",
+            "dry-run",
             "m_viewpoints",  # Computed internally, still uses snake_case
             "sensor",
         ]

--- a/flexmeasures/data/models/forecasting/pipelines/predict.py
+++ b/flexmeasures/data/models/forecasting/pipelines/predict.py
@@ -20,6 +20,7 @@ from flexmeasures.data.models.forecasting.utils import (
 from flexmeasures.data.models.forecasting.pipelines.base import BasePipeline
 from flexmeasures.data.schemas.sensors import SensorReference
 from flexmeasures.data.utils import save_to_db
+from flexmeasures.utils.flexmeasures_inflection import pluralize
 
 
 class PredictPipeline(BasePipeline):
@@ -300,7 +301,7 @@ class PredictPipeline(BasePipeline):
 
         if self.dry_run:
             logging.info(
-                f"Not saving predictions to DB (because of --dry-run). Would have saved {len(bdf)} beliefs with source: {bdf.sources[0]}, sensor: {self.sensor_to_save}, sensor_id: {self.sensor_to_save.id}."
+                f"Not saving predictions to DB (because of --dry-run). Would have saved {pluralize('belief', len(bdf), include_count=True)} with source: {bdf.sources[0]}, sensor: {self.sensor_to_save}, sensor_id: {self.sensor_to_save.id}."
             )
         else:
             save_to_db(

--- a/flexmeasures/data/models/forecasting/pipelines/predict.py
+++ b/flexmeasures/data/models/forecasting/pipelines/predict.py
@@ -46,6 +46,7 @@ class PredictPipeline(BasePipeline):
         missing_threshold: float = 1.0,
         annotation_regressors: list[dict] | None = None,
         post_processing_config: dict | None = None,
+        dry_run: bool = False,
     ) -> None:
         """
         Initialize the PredictPipeline.
@@ -70,6 +71,7 @@ class PredictPipeline(BasePipeline):
         :param sensor_to_save: Sensor to which the predictions will be attributed.
         :param missing_threshold: Max fraction of missing data allowed before failure. Missing data under the threshold will be filled with our interpolation methods.
         :param post_processing_config: Optional clipping and snapping configuration for forecast values.
+        :param dry_run: If True, compute the forecast but do not save it to the database.
         """
         super().__init__(
             future_regressors=future_regressors,
@@ -97,6 +99,7 @@ class PredictPipeline(BasePipeline):
         self.predict_start = predict_start
         self.predict_end = predict_end
         self.post_processing_config = post_processing_config or {}
+        self.dry_run = dry_run
 
         self.sensor_resolution = self.target_sensor.event_resolution
         self.readable_resolution = duration_isoformat(self.sensor_resolution)
@@ -295,13 +298,18 @@ class PredictPipeline(BasePipeline):
         if self.output_path is not None:
             self.save_results_to_CSV(bdf)
 
-        save_to_db(
-            bdf, save_changed_beliefs_only=False
-        )  # save all beliefs of forecasted values even if they are the same values as the previous beliefs.
-        db.session.commit()
-        logging.info(
-            f"Saved predictions to DB with source: {bdf.sources[0]}, sensor: {self.sensor_to_save}, sensor_id: {self.sensor_to_save.id}."
-        )
+        if self.dry_run:
+            logging.info(
+                f"Not saving predictions to DB (because of dry-run). Would have saved {len(bdf)} beliefs with source: {bdf.sources[0]}, sensor: {self.sensor_to_save}, sensor_id: {self.sensor_to_save.id}."
+            )
+        else:
+            save_to_db(
+                bdf, save_changed_beliefs_only=False
+            )  # save all beliefs of forecasted values even if they are the same values as the previous beliefs.
+            db.session.commit()
+            logging.info(
+                f"Saved predictions to DB with source: {bdf.sources[0]}, sensor: {self.sensor_to_save}, sensor_id: {self.sensor_to_save.id}."
+            )
         if delete_model:
             os.remove(self.model_path)
 

--- a/flexmeasures/data/models/forecasting/pipelines/predict.py
+++ b/flexmeasures/data/models/forecasting/pipelines/predict.py
@@ -300,7 +300,7 @@ class PredictPipeline(BasePipeline):
 
         if self.dry_run:
             logging.info(
-                f"Not saving predictions to DB (because of dry-run). Would have saved {len(bdf)} beliefs with source: {bdf.sources[0]}, sensor: {self.sensor_to_save}, sensor_id: {self.sensor_to_save.id}."
+                f"Not saving predictions to DB (because of --dry-run). Would have saved {len(bdf)} beliefs with source: {bdf.sources[0]}, sensor: {self.sensor_to_save}, sensor_id: {self.sensor_to_save.id}."
             )
         else:
             save_to_db(

--- a/flexmeasures/data/models/forecasting/pipelines/train_predict.py
+++ b/flexmeasures/data/models/forecasting/pipelines/train_predict.py
@@ -304,6 +304,7 @@ class TrainPredictPipeline(Forecaster):
                 "upper": self._config.get("upper"),
                 "snap": self._config.get("snap"),
             },
+            dry_run=self._parameters.get("dry_run", False),
         )
         logging.info(
             f"Prediction cycle from {predict_start} to {predict_end} started ..."

--- a/flexmeasures/data/schemas/forecasting/pipeline.py
+++ b/flexmeasures/data/schemas/forecasting/pipeline.py
@@ -554,6 +554,18 @@ class ForecasterParametersSchema(Schema):
             },
         },
     )
+    dry_run = fields.Bool(
+        data_key="dry-run",
+        load_default=False,
+        metadata={
+            "description": "Add this flag to avoid saving the results to the database.",
+            "cli": {
+                "cli-exclusive": True,
+                "is_flag": True,
+                "option": "--dry-run",
+            },
+        },
+    )
 
     @pre_load
     def sanitize_input(self, data, **kwargs):
@@ -725,6 +737,7 @@ class ForecasterParametersSchema(Schema):
             save_belief_time=save_belief_time,
             beliefs_before=data.get("belief_time"),
             m_viewpoints=m_viewpoints,
+            dry_run=data.get("dry_run", False),
         )
         if "config" in data:
             result["config"] = data["config"]

--- a/flexmeasures/data/services/scheduling.py
+++ b/flexmeasures/data/services/scheduling.py
@@ -885,8 +885,16 @@ def make_schedule(  # noqa: C901
             save_to_db(bdf)
             num_beliefs_created += len(bdf)
         else:
+            # Report what would have been saved, in the same terms as a forecast dry run does:
+            # the sensor, the number of beliefs, and the events they cover.
+            event_range = (
+                f", covering events from {bdf.event_starts.min()} until {bdf.event_ends.max()}"
+                if not bdf.empty
+                else ""
+            )
             print(
-                f"\nNot saving schedule for sensor `{bdf.sensor}` to the database (because of dry-run), but this is what I computed:\n{bdf}"
+                f"\nNot saving schedule for sensor `{bdf.sensor}` (ID {bdf.sensor.id}) to the database (because of --dry-run),"
+                f" but this is what I computed ({len(bdf)} beliefs{event_range}):\n{bdf}"
             )
 
     # num_beliefs_created counts beliefs actually saved; in dry_run mode this is always 0


### PR DESCRIPTION
## Why

`flexmeasures add forecasts` always writes its forecasts to the database. There was no way to run a forecast just to see what it would produce — to check a config, compare a training window, or reproduce a problem — without adding beliefs. `flexmeasures add schedule` and `flexmeasures add report` already have a `--dry-run` flag; this gives forecasts the same.

## What

`flexmeasures add forecasts --dry-run` computes the forecast in full, but records nothing, and reports what it would have done:

```
Not saving forecasts to the database (because of --dry-run), but this is what I computed:
48 forecast beliefs across 1 unique belief times, for sensor `sensor 1` (ID 1),
to be recorded under data source `TrainPredictPipeline` (ID 3), covering events
from 2026-09-06 12:00:00+00:00 until 2026-09-08 12:00:00+00:00.
```
followed by the computed `BeliefsDataFrame` itself (as `add report --dry-run` does).

## How the flag threads through

The saving happens in the forecasting pipeline, not in the CLI, so the flag travels as a forecaster parameter:

1. `--dry-run` is a new (CLI-exclusive) field on `ForecasterParametersSchema`, whose help text follows the wording of `add schedule --dry-run`.
2. `resolve_config` puts `dry_run` in the resolved parameters, and `Forecaster._clean_parameters` strips `dry-run` again, so a dry run never ends up in a data source's stored parameters.
3. `TrainPredictPipeline.run_cycle` passes it to `PredictPipeline`, which skips `save_to_db` and the commit, and logs what it would have saved instead. Everything else — training, prediction, post-processing, the optional CSV export via `--output-path` — is unchanged.

A normal run is untouched: the non-dry branch is exactly the code that was there before.

### What a dry run touches in the database

Nothing survives it. The forecaster's data source *is* flushed — `DataGenerator.data_source` calls `get_or_create_source`, which adds and flushes, and a dry run reads that source, both to build the `BeliefsDataFrame` and to report which source it would have recorded under. But no commit follows on this path (the only two commits in the forecasting pipeline are the one this PR skips and the one on the `--as-job` path), so the row is rolled back when the session goes away.

Measured on a fresh database, for a configuration that had no source yet: 1 source and 200 beliefs before, 2 sources and 200 beliefs while the session is still open, and 1 source and 200 beliefs after the session rolls back. The test asserts both counts, after an explicit rollback.

This is also a second reason to reject `--dry-run` with `--as-job`: `TrainPredictPipeline.run()` commits the data source deliberately on the job path, to make its ID available to the worker, so a queued dry run really would leave a source behind.

## `add schedule --dry-run` was quietly writing schedules

While making the three `--dry-run` flags behave alike, one turned out to be broken: `flexmeasures add schedule --dry-run --as-job` accepted the flag, dropped it without a word, queued a job — and that job saves its schedule when a worker picks it up. A flag that promises to write nothing wrote a schedule. Measured before the fix: exit code 0, `New scheduling job <id> has been added to the queue.`, one job on the `scheduling` queue.

`add schedule` now rejects that combination, the same way `add report` and (as of this PR) `add forecasts` do. `make_schedule` already supported `dry_run` on the non-job path, so this is a guard, not new threading.

A schedule dry run also reports more: it already printed the computed frame, but now says which sensor, how many beliefs and which events they cover, and the CLI closes with "The schedule above was computed but not stored (because of --dry-run)." instead of falling silent where a normal run says "New schedule is stored."

### Remaining difference between the three commands

`add forecasts` honours `dry-run` supplied through `--parameters` (see the Copilot thread below: a parameters-file `dry-run` used to slip past the `--as-job` guard); `add schedule` and `add report` have no parameters file, so their flags are option-only. That is a consequence of how forecasts take their parameters, not an inconsistency to iron out.

## About `--as-job`

`--dry-run` with `--as-job` is **rejected** with a CLI error. A queued job runs on a worker, so the whole point of a dry run — seeing the forecast — would be lost: the user would get a job ID and the computed forecast would be discarded unseen on the worker. This matches what `flexmeasures add report` already does with the same combination.

For the same reason, dry runs stay CLI-only:

* the API's forecast trigger (which always queues a job) excludes the field, so posting `dry-run` is rejected as an unknown field; it was already absent from the OpenAPI spec, since CLI-exclusive fields are dropped there;
* `flexmeasures add automation` rejects it too (an automation exists to record its forecasts), which also keeps `dry-run` out of the parameters stored on automations.

## Testing

`flexmeasures/cli/tests/test_data_add_fresh_db.py`:

* `test_add_forecast_dry_run_saves_no_beliefs` — the belief count for the target sensor is unchanged after a dry run, the data source count is unchanged too, and a subsequent normal run does increase the belief count (so the dry run really skipped a step that otherwise happens). Proven to fail: with the `dry_run` branch in `PredictPipeline.run` disabled, it goes red with `assert 248 == 200`; with a `db.session.commit()` added to the dry-run branch, the source assertion goes red with `assert 2 == 1`.
* `test_add_forecast_rejects_dry_run_as_job` — proven to fail with the guard disabled: `assert 0 == 1` on the exit code.

* `test_add_forecast_rejects_dry_run_as_job_from_parameters_file` — a `dry-run` in a `--parameters` file is rejected with `--as-job` too. Proven to fail with the old `kwargs`-only reading: `assert 0 == 1` (it queued a job instead).
* `test_add_schedule_dry_run_saves_no_beliefs` — a schedule dry run reports what it computed and records nothing, while a normal run does record. Proven to fail: with the event range dropped from the report, `AssertionError: assert 'covering events from' in '...Not saving schedule for sensor `power` (ID 1)...'`.
* `test_add_schedule_rejects_dry_run_as_job` — proven to fail with the new guard disabled: `assert 0 == 1` on the exit code, and before the fix the same setup queued a job (`New scheduling job <id> has been added to the queue.`, queue count 1).

`flexmeasures/cli/tests/`, `flexmeasures/data/tests/test_scheduling_jobs.py`, `flexmeasures/data/tests/test_forecasting_pipeline.py`, `flexmeasures/data/schemas/tests/test_forecasting.py` and the v3.0 forecasting API tests all pass (274 passed, 1 xfailed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeRZd2nDDShZTE8ZmbERzn
