### PR TITLE
Read plugin-declared settings from the environment, and say whether a missing one has a default

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -35,6 +35,7 @@ Infrastructure / Support
 * Train and predict a forecaster's per-horizon models side by side rather than one after another, which cuts the training time of a long forecast horizon several-fold while leaving the forecasts themselves unchanged [see `PR #2479 <https://www.github.com/FlexMeasures/flexmeasures/pull/2479>`_]
 * The UI's JavaScript modules can now be tested, by running them in a headless browser from pytest, without adding a Node.js toolchain [see `PR #2435 <https://www.github.com/FlexMeasures/flexmeasures/pull/2435>`_]
 * Add ``FLEXMEASURES_DEPRECATION_AND_SUNSET`` so hosts can configure deprecation and sunset dates and information links per deprecated API version [see `PR #2362 <https://github.com/FlexMeasures/flexmeasures/pull/2362>`_].
+* Settings that a plugin declares in its ``__settings__`` can now be set as environment variables, next to being set in the config file (which still wins), can declare a ``default`` to fall back to, and are reported as missing with a message that says whether such a default applies or the setting stays unset [see `PR #2501 <https://www.github.com/FlexMeasures/flexmeasures/pull/2501>`_]
 
 Bugfixes
 -----------

--- a/documentation/plugin/customisation.rst
+++ b/documentation/plugin/customisation.rst
@@ -188,6 +188,7 @@ Config settings can be registered by setting the (optional) ``__settings__`` att
         "MY_PLUGIN_COLOR": {
             "description": "Color used to override the default plugin color.",
             "level": "info",
+            "default": "blue",
         },
     }
 
@@ -208,7 +209,36 @@ Alternatively, use ``from my_plugin import __settings__`` in your plugin module,
     MY_PLUGIN_COLOR = {
         "description": "Color used to override the default plugin color.",
         "level": "info",
+        "default": "blue",
     }
+
+
+Each setting is described with the following (all optional) keys:
+
+- ``description``: what the setting is used for. It is included in the log message when the setting is missing.
+- ``level``: the level to log at when the setting is missing (``error`` by default).
+- ``message_if_missing``: extra advice to log when the setting is missing, for instance where to get a token.
+- ``parse_as``: the type the setting should have. FlexMeasures logs a warning if it has another type,
+  and uses this type to interpret the setting when it is read from an environment variable (see below).
+- ``default``: the value to fall back to when the setting is missing.
+  FlexMeasures says in its log message whether a missing setting falls back to a default or stays unset,
+  so declare a ``default`` here rather than only promising one in ``message_if_missing``.
+
+Where these settings can be set
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Plugin settings are set just like FlexMeasures' own settings (see :ref:`configuration`):
+in your FlexMeasures config file, or as environment variables.
+
+Your plugin is registered after the config file has been read, so a setting that the config file sets keeps that value,
+and the environment is only consulted for settings that are still unset.
+
+Environment variables are strings, so declare a ``parse_as`` for any setting that should not be one.
+FlexMeasures then reads ``parse_as: int`` and ``parse_as: float`` settings as numbers,
+``parse_as: bool`` settings as ``True`` for ``1``, ``true``, ``yes`` or ``on`` (case-insensitively) and ``False`` otherwise,
+and ``parse_as: list`` and ``parse_as: dict`` settings as JSON.
+
+.. note:: While the test suite and the documentation build are running, FlexMeasures reads no settings from the environment ― neither its own, nor your plugin's.
 
 
 Set config programmatically - Example of using a custom logo

--- a/documentation/plugin/customisation.rst
+++ b/documentation/plugin/customisation.rst
@@ -238,7 +238,10 @@ FlexMeasures then reads ``parse_as: int`` and ``parse_as: float`` settings as nu
 ``parse_as: bool`` settings as ``True`` for ``1``, ``true``, ``yes`` or ``on`` (case-insensitively) and ``False`` otherwise,
 and ``parse_as: list`` and ``parse_as: dict`` settings as JSON.
 
