### PR TITLE
Keep the chart legend off the plot in PNG/SVG exports

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -51,6 +51,7 @@ Bugfixes
 * ``flexmeasures add schedule --dry-run`` no longer saves a schedule when it is combined with ``--as-job``, where the flag used to be dropped without a word and the queued job stored its schedule anyway; that combination is now rejected, and a dry run says how many beliefs it would have saved and which events they cover [see `PR #2483 <https://www.github.com/FlexMeasures/flexmeasures/pull/2483>`_]
 * The time range sent when loading an asset's KPIs was off by the viewer's UTC offset, so KPIs could cover the wrong days [see `PR #2435 <https://www.github.com/FlexMeasures/flexmeasures/pull/2435>`_]
 * An asset's status page showed only some of the sensors it reported on, in an order that changed between reloads, and it reported on fixed quantities from the flex-context, which have no data to be up to date with [see `PR #2489 <https://www.github.com/FlexMeasures/flexmeasures/pull/2489>`_]
+* Saving an asset chart as PNG or SVG drew the legend over the graph whenever it listed more sensors than fit beside a subplot; the exported image now makes room for every entry beside its own plot, without shrinking the plot, and spells out the sensor names that the on-screen legend abbreviates [see `PR #2517 <https://www.github.com/FlexMeasures/flexmeasures/pull/2517>`_]
 
 
 

--- a/flexmeasures/ui/static/js/fast-chart.js
+++ b/flexmeasures/ui/static/js/fast-chart.js
@@ -61,6 +61,14 @@ const IS_TOUCH =
 const BOTTOM_OFFSET = 92; // room for the slider and the last two-line x-axis labels
 const GRID_LEFT = 70; // room for the y-axis labels
 const LEGEND_WIDTH = 220; // width of the legend column beside each subplot
+// Legend geometry used to size image exports (see buildExportOption): the height
+// of one entry row, the offset of a label from its column's left edge (symbol +
+// gap), the gap between columns, and a cap on how wide a single label may get.
+const LEGEND_ROW_HEIGHT = FONT_SIZE + 9;
+const LEGEND_LABEL_OFFSET = 28;
+const LEGEND_COLUMN_GAP = 20;
+const LEGEND_PLOT_GAP = 12;
+const MAX_EXPORT_LABEL_WIDTH = 400;
 
 // Diverging color scale approximating Vega's "blueorange" scheme (centered at 0)
 const BLUE_ORANGE = ["#2166ac", "#67a9cf", "#d1e5f0", "#f7f7f7", "#fee0b6", "#f1a340", "#b35806"];
