### PR TITLE
tooling: let the pre-commit hook check non-uv checkouts

### DIFF
--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -31,7 +31,22 @@ command -v python3 >/dev/null 2>&1 || exit 0
 target="$(printf '%s' "$payload" | python3 "$(dirname "${BASH_SOURCE[0]}")/pre_commit_target.py" 2>/dev/null || true)"
 [ -n "$target" ] || exit 0
 
-if ! output=$(cd "$target" && uv run pre-commit run --all-files 2>&1); then
+# Pick a runner for the target checkout.
+# `uv run` only works where the target is a uv project whose dependencies resolve,
+# which is not a given: commits from this session also land in worktrees of other repositories,
+# where uv fails to build an environment for reasons that have nothing to do with the commit,
+# and blocking on that would be a false positive.
+# The hook versions come from the target's own .pre-commit-config.yaml either way, so a pre-commit on PATH checks exactly the same things.
+if [ -f "$target/uv.lock" ] && command -v uv >/dev/null 2>&1 && (cd "$target" && uv run pre-commit --version) >/dev/null 2>&1; then
+    runner=(uv run pre-commit)
+elif command -v pre-commit >/dev/null 2>&1; then
+    runner=(pre-commit)
+else
+    # No way to run the hooks; fail open, as above.
+    exit 0
+fi
+
+if ! output=$(cd "$target" && "${runner[@]}" run --all-files 2>&1); then
     echo "pre-commit failed in $target — fix the issues below before committing:" >&2
     echo "$output" >&2
     exit 2


### PR DESCRIPTION
The `pre-commit-check.sh` hook ran `uv run pre-commit`, which assumes the commit targets a uv project whose dependencies resolve. Commits from a session also land in worktrees of other repositories, where `uv` fails to build an environment for reasons unrelated to the commit — so the hook blocked a good commit on an environment error.

It now falls back to a `pre-commit` on PATH when `uv` cannot run there. Hook versions come from the target's own `.pre-commit-config.yaml` either way, so the same checks run. The probe is gated on `uv.lock`, so foreign checkouts no longer get a stray `.venv/`.

Verified by feeding the hook a payload for each case: FlexMeasures still takes the uv path; a non-uv worktree passes clean, and still exits 2 when I break its formatting on purpose.

No changelog entry — dev tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASeQ7rfgERhFFEynjebLGh