-.. note:: While the test suite and the documentation build are running, FlexMeasures reads no settings from the environment ― neither its own, nor your plugin's.
+.. note:: While the test suite and the documentation build are running, FlexMeasures runs on defaults:
+          it reads neither your config file nor the environment, so your plugin's settings are not read from the environment either.
+          (A few of FlexMeasures' own settings are exceptions, among them ``FLEXMEASURES_ENV``, ``SECRET_KEY`` and ``SQLALCHEMY_TEST_DATABASE_URI``.)
+          If your plugin has its own test suite, set your plugin's settings on the app config directly.
 
 
 Set config programmatically - Example of using a custom logo

--- a/flexmeasures/utils/plugin_utils.py
+++ b/flexmeasures/utils/plugin_utils.py
@@ -183,7 +183,7 @@ def register_plugins(app: Flask):  # noqa: C901
 def check_config_settings(app, settings: dict[str, dict]):
     """Make sure expected config settings exist.
 
-    Settings that are not in the app config yet are looked up in the environment,
+    Plugin settings that are not in the app config yet are looked up in the environment,
     so a plugin setting can be set the same way a FlexMeasures setting can.
     Settings that are still missing afterwards are logged,
     and are set to the "default" that the plugin declared for them, if any.

--- a/flexmeasures/utils/plugin_utils.py
+++ b/flexmeasures/utils/plugin_utils.py
@@ -187,6 +187,7 @@ def check_config_settings(app, settings: dict[str, dict]):
     so a plugin setting can be set the same way a FlexMeasures setting can.
     Settings that are still missing afterwards are logged,
     and are set to the "default" that the plugin declared for them, if any.
+    Whatever a setting ends up holding, a declared default included, is checked against its "parse_as" type.
 
     For example:
 
@@ -223,25 +224,23 @@ def check_config_settings(app, settings: dict[str, dict]):
 
     read_plugin_settings_from_env(app, settings)
 
-    missing_config_settings = []
-    config_settings_with_wrong_type = []
+    # Report what is missing, and fall back to the declared default where there is one.
     for setting_name, setting_fields in settings.items():
-        setting = app.config.get(setting_name)
-        if setting is None:
-            missing_config_settings.append(setting_name)
-        elif "parse_as" in setting_fields and not isinstance(
-            setting, setting_fields["parse_as"]
-        ):
-            config_settings_with_wrong_type.append((setting_name, setting))
-    for setting_name, setting in config_settings_with_wrong_type:
-        log_wrong_type_for_config_setting(
-            app, setting_name, settings[setting_name], type(setting)
-        )
-    for setting_name in missing_config_settings:
-        setting_fields = settings[setting_name]
+        if app.config.get(setting_name) is not None:
+            continue
         log_missing_config_setting(app, setting_name, setting_fields)
         if "default" in setting_fields:
             app.config[setting_name] = setting_fields["default"]
+
+    # Check the type of every setting that has a value by now, defaults included.
+    for setting_name, setting_fields in settings.items():
+        setting = app.config.get(setting_name)
+        if setting is None or "parse_as" not in setting_fields:
+            continue
+        if not isinstance(setting, setting_fields["parse_as"]):
+            log_wrong_type_for_config_setting(
+                app, setting_name, setting_fields, type(setting)
+            )
 
 
 def read_plugin_settings_from_env(app: Flask, settings: dict[str, dict]):

--- a/flexmeasures/utils/plugin_utils.py
+++ b/flexmeasures/utils/plugin_utils.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import importlib.machinery
 import importlib.util
+import json
 import os
 import sys
 from importlib.abc import Loader
@@ -181,6 +182,11 @@ def register_plugins(app: Flask):  # noqa: C901
 def check_config_settings(app, settings: dict[str, dict]):
     """Make sure expected config settings exist.
 
+    Settings that are not in the app config yet are looked up in the environment,
+    so a plugin setting can be set the same way a FlexMeasures setting can.
+    Settings that are still missing afterwards are logged,
+    and are set to the "default" that the plugin declared for them, if any.
+
     For example:
 
         settings = {
@@ -191,12 +197,13 @@ def check_config_settings(app, settings: dict[str, dict]):
             "MY_PLUGIN_TOKEN": {
                 "description": "Token used by my plugin for y.",
                 "level": "warning",
-                "message": "Without this token, my plugin will not do y.",
+                "message_if_missing": "Without this token, my plugin will not do y.",
                 "parse_as": str,
             },
             "MY_PLUGIN_COLOR": {
                 "description": "Color used to override the default plugin color.",
                 "level": "info",
+                "default": "blue",
             },
         }
 
@@ -213,6 +220,8 @@ def check_config_settings(app, settings: dict[str, dict]):
     for setting_name, setting_fields in settings.items():
         assert isinstance(setting_fields, dict), f"{setting_name} should be a dict"
 
+    read_plugin_settings_from_env(app, settings)
+
     missing_config_settings = []
     config_settings_with_wrong_type = []
     for setting_name, setting_fields in settings.items():
@@ -228,7 +237,64 @@ def check_config_settings(app, settings: dict[str, dict]):
             app, setting_name, settings[setting_name], type(setting)
         )
     for setting_name in missing_config_settings:
