### PR TITLE
Reject a resolution that spans no positive time

### DIFF
--- a/documentation/api/change_log.rst
+++ b/documentation/api/change_log.rst
@@ -5,6 +5,10 @@ API change log
 
 .. note:: The FlexMeasures API follows its own versioning scheme. This is also reflected in the URL (e.g. `/api/v3_0`), allowing developers to upgrade at their own pace.
 
+v3.0-35 | September 9, 2026
+"""""""""""""""""""""""""""
+- The ``resolution`` query parameter is now rejected with a ``422 (Unprocessable Entity)`` response unless it spans a positive amount of time. This applies to ``GET /api/v3_0/sensors/<id>/data``, to the ``chart_data`` endpoints under ``api/dev``, and to the ``POST`` schedule trigger endpoints. Previously, a zero resolution (such as ``PT0S``) either crashed the request with a ``500`` or was silently ignored, and a negative resolution returned an empty set of values.
+
 v3.0-34 | September 2, 2026
 """""""""""""""""""""""""""
 - Added ``POST /api/v3_0/assets/<id>/automations/<automation_id>/trigger``, to run one automation now, once, on top of its recurring runs. The response is the standard job response, extended with ``n_jobs``: how many jobs the run queued. An on-demand run does not affect the automation's recurrence, and inactive automations can be triggered, too. Triggering requires the same permission as writing data under the asset, and falls under the stricter rate limit that the other triggering endpoints share.

--- a/documentation/api/change_log.rst
+++ b/documentation/api/change_log.rst
@@ -7,7 +7,7 @@ API change log
 
 v3.0-35 | September 9, 2026
 """""""""""""""""""""""""""
-- The ``resolution`` query parameter is now rejected with a ``422 (Unprocessable Entity)`` response unless it spans a positive amount of time. This applies to ``GET /api/v3_0/sensors/<id>/data``, to the ``chart_data`` endpoints under ``api/dev``, and to the ``POST`` schedule trigger endpoints. Previously, a zero resolution (such as ``PT0S``) either crashed the request with a ``500`` or was silently ignored, and a negative resolution returned an empty set of values.
+- The ``resolution`` field is now rejected with a ``422 (Unprocessable Entity)`` response unless it spans a positive amount of time. This applies wherever the API accepts one: as a query parameter on ``GET /api/v3_0/sensors/<id>/data`` and on the ``chart_data`` endpoints under ``api/dev``, and in the request body of the ``POST`` schedule trigger endpoints. Previously, a zero resolution (such as ``PT0S``) either crashed the request with a ``500`` or was silently ignored, and a negative resolution returned an empty set of values.
 
 v3.0-34 | September 2, 2026
 """""""""""""""""""""""""""

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -39,6 +39,7 @@ Infrastructure / Support
 Bugfixes
 -----------
 
