### PR TITLE
Resolve output-sensor references instead of skipping them

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -39,6 +39,7 @@ Infrastructure / Support
 Bugfixes
 -----------
 
+* Triggering a schedule no longer fails with a server error when a device's output sensor is referenced by ID rather than by a sensor the scheduler already resolved [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
 * Asking the API for sensor data, a chart or a schedule at a resolution that spans no time (such as ``PT0S``), or at a negative one, now gets the same clear rejection as any other unsupported resolution, instead of a server error or a silently empty result [see `PR #2502 <https://www.github.com/FlexMeasures/flexmeasures/pull/2502>`_]
 * Where several data sources report the same event, which one a search keeps is now decided the same way every time: a source version only counts against other versions of that source, and a caller that lists its sources gets the order it asked for [see `PR #2494 <https://www.github.com/FlexMeasures/flexmeasures/pull/2494>`_]
 * Schedules saved to the flex-context's ``aggregate-consumption`` sensor had their sign flipped, showing production where consumption was scheduled and vice versa, because the sign convention implied by the field name was never recorded on the sensor [see `PR #2499 <https://www.github.com/FlexMeasures/flexmeasures/pull/2499>`_]

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -39,7 +39,7 @@ Infrastructure / Support
 Bugfixes
 -----------
 
-* Triggering a schedule no longer fails with a server error when a device's output sensor is referenced by ID rather than by a sensor the scheduler already resolved [see `PR #XXXX <https://www.github.com/FlexMeasures/flexmeasures/pull/XXXX>`_]
+* Triggering a schedule no longer fails with a server error when a device's output sensor is referenced by ID rather than by a sensor the scheduler already resolved [see `PR #2507 <https://www.github.com/FlexMeasures/flexmeasures/pull/2507>`_]
 * Asking the API for sensor data, a chart or a schedule at a resolution that spans no time (such as ``PT0S``), or at a negative one, now gets the same clear rejection as any other unsupported resolution, instead of a server error or a silently empty result [see `PR #2502 <https://www.github.com/FlexMeasures/flexmeasures/pull/2502>`_]
 * Where several data sources report the same event, which one a search keeps is now decided the same way every time: a source version only counts against other versions of that source, and a caller that lists its sources gets the order it asked for [see `PR #2494 <https://www.github.com/FlexMeasures/flexmeasures/pull/2494>`_]
 * Schedules saved to the flex-context's ``aggregate-consumption`` sensor had their sign flipped, showing production where consumption was scheduled and vice versa, because the sign convention implied by the field name was never recorded on the sensor [see `PR #2499 <https://www.github.com/FlexMeasures/flexmeasures/pull/2499>`_]