@@ -69,6 +77,19 @@ const BLUE_ORANGE = ["#2166ac", "#67a9cf", "#d1e5f0", "#f7f7f7", "#fee0b6", "#f1
 const instances = {};
 
 /* ============================== formatting ============================== */
+
+// Width of a label in the chart font, used to size the legend column of an
+// image export. Measured on a scratch canvas, since ECharts only exposes text
+// metrics once a chart is rendered.
+let measureContext = null;
+function textWidth(text) {
+  if (!measureContext) {
+    measureContext = document.createElement("canvas").getContext("2d");
+  }
+  if (!measureContext) return 0;
+  measureContext.font = FONT_SIZE + "px " + CHART_FONT;
+  return measureContext.measureText(String(text == null ? "" : text)).width;
+}
 
 // Build a label for a single source. Mirrors the Vega-Lite "source_legend_label"
 // transform: keep source.name visible, and only when sources share a name do we
@@ -773,32 +794,90 @@ function exportCSV(elementId, datasetName) {
 
 // Build the option used for image exports: no toolbox buttons, and "scroll"
 // legends switched to "plain" so every entry renders instead of just one page.
-function buildExportOption(lastOption) {
-  const legend = (
-    Array.isArray(lastOption.legend)
-      ? lastOption.legend
-      : lastOption.legend
-      ? [lastOption.legend]
-      : []
-  ).map((l) => Object.assign({}, l, { type: "plain" }));
+//
+// A plain legend needs more room than the paginated one it replaces: on screen
+// only one page of entries shows beside its subplot, but all of them have to
+// fit in the export. So each side legend gets the full vertical band beside its
+// subplot and its labels in full (an image has no hover to reveal a truncated
+// name), and when that still leaves entries wrapping into extra columns, the
+// exported canvas grows to the right by just enough for them — otherwise the
+// extra columns would spill over the plot (see #2513).
+//
+// Returns the option together with the canvas size the export should use.
+// (Exported for the JavaScript tests, which check the legend never covers a plot.)
+export function buildExportOption(lastOption, width, height) {
+  const asList = (value) => (Array.isArray(value) ? value : value ? [value] : []);
+  const grids = asList(lastOption.grid);
+  // The room the on-screen layout reserves beside the plots for the legend
+  // column (grid.right, minus the gap the legend keeps from the plot).
+  const availableLegendWidth = LEGEND_WIDTH + 40 - LEGEND_PLOT_GAP;
+  let extraWidth = 0;
+
+  const legend = asList(lastOption.legend).map((l) => {
+    const exportLegend = Object.assign({}, l, { type: "plain" });
+    // Only the side legends are constrained; the legends-below layout already
+    // grows the chart to fit every entry.
+    if (l.orient !== "vertical" || typeof l.top !== "number" || l.height == null) {
+      return exportLegend;
+    }
+    const grid = grids.find(
+      (g) => l.top >= g.top && l.top <= g.top + g.height
+    );
+    if (!grid) return exportLegend;
+    // The band beside this subplot: from its grid top down to where the next
+    // subplot's title starts, or to the bottom of the canvas for the last one.
+    const next = grids
+      .filter((g) => g.top > grid.top)
+      .reduce((a, g) => (a === null || g.top < a.top ? g : a), null);
+    const bandTop = grid.top;
+    const bandBottom = (next ? next.top - TITLE_RAISE : height) - 8;
+    const bandHeight = Math.max(LEGEND_ROW_HEIGHT, bandBottom - bandTop);
+    const labels = l.data || [];
+    const rows = Math.max(1, Math.floor(bandHeight / LEGEND_ROW_HEIGHT));
+    const columns = Math.ceil(labels.length / rows);
+    // Show the names in full — an image has no hover to reveal a truncated one —
+    // but keep a cap, so one very long sensor name cannot blow up the exported
+    // image; only labels past that cap stay truncated.
+    const widestLabel = labels.reduce((w, label) => Math.max(w, textWidth(label)), 0);
+    const capped = widestLabel > MAX_EXPORT_LABEL_WIDTH;
+    const labelWidth = capped ? MAX_EXPORT_LABEL_WIDTH : widestLabel;
+    const columnWidth = LEGEND_LABEL_OFFSET + labelWidth + LEGEND_COLUMN_GAP;
+    extraWidth = Math.max(extraWidth, columns * columnWidth - availableLegendWidth);
+    exportLegend.top = bandTop;
+    exportLegend.height = bandHeight;
+    // Anchor the legend to the plot instead of to the right edge, so a legend
+    // that needs fewer columns than the widest one still sits beside its own
+    // subplot rather than drifting off to the right.
+    exportLegend.left = width - grid.right + LEGEND_PLOT_GAP;
+    exportLegend.right = null;
+    exportLegend.textStyle = Object.assign({}, l.textStyle, {
+      width: capped ? MAX_EXPORT_LABEL_WIDTH : null,
+      overflow: capped ? "truncate" : "none",
+    });
+    return exportLegend;
+  });
+  extraWidth = Math.max(0, Math.ceil(extraWidth));
+
   // Render every series in a single synchronous pass. Heatmaps use progressive
   // rendering (cells drawn across animation frames); the export reads the
   // canvas/SVG immediately after setOption, so without this a large heatmap
   // (e.g. a year of data, > 5000 cells) loses every cell past the first chunk.
-  const series = (
-    Array.isArray(lastOption.series)
-      ? lastOption.series
-      : lastOption.series
-      ? [lastOption.series]
-      : []
-  ).map((s) => Object.assign({}, s, { progressive: 0, animation: false }));
-  return Object.assign({}, lastOption, {
+  const series = asList(lastOption.series).map((s) =>
+    Object.assign({}, s, { progressive: 0, animation: false })
+  );
+  // Widening the canvas must not stretch the plots: every grid keeps its width
+  // by giving the added space to its right margin.
+  const option = Object.assign({}, lastOption, {
     animation: false,
     backgroundColor: "#fff",
     toolbox: { show: false },
     legend: legend,
     series: series,
   });
+  if (extraWidth > 0) {
+    option.grid = grids.map((g) => Object.assign({}, g, { right: g.right + extraWidth }));
+  }
+  return { option: option, width: width + extraWidth, height: height };
 }
 
 function exportSVG(elementId, datasetName) {
@@ -807,14 +886,19 @@ function exportSVG(elementId, datasetName) {
     return;
   }
   // Render the current option to SVG with a temporary server-side-rendering instance
+  const exported = buildExportOption(
+    instance.lastOption,
+    instance.chart.getWidth(),
+    instance.chart.getHeight()
+  );
   const svgChart = echarts.init(null, null, {
     renderer: "svg",
     ssr: true,
-    width: instance.chart.getWidth(),
-    height: instance.chart.getHeight(),
+    width: exported.width,
+    height: exported.height,
   });
   try {
-    svgChart.setOption(buildExportOption(instance.lastOption));
+    svgChart.setOption(exported.option);
     downloadBlob(svgChart.renderToSVGString(), "image/svg+xml", (datasetName || "chart") + ".svg");
   } finally {
     svgChart.dispose();
@@ -828,12 +912,21 @@ function exportPNG(elementId, datasetName) {
   }
   // Render to a detached canvas instance so the saved PNG shows all legend
   // entries and no toolbox, instead of snapshotting the paginated on-screen chart.
+  const exported = buildExportOption(
+    instance.lastOption,
+    instance.chart.getWidth(),
+    instance.chart.getHeight()
+  );
   const holder = document.createElement("div");
-  holder.style.width = instance.chart.getWidth() + "px";
-  holder.style.height = instance.chart.getHeight() + "px";
-  const pngChart = echarts.init(holder, null, { renderer: "canvas" });
+  holder.style.width = exported.width + "px";
+  holder.style.height = exported.height + "px";
+  const pngChart = echarts.init(holder, null, {
+    renderer: "canvas",
+    width: exported.width,
+    height: exported.height,
+  });
   try {
-    pngChart.setOption(buildExportOption(instance.lastOption));
+    pngChart.setOption(exported.option);
     const url = pngChart.getDataURL({
       type: "png",
       pixelRatio: 2,

--- a/flexmeasures/ui/tests/js/test_fast_chart.py
+++ b/flexmeasures/ui/tests/js/test_fast_chart.py
@@ -29,9 +29,7 @@ SIDE_LEGEND_CHART = """
 
 def test_export_legend_clears_the_plot(assert_js):
     """Every legend entry shows in an export, to the right of the plot (issue #2513)."""
-    assert_js(
-        SIDE_LEGEND_CHART
-        + """
+    assert_js(SIDE_LEGEND_CHART + """
         import { buildExportOption } from "/js/fast-chart.js";
         const exported = buildExportOption(chart(13), 1200, 400);
         const legend = exported.option.legend[0];
@@ -42,15 +40,12 @@ def test_export_legend_clears_the_plot(assert_js):
               `width ${exported.width}`);
         eq("the plot keeps its width", plotRight(exported) - exported.option.grid[0].left, 1200 - 260 - 70);
         eq("the exported chart keeps its height", exported.height, 400);
-        """
-    )
+        """)
 
 
 def test_export_legend_uses_the_full_band_beside_its_subplot(assert_js):
     """One subplot means the legend may run past the plot's height, into a single column."""
-    assert_js(
-        SIDE_LEGEND_CHART
-        + """
+    assert_js(SIDE_LEGEND_CHART + """
         import { buildExportOption } from "/js/fast-chart.js";
         const exported = buildExportOption(chart(13), 1200, 400);
         const legend = exported.option.legend[0];
@@ -58,15 +53,12 @@ def test_export_legend_uses_the_full_band_beside_its_subplot(assert_js):
         check("the legend may use the height below the plot too", legend.height > 150,
               `height ${legend.height}`);
         check("13 entries fit in one column", legend.height >= 13 * 25, `height ${legend.height}`);
-        """
-    )
+        """)
 
 
 def test_export_legend_shows_names_in_full(assert_js):
     """An image has no hover to reveal a truncated name, so the export shows them all."""
-    assert_js(
-        SIDE_LEGEND_CHART
-        + """
+    assert_js(SIDE_LEGEND_CHART + """
         import { buildExportOption } from "/js/fast-chart.js";
         const exported = buildExportOption(chart(13), 1200, 400);
         eq("labels are no longer truncated", exported.option.legend[0].textStyle.overflow, "none");
@@ -78,14 +70,12 @@ def test_export_legend_shows_names_in_full(assert_js):
         eq("a very long name stays truncated", wide.option.legend[0].textStyle.overflow, "truncate");
         check("the exported image stays a sane width", wide.width < 1200 + 500,
               `width ${wide.width}`);
-        """
-    )
+        """)
 
 
 def test_export_leaves_a_legend_below_the_plots_alone(assert_js):
     """With legends below (the "keep legends below graphs" setting), the chart already fits them."""
-    assert_js(
-        """
+    assert_js("""
         import { buildExportOption } from "/js/fast-chart.js";
         const option = {
             grid: [{top: 66, height: 150, left: 70, right: 30}],
@@ -96,15 +86,12 @@ def test_export_leaves_a_legend_below_the_plots_alone(assert_js):
         eq("the canvas is not widened", exported.width, 1200);
         eq("the legend stays where it is", exported.option.legend[0].left, 70);
         eq("the plot keeps its margins", exported.option.grid[0].right, 30);
-        """
-    )
+        """)
 
 
 def test_export_hides_the_toolbox(assert_js):
     """The zoom/pan/save buttons are chrome, not part of the picture."""
-    assert_js(
-        SIDE_LEGEND_CHART
-        + """
+    assert_js(SIDE_LEGEND_CHART + """
         import { buildExportOption } from "/js/fast-chart.js";
         const exported = buildExportOption(chart(3), 1200, 400);
         eq("the toolbox is hidden", exported.option.toolbox.show, false);
@@ -112,5 +99,4 @@ def test_export_hides_the_toolbox(assert_js):
            exported.option.backgroundColor, "#fff");
         eq("progressive rendering is off, so every series is drawn in one pass",
            exported.option.series[0].progressive, 0);
-        """
-    )
+        """)

--- a/flexmeasures/ui/tests/js/test_fast_chart.py
+++ b/flexmeasures/ui/tests/js/test_fast_chart.py
@@ -1,0 +1,116 @@
+"""Tests for flexmeasures/ui/static/js/fast-chart.js."""
+
+# A chart as fast-chart.js lays one out: a 1200x400 canvas with one subplot and,
+# beside it, a paginated legend of 13 sensors (the case reported in issue #2513).
+SIDE_LEGEND_CHART = """
+    const chart = (entries) => {
+        const labels = [];
+        for (let i = 0; i < entries; i++) {
+            labels.push("consumption tariff (Supplier " + i + ", low voltage)");
+        }
+        return {
+            grid: [{top: 66, height: 150, left: 70, right: 260}],
+            legend: [{
+                data: labels,
+                type: "scroll",
+                orient: "vertical",
+                right: 8,
+                top: 66,
+                height: 150,
+                textStyle: {fontSize: 16, width: 190, overflow: "truncate"},
+            }],
+            series: [{type: "line", data: []}],
+            toolbox: [{feature: {}}],
+        };
+    };
+    const plotRight = (exported) => exported.width - exported.option.grid[0].right;
+"""
+
+
+def test_export_legend_clears_the_plot(assert_js):
+    """Every legend entry shows in an export, to the right of the plot (issue #2513)."""
+    assert_js(
+        SIDE_LEGEND_CHART
+        + """
+        import { buildExportOption } from "/js/fast-chart.js";
+        const exported = buildExportOption(chart(13), 1200, 400);
+        const legend = exported.option.legend[0];
+        eq("the paginated legend becomes a plain one, so no entry is hidden", legend.type, "plain");
+        check("the legend starts to the right of the plot", legend.left >= plotRight(exported),
+              `legend at ${legend.left}, plot ends at ${plotRight(exported)}`);
+        check("the canvas grows to make room for the legend", exported.width > 1200,
+              `width ${exported.width}`);
+        eq("the plot keeps its width", plotRight(exported) - exported.option.grid[0].left, 1200 - 260 - 70);
+        eq("the exported chart keeps its height", exported.height, 400);
+        """
+    )
+
+
+def test_export_legend_uses_the_full_band_beside_its_subplot(assert_js):
+    """One subplot means the legend may run past the plot's height, into a single column."""
+    assert_js(
+        SIDE_LEGEND_CHART
+        + """
+        import { buildExportOption } from "/js/fast-chart.js";
+        const exported = buildExportOption(chart(13), 1200, 400);
+        const legend = exported.option.legend[0];
+        eq("the legend starts level with its subplot", legend.top, 66);
+        check("the legend may use the height below the plot too", legend.height > 150,
+              `height ${legend.height}`);
+        check("13 entries fit in one column", legend.height >= 13 * 25, `height ${legend.height}`);
+        """
+    )
+
+
+def test_export_legend_shows_names_in_full(assert_js):
+    """An image has no hover to reveal a truncated name, so the export shows them all."""
+    assert_js(
+        SIDE_LEGEND_CHART
+        + """
+        import { buildExportOption } from "/js/fast-chart.js";
+        const exported = buildExportOption(chart(13), 1200, 400);
+        eq("labels are no longer truncated", exported.option.legend[0].textStyle.overflow, "none");
+
+        // ... except for a name so long that showing it would blow up the image.
+        const long = chart(2);
+        long.legend[0].data = ["x".repeat(400), "short"];
+        const wide = buildExportOption(long, 1200, 400);
+        eq("a very long name stays truncated", wide.option.legend[0].textStyle.overflow, "truncate");
+        check("the exported image stays a sane width", wide.width < 1200 + 500,
+              `width ${wide.width}`);
+        """
+    )
+
+
+def test_export_leaves_a_legend_below_the_plots_alone(assert_js):
+    """With legends below (the "keep legends below graphs" setting), the chart already fits them."""
+    assert_js(
+        """
+        import { buildExportOption } from "/js/fast-chart.js";
+        const option = {
+            grid: [{top: 66, height: 150, left: 70, right: 30}],
+            legend: [{data: ["a", "b"], type: "plain", orient: "vertical", left: 70, top: 300}],
+            series: [{type: "line", data: []}],
+        };
+        const exported = buildExportOption(option, 1200, 500);
+        eq("the canvas is not widened", exported.width, 1200);
+        eq("the legend stays where it is", exported.option.legend[0].left, 70);
+        eq("the plot keeps its margins", exported.option.grid[0].right, 30);
+        """
+    )
+
+
+def test_export_hides_the_toolbox(assert_js):
+    """The zoom/pan/save buttons are chrome, not part of the picture."""
+    assert_js(
+        SIDE_LEGEND_CHART
+        + """
+        import { buildExportOption } from "/js/fast-chart.js";
+        const exported = buildExportOption(chart(3), 1200, 400);
+        eq("the toolbox is hidden", exported.option.toolbox.show, false);
+        eq("the background is opaque, so the image is not transparent",
+           exported.option.backgroundColor, "#fff");
+        eq("progressive rendering is off, so every series is drawn in one pass",
+           exported.option.series[0].progressive, 0);
+        """
+    )


### PR DESCRIPTION
Closes #2513.

## The bug

On screen, an asset chart with more sensors than fit beside a subplot paginates its legend — six entries per page, at 150 px of subplot height and a 25 px row. The image exports (*Save as PNG* / *Save as SVG*) switch that legend to `"plain"` so that every entry shows, but they kept the on-screen geometry: the same canvas size, the same legend box anchored 8 px from the right edge, and the same truncated labels. The entries that no longer fitted wrapped into extra columns, which grew leftwards over the plot.

<img width="2400" height="800" alt="export_base" src="https://github.com/user-attachments/assets/ea5b9ccb-2ece-401c-abff-09d487a88713" />

## The fix

`buildExportOption` now also lays the legend out, and reports the canvas size the export should use:

* each side legend gets the **full vertical band beside its subplot** (down to the next subplot's title, or to the bottom of the canvas for the last one), so the common case fits in a single column;
* it is **anchored to its own plot** instead of to the right edge, so a legend needing fewer columns than its neighbours still sits next to its subplot;
* when the entries still wrap into extra columns, the **exported canvas grows to the right** by just enough to hold them, with every grid's right margin growing along, so each plot keeps exactly the size it has on screen;
* labels are **no longer truncated** (up to a 400 px cap) — a static image has no hover to reveal the rest of a name.

Nothing changes on screen, or for the legends-below layout (the *keep legends below graphs* setting and the sensor page), where the chart already grows to fit every entry.

<img width="2602" height="800" alt="export_fixed2" src="https://github.com/user-attachments/assets/2eb94e54-d5a8-43a4-b1f0-386af5f952e0" />


## Verification

* New JavaScript tests (`flexmeasures/ui/tests/js/test_fast_chart.py`, run in headless Chrome by the existing harness from #2435) cover the legend clearing the plot, the single-column band, untruncated labels with the long-name cap, the untouched legends-below layout, and the hidden toolbox.
* Checked end to end in a standalone harness that renders `fast-chart.js` with ECharts 5.6.0 and drives the real *Save as SVG* / *Save as PNG* toolbox actions, asserting that no legend label's bounding box intersects any plot rectangle: 13, 17 and 3×13 sensors, plus 3 sensors and both legends-below cases. All six fail before this change (7, 14 and 21 overlapping labels) and pass after.

Before/after images of the reported case (13 sensors, one subplot), rendered by that harness, posted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DcEgdFRXAWB25wDMiQ4hJH