+* Asking the API for sensor data, a chart or a schedule at a resolution of zero (such as ``PT0S``) now gets the same clear rejection as any other unsupported resolution, instead of a server error or a silently empty result [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
 * Where several data sources report the same event, which one a search keeps is now decided the same way every time: a source version only counts against other versions of that source, and a caller that lists its sources gets the order it asked for [see `PR #2494 <https://www.github.com/FlexMeasures/flexmeasures/pull/2494>`_]
 * A KPI on the asset page counted an event once per data source that reported it, so a total could come out higher than any source reported; it now reduces one value per event, from the latest source version and the most recent belief within it [see `PR #2472 <https://www.github.com/FlexMeasures/flexmeasures/pull/2472>`_]
 * ``flexmeasures add schedule --dry-run`` no longer saves a schedule when it is combined with ``--as-job``, where the flag used to be dropped without a word and the queued job stored its schedule anyway; that combination is now rejected, and a dry run says how many beliefs it would have saved and which events they cover [see `PR #2483 <https://www.github.com/FlexMeasures/flexmeasures/pull/2483>`_]

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -39,7 +39,7 @@ Infrastructure / Support
 Bugfixes
 -----------
 
-* Asking the API for sensor data, a chart or a schedule at a resolution of zero (such as ``PT0S``) now gets the same clear rejection as any other unsupported resolution, instead of a server error or a silently empty result [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
+* Asking the API for sensor data, a chart or a schedule at a resolution of zero (such as ``PT0S``) now gets the same clear rejection as any other unsupported resolution, instead of a server error or a silently empty result [see `PR #2502 <https://www.github.com/FlexMeasures/flexmeasures/pull/2502>`_]
 * Where several data sources report the same event, which one a search keeps is now decided the same way every time: a source version only counts against other versions of that source, and a caller that lists its sources gets the order it asked for [see `PR #2494 <https://www.github.com/FlexMeasures/flexmeasures/pull/2494>`_]
 * A KPI on the asset page counted an event once per data source that reported it, so a total could come out higher than any source reported; it now reduces one value per event, from the latest source version and the most recent belief within it [see `PR #2472 <https://www.github.com/FlexMeasures/flexmeasures/pull/2472>`_]
 * ``flexmeasures add schedule --dry-run`` no longer saves a schedule when it is combined with ``--as-job``, where the flag used to be dropped without a word and the queued job stored its schedule anyway; that combination is now rejected, and a dry run says how many beliefs it would have saved and which events they cover [see `PR #2483 <https://www.github.com/FlexMeasures/flexmeasures/pull/2483>`_]

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -39,7 +39,7 @@ Infrastructure / Support
 Bugfixes
 -----------
 
-* Asking the API for sensor data, a chart or a schedule at a resolution of zero (such as ``PT0S``) now gets the same clear rejection as any other unsupported resolution, instead of a server error or a silently empty result [see `PR #2502 <https://www.github.com/FlexMeasures/flexmeasures/pull/2502>`_]
+* Asking the API for sensor data, a chart or a schedule at a resolution that spans no time (such as ``PT0S``), or at a negative one, now gets the same clear rejection as any other unsupported resolution, instead of a server error or a silently empty result [see `PR #2502 <https://www.github.com/FlexMeasures/flexmeasures/pull/2502>`_]
 * Where several data sources report the same event, which one a search keeps is now decided the same way every time: a source version only counts against other versions of that source, and a caller that lists its sources gets the order it asked for [see `PR #2494 <https://www.github.com/FlexMeasures/flexmeasures/pull/2494>`_]
 * A KPI on the asset page counted an event once per data source that reported it, so a total could come out higher than any source reported; it now reduces one value per event, from the latest source version and the most recent belief within it [see `PR #2472 <https://www.github.com/FlexMeasures/flexmeasures/pull/2472>`_]
 * ``flexmeasures add schedule --dry-run`` no longer saves a schedule when it is combined with ``--as-job``, where the flag used to be dropped without a word and the queued job stored its schedule anyway; that combination is now rejected, and a dry run says how many beliefs it would have saved and which events they cover [see `PR #2483 <https://www.github.com/FlexMeasures/flexmeasures/pull/2483>`_]

--- a/flexmeasures/api/common/schemas/sensor_data.py
+++ b/flexmeasures/api/common/schemas/sensor_data.py
@@ -20,7 +20,12 @@ from flexmeasures.api.common.schemas.sensors import (
 from flexmeasures.api.common.schemas.users import AccountIdField
 from flexmeasures.api.common.utils.api_utils import upsample_values
 from flexmeasures.data.models.planning.utils import initialize_index
-from flexmeasures.data.schemas import AwareDateTimeField, DurationField, SourceIdField
+from flexmeasures.data.schemas import (
+    AwareDateTimeField,
+    DurationField,
+    ResolutionField,
+    SourceIdField,
+)
 from flexmeasures.data.services.data_sources import get_or_create_source
 from flexmeasures.data.services.time_series import simplify_index
 from flexmeasures.utils.time_utils import (
@@ -154,7 +159,7 @@ class SensorDataDescriptionSchema(SensorDataTimingDescriptionSchema):
 class GetSensorDataFilterSchemaMixin:
     """Shared filters for GET sensor data request parsing and docs."""
 
-    resolution = DurationField(
+    resolution = ResolutionField(
         required=False,
         metadata=dict(
             description="Resolution of the returned sensor data in ISO 8601 duration format.",

--- a/flexmeasures/api/dev/sensors.py
+++ b/flexmeasures/api/dev/sensors.py
@@ -12,7 +12,7 @@ from flexmeasures.auth.policy import ADMIN_ROLE, ADMIN_READER_ROLE
 from flexmeasures.auth.decorators import permission_required_for_context
 from flexmeasures.data.schemas import (
     AssetIdField,
-    DurationField,
+    ResolutionField,
     SensorIdField,
 )
 from flexmeasures.api.common.schemas.generic_schemas import (
@@ -102,7 +102,7 @@ class SensorChartDataKwargsSchema(EventWindowSchema, BeliefTimeFilterSchema):
         "compress_json": "compress-json",
     }
 
-    resolution = DurationField(
+    resolution = ResolutionField(
         required=False,
         metadata=dict(
             description="Resolution of the requested data, in ISO 8601 duration format.",

--- a/flexmeasures/api/v3_0/sensors.py
+++ b/flexmeasures/api/v3_0/sensors.py
@@ -67,8 +67,8 @@ from flexmeasures.data.schemas.sensors import (  # noqa F401
 )
 from flexmeasures.data.schemas.times import (
     AwareDateTimeField,
-    DurationField,
     PlanningDurationField,
+    ResolutionField,
 )
 from flexmeasures.data.schemas import AssetIdField, SourceIdField
 from flexmeasures.api.common.schemas.search import SearchFilterField
@@ -286,7 +286,7 @@ class TriggerScheduleKwargsSchema(SupportsLegacyFieldAliases, Schema):
             example="PT24H",
         ),
     )
-    resolution = DurationField(
+    resolution = ResolutionField(
         metadata=dict(
             description="The resolution of the requested schedule in ISO 8601 duration format. "
             "This governs how often setpoints are allowed to change. "

--- a/flexmeasures/api/v3_0/tests/test_sensor_data.py
+++ b/flexmeasures/api/v3_0/tests/test_sensor_data.py
@@ -45,6 +45,40 @@ def test_get_no_sensor_data(
     assert all(a == b for a, b in zip(values, [None, None, None, None]))
 
 
+@pytest.mark.parametrize("resolution", ["PT0S", "PT0M", "P0D", "-PT20M"])
+@pytest.mark.parametrize(
+    "requesting_user", ["test_supplier_user_4@seita.nl"], indirect=True
+)
+def test_get_sensor_data_with_non_positive_resolution(
+    client,
+    setup_api_test_data: dict[str, Sensor],
+    resolution,
+    requesting_user,
+):
+    """Check that the /sensors/data endpoint rejects a resolution that spans no positive time.
+
+    A zero resolution used to result in an uncaught ZeroDivisionError (a 500 response).
+    """
+    sensor = setup_api_test_data["some gas sensor"]
+    message = {
+        "start": "2021-05-02T00:00:00+02:00",
+        "duration": "PT1H20M",
+        "horizon": "PT0H",
+        "unit": "m³/h",
+        "resolution": resolution,
+    }
+    response = client.get(
+        url_for("SensorAPI:get_data", id=sensor.id),
+        query_string=message,
+    )
+    print("Server responded with:\n%s" % response.json)
+    assert response.status_code == 422
+    assert (
+        "FlexMeasures only supports a positive resolution"
+        in response.json["message"]["combined_sensor_data_description"]["resolution"][0]
+    )
+
+
 @pytest.mark.parametrize("use_oldstyle_endpoint", [True, False])
 @pytest.mark.parametrize(
     "requesting_user", ["test_supplier_user_4@seita.nl"], indirect=True

--- a/flexmeasures/data/schemas/__init__.py
+++ b/flexmeasures/data/schemas/__init__.py
@@ -10,6 +10,7 @@ from .sources import DataSourceIdField as SourceIdField
 from .times import (
     AwareDateTimeField,
     DurationField,
+    ResolutionField,
     TimeIntervalField,
     StartEndTimeSchema,
 )

--- a/flexmeasures/data/schemas/scheduling/__init__.py
+++ b/flexmeasures/data/schemas/scheduling/__init__.py
@@ -37,6 +37,7 @@ from flexmeasures.data.schemas.times import (
     AwareDateTimeField,
     DurationField,
     PlanningDurationField,
+    ResolutionField,
 )
 from flexmeasures.data.schemas.utils import FMValidationError
 from flexmeasures.utils.flexmeasures_inflection import p
@@ -1799,7 +1800,7 @@ class AssetTriggerSchema(Schema):
             example="PT24H",
         ),
     )
-    resolution = DurationField(
+    resolution = ResolutionField(
         metadata=dict(
             description="The resolution of the requested schedule in ISO 8601 duration format. "
             "This governs how often setpoints are allowed to change. "

--- a/flexmeasures/data/schemas/tests/test_times.py
+++ b/flexmeasures/data/schemas/tests/test_times.py
@@ -86,7 +86,7 @@ def test_duration_field_invalid(duration_input, error_msg):
         ("PT1H", timedelta(hours=1)),
         ("P1D", timedelta(days=1)),
         ("P1M", isodate.Duration(months=1)),
-        # a nominal duration holds its days and seconds in its tdelta, not next to it
+        # a nominal duration holds its days and seconds in its tdelta, not next to it.
         ("P1M1D", isodate.Duration(months=1, days=1)),
         ("P1Y1D", isodate.Duration(years=1, days=1)),
         ("P1MT1H", isodate.Duration(months=1, hours=1)),

--- a/flexmeasures/data/schemas/tests/test_times.py
+++ b/flexmeasures/data/schemas/tests/test_times.py
@@ -86,6 +86,10 @@ def test_duration_field_invalid(duration_input, error_msg):
         ("PT1H", timedelta(hours=1)),
         ("P1D", timedelta(days=1)),
         ("P1M", isodate.Duration(months=1)),
+        # a nominal duration holds its days and seconds in its tdelta, not next to it
+        ("P1M1D", isodate.Duration(months=1, days=1)),
+        ("P1Y1D", isodate.Duration(years=1, days=1)),
+        ("P1MT1H", isodate.Duration(months=1, hours=1)),
     ],
 )
 def test_resolution_field_positive(resolution_input, exp_deserialization):
@@ -103,6 +107,7 @@ def test_resolution_field_positive(resolution_input, exp_deserialization):
         "-PT15M",
         "-P1D",
         "-P1M",
+        "-P1M1D",
     ],
 )
 def test_resolution_field_not_positive(resolution_input):

--- a/flexmeasures/data/schemas/tests/test_times.py
+++ b/flexmeasures/data/schemas/tests/test_times.py
@@ -50,7 +50,8 @@ def test_duration_field_nominal_grounded(
     We want to test if we can ground them as expected.
     We use a particular datetime to ground, in a leap year February.
     For the Europe/Amsterdam timezone, daylight saving time started on March 29th 2020.
-    # todo: the commented out tests would work if isodate.parse_duration would have the option to stop coercing ISO 8601 days into datetime.timedelta days
+    # todo: the commented out tests pass as soon as we parse with isodate.parse_duration(..., as_timedelta_if_possible=False), which stops it coercing ISO 8601 days into datetime.timedelta days.
+    # That option landed in https://github.com/gweis/isodate/pull/64, after this todo was written, but adopting it needs each caller to ground its duration first.
     """
     df = DurationField()
     deser = df.deserialize(duration_input, None, None)

--- a/flexmeasures/data/schemas/tests/test_times.py
+++ b/flexmeasures/data/schemas/tests/test_times.py
@@ -4,7 +4,11 @@ import pytest
 import pytz
 import isodate
 
-from flexmeasures.data.schemas.times import DurationField, DurationValidationError
+from flexmeasures.data.schemas.times import (
+    DurationField,
+    DurationValidationError,
+    ResolutionField,
+)
 
 
 @pytest.mark.parametrize(
@@ -73,3 +77,49 @@ def test_duration_field_invalid(duration_input, error_msg):
     with pytest.raises(DurationValidationError) as ve:
         df.deserialize(duration_input, None, None)
     assert error_msg in str(ve)
+
+
+@pytest.mark.parametrize(
+    "resolution_input, exp_deserialization",
+    [
+        ("PT15M", timedelta(minutes=15)),
+        ("PT1H", timedelta(hours=1)),
+        ("P1D", timedelta(days=1)),
+        ("P1M", isodate.Duration(months=1)),
+    ],
+)
+def test_resolution_field_positive(resolution_input, exp_deserialization):
+    """A resolution spanning a positive amount of time deserializes like any other duration."""
+    rf = ResolutionField()
+    assert rf.deserialize(resolution_input, None, None) == exp_deserialization
+
+
+@pytest.mark.parametrize(
+    "resolution_input",
+    [
+        "PT0S",
+        "PT0M",
+        "P0D",
+        "-PT15M",
+        "-P1D",
+        "-P1M",
+    ],
+)
+def test_resolution_field_not_positive(resolution_input):
+    """A resolution that does not span a positive amount of time is rejected.
+
+    Without this validation, a zero resolution would crash the API with a ZeroDivisionError,
+    and a negative resolution would silently describe an empty set of events.
+    """
+    rf = ResolutionField()
+    with pytest.raises(DurationValidationError) as ve:
+        rf.deserialize(resolution_input, None, None)
+    assert "FlexMeasures only supports a positive resolution" in str(ve)
+
+
+def test_resolution_field_still_validates_duration():
+    """A resolution is still subject to the validation that any duration is subject to."""
+    rf = ResolutionField()
+    with pytest.raises(DurationValidationError) as ve:
+        rf.deserialize("PT40S", None, None)
+    assert "FlexMeasures only support multiples of 1 minute." in str(ve)

--- a/flexmeasures/data/schemas/times.py
+++ b/flexmeasures/data/schemas/times.py
@@ -103,6 +103,8 @@ def _spans_positive_time(duration: timedelta | isodate.Duration) -> bool:
 
     Nominal durations (such as "P1M") are not grounded to an actual time span here,
     because their sign does not depend on the time span they are grounded to.
+    Only years and months sit outside an isodate.Duration's tdelta;
+    its days and seconds are held by that tdelta, so checking it covers them both.
     """
     if isinstance(duration, isodate.Duration):
         return (

--- a/flexmeasures/data/schemas/times.py
+++ b/flexmeasures/data/schemas/times.py
@@ -80,6 +80,37 @@ class DurationField(MarshmallowClickMixin, fields.Str):
         return duration
 
 
+class ResolutionField(DurationField):
+    """Field that deserializes to an ISO8601 Duration to be used as a resolution.
+
+    On top of what DurationField accepts, a resolution must span a positive amount of time.
+    A zero resolution describes no event frequency at all,
+    and a negative resolution describes events going back in time,
+    neither of which can be turned into a series of events.
+    """
+
+    def _deserialize(self, value, attr, data, **kwargs) -> timedelta | isodate.Duration:
+        duration_value = super()._deserialize(value, attr, data, **kwargs)
+        if not _spans_positive_time(duration_value):
+            raise DurationValidationError(
+                f"FlexMeasures only supports a positive resolution, got: {value}."
+            )
+        return duration_value
+
+
+def _spans_positive_time(duration: timedelta | isodate.Duration) -> bool:
+    """Whether the given duration spans a positive amount of time.
+
+    Nominal durations (such as "P1M") are not grounded to an actual time span here,
+    because their sign does not depend on the time span they are grounded to.
+    """
+    if isinstance(duration, isodate.Duration):
+        return (
+            duration.years > 0 or duration.months > 0 or duration.tdelta > timedelta(0)
+        )
+    return duration > timedelta(0)
+
+
 class PlanningDurationField(DurationField):
     @classmethod
     def load_default(cls):


### PR DESCRIPTION
## Description

Fixes #2493: `GET /sensors/<id>/data?resolution=PT0S` answered with a bare 500 (`{"message": "integer division or modulo by zero", "status": 500}`), where every other unsupported resolution gets a 422.

- [x] `DurationField` only rejects durations that are not a whole number of minutes, and `PT0S` passes that check (`0 % 60 == 0`). The zero duration then reaches `initialize_index`, whose `pd.date_range(freq=to_offset(timedelta(0)))` raises an uncaught `ZeroDivisionError`.
- [x] Added `ResolutionField`, a `DurationField` that additionally requires the duration to span a positive amount of time, and used it everywhere the API accepts a `resolution`: as a query parameter on `GET /sensors/<id>/data` and on the `chart_data` endpoints under `api/dev`, and in the request body of the sensor- and asset-level schedule triggers.
- [x] A negative resolution (e.g. `-PT15M`) was accepted too. It never crashed, but `pd.date_range` returns an empty index for it, so the endpoint answered 200 with no values. It is now rejected the same way.
- [x] Added changelog item in `documentation/changelog.rst`, and an API changelog entry under a new `v3.0-35` heading (happy to fold that into whichever version heading you prefer).

This is the GET-side counterpart of #2116, which added a resolution-compatibility guard to the POST schema only, based on the resolution *inferred from posted values* rather than on a `resolution` parameter supplied directly.

## Look & Feel

Before:

```
$ curl ".../sensors/1/data?start=...&duration=PT1H&resolution=PT0S&unit=kW"
{"message": "integer division or modulo by zero", "status": 500}
```

After:

```json
{
  "message": {
    "combined_sensor_data_description": {
      "resolution": ["FlexMeasures only supports a positive resolution, got: PT0S."]
    }
  },
  "result": "Rejected",
  "status": "UNPROCESSABLE_ENTITY"
}
```

which matches the 422 that `PT1S` already produced.

## How to test

- `flexmeasures/data/schemas/tests/test_times.py::test_resolution_field_positive`, `::test_resolution_field_not_positive` and `::test_resolution_field_still_validates_duration` cover the field itself, including that nominal durations (`P1M`) and the existing multiple-of-a-minute validation are unaffected.
- `flexmeasures/api/v3_0/tests/test_sensor_data.py::test_get_sensor_data_with_non_positive_resolution` covers the endpoint from the issue, for `PT0S`, `PT0M`, `P0D` and `-PT20M`. Reverting just the field swap in `sensor_data.py` makes it fail with the original `ZeroDivisionError`.

Ran green: `flexmeasures/api/v3_0/tests/test_sensor_data.py`, `test_sensor_data_fresh_db.py`, `flexmeasures/data/schemas/tests/`, `flexmeasures/api/dev`, `test_sensor_schedules.py`, `test_sensor_schedules_fresh_db.py`, `test_asset_schedules_fresh_db.py`, `flexmeasures/ui/tests`.

## Further Improvements

`resolution` also appears on the reporter/forecaster config schemas (`data/schemas/io.py`, `data/schemas/reporting/__init__.py`) and on `BeliefsSearchConfigSchema`. Those are not part of the reported bug and were left alone; switching them over to `ResolutionField` would be a straightforward follow-up if you want the guard everywhere.

Separately, `POST /sensors/<id>/schedules/trigger` computes `resolution % sensor.event_resolution`, which raises `ZeroDivisionError` for an instantaneous sensor. That is a different code path than the one reported here and is not addressed in this PR.

## Related Items

Closes #2493. GET-side counterpart of #2116.

---

#### Sign-off

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or other license that is incompatible with FlexMeasures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgnoDDysWF5CMi3k827rHM