-        log_missing_config_setting(app, setting_name, settings[setting_name])
+        setting_fields = settings[setting_name]
+        log_missing_config_setting(app, setting_name, setting_fields)
+        if "default" in setting_fields:
+            app.config[setting_name] = setting_fields["default"]
+
+
+def read_plugin_settings_from_env(app: Flask, settings: dict[str, dict]):
+    """Fill in plugin-declared settings that are still unset from the environment.
+
+    Plugins are registered after the config file has been read,
+    so a setting that already has a value keeps it, and the environment only fills the gaps.
+    That is the same precedence that FlexMeasures' own settings get,
+    where the environment is read first and the config file may then override it.
+
+    Like FlexMeasures' own settings,
+    plugin settings are not read from the environment while testing or while building the documentation,
+    which both run on defaults.
+    """
+    if app.testing or app.config.get("FLEXMEASURES_ENV") == "documentation":
+        return
+    for setting_name, setting_fields in settings.items():
+        if app.config.get(setting_name) is not None:
+            continue
+        env_value = os.environ.get(setting_name)
+        if env_value is None:
+            continue
+        app.config[setting_name] = parse_setting_from_env(
+            app, setting_name, env_value, setting_fields.get("parse_as")
+        )
+
+
+def parse_setting_from_env(
+    app: Flask, setting_name: str, value: str, parse_as: type | None
+):
+    """Interpret an environment variable as the type the plugin declared for it.
+
+    Environment variables are always strings, so a setting that should be, say, an int is converted here.
+    Lists and dicts are expected to be JSON-encoded.
+    A value we cannot convert is passed on unconverted,
+    which lets the type check in check_config_settings report it to the plugin author.
+    """
+    if parse_as is None or parse_as is str:
+        return value
+    try:
+        if parse_as is bool:
+            return value.strip().lower() in ("1", "true", "yes", "on")
+        if parse_as in (int, float):
+            return parse_as(value)
+        if parse_as in (list, dict):
+            parsed_value = json.loads(value)
+            if not isinstance(parsed_value, parse_as):
+                raise ValueError(f"{parsed_value} is not a {parse_as}")
+            return parsed_value
+    except ValueError as e:
+        app.logger.warning(
+            f"Could not read config setting '{setting_name}' from the environment as a {parse_as}: {e}"
+        )
+    return value
 
 
 def log_wrong_type_for_config_setting(
@@ -245,6 +311,9 @@ def log_missing_config_setting(app, setting_name: str, setting_fields: dict):
 
     The logging level is taken from the 'level' key. If missing, we default to error.
     If present, we also log the 'description' and the 'message_if_missing' keys.
+
+    We close with whether the setting falls back to the 'default' the plugin declared, or stays unset,
+    so that a 'message_if_missing' promising a fallback cannot leave the impression that a setting without one is optional.
     """
     message_if_missing = (
         f" {setting_fields['message_if_missing']}"
@@ -254,6 +323,10 @@ def log_missing_config_setting(app, setting_name: str, setting_fields: dict):
     description = (
         f" ({setting_fields['description']})" if "description" in setting_fields else ""
     )
+    if "default" in setting_fields:
+        fallback = f" Falling back to the default declared by the plugin: {setting_fields['default']!r}."
+    else:
+        fallback = " No default is declared for it, so it stays unset."
     level = setting_fields["level"] if "level" in setting_fields else "error"
     if not hasattr(app.logger, level):
         app.logger.warning(
@@ -261,5 +334,5 @@ def log_missing_config_setting(app, setting_name: str, setting_fields: dict):
         )
         level = "error"
     getattr(app.logger, level)(
-        f"Missing config setting '{setting_name}'{description}.{message_if_missing}",
+        f"Missing config setting '{setting_name}'{description}.{message_if_missing}{fallback}",
     )

--- a/flexmeasures/utils/plugin_utils.py
+++ b/flexmeasures/utils/plugin_utils.py
@@ -16,6 +16,7 @@ import sentry_sdk
 from flask import Flask, Blueprint
 
 from flexmeasures.utils.coding_utils import get_classes_module
+from flexmeasures.utils.config_utils import parse_bool_env
 
 
 def is_written_as_path(plugin: str) -> bool:
@@ -282,7 +283,7 @@ def parse_setting_from_env(
         return value
     try:
         if parse_as is bool:
-            return value.strip().lower() in ("1", "true", "yes", "on")
+            return parse_bool_env(value)
         if parse_as in (int, float):
             return parse_as(value)
         if parse_as in (list, dict):

--- a/flexmeasures/utils/tests/test_plugin_utils.py
+++ b/flexmeasures/utils/tests/test_plugin_utils.py
@@ -1,294 +1,118 @@
-"""Tests for loading plugins, i.e. for the FLEXMEASURES_PLUGINS setting."""
-
-from __future__ import annotations
-
-import importlib.util
-import os
-import sys
+import logging
 
 import pytest
 from flask import Flask
 
-from flexmeasures.utils.plugin_utils import register_plugins
-
-
-def write_plugin(root, pkg_name: str, marker: str, with_init: bool = True):
-    """Write a minimal plugin package, whose Blueprint gets its route from a submodule.
-
-    This mirrors the common plugin layout: the Blueprint is created in ``__init__.py``, and ``views.py`` imports it to attach routes.
-    The marker distinguishes two copies of the same plugin, and rides along on the module and its route.
-    """
-    pkg = root / pkg_name
-    pkg.mkdir(parents=True)
-    if not with_init:
-        return pkg
-    (pkg / "__init__.py").write_text(
-        "from flask import Blueprint\n"
-        f"MARKER = '{marker}'\n"
-        f"__version__ = '{marker}'\n"
-        f"bp = Blueprint('{pkg_name}_{marker}', __name__)\n"
-        f"import {pkg_name}.views  # noqa: E402,F401 (attaches the routes to bp)\n"
-    )
-    (pkg / "views.py").write_text(
-        f"from {pkg_name} import bp\n"
-        "\n"
-        f"@bp.route('/{marker}')\n"
-        "def a_route():\n"
-        f"    return '{marker}'\n"
-    )
-    return pkg
+from flexmeasures.utils.plugin_utils import check_config_settings
 
 
 @pytest.fixture
-def clean_import_state():
-    """Undo the sys.path and sys.modules changes that loading a plugin makes.
+def bare_app():
+    """A minimal app to check plugin settings against, which is not in testing mode.
 
-    Only the modules a test added are dropped, so that unrelated imports in the same session are left alone.
+    Settings are only read from the environment outside of testing mode,
+    just like FlexMeasures' own settings are.
     """
-    original_path = list(sys.path)
-    original_modules = set(sys.modules)
-    yield
-    sys.path[:] = original_path
-    for name in set(sys.modules) - original_modules:
-        del sys.modules[name]
-
-
-def make_app(plugins: list[str]) -> Flask:
-    app = Flask(__name__)
-    app.config["FLEXMEASURES_PLUGINS"] = plugins
+    app = Flask("test_plugin_utils")
+    app.logger.setLevel(logging.DEBUG)
     return app
 
 
-def test_installed_package_wins_from_folder_in_working_directory(
-    tmp_path, monkeypatch, clean_import_state
+def test_setting_is_read_from_env(bare_app, monkeypatch, caplog):
+    """A plugin setting that is only set in the environment ends up in the config."""
+    monkeypatch.setenv("MY_PLUGIN_TOKEN", "token-from-env")
+    with caplog.at_level(logging.ERROR):
+        check_config_settings(bare_app, {"MY_PLUGIN_TOKEN": {"level": "error"}})
+    assert bare_app.config["MY_PLUGIN_TOKEN"] == "token-from-env"
+    assert "Missing config setting" not in caplog.text
+
+
+def test_config_wins_over_env(bare_app, monkeypatch):
+    """The config file is read before plugins are registered, so its value is kept."""
+    monkeypatch.setenv("MY_PLUGIN_TOKEN", "token-from-env")
+    bare_app.config["MY_PLUGIN_TOKEN"] = "token-from-config"
+    check_config_settings(bare_app, {"MY_PLUGIN_TOKEN": {}})
+    assert bare_app.config["MY_PLUGIN_TOKEN"] == "token-from-config"
+
+
+def test_env_is_not_read_while_testing(monkeypatch):
+    """Tests run on defaults, so they should not pick up settings from the environment."""
+    monkeypatch.setenv("MY_PLUGIN_TOKEN", "token-from-env")
+    app = Flask("test_plugin_utils")
+    app.testing = True
+    check_config_settings(app, {"MY_PLUGIN_TOKEN": {}})
+    assert app.config.get("MY_PLUGIN_TOKEN") is None
+
+
+@pytest.mark.parametrize(
+    "parse_as, env_value, expected_value",
+    [
+        (str, "some-string", "some-string"),
+        (int, "42", 42),
+        (float, "4.2", 4.2),
+        (bool, "True", True),
+        (bool, "0", False),
+        (list, '["a", "b"]', ["a", "b"]),
+        (dict, '{"a": 1}', {"a": 1}),
+    ],
+)
+def test_env_value_is_parsed(
+    bare_app, monkeypatch, parse_as, env_value, expected_value
 ):
-    """A bare plugin name resolves to the installed package, not to a folder in the cwd.
-
-    Regression test for GH issue #2415: loading the folder executed ``__init__.py`` a second time,
-    so the routes that ``views.py`` had attached to the first Blueprint were lost, and the Blueprint that got registered was empty.
-    Both copies here define a route, so the routing table tells us which module was loaded, and whether its routes survived.
-    """
-    installed = tmp_path / "site-packages"
-    write_plugin(installed, "fm_test_plugin", marker="installed")
-    monkeypatch.syspath_prepend(str(installed))
-
-    working_directory = tmp_path / "plugin-repo"
-    write_plugin(working_directory, "fm_test_plugin", marker="shadow")
-    monkeypatch.chdir(working_directory)
-    assert os.path.exists("fm_test_plugin"), "the shadowing folder must be in the cwd"
-
-    app = make_app(["fm_test_plugin"])
-    register_plugins(app)
-
-    assert app.config["LOADED_PLUGINS"] == {"fm_test_plugin": "installed"}
-    assert sys.modules["fm_test_plugin"].MARKER == "installed"
-    routes = [str(rule) for rule in app.url_map.iter_rules()]
-    assert "/installed" in routes, "the installed plugin's route must be registered"
-    assert "/shadow" not in routes
+    """Environment variables are strings, so they are read as the declared type."""
+    monkeypatch.setenv("MY_PLUGIN_SETTING", env_value)
+    check_config_settings(bare_app, {"MY_PLUGIN_SETTING": {"parse_as": parse_as}})
+    assert bare_app.config["MY_PLUGIN_SETTING"] == expected_value
+    assert isinstance(bare_app.config["MY_PLUGIN_SETTING"], parse_as)
 
 
-def test_folder_in_working_directory_is_loaded_when_nothing_is_installed(
-    tmp_path, monkeypatch, clean_import_state
-):
-    """Without another package of that name, a bare name still resolves to the folder in the cwd.
-
-    The cwd is on ``sys.path`` here, as it is for a plugin repo one runs FlexMeasures from, so the folder is importable and loads as a package.
-    """
-    working_directory = tmp_path / "plugin-repo"
-    write_plugin(working_directory, "fm_test_lonely_plugin", marker="from-cwd")
-    monkeypatch.chdir(working_directory)
-    monkeypatch.syspath_prepend(str(working_directory))
-
-    app = make_app(["fm_test_lonely_plugin"])
-    register_plugins(app)
-
-    assert app.config["LOADED_PLUGINS"] == {"fm_test_lonely_plugin": "from-cwd"}
-    assert "/from-cwd" in [str(rule) for rule in app.url_map.iter_rules()]
+def test_unparsable_env_value_is_reported(bare_app, monkeypatch, caplog):
+    """A value we cannot read as the declared type is reported rather than swallowed."""
+    monkeypatch.setenv("MY_PLUGIN_SETTING", "not-a-number")
+    with caplog.at_level(logging.WARNING):
+        check_config_settings(bare_app, {"MY_PLUGIN_SETTING": {"parse_as": int}})
+    assert "Could not read config setting 'MY_PLUGIN_SETTING'" in caplog.text
+    assert "is a <class 'str'> whereas a <class 'int'> was expected" in caplog.text
 
 
-def test_a_bare_name_resolves_the_way_python_would_import_it(
-    tmp_path, monkeypatch, clean_import_state
-):
-    """With the working directory ahead of site-packages on sys.path, the cwd copy is what gets imported.
-
-    That is normal import resolution, and we deliberately do not fight it: forcing the installed copy here would give the process two module objects for one name,
-    which is the very split that GH issue #2415 is about.
-    What matters is that the folder is imported as a module, once, rather than executed a second time by path, so its routes survive either way.
-    """
-    installed = tmp_path / "site-packages"
-    write_plugin(installed, "fm_test_plugin", marker="installed")
-
-    working_directory = tmp_path / "plugin-repo"
-    write_plugin(working_directory, "fm_test_plugin", marker="from-cwd")
-    monkeypatch.chdir(working_directory)
-    monkeypatch.syspath_prepend(str(installed))
-    monkeypatch.syspath_prepend(
-        str(working_directory)
-    )  # as for `python -m`, the cwd comes first.
-
-    app = make_app(["fm_test_plugin"])
-    register_plugins(app)
-
-    assert app.config["LOADED_PLUGINS"] == {"fm_test_plugin": "from-cwd"}
-    routes = [str(rule) for rule in app.url_map.iter_rules()]
-    assert "/from-cwd" in routes, "the routes of the imported copy must survive"
-    assert "/installed" not in routes
-
-
-def test_loading_a_cwd_folder_that_is_not_importable_warns(
-    tmp_path, monkeypatch, clean_import_state, caplog
-):
-    """A bare name that only resolves to a folder in the cwd is loaded by path, with a warning.
-
-    This is the one case the loader cannot tell apart from a mistyped package name, so it says what it did.
-    """
-    working_directory = tmp_path / "plugin-repo"
-    write_plugin(working_directory, "fm_test_unimportable_plugin", marker="from-cwd")
-    monkeypatch.chdir(working_directory)
-    # Some runners put the working directory on sys.path, as "" or spelled out.
-    # Both would make the plugin importable by name, which is the other branch.
-    monkeypatch.setattr(
-        sys,
-        "path",
-        [
-            entry
-            for entry in sys.path
-            if entry not in ("", str(working_directory), os.curdir)
-        ],
-    )
+def test_missing_setting_without_default(bare_app, caplog):
+    """The log message says the setting stays unset, even if the plugin suggests otherwise."""
+    with caplog.at_level(logging.WARNING):
+        check_config_settings(
+            bare_app,
+            {
+                "MY_PLUGIN_COUNTRY": {
+                    "description": "Country used by my plugin.",
+                    "level": "warning",
+                    "message_if_missing": "'NL' will be used as a default.",
+                }
+            },
+        )
     assert (
-        importlib.util.find_spec("fm_test_unimportable_plugin") is None
-    ), "this test is about the folder that cannot be imported by name"
-
-    app = make_app(["fm_test_unimportable_plugin"])
-    with caplog.at_level("WARNING"):
-        register_plugins(app)
-
-    assert app.config["LOADED_PLUGINS"] == {"fm_test_unimportable_plugin": "from-cwd"}
-    assert (
-        "Loading plugin fm_test_unimportable_plugin from the folder of that name in the working directory"
-        in caplog.text
-    ), "loading a folder for a bare name is ambiguous enough to warn about"
-
-
-def test_path_entry_still_loads_the_folder_it_points_to(
-    tmp_path, monkeypatch, clean_import_state
-):
-    """Spelling out a path loads that folder, even when a package of that name is installed."""
-    installed = tmp_path / "site-packages"
-    write_plugin(installed, "fm_test_plugin", marker="installed")
-    monkeypatch.syspath_prepend(str(installed))
-
-    working_directory = tmp_path / "plugin-repo"
-    write_plugin(working_directory, "fm_test_plugin", marker="by-path")
-    monkeypatch.chdir(working_directory)
-
-    app = make_app([f".{os.sep}fm_test_plugin"])
-    register_plugins(app)
-
-    assert app.config["LOADED_PLUGINS"] == {"fm_test_plugin": "by-path"}
-    assert "/by-path" in [str(rule) for rule in app.url_map.iter_rules()]
-
-
-def test_absolute_path_entry_loads_the_folder_it_points_to(
-    tmp_path, monkeypatch, clean_import_state
-):
-    """An absolute path is a path, too, wherever the process happens to run from."""
-    plugin = write_plugin(tmp_path / "elsewhere", "fm_test_plugin", marker="absolute")
-    monkeypatch.syspath_prepend(str(tmp_path / "elsewhere"))
-    monkeypatch.chdir(tmp_path)
-
-    app = make_app([str(plugin)])
-    register_plugins(app)
-
-    assert app.config["LOADED_PLUGINS"] == {"fm_test_plugin": "absolute"}
-
-
-def test_folder_without_init_file_reports_a_clear_error(
-    tmp_path, monkeypatch, clean_import_state, caplog
-):
-    """A folder without __init__.py is importable as a namespace package, but we don't.
-
-    Reporting the missing ``__init__.py`` is more useful than loading an empty namespace package,
-    and then complaining that it defines no Blueprints.
-    """
-    working_directory = tmp_path / "plugin-repo"
-    write_plugin(
-        working_directory, "fm_test_no_init_plugin", marker="", with_init=False
+        "Missing config setting 'MY_PLUGIN_COUNTRY' (Country used by my plugin.)."
+        " 'NL' will be used as a default."
+        " No default is declared for it, so it stays unset." in caplog.text
     )
-    monkeypatch.chdir(working_directory)
-    monkeypatch.syspath_prepend(str(working_directory))
-
-    app = make_app(["fm_test_no_init_plugin"])
-    with caplog.at_level("ERROR"):
-        register_plugins(app)
-
-    assert app.config["LOADED_PLUGINS"] == {}
-    assert "does not contain an '__init__.py' file" in caplog.text
+    assert bare_app.config.get("MY_PLUGIN_COUNTRY") is None
 
 
-def test_missing_plugin_reports_that_it_is_not_installed(
-    tmp_path, monkeypatch, clean_import_state, caplog
-):
-    """A name that is neither installed nor a folder is reported as not installed."""
-    monkeypatch.chdir(tmp_path)
-
-    app = make_app(["fm_test_there_is_no_such_plugin"])
-    with caplog.at_level("ERROR"):
-        register_plugins(app)
-
-    assert app.config["LOADED_PLUGINS"] == {}
-    assert "it is not installed" in caplog.text
-
-
-def test_path_entry_with_a_trailing_separator_still_names_the_plugin(
-    tmp_path, monkeypatch, clean_import_state
-):
-    """A path that ends in a separator names the folder it points to, not the empty string.
-
-    Splitting the entry on "/" used to yield an empty plugin name here, which then became the module name and the LOADED_PLUGINS key.
-    """
-    write_plugin(tmp_path, "fm_test_plugin", marker="trailing")
-    monkeypatch.chdir(tmp_path)
-
-    app = make_app([f".{os.sep}fm_test_plugin{os.sep}"])
-    register_plugins(app)
-
-    assert app.config["LOADED_PLUGINS"] == {"fm_test_plugin": "trailing"}
-    assert "/trailing" in [str(rule) for rule in app.url_map.iter_rules()]
+def test_missing_setting_with_default(bare_app, caplog):
+    """A declared default is applied, and named in the log message."""
+    with caplog.at_level(logging.WARNING):
+        check_config_settings(
+            bare_app, {"MY_PLUGIN_COUNTRY": {"level": "warning", "default": "NL"}}
+        )
+    assert (
+        "Missing config setting 'MY_PLUGIN_COUNTRY'."
+        " Falling back to the default declared by the plugin: 'NL'." in caplog.text
+    )
+    assert bare_app.config["MY_PLUGIN_COUNTRY"] == "NL"
 
 
-def test_path_entry_that_does_not_exist_is_reported_as_a_missing_path(
-    tmp_path, monkeypatch, clean_import_state, caplog
-):
-    """A path that does not exist is reported as such, rather than resolved as a package name.
-
-    An installed package goes by the same name here, to show that spelling out a path rules it out.
-    """
-    installed = tmp_path / "site-packages"
-    write_plugin(installed, "fm_test_plugin", marker="installed")
-    monkeypatch.syspath_prepend(str(installed))
-    monkeypatch.chdir(tmp_path / "site-packages")
-
-    app = make_app([f"..{os.sep}nowhere{os.sep}fm_test_plugin"])
-    with caplog.at_level("ERROR"):
-        register_plugins(app)
-
-    assert app.config["LOADED_PLUGINS"] == {}
-    assert "does not exist" in caplog.text
-    assert "/installed" not in [str(rule) for rule in app.url_map.iter_rules()]
-
-
-def test_register_plugins_error_hints_at_comma_separated_format(caplog):
-    """Failing to import an unrecognised plugin should hint at the expected comma-separated format,
-    so that a malformed setting (e.g. a JSON array) does not read as a packaging problem.
-    """
-    app = Flask(__name__)
-    app.config["FLEXMEASURES_PLUGINS"] = '["flexmeasures_entsoe"]'
-    register_plugins(app)
-    errors = [
-        record.message
-        for record in caplog.records
-        if "comma-separated" in record.message
-    ]
-    assert errors
+def test_default_does_not_override_a_set_value(bare_app, monkeypatch, caplog):
+    """A setting that is set is not touched, and is not reported as missing."""
+    monkeypatch.setenv("MY_PLUGIN_COUNTRY", "BE")
+    with caplog.at_level(logging.WARNING):
+        check_config_settings(bare_app, {"MY_PLUGIN_COUNTRY": {"default": "NL"}})
+    assert bare_app.config["MY_PLUGIN_COUNTRY"] == "BE"
+    assert caplog.text == ""

--- a/flexmeasures/utils/tests/test_plugin_utils.py
+++ b/flexmeasures/utils/tests/test_plugin_utils.py
@@ -1,9 +1,298 @@
+"""Tests for loading plugins, i.e. for the FLEXMEASURES_PLUGINS setting, and for the settings a plugin declares."""
+
+from __future__ import annotations
+
+import importlib.util
 import logging
+import os
+import sys
 
 import pytest
 from flask import Flask
 
-from flexmeasures.utils.plugin_utils import check_config_settings
+from flexmeasures.utils.plugin_utils import check_config_settings, register_plugins
+
+
+def write_plugin(root, pkg_name: str, marker: str, with_init: bool = True):
+    """Write a minimal plugin package, whose Blueprint gets its route from a submodule.
+
+    This mirrors the common plugin layout: the Blueprint is created in ``__init__.py``, and ``views.py`` imports it to attach routes.
+    The marker distinguishes two copies of the same plugin, and rides along on the module and its route.
+    """
+    pkg = root / pkg_name
+    pkg.mkdir(parents=True)
+    if not with_init:
+        return pkg
+    (pkg / "__init__.py").write_text(
+        "from flask import Blueprint\n"
+        f"MARKER = '{marker}'\n"
+        f"__version__ = '{marker}'\n"
+        f"bp = Blueprint('{pkg_name}_{marker}', __name__)\n"
+        f"import {pkg_name}.views  # noqa: E402,F401 (attaches the routes to bp)\n"
+    )
+    (pkg / "views.py").write_text(
+        f"from {pkg_name} import bp\n"
+        "\n"
+        f"@bp.route('/{marker}')\n"
+        "def a_route():\n"
+        f"    return '{marker}'\n"
+    )
+    return pkg
+
+
+@pytest.fixture
+def clean_import_state():
+    """Undo the sys.path and sys.modules changes that loading a plugin makes.
+
+    Only the modules a test added are dropped, so that unrelated imports in the same session are left alone.
+    """
+    original_path = list(sys.path)
+    original_modules = set(sys.modules)
+    yield
+    sys.path[:] = original_path
+    for name in set(sys.modules) - original_modules:
+        del sys.modules[name]
+
+
+def make_app(plugins: list[str]) -> Flask:
+    app = Flask(__name__)
+    app.config["FLEXMEASURES_PLUGINS"] = plugins
+    return app
+
+
+def test_installed_package_wins_from_folder_in_working_directory(
+    tmp_path, monkeypatch, clean_import_state
+):
+    """A bare plugin name resolves to the installed package, not to a folder in the cwd.
+
+    Regression test for GH issue #2415: loading the folder executed ``__init__.py`` a second time,
+    so the routes that ``views.py`` had attached to the first Blueprint were lost, and the Blueprint that got registered was empty.
+    Both copies here define a route, so the routing table tells us which module was loaded, and whether its routes survived.
+    """
+    installed = tmp_path / "site-packages"
+    write_plugin(installed, "fm_test_plugin", marker="installed")
+    monkeypatch.syspath_prepend(str(installed))
+
+    working_directory = tmp_path / "plugin-repo"
+    write_plugin(working_directory, "fm_test_plugin", marker="shadow")
+    monkeypatch.chdir(working_directory)
+    assert os.path.exists("fm_test_plugin"), "the shadowing folder must be in the cwd"
+
+    app = make_app(["fm_test_plugin"])
+    register_plugins(app)
+
+    assert app.config["LOADED_PLUGINS"] == {"fm_test_plugin": "installed"}
+    assert sys.modules["fm_test_plugin"].MARKER == "installed"
+    routes = [str(rule) for rule in app.url_map.iter_rules()]
+    assert "/installed" in routes, "the installed plugin's route must be registered"
+    assert "/shadow" not in routes
+
+
+def test_folder_in_working_directory_is_loaded_when_nothing_is_installed(
+    tmp_path, monkeypatch, clean_import_state
+):
+    """Without another package of that name, a bare name still resolves to the folder in the cwd.
+
+    The cwd is on ``sys.path`` here, as it is for a plugin repo one runs FlexMeasures from, so the folder is importable and loads as a package.
+    """
+    working_directory = tmp_path / "plugin-repo"
+    write_plugin(working_directory, "fm_test_lonely_plugin", marker="from-cwd")
+    monkeypatch.chdir(working_directory)
+    monkeypatch.syspath_prepend(str(working_directory))
+
+    app = make_app(["fm_test_lonely_plugin"])
+    register_plugins(app)
+
+    assert app.config["LOADED_PLUGINS"] == {"fm_test_lonely_plugin": "from-cwd"}
+    assert "/from-cwd" in [str(rule) for rule in app.url_map.iter_rules()]
+
+
+def test_a_bare_name_resolves_the_way_python_would_import_it(
+    tmp_path, monkeypatch, clean_import_state
+):
+    """With the working directory ahead of site-packages on sys.path, the cwd copy is what gets imported.
+
+    That is normal import resolution, and we deliberately do not fight it: forcing the installed copy here would give the process two module objects for one name,
+    which is the very split that GH issue #2415 is about.
+    What matters is that the folder is imported as a module, once, rather than executed a second time by path, so its routes survive either way.
+    """
+    installed = tmp_path / "site-packages"
+    write_plugin(installed, "fm_test_plugin", marker="installed")
+
+    working_directory = tmp_path / "plugin-repo"
+    write_plugin(working_directory, "fm_test_plugin", marker="from-cwd")
+    monkeypatch.chdir(working_directory)
+    monkeypatch.syspath_prepend(str(installed))
+    monkeypatch.syspath_prepend(
+        str(working_directory)
+    )  # as for `python -m`, the cwd comes first.
+
+    app = make_app(["fm_test_plugin"])
+    register_plugins(app)
+
+    assert app.config["LOADED_PLUGINS"] == {"fm_test_plugin": "from-cwd"}
+    routes = [str(rule) for rule in app.url_map.iter_rules()]
+    assert "/from-cwd" in routes, "the routes of the imported copy must survive"
+    assert "/installed" not in routes
+
+
+def test_loading_a_cwd_folder_that_is_not_importable_warns(
+    tmp_path, monkeypatch, clean_import_state, caplog
+):
+    """A bare name that only resolves to a folder in the cwd is loaded by path, with a warning.
+
+    This is the one case the loader cannot tell apart from a mistyped package name, so it says what it did.
+    """
+    working_directory = tmp_path / "plugin-repo"
+    write_plugin(working_directory, "fm_test_unimportable_plugin", marker="from-cwd")
+    monkeypatch.chdir(working_directory)
+    # Some runners put the working directory on sys.path, as "" or spelled out.
+    # Both would make the plugin importable by name, which is the other branch.
+    monkeypatch.setattr(
+        sys,
+        "path",
+        [
+            entry
+            for entry in sys.path
+            if entry not in ("", str(working_directory), os.curdir)
+        ],
+    )
+    assert (
+        importlib.util.find_spec("fm_test_unimportable_plugin") is None
+    ), "this test is about the folder that cannot be imported by name"
+
+    app = make_app(["fm_test_unimportable_plugin"])
+    with caplog.at_level("WARNING"):
+        register_plugins(app)
+
+    assert app.config["LOADED_PLUGINS"] == {"fm_test_unimportable_plugin": "from-cwd"}
+    assert (
+        "Loading plugin fm_test_unimportable_plugin from the folder of that name in the working directory"
+        in caplog.text
+    ), "loading a folder for a bare name is ambiguous enough to warn about"
+
+
+def test_path_entry_still_loads_the_folder_it_points_to(
+    tmp_path, monkeypatch, clean_import_state
+):
+    """Spelling out a path loads that folder, even when a package of that name is installed."""
+    installed = tmp_path / "site-packages"
+    write_plugin(installed, "fm_test_plugin", marker="installed")
+    monkeypatch.syspath_prepend(str(installed))
+
+    working_directory = tmp_path / "plugin-repo"
+    write_plugin(working_directory, "fm_test_plugin", marker="by-path")
+    monkeypatch.chdir(working_directory)
+
+    app = make_app([f".{os.sep}fm_test_plugin"])
+    register_plugins(app)
+
+    assert app.config["LOADED_PLUGINS"] == {"fm_test_plugin": "by-path"}
+    assert "/by-path" in [str(rule) for rule in app.url_map.iter_rules()]
+
+
+def test_absolute_path_entry_loads_the_folder_it_points_to(
+    tmp_path, monkeypatch, clean_import_state
+):
+    """An absolute path is a path, too, wherever the process happens to run from."""
+    plugin = write_plugin(tmp_path / "elsewhere", "fm_test_plugin", marker="absolute")
+    monkeypatch.syspath_prepend(str(tmp_path / "elsewhere"))
+    monkeypatch.chdir(tmp_path)
+
+    app = make_app([str(plugin)])
+    register_plugins(app)
+
+    assert app.config["LOADED_PLUGINS"] == {"fm_test_plugin": "absolute"}
+
+
+def test_folder_without_init_file_reports_a_clear_error(
+    tmp_path, monkeypatch, clean_import_state, caplog
+):
+    """A folder without __init__.py is importable as a namespace package, but we don't.
+
+    Reporting the missing ``__init__.py`` is more useful than loading an empty namespace package,
+    and then complaining that it defines no Blueprints.
+    """
+    working_directory = tmp_path / "plugin-repo"
+    write_plugin(
+        working_directory, "fm_test_no_init_plugin", marker="", with_init=False
+    )
+    monkeypatch.chdir(working_directory)
+    monkeypatch.syspath_prepend(str(working_directory))
+
+    app = make_app(["fm_test_no_init_plugin"])
+    with caplog.at_level("ERROR"):
+        register_plugins(app)
+
+    assert app.config["LOADED_PLUGINS"] == {}
+    assert "does not contain an '__init__.py' file" in caplog.text
+
+
+def test_missing_plugin_reports_that_it_is_not_installed(
+    tmp_path, monkeypatch, clean_import_state, caplog
+):
+    """A name that is neither installed nor a folder is reported as not installed."""
+    monkeypatch.chdir(tmp_path)
+
+    app = make_app(["fm_test_there_is_no_such_plugin"])
+    with caplog.at_level("ERROR"):
+        register_plugins(app)
+
+    assert app.config["LOADED_PLUGINS"] == {}
+    assert "it is not installed" in caplog.text
+
+
+def test_path_entry_with_a_trailing_separator_still_names_the_plugin(
+    tmp_path, monkeypatch, clean_import_state
+):
+    """A path that ends in a separator names the folder it points to, not the empty string.
+
+    Splitting the entry on "/" used to yield an empty plugin name here, which then became the module name and the LOADED_PLUGINS key.
+    """
+    write_plugin(tmp_path, "fm_test_plugin", marker="trailing")
+    monkeypatch.chdir(tmp_path)
+
+    app = make_app([f".{os.sep}fm_test_plugin{os.sep}"])
+    register_plugins(app)
+
+    assert app.config["LOADED_PLUGINS"] == {"fm_test_plugin": "trailing"}
+    assert "/trailing" in [str(rule) for rule in app.url_map.iter_rules()]
+
+
+def test_path_entry_that_does_not_exist_is_reported_as_a_missing_path(
+    tmp_path, monkeypatch, clean_import_state, caplog
+):
+    """A path that does not exist is reported as such, rather than resolved as a package name.
+
+    An installed package goes by the same name here, to show that spelling out a path rules it out.
+    """
+    installed = tmp_path / "site-packages"
+    write_plugin(installed, "fm_test_plugin", marker="installed")
+    monkeypatch.syspath_prepend(str(installed))
+    monkeypatch.chdir(tmp_path / "site-packages")
+
+    app = make_app([f"..{os.sep}nowhere{os.sep}fm_test_plugin"])
+    with caplog.at_level("ERROR"):
+        register_plugins(app)
+
+    assert app.config["LOADED_PLUGINS"] == {}
+    assert "does not exist" in caplog.text
+    assert "/installed" not in [str(rule) for rule in app.url_map.iter_rules()]
+
+
+def test_register_plugins_error_hints_at_comma_separated_format(caplog):
+    """Failing to import an unrecognised plugin should hint at the expected comma-separated format,
+    so that a malformed setting (e.g. a JSON array) does not read as a packaging problem.
+    """
+    app = Flask(__name__)
+    app.config["FLEXMEASURES_PLUGINS"] = '["flexmeasures_entsoe"]'
+    register_plugins(app)
+    errors = [
+        record.message
+        for record in caplog.records
+        if "comma-separated" in record.message
+    ]
+    assert errors
 
 
 @pytest.fixture
@@ -13,7 +302,7 @@ def bare_app():
     Settings are only read from the environment outside of testing mode,
     just like FlexMeasures' own settings are.
     """
-    app = Flask("test_plugin_utils")
+    app = Flask("test_plugin_settings")
     app.logger.setLevel(logging.DEBUG)
     return app
 
@@ -38,8 +327,17 @@ def test_config_wins_over_env(bare_app, monkeypatch):
 def test_env_is_not_read_while_testing(monkeypatch):
     """Tests run on defaults, so they should not pick up settings from the environment."""
     monkeypatch.setenv("MY_PLUGIN_TOKEN", "token-from-env")
-    app = Flask("test_plugin_utils")
+    app = Flask("test_plugin_settings")
     app.testing = True
+    check_config_settings(app, {"MY_PLUGIN_TOKEN": {}})
+    assert app.config.get("MY_PLUGIN_TOKEN") is None
+
+
+def test_env_is_not_read_while_building_the_documentation(monkeypatch):
+    """The documentation build runs on defaults, too."""
+    monkeypatch.setenv("MY_PLUGIN_TOKEN", "token-from-env")
+    app = Flask("test_plugin_settings")
+    app.config["FLEXMEASURES_ENV"] = "documentation"
     check_config_settings(app, {"MY_PLUGIN_TOKEN": {}})
     assert app.config.get("MY_PLUGIN_TOKEN") is None
 
@@ -107,6 +405,16 @@ def test_missing_setting_with_default(bare_app, caplog):
         " Falling back to the default declared by the plugin: 'NL'." in caplog.text
     )
     assert bare_app.config["MY_PLUGIN_COUNTRY"] == "NL"
+
+
+def test_default_of_the_wrong_type_is_reported(bare_app, caplog):
+    """A default that does not match the declared type is reported, like any other value."""
+    with caplog.at_level(logging.WARNING):
+        check_config_settings(
+            bare_app, {"MY_PLUGIN_TIMEOUT": {"parse_as": int, "default": "30"}}
+        )
+    assert "is a <class 'str'> whereas a <class 'int'> was expected" in caplog.text
+    assert bare_app.config["MY_PLUGIN_TIMEOUT"] == "30"
 
 
 def test_default_does_not_override_a_set_value(bare_app, monkeypatch, caplog):


### PR DESCRIPTION
## Description

Plugin-declared settings could only be set in a config file. Setting one as an environment variable — the natural thing to do in a container — had no effect, and FlexMeasures still reported it as missing. On top of that, the "missing setting" message repeated whatever the plugin put in `message_if_missing`, so a plugin promising `"'NL' will be used as a default."` made a setting that has no fallback read as optional.

- [x] Plugin settings that are still unset when the plugin is registered are now looked up in the environment. Plugins are registered after the config file has been read, so a value from the config file keeps precedence and the environment only fills the gaps — the same order `read_env_vars()` applies to FlexMeasures' own settings.
- [x] Environment values are interpreted as the `parse_as` type the plugin declared: `int`/`float` as numbers, `bool` as `True` for `1`/`true`/`yes`/`on` (case-insensitively), `list`/`dict` as JSON. A value we cannot convert is passed on unconverted, so the existing type check reports it. Without `parse_as`, the value stays a string.
- [x] A `__settings__` entry can now declare a `default`, which is applied when the setting is missing.
- [x] The message for a missing setting now ends with a statement from FlexMeasures itself: either `Falling back to the default declared by the plugin: 'NL'.` or `No default is declared for it, so it stays unset.` A plugin's own `message_if_missing` can no longer be the last word on whether a setting is optional.
- [x] Documented the keys of a `__settings__` entry, and where those settings can be set.
- [x] Added changelog item in `documentation/changelog.rst`

As before, nothing is read from the environment while testing or while building the documentation, which both run on defaults.

### On reading *everything* from the environment

The issue discussion raises whether `read_env_vars()` should simply promote every environment variable. This PR does not do that: the app config would then absorb every variable in the environment (`PATH`, cloud credentials, whatever the deployment happens to export), and Flask config values are visible to every plugin and template. Promoting exactly the settings a plugin declared gets the reported use case working without that. If we do want the broader change, it seems worth a separate discussion.

## Look & Feel

A plugin declaring:

```python
__settings__ = {
    "MY_PLUGIN_TOKEN": {"description": "Token used by my plugin.", "level": "error"},
    "MY_PLUGIN_COUNTRY": {"level": "warning", "message_if_missing": "'NL' will be used as a default.", "default": "NL"},
    "MY_PLUGIN_TIMEOUT": {"level": "warning", "parse_as": int},
}
```

started with `MY_PLUGIN_TOKEN=repro-token-value MY_PLUGIN_TIMEOUT=30`:

```
INFO Importing plugin repro_plugin ...
WARNING Missing config setting 'MY_PLUGIN_COUNTRY'. 'NL' will be used as a default. Falling back to the default declared by the plugin: 'NL'.
INFO Loaded plugins: {'repro_plugin': '0.1'}

MY_PLUGIN_TOKEN   = 'repro-token-value'
MY_PLUGIN_COUNTRY = 'NL'
MY_PLUGIN_TIMEOUT = 30
```

Before this PR, `MY_PLUGIN_TOKEN` and `MY_PLUGIN_TIMEOUT` were both `None` and reported as missing, and the `MY_PLUGIN_COUNTRY` warning stopped after `'NL' will be used as a default.` while `MY_PLUGIN_COUNTRY` stayed `None`.

## How to test

`pytest flexmeasures/utils/tests/test_plugin_utils.py` covers env promotion, config-file precedence, the testing-mode exemption, each `parse_as` conversion, an unparsable value, and the missing-setting message with and without a `default`.

The issue's Docker repro is the end-to-end check: build the one-setting plugin image, set the setting as a container environment variable, and the server now boots without reporting it missing.

## Further Improvements

- Whether `read_env_vars()` should read all settings from the environment (see above) is left open.

## Related Items

Closes #2492

---

#### Sign-off

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2KPuf29L3FLQhfcvdg85x