--- a/flexmeasures/data/services/scheduling.py
+++ b/flexmeasures/data/services/scheduling.py
@@ -609,7 +609,7 @@ def _set_flex_model_output_sensors_consumption_is_positive(
     so that a flex-model which reached this function undeserialized still gets its sign conventions recorded.
 
     :param flex_model: Flex model — either a single-device ``dict`` or a ``list`` of per-device dicts.
-                       Consumption/production fields are expected to be dicts with a ``"sensor"`` key.
+                       Consumption/production fields are expected to reference a sensor, in any of the shapes :func:`_resolve_output_sensor` accepts.
     :raises ValueError: When ``consumption_is_positive`` is already set to the wrong value for the given flex-model field,
                         or when an output-sensor reference does not resolve to a sensor.
     """
@@ -642,9 +642,9 @@ def _set_flex_model_output_sensors_consumption_is_positive(
 def _resolve_output_sensor(field, field_name: str) -> Sensor | None:
     """The sensor that an output-sensor field refers to, if it refers to one at all.
 
-    Such a field is a dict with a ``"sensor"`` key, whose value is a ``Sensor`` once the flex-config has been deserialized,
-    and the ID the client posted when it has not.
-    Both forms resolve here, rather than the latter being skipped,
+    Such a field carries its sensor under ``"sensor"``: as a key when the field is a dict, and as an attribute when it is a sensor reference object.
+    The value there is a ``Sensor`` once the flex-config has been deserialized, and the ID the client posted when it has not.
+    All of these shapes resolve here, rather than the undeserialized ones being skipped,
     so that a reference which reached its caller undeserialized is still handled instead of silently ignored.
     A field that is not a sensor reference at all is not our business, and returns None:
     a custom scheduler is free to use these field names for something else entirely.
@@ -698,7 +698,7 @@ def _assign_consumption_is_positive(
 
 
 def _set_flex_context_output_sensors_consumption_is_positive(
-    flex_context: dict | None,
+    flex_context: dict | list | None,
 ) -> None:
     """Set the ``consumption_is_positive`` attribute on aggregate output sensors.
 

--- a/flexmeasures/data/services/scheduling.py
+++ b/flexmeasures/data/services/scheduling.py
@@ -605,40 +605,75 @@ def _set_flex_model_output_sensors_consumption_is_positive(
     but has the wrong value for the flex-model field that references it. Calling this function
     at job-creation time lets the API surface conflicts before any work is queued.
 
-    Fields that do not resolve to a sensor are skipped,
-    which keeps the function safe to call on a flex-model that a custom scheduler left undeserialized.
+    A reference that is still a sensor ID is looked up rather than skipped,
+    so that a flex-model which reached this function undeserialized still gets its sign conventions recorded.
 
-    :param flex_model: Deserialized flex model — either a single-device ``dict`` or a ``list`` of per-device dicts.
+    :param flex_model: Flex model — either a single-device ``dict`` or a ``list`` of per-device dicts.
                        Consumption/production fields are expected to be dicts with a ``"sensor"`` key.
-    :raises ValueError: When ``consumption_is_positive`` is already set to the wrong value
-                        for the given flex-model field.
+    :raises ValueError: When ``consumption_is_positive`` is already set to the wrong value for the given flex-model field,
+                        or when an output-sensor reference does not resolve to a sensor.
     """
-    if not isinstance(flex_model, (dict, list)):
+    if flex_model is None:
         return
     models = flex_model if isinstance(flex_model, list) else [flex_model]
     for flex_model_d in models:
         if not isinstance(flex_model_d, dict):
             continue
-        consumption_field = flex_model_d.get("consumption")
-        production_field = flex_model_d.get("production")
-        consumption_sensor = (
-            consumption_field.get("sensor")
-            if isinstance(consumption_field, dict)
-            else None
+        # A device's flex-model is nested under its own key in the multi-sensor form,
+        # which is how a flex-model travels between the API and the scheduler (see MultiSensorFlexModelSchema).
+        nested = flex_model_d.get(
+            "sensor_flex_model", flex_model_d.get("sensor-flex-model")
         )
-        production_sensor = (
-            production_field.get("sensor")
-            if isinstance(production_field, dict)
-            else None
-        )
-        for sensor, intended in [
-            (consumption_sensor, True),
-            (production_sensor, False),
+        if isinstance(nested, dict):
+            _set_flex_model_output_sensors_consumption_is_positive(nested)
+        for field_name, intended in [
+            ("consumption", True),
+            ("production", False),
         ]:
-            if not isinstance(sensor, Sensor):
+            sensor = _resolve_output_sensor(flex_model_d.get(field_name), field_name)
+            if sensor is None:
                 continue
-            field_name = "consumption_schedule" if intended else "production_schedule"
-            _assign_consumption_is_positive(sensor, intended, field_name)
+            schedule_name = (
+                "consumption_schedule" if intended else "production_schedule"
+            )
+            _assign_consumption_is_positive(sensor, intended, schedule_name)
+
+
+def _resolve_output_sensor(field, field_name: str) -> Sensor | None:
+    """The sensor that an output-sensor field refers to, if it refers to one at all.
+
+    Such a field is a dict with a ``"sensor"`` key, whose value is a ``Sensor`` once the flex-config has been deserialized,
+    and the ID the client posted when it has not.
+    Both forms resolve here, rather than the latter being skipped,
+    so that a reference which reached its caller undeserialized is still handled instead of silently ignored.
+    A field that is not a sensor reference at all is not our business, and returns None:
+    a custom scheduler is free to use these field names for something else entirely.
+
+    :param field:       The output-sensor field, or None when the flex-config does not set it.
+    :param field_name:  Name of the field, used in the error message.
+    :returns:           The referenced sensor, or None when the field does not reference one.
+    :raises ValueError: When the field references a sensor that cannot be resolved.
+    """
+    if isinstance(field, dict):
+        reference = field.get("sensor")
+    else:
+        reference = getattr(field, "sensor", None)
+    if reference is None:
+        return None
+    if isinstance(reference, Sensor):
+        return reference
+    if isinstance(reference, int) or (
+        isinstance(reference, str) and reference.isdigit()
+    ):
+        sensor = db.session.get(Sensor, int(reference))
+        if sensor is None:
+            raise ValueError(
+                f"The '{field_name}' output sensor references sensor {reference}, which does not exist."
+            )
+        return sensor
+    raise ValueError(
+        f"The '{field_name}' output sensor reference could not be resolved to a sensor: {reference!r}."
+    )
 
 
 def _assign_consumption_is_positive(
@@ -677,16 +712,27 @@ def _set_flex_context_output_sensors_consumption_is_positive(
     following the default convention for power sensors (see :func:`_resolve_schedule_output_sign`).
 
     Both the single-dict flex-context and each entry of its ``commodities`` list can define these sensors,
-    so both are visited here (the list is keyed ``commodity_contexts`` once deserialized).
-    Fields that do not resolve to a sensor are skipped,
-    which keeps the function safe to call on a flex-context that a custom scheduler left undeserialized.
+    so both are visited here.
+    A flex-context which reached this function undeserialized is handled rather than skipped,
+    so its sign conventions are still recorded: a multi-commodity flex-context is a list before deserialization and a dict after,
+    its per-commodity contexts are keyed ``commodities`` before and ``commodity_contexts`` after,
+    and a reference that is still a sensor ID is looked up.
 
-    :param flex_context: Deserialized flex context, or None when the scheduler has none.
-    :raises ValueError:  When ``consumption_is_positive`` is already set to the wrong value for the given flex-context field.
+    :param flex_context: Flex context, or None when the scheduler has none.
+    :raises ValueError:  When ``consumption_is_positive`` is already set to the wrong value for the given flex-context field,
+                         or when an aggregate output-sensor reference does not resolve to a sensor.
     """
-    if not isinstance(flex_context, dict):
+    if flex_context is None:
         return
-    contexts = [flex_context] + list(flex_context.get("commodity_contexts") or [])
+    top_level = flex_context if isinstance(flex_context, list) else [flex_context]
+    contexts = []
+    for context in top_level:
+        if not isinstance(context, dict):
+            continue
+        contexts.append(context)
+        contexts.extend(
+            context.get("commodity_contexts") or context.get("commodities") or []
+        )
     for context in contexts:
         if not isinstance(context, dict):
             continue
@@ -694,13 +740,13 @@ def _set_flex_context_output_sensors_consumption_is_positive(
             ("aggregate_consumption", True),
             ("aggregate_production", False),
         ]:
-            field = context.get(field_name)
-            sensor = field.get("sensor") if isinstance(field, dict) else None
-            if not isinstance(sensor, Sensor):
+            # The field is keyed with an underscore once deserialized, and with a dash as posted.
+            field_label = field_name.replace("_", "-")
+            field = context.get(field_name, context.get(field_label))
+            sensor = _resolve_output_sensor(field, field_label)
+            if sensor is None:
                 continue
-            _assign_consumption_is_positive(
-                sensor, intended, field_name.replace("_", "-")
-            )
+            _assign_consumption_is_positive(sensor, intended, field_label)
 
 
 def _set_output_sensor_consumption_is_positive(

--- a/flexmeasures/data/tests/test_scheduling_output_sensors.py
+++ b/flexmeasures/data/tests/test_scheduling_output_sensors.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import pytest
+
+from flexmeasures import Sensor
+from flexmeasures.data.services.scheduling import (
+    _set_flex_context_output_sensors_consumption_is_positive,
+    _set_flex_model_output_sensors_consumption_is_positive,
+)
+
+
+@pytest.fixture
+def output_sensors(db, add_battery_assets, request) -> tuple[Sensor, Sensor]:
+    """Two power sensors to use as output sensors, without a sign convention of their own.
+
+    Each test gets its own pair, since these tests share a database and set an attribute on them.
+    """
+    battery = add_battery_assets["Test battery"]
+    sensors = []
+    for name in (f"{request.node.name} A", f"{request.node.name} B"):
+        sensor = Sensor(
+            name=name,
+            generic_asset=battery,
+            unit="MW",
+            event_resolution=battery.sensors[0].event_resolution,
+        )
+        db.session.add(sensor)
+        sensors.append(sensor)
+    db.session.flush()
+    return sensors[0], sensors[1]
+
+
+def test_flex_model_output_sensor_given_by_id(db, output_sensors):
+    """A flex-model that reaches the setter undeserialized still gets its sign convention recorded.
+
+    Skipping the reference instead would leave the sensor on the default production-positive convention,
+    under which the scheduler's consumption-positive values are saved sign-flipped.
+    """
+    consumption_sensor, production_sensor = output_sensors
+    _set_flex_model_output_sensors_consumption_is_positive(
+        [
+            {
+                "consumption": {"sensor": consumption_sensor.id},
+                "production": {"sensor": production_sensor.id},
+            }
+        ]
+    )
+    assert consumption_sensor.attributes["consumption_is_positive"] is True
+    assert production_sensor.attributes["consumption_is_positive"] is False
+
+
+def test_flex_model_output_sensor_nested_in_the_multi_sensor_form(db, output_sensors):
+    """A device flex-model nested under its own key is visited, too."""
+    consumption_sensor, _ = output_sensors
+    _set_flex_model_output_sensors_consumption_is_positive(
+        [
+            {
+                "sensor": consumption_sensor.id,
+                "sensor-flex-model": {"consumption": {"sensor": consumption_sensor.id}},
+            }
+        ]
+    )
+    assert consumption_sensor.attributes["consumption_is_positive"] is True
+
+
+def test_flex_context_aggregate_sensor_given_by_id(db, output_sensors):
+    """An aggregate output sensor is resolved from the field key and reference the client posted."""
+    consumption_sensor, production_sensor = output_sensors
+    _set_flex_context_output_sensors_consumption_is_positive(
+        {
+            "aggregate-consumption": {"sensor": consumption_sensor.id},
+            "aggregate-production": {"sensor": production_sensor.id},
+        }
+    )
+    assert consumption_sensor.attributes["consumption_is_positive"] is True
+    assert production_sensor.attributes["consumption_is_positive"] is False
+
+
+def test_flex_context_in_its_multi_commodity_list_form(db, output_sensors):
+    """A multi-commodity flex-context is a list before deserialization, and is visited as one."""
+    consumption_sensor, _ = output_sensors
+    _set_flex_context_output_sensors_consumption_is_positive(
+        [
+            {
+                "commodity": "electricity",
+                "aggregate-consumption": {"sensor": consumption_sensor.id},
+            }
+        ]
+    )
+    assert consumption_sensor.attributes["consumption_is_positive"] is True
+
+
+def test_flex_context_commodities_before_deserialization(db, output_sensors):
+    """Per-commodity contexts are keyed `commodities` before deserialization, and `commodity_contexts` after."""
+    consumption_sensor, _ = output_sensors
+    _set_flex_context_output_sensors_consumption_is_positive(
+        {
+            "commodities": [
+                {
+                    "commodity": "gas",
+                    "aggregate-consumption": {"sensor": consumption_sensor.id},
+                }
+            ]
+        }
+    )
+    assert consumption_sensor.attributes["consumption_is_positive"] is True
+
+
+def test_unresolvable_output_sensor_reference_is_reported(db, add_battery_assets):
+    """A reference that names no sensor is reported, rather than passing unnoticed."""
+    with pytest.raises(ValueError, match="which does not exist"):
+        _set_flex_model_output_sensors_consumption_is_positive(
+            [{"consumption": {"sensor": 2147483647}}]
+        )
+    with pytest.raises(ValueError, match="could not be resolved"):
+        _set_flex_model_output_sensors_consumption_is_positive(
+            [{"consumption": {"sensor": ["not a sensor"]}}]
+        )
+
+
+def test_fields_that_are_not_sensor_references_are_left_alone(db, add_battery_assets):
+    """A custom scheduler is free to use these field names for something else entirely."""
+    _set_flex_model_output_sensors_consumption_is_positive(
+        [{"consumption": "10 kW", "production": None}]
+    )
+    _set_flex_model_output_sensors_consumption_is_positive(None)
+    _set_flex_context_output_sensors_consumption_is_positive(None)


### PR DESCRIPTION
## Description

- Marking output sensors with their sign convention silently skipped any reference that was not already a `Sensor` object. This PR looks the reference up instead, and reports one that names no sensor
- That silent skip is what closes #2497 properly: the reported `AttributeError` came from a path where the flex-config reached this code undeserialized, and skipping such a reference retires the crash without covering the case. The sensor then keeps the default production-positive convention (so the scheduler's consumption-positive values are saved sign-flipped), and the conflict check that should reject a mismatching attribute at trigger time does not run
- The same skip hid three further shapes of an undeserialized flex-config, each of which now resolves as well:
  - a flex-context in its multi-commodity **list** form (a dict only after deserialization)
  - per-commodity contexts under the `commodities` key they carry before deserialization, not only `commodity_contexts` after it
  - aggregate fields under their dashed keys (`aggregate-consumption`), not only the underscored ones
  - a device flex-model nested in the multi-sensor form (`sensor-flex-model`)
- A field that is not a sensor reference at all is still left alone, since a custom scheduler is free to use these field names for something else
- [x] Added changelog item in `documentation/changelog.rst`

Closes #2497

## How to test

`flexmeasures/data/tests/test_scheduling_output_sensors.py`, which exercises each shape directly. Six of its seven tests fail without this change: the five that assert the attribute is recorded see it left unset, and the sixth sees no error raised for a reference that names no sensor. The seventh guards the "not a sensor reference" case and passes either way.

Note that #2497's own reproduction was never confirmed — see the analysis in that issue. This PR covers the failure mode rather than the specific report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nk1JXQKQNvKa8iuvdqqWW